### PR TITLE
Android e2e UI test harness (on-device project lifecycle)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,74 @@ jobs:
           path: |
             integrationTests/build/reports/tests/jvmTest/
             integrationTests/build/test-results/jvmTest/
+
+  android-instrumented-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # The hardware-accelerated emulator needs KVM, which ubuntu-latest exposes once permissioned.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Cache the emulator system image + AVD snapshot so subsequent runs skip the slow cold
+      # boot. Keyed on every parameter that defines the AVD - bump the key if any `with:` value
+      # below changes, or the cached snapshot won't match.
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api34-x86_64-google_apis-pixel_6
+
+      # On a cache miss, cold-boot once and let the action save a snapshot for the cache. No tests here.
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          profile: pixel_6
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run instrumented tests on emulator
+        id: instrumented-tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          profile: pixel_6
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: ./gradlew :android:connectedDebugAndroidTest
+
+      - name: Upload instrumented test report on failure
+        if: failure() && steps.instrumented-tests.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: instrumented-tests-report
+          path: |
+            android/build/reports/androidTests/connected/
+            android/build/outputs/androidTest-results/connected/
+
 #  ios:
 #    runs-on: macos-latest
 #    steps:

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
 	androidTestImplementation(libs.core)
 	androidTestImplementation(libs.core.ktx)
 	androidTestImplementation(libs.androidx.runner)
+	androidTestImplementation(libs.jetbrains.compose.ui.test.junit4)
 	androidTestUtil(libs.orchestrator)
 
 	implementation(libs.aboutlibraries.core)

--- a/android/src/androidTest/kotlin/HashTest.kt
+++ b/android/src/androidTest/kotlin/HashTest.kt
@@ -1,13 +1,20 @@
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertEquals
+import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.time.Instant
 
