### PR TITLE
Clean up Codacy Lizard config (drop composeUi exclusion, fix engine casing)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -38,7 +38,9 @@ engines:
     # don't map well to Jetpack Compose composables — long declarative UI
     # functions and many composable parameters are idiomatic. Disable Lizard
     # for composeUi entirely; detekt still enforces complexity on this code.
-    Lizard:
+    # NOTE: engine names must be lowercase (`lizard`, not `Lizard`) — an
+    # unrecognized engine key makes Codacy mis-handle the whole engines block.
+    lizard:
         exclude_paths:
             - 'composeUi/**'
             - 'android/src/main/kotlin/**/widgets/**'

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -35,12 +35,11 @@ exclude_paths:
 
 engines:
     # Lizard's language-agnostic complexity metrics (NLOC, CCN, parameter count)
-    # don't map well to Jetpack Compose composables — long declarative UI
-    # functions and many composable parameters are idiomatic. Disable Lizard
-    # for composeUi entirely; detekt still enforces complexity on this code.
+    # don't map well to Jetpack Compose widgets — long declarative UI functions
+    # and many composable parameters are idiomatic. detekt still enforces
+    # complexity on this code.
     # NOTE: engine names must be lowercase (`lizard`, not `Lizard`) — an
     # unrecognized engine key makes Codacy mis-handle the whole engines block.
     lizard:
         exclude_paths:
-            - 'composeUi/**'
             - 'android/src/main/kotlin/**/widgets/**'


### PR DESCRIPTION
## Summary

Cleans up the `engines` section of `.codacy.yaml`:

1. **Drop the `composeUi/**` Lizard exclusion** — Lizard's complexity metrics now run on `composeUi` again (detekt already covered it). The Android `widgets/**` exemption is kept.
2. **Fix engine key casing** (`Lizard` → `lizard`) — Codacy engine names must be lowercase; `Lizard` was an unrecognized key.

## Context / what this does *not* fix

This came out of investigating Codacy's monitored LOC dropping (~71k → ~12k). For the record: **this PR does not fix that drop.**

I simulated Codacy's actual globber (Java `PathMatcher`) over every tracked file — the top-level `exclude_paths` remove exactly **227 files / 28,472 Kotlin code lines** (tests + previews), leaving **66,719 monitored**. So `.codacy.yaml` is behaving as intended and does not account for a drop to 12k.

That ~55k gap is applied on the **Codacy UI side**, not in this file. Per Codacy's docs, tools can only be enabled/disabled in the UI (not the config file), so the most likely cause is **detekt being disabled on the *Code Patterns* page** (which would stop all Kotlin from being counted, leaving ~non-Kotlin only ≈ 12k), or a broad pattern under **Settings → Ignored Paths**. Worth checking there.

This PR is config hygiene; the LOC recovery needs a UI change.

https://claude.ai/code/session_01Ne5hT7t2tQ13G5ADpCS6TD