### PR TITLE
Added a server config option to use a different HTTPS port

### DIFF
--- a/HOW-TO-RUN-A-SERVER.md
+++ b/HOW-TO-RUN-A-SERVER.md
@@ -16,7 +16,10 @@ port = 80
 serverMessage = "Welcome to the my personal Hammer server!"
 contact = "bob@example.com"
 
-# Optional, if you don't care about HTTPS, just leave this section out
+# Below this line is optional, if you don't care about HTTPS, just leave it out
+
+sslPort = 443
+
 [sslCert]
 path = "/etc/letsencrypt/live/example.com/cert.jks"
 storePassword = "1234567890"

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -51,6 +51,7 @@ private fun startServer(config: ServerConfig) {
 				privateKeyPassword = { (keyPassword ?: "").toCharArray() }) {
 				keyStorePath = File(path)
 				host = bindHost
+				port = config.sslPort
 			}
 		}
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 data class ServerConfig(
 	val host: String = "localhost",
 	val port: Int = 8080,
+	val sslPort: Int = 443,
 	val serverMessage: String = DEFAULT_MESSAGE,
 	val contact: String? = null,
 	val sslCert: SslCertConfig? = null,

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
@@ -28,6 +28,8 @@ fun Application.configureHTTP(config: ServerConfig) {
 	}
 
 	if (config.sslCert?.forceHttps == true) {
-		install(HttpsRedirect)
+		install(HttpsRedirect) {
+		    sslPort = config.sslPort
+		}
 	}
 }


### PR DESCRIPTION
This pull request would allow users to use a different HTTPS port by setting `sslPort` in `serverConfig.toml`.

(The commit is unverified because there is no email address associated with my key. This is because I am uncomfortable branding my permanent cryptographic identity with the name of a corporation, but have yet to setup self-hosted email. I can offer as reassurance only my word that the key is mine and its private counterpart has never been leaked and is protected with a strong password. If you are nonetheless uncomfortable merging my changes due to the unverified commit, I would ask you to consider instead committing the same changes yourself, and would not hold it against you were you to do so.)