+/**
+ * On-device guard that [EntityHasher] produces the same golden hash on Android (ART) as on the
+ * JVM — the cross-platform invariant sync relies on. Uses JUnit4 (not Jupiter) so the
+ * AndroidJUnit4 runner can execute it, and assertEquals (not `assert`, which is a no-op when
+ * assertions are disabled on-device). Golden vector matches base's EntityHasherTest.
+ */
 @RunWith(AndroidJUnit4::class)
 class HashTest {
 	@Test
-	fun EntityHashTest() {
+	fun entityHashMatchesGoldenVector() {
 		val hash = EntityHasher.hashNote(
 			id = 2,
 			created = Instant.fromEpochMilliseconds(0),
@@ -15,7 +22,6 @@ class HashTest {
 			tags = emptySet(),
 		)
 
-		val expected = "NKZ2n0XDoHLagRABzkb8Yg"
-		assert(expected == hash)
+		assertEquals("NKZ2n0XDoHLagRABzkb8Yg", hash)
 	}
 }

--- a/android/src/androidTest/kotlin/ProjectLifecycleTest.kt
+++ b/android/src/androidTest/kotlin/ProjectLifecycleTest.kt
@@ -1,0 +1,94 @@
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.android.ProjectSelectActivity
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
+import com.darkrockstudios.apps.hammer.common.projectselection.CreateProjectButtonTestTag
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.java.KoinJavaComponent.getKoin
+
+/**
+ * End-to-end test driving the real running app on a device/emulator:
+ * launch the project-select screen, create a project, see it in the list, and open it.
+ *
+ * Unlike the desktop UI tests (which drive isolated composables with fake components),
+ * this launches the actual [ProjectSelectActivity] with the real Koin graph and writes a
+ * real project to the device filesystem — so it uses a unique name and cleans up after.
+ */
+@OptIn(ExperimentalMaterialApi::class, ExperimentalComposeApi::class)
+@RunWith(AndroidJUnit4::class)
+class ProjectLifecycleTest {
+
+	@get:Rule
+	val composeRule = createAndroidComposeRule<ProjectSelectActivity>()
+
+	// Unique per run so re-runs don't collide on the "already exists" validation.
+	private val projectName = "E2E Smoke ${System.currentTimeMillis()}"
+
+	@Test
+	fun createProjectThenOpenIt() {
+		// 1. Open the create dialog (masthead button when wide, bottom bar when narrow).
+		composeRule.onNodeWithTag(CreateProjectButtonTestTag).performClick()
+
+		// 2. Type the project name into the dialog's only editable field, then confirm.
+		composeRule.waitUntil(timeoutMillis = 5_000) {
+			composeRule.onAllNodes(hasSetTextAction()).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNode(hasSetTextAction()).performTextInput(projectName)
+
+		// The confirm button and the dialog title both read "Create Project";
+		// only the button is clickable, so combine the matchers to disambiguate.
+		composeRule.onNode(hasText("Create Project").and(hasClickAction())).performClick()
+
+		// 3. createProject and the list refresh run off the test thread, so poll rather than
+		// asserting immediately. First wait for the dialog to dismiss - until its editable field
+		// is gone it also matches the project name - then for the new project's card to appear.
+		// It sorts to the top (lastAccessed = now), so no scrolling is needed.
+		composeRule.waitUntil(timeoutMillis = 10_000) {
+			composeRule.onAllNodes(hasSetTextAction()).fetchSemanticsNodes().isEmpty()
+		}
+		composeRule.waitUntil(timeoutMillis = 10_000) {
+			composeRule.onAllNodesWithText(projectName).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithText(projectName).assertIsDisplayed()
+
+		// 4. Open it: tapping the card launches ProjectRootActivity. Verify the navigation
+		// fired via an ActivityMonitor rather than coupling to the second activity's tree.
+		val instrumentation = InstrumentationRegistry.getInstrumentation()
+		val monitor = instrumentation.addMonitor(ProjectRootActivity::class.java.name, null, false)
+
+		composeRule.onNodeWithText(projectName).performClick()
+
+		val opened = monitor.waitForActivityWithTimeout(10_000)
+		assertNotNull("Opening a project should launch ProjectRootActivity", opened)
+		instrumentation.removeMonitor(monitor)
+
+		// Finish the project activity and wait for its destroy - and the Koin project-scope close
+		// that flushes scene buffers - to complete before @After deletes the project directory.
+		// Otherwise teardown races the async scope close and crashes the process.
+		opened?.let { activity -> instrumentation.runOnMainSync { activity.finish() } }
+		instrumentation.waitForIdleSync()
+	}
+
+	@After
+	fun deleteCreatedProject() {
+		val repository = getKoin().get<ProjectsRepository>()
+		repository.deleteProject(repository.getProjectDefinition(projectName))
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
@@ -203,9 +203,6 @@ class SceneDatasource(
 		val sceneDirPath = projOkPath.div(SCENE_DIRECTORY)
 		val bufferPathSegment = sceneDirPath.div(BUFFER_DIRECTORY)
 		if (!fileSystem.exists(bufferPathSegment)) {
-			// createDirectories (not createDirectory): the scenes/ parent may not exist yet, e.g.
-			// closing a never-edited project. A throw here is on the scope-close path and crashes
-			// the process. Matches getSceneDirectory/getArchivedDirectory.
 			fileSystem.createDirectories(bufferPathSegment)
 		}
 		return bufferPathSegment.toHPath()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
@@ -203,7 +203,10 @@ class SceneDatasource(
 		val sceneDirPath = projOkPath.div(SCENE_DIRECTORY)
 		val bufferPathSegment = sceneDirPath.div(BUFFER_DIRECTORY)
 		if (!fileSystem.exists(bufferPathSegment)) {
-			fileSystem.createDirectory(bufferPathSegment)
+			// createDirectories (not createDirectory): the scenes/ parent may not exist yet, e.g.
+			// closing a never-edited project. A throw here is on the scope-close path and crashes
+			// the process. Matches getSceneDirectory/getArchivedDirectory.
+			fileSystem.createDirectories(bufferPathSegment)
 		}
 		return bufferPathSegment.toHPath()
 	}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -42,6 +43,9 @@ import kotlin.time.Instant
 
 private val WideContentPadding: Dp = Ui.Padding.XXL
 private val NarrowContentPadding: Dp = Ui.Padding.XL
+
+/** Tags the "Create Project" affordance (masthead button when wide, bottom bar when narrow). */
+const val CreateProjectButtonTestTag = "create-project-button"
 
 private enum class ProjectsSortMode(
 	override val labelRes: StringResource,
@@ -239,6 +243,7 @@ private fun Masthead(
 				label = "＋  ${Res.string.projects_list_create_button.get()}",
 				onClick = onCreate,
 				emphasised = true,
+				modifier = Modifier.testTag(CreateProjectButtonTestTag),
 			)
 		}
 	}
@@ -414,6 +419,7 @@ private fun BottomCreateBar(
 			modifier = Modifier
 				.fillMaxWidth()
 				.height(44.dp)
+				.testTag(CreateProjectButtonTestTag)
 				.background(MaterialTheme.colorScheme.primary)
 				.border(
 					width = Dp.Hairline,


### PR DESCRIPTION
## Summary

On-device end-to-end UI test that drives the **running** app, plus the CI to run it. WIP — see status below.

> **Stacked on #518** (the androidTest compile gate). Review/merge #518 first; I'll retarget this to `develop` afterward. The entity-hash hardening that was originally bundled here now lives in #517.

## What this adds

- **[ProjectLifecycleTest](android/src/androidTest/kotlin/ProjectLifecycleTest.kt):** launches the real `ProjectSelectActivity`, creates a project, asserts it appears in the list, taps it, and verifies `ProjectRootActivity` launches (via `ActivityMonitor`). Cleans up the created project in `@After`. Uses the same Compose test APIs as the desktop UI tests.
- **[ProjectListUi.kt](composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt):** `CreateProjectButtonTestTag` (the "Create Project" string appears three times on screen).
- **[android/build.gradle.kts](android/build.gradle.kts):** `jetbrains-compose ui-test-junit4` in the `androidTest` source set.
- **[build.yml](.github/workflows/build.yml):** `android-instrumented-tests` job — boots an emulator (API 34) and runs `:android:connectedDebugAndroidTest`, with AVD snapshot caching and failure-report upload.
- **[SceneDatasource.kt](common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt):** fix a scope-close crash the e2e test exposed — `getSceneBufferDirectory` used a non-recursive `createDirectory`, so closing a project whose `scenes/` dir is absent threw on the teardown path and crashed the process. Now uses `createDirectories` (matching its siblings); the test teardown is also ordered so it doesn't delete the project while the scope is still closing.

## Status / TODO

- [x] Test logic written; passes locally on a Pixel_8a emulator (earlier run).
- [ ] **Re-verify the scope-close crash fix on an emulator** — the last local run failed at the *install* step (emulator out of disk), not the crash, so the fix is plausible but not yet re-confirmed.
- [ ] Retarget base to `develop` once #518 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
