### PR TITLE
Harden EntityHasher field-coverage test (nested DTOs + new entity types)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      # Explicit gate for the server unit tests (incl. EntityHashSensitivityTest). These otherwise
+      # only run as a side-effect of koverXmlReport, which is fragile - a kover config change would
+      # silently stop running them.
+      - name: Run Server Unit Tests
+        run: ./gradlew :server:test
       - name: Run Server Migration Tests
         run: ./gradlew :server:verifySqlDelightMigration
       - name: Run Round-Trip Sync Integration Tests

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/EntityHashSensitivityTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/EntityHashSensitivityTest.kt
@@ -2,9 +2,13 @@ package com.darkrockstudios.apps.hammer.utilities
 
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.base.http.ApiSceneType
-import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.descriptors.elementNames
-import kotlinx.serialization.serializer
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectTheme
+import com.darkrockstudios.apps.hammer.base.http.projectdata.WordCountGoal
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KClass
 import kotlin.test.assertEquals
@@ -12,23 +16,113 @@ import kotlin.test.assertNotEquals
 import kotlin.time.Instant
 
 /**
- * Defends against the bug class where a new field gets added to an [ApiProjectEntity]
- * subtype but the hasher silently keeps ignoring it (so two clients can never converge
- * on the new data, while no test fails).
+ * Defends against the bug class where a new field gets added to a synced DTO but the hasher
+ * silently keeps ignoring it - so two clients can never converge on the new data, while no
+ * test fails.
  *
- * The pattern in [EntityHasherExtTest] - "extension call must equal direct call" - was
- * a tautology trap: when a field was forgotten on both sides simultaneously, the test
- * still passed because the two paths agreed with each other on a *wrong* answer. These
- * tests assert the stronger invariant: **every serialized field of the DTO must affect
- * the hash**. They use `@Serializable`'s descriptor (not Kotlin reflection) as the
- * source of truth for "what fields exist," so adding a field forces the test author to
- * declare a mutation for it - omitting one fails the coverage assertion immediately.
+ * The pattern in [EntityHasherExtTest] - "extension call must equal direct call" - is a
+ * tautology trap: when a field is forgotten on both sides simultaneously, the two paths still
+ * agree on a *wrong* answer and the test passes. This suite asserts the stronger invariant:
+ * **every serialized field of every synced DTO must affect its hash.**
+ *
+ * It is driven entirely by `@Serializable` descriptors (the same source of truth serialization
+ * uses), so the structure can't drift from what actually rides the sync wire. Three holes that
+ * a hand-written "differs when X differs" test leaves open are closed here:
+ *
+ *  1. **New field** - [leafPaths] reads the descriptor, so adding a field expands the declared
+ *     set and immediately fails the coverage assertion until a mutation is declared; the
+ *     sensitivity loop then fails until the hasher actually folds the field in.
+ *  2. **New field on a nested DTO** ([ProjectTheme], [WordCountGoal], `EncyclopediaEntryEntity.Image`)
+ *     - [leafPaths] recurses into owned nested classes, so `theme.tertiary` or `image.caption`
+ *     is a tracked path, not an invisible sub-field of a single `theme`/`image` element.
+ *  3. **New entity type** - [`every ApiProjectEntity Type has a sensitivity spec`] ties the spec
+ *     list to the [ApiProjectEntity.Type] registry, so a new subtype can't ship without a spec.
  */
-@OptIn(InternalSerializationApi::class)
 class EntityHashSensitivityTest {
 
 	@Test
-	fun `every serialized field of SceneEntity affects the hash`() {
+	fun `every serialized field affects the hash, recursing into nested DTOs`() {
+		allSpecs.forEach(::assertEveryFieldAffectsHash)
+	}
+
+	@Test
+	fun `every ApiProjectEntity Type has a sensitivity spec`() {
+		val declaredTypes = ApiProjectEntity.Type.entries.toSet()
+		val coveredTypes = allSpecs.mapNotNull { it.entityType }.toSet()
+		assertEquals(
+			declaredTypes, coveredTypes,
+			"An ApiProjectEntity Type has no hash-sensitivity spec. Add a Spec(...) for the new " +
+				"entity subtype to `allSpecs` so its fields are structurally checked against its hasher."
+		)
+	}
+
+	private fun assertEveryFieldAffectsHash(spec: Spec<*>) {
+		// Source of truth: the @Serializable descriptor (flattened through owned nested DTOs).
+		// Adding a field anywhere in the tree expands this set, failing the coverage assertion
+		// until a mutation is declared - which then fails the sensitivity loop until the hasher
+		// is updated. No silent passes.
+		val declared = leafPaths(spec.serializer.descriptor) - EXEMPT_FIELDS
+		assertEquals(
+			declared, spec.mutations.keys,
+			"Mutations for ${spec.klass.simpleName} are out of sync with its @Serializable descriptor. " +
+				"Add a copy() mutation for each missing path (nested fields use dot paths like " +
+				"'theme.primary'), or add the path to EXEMPT_FIELDS if it cannot be meaningfully mutated."
+		)
+
+		val baseHash = spec.baseHash
+		spec.mutatedHashes().forEach { (path, mutatedHash) ->
+			assertNotEquals(
+				baseHash, mutatedHash,
+				"Hash of ${spec.klass.simpleName} did not change when '$path' changed - the hasher is " +
+					"silently dropping this field, so two clients with different values will never " +
+					"converge through sync."
+			)
+		}
+	}
+
+	/**
+	 * Flattens a descriptor into dot-separated field paths, recursing into owned nested DTOs so
+	 * their sub-fields are tracked individually. A nested owned class contributes both its own
+	 * path (the presence / whole-object swap, which matters for nullable DTOs) and one path per
+	 * leaf beneath it. Collections, enums, primitives and foreign types (e.g. [Instant]) are leaves.
+	 */
+	private fun leafPaths(descriptor: SerialDescriptor, prefix: String = ""): Set<String> {
+		val paths = linkedSetOf<String>()
+		for (i in 0 until descriptor.elementsCount) {
+			val name = descriptor.getElementName(i)
+			val path = if (prefix.isEmpty()) name else "$prefix.$name"
+			val child = descriptor.getElementDescriptor(i)
+			if (child.kind == StructureKind.CLASS &&
+				child.serialName.removeSuffix("?").startsWith(OWNED_PACKAGE)
+			) {
+				paths += path
+				paths += leafPaths(child, path)
+			} else {
+				paths += path
+			}
+		}
+		return paths
+	}
+
+	private class Spec<T : Any>(
+		val klass: KClass<T>,
+		val serializer: KSerializer<T>,
+		/** Non-null for [ApiProjectEntity] subtypes; ties the spec to the Type registry. Null for standalone DTOs. */
+		val entityType: ApiProjectEntity.Type?,
+		private val base: T,
+		private val hashOf: (T) -> String,
+		val mutations: Map<String, T>,
+	) {
+		val baseHash: String get() = hashOf(base)
+		fun mutatedHashes(): Map<String, String> = mutations.mapValues { hashOf(it.value) }
+	}
+
+	// ---------------------------------------------------------------------------------------
+	// Specs - one per synced DTO. `base` populates every field (including nested) with a
+	// non-default value so each mutation is a genuine, isolated change.
+	// ---------------------------------------------------------------------------------------
+
+	private val sceneSpec = run {
 		val base = ApiProjectEntity.SceneEntity(
 			id = 1,
 			sceneType = ApiSceneType.Scene,
@@ -41,75 +135,58 @@ class EntityHashSensitivityTest {
 			archived = false,
 			confirmedReferences = emptySet(),
 			dismissedReferences = emptySet(),
+			tags = setOf("base-tag"),
 			created = Instant.fromEpochMilliseconds(1_000_000),
 			lastEdited = Instant.fromEpochMilliseconds(2_000_000),
 		)
-		val mutations = mapOf(
-			"id" to base.copy(id = 999),
-			"sceneType" to base.copy(sceneType = ApiSceneType.Group),
-			"order" to base.copy(order = 999),
-			"name" to base.copy(name = "different"),
-			"path" to base.copy(path = listOf(99, 99)),
-			"content" to base.copy(content = "different"),
-			"outline" to base.copy(outline = "different"),
-			"notes" to base.copy(notes = "different"),
-			"archived" to base.copy(archived = true),
-			"confirmedReferences" to base.copy(confirmedReferences = setOf(7)),
-			"dismissedReferences" to base.copy(dismissedReferences = setOf(7)),
-			"tags" to base.copy(tags = setOf("important")),
-			"created" to base.copy(created = Instant.fromEpochMilliseconds(9_000_000)),
-			"lastEdited" to base.copy(lastEdited = Instant.fromEpochMilliseconds(9_000_000)),
-		)
-		assertEveryFieldAffectsHash(base, mutations, ApiProjectEntity.SceneEntity::class)
-	}
-
-	@Test
-	fun `every serialized field of EncyclopediaEntryEntity affects the hash`() {
-		val base = ApiProjectEntity.EncyclopediaEntryEntity(
-			id = 1,
-			name = "base",
-			entryType = "person",
-			text = "base text",
-			tags = setOf("base-tag"),
-			image = null,
-			aliases = emptyList(),
-		)
-		val mutations = mapOf(
-			"id" to base.copy(id = 999),
-			"name" to base.copy(name = "different"),
-			"entryType" to base.copy(entryType = "place"),
-			"text" to base.copy(text = "different"),
-			"tags" to base.copy(tags = setOf("different")),
-			"image" to base.copy(
-				image = ApiProjectEntity.EncyclopediaEntryEntity.Image(
-					base64 = "abc",
-					fileExtension = "png",
-				)
+		Spec(
+			klass = ApiProjectEntity.SceneEntity::class,
+			serializer = ApiProjectEntity.SceneEntity.serializer(),
+			entityType = ApiProjectEntity.Type.SCENE,
+			base = base,
+			hashOf = { it.hash() },
+			mutations = mapOf(
+				"id" to base.copy(id = 999),
+				"sceneType" to base.copy(sceneType = ApiSceneType.Group),
+				"order" to base.copy(order = 999),
+				"name" to base.copy(name = "different"),
+				"path" to base.copy(path = listOf(99, 99)),
+				"content" to base.copy(content = "different"),
+				"outline" to base.copy(outline = "different"),
+				"notes" to base.copy(notes = "different"),
+				"archived" to base.copy(archived = true),
+				"confirmedReferences" to base.copy(confirmedReferences = setOf(7)),
+				"dismissedReferences" to base.copy(dismissedReferences = setOf(7)),
+				"tags" to base.copy(tags = setOf("important")),
+				"created" to base.copy(created = Instant.fromEpochMilliseconds(9_000_000)),
+				"lastEdited" to base.copy(lastEdited = Instant.fromEpochMilliseconds(9_000_000)),
 			),
-			"aliases" to base.copy(aliases = listOf("Bobby")),
 		)
-		assertEveryFieldAffectsHash(base, mutations, ApiProjectEntity.EncyclopediaEntryEntity::class)
 	}
 
-	@Test
-	fun `every serialized field of NoteEntity affects the hash`() {
+	private val noteSpec = run {
 		val base = ApiProjectEntity.NoteEntity(
 			id = 1,
 			content = "base content",
 			created = Instant.fromEpochMilliseconds(0),
 			tags = setOf("base-tag"),
 		)
-		val mutations = mapOf(
-			"id" to base.copy(id = 999),
-			"content" to base.copy(content = "different"),
-			"created" to base.copy(created = Instant.fromEpochMilliseconds(1_000_000)),
-			"tags" to base.copy(tags = setOf("different")),
+		Spec(
+			klass = ApiProjectEntity.NoteEntity::class,
+			serializer = ApiProjectEntity.NoteEntity.serializer(),
+			entityType = ApiProjectEntity.Type.NOTE,
+			base = base,
+			hashOf = { it.hash() },
+			mutations = mapOf(
+				"id" to base.copy(id = 999),
+				"content" to base.copy(content = "different"),
+				"created" to base.copy(created = Instant.fromEpochMilliseconds(1_000_000)),
+				"tags" to base.copy(tags = setOf("different")),
+			),
 		)
-		assertEveryFieldAffectsHash(base, mutations, ApiProjectEntity.NoteEntity::class)
 	}
 
-	@Test
-	fun `every serialized field of TimelineEventEntity affects the hash`() {
+	private val timelineSpec = run {
 		val base = ApiProjectEntity.TimelineEventEntity(
 			id = 1,
 			order = 0,
@@ -117,18 +194,54 @@ class EntityHashSensitivityTest {
 			content = "base content",
 			tags = setOf("base-tag"),
 		)
-		val mutations = mapOf(
-			"id" to base.copy(id = 999),
-			"order" to base.copy(order = 999),
-			"date" to base.copy(date = "Year 2"),
-			"content" to base.copy(content = "different"),
-			"tags" to base.copy(tags = setOf("different")),
+		Spec(
+			klass = ApiProjectEntity.TimelineEventEntity::class,
+			serializer = ApiProjectEntity.TimelineEventEntity.serializer(),
+			entityType = ApiProjectEntity.Type.TIMELINE_EVENT,
+			base = base,
+			hashOf = { it.hash() },
+			mutations = mapOf(
+				"id" to base.copy(id = 999),
+				"order" to base.copy(order = 999),
+				"date" to base.copy(date = "Year 2"),
+				"content" to base.copy(content = "different"),
+				"tags" to base.copy(tags = setOf("different")),
+			),
 		)
-		assertEveryFieldAffectsHash(base, mutations, ApiProjectEntity.TimelineEventEntity::class)
 	}
 
-	@Test
-	fun `every serialized field of SceneDraftEntity affects the hash`() {
+	private val encyclopediaSpec = run {
+		val base = ApiProjectEntity.EncyclopediaEntryEntity(
+			id = 1,
+			name = "base",
+			entryType = "person",
+			text = "base text",
+			tags = setOf("base-tag"),
+			// Non-null so the nested image.* sub-fields can be mutated individually.
+			image = ApiProjectEntity.EncyclopediaEntryEntity.Image(base64 = "abc", fileExtension = "png"),
+			aliases = listOf("Bob"),
+		)
+		Spec(
+			klass = ApiProjectEntity.EncyclopediaEntryEntity::class,
+			serializer = ApiProjectEntity.EncyclopediaEntryEntity.serializer(),
+			entityType = ApiProjectEntity.Type.ENCYCLOPEDIA_ENTRY,
+			base = base,
+			hashOf = { it.hash() },
+			mutations = mapOf(
+				"id" to base.copy(id = 999),
+				"name" to base.copy(name = "different"),
+				"entryType" to base.copy(entryType = "place"),
+				"text" to base.copy(text = "different"),
+				"tags" to base.copy(tags = setOf("different")),
+				"image" to base.copy(image = null),
+				"image.base64" to base.copy(image = base.image!!.copy(base64 = "abcd")),
+				"image.fileExtension" to base.copy(image = base.image!!.copy(fileExtension = "jpg")),
+				"aliases" to base.copy(aliases = listOf("Bobby")),
+			),
+		)
+	}
+
+	private val draftSpec = run {
 		val base = ApiProjectEntity.SceneDraftEntity(
 			id = 1,
 			sceneId = 10,
@@ -136,50 +249,59 @@ class EntityHashSensitivityTest {
 			name = "base draft",
 			content = "base content",
 		)
-		val mutations = mapOf(
-			"id" to base.copy(id = 999),
-			"sceneId" to base.copy(sceneId = 999),
-			"created" to base.copy(created = Instant.fromEpochMilliseconds(1_000_000)),
-			"name" to base.copy(name = "different"),
-			"content" to base.copy(content = "different"),
+		Spec(
+			klass = ApiProjectEntity.SceneDraftEntity::class,
+			serializer = ApiProjectEntity.SceneDraftEntity.serializer(),
+			entityType = ApiProjectEntity.Type.SCENE_DRAFT,
+			base = base,
+			hashOf = { it.hash() },
+			mutations = mapOf(
+				"id" to base.copy(id = 999),
+				"sceneId" to base.copy(sceneId = 999),
+				"created" to base.copy(created = Instant.fromEpochMilliseconds(1_000_000)),
+				"name" to base.copy(name = "different"),
+				"content" to base.copy(content = "different"),
+			),
 		)
-		assertEveryFieldAffectsHash(base, mutations, ApiProjectEntity.SceneDraftEntity::class)
 	}
 
-	private fun <T : ApiProjectEntity> assertEveryFieldAffectsHash(
-		base: T,
-		mutations: Map<String, T>,
-		entityClass: KClass<T>,
-	) {
-		// Source of truth: the @Serializable descriptor. Adding a field to the DTO will
-		// expand this set, immediately failing the coverage assertion below until the
-		// test author declares a mutation - which then fails the sensitivity loop until
-		// the hasher is updated. No silent passes.
-		val declared = entityClass.serializer().descriptor.elementNames.toSet() - EXEMPT_FIELDS
-		val covered = mutations.keys
-
-		assertEquals(
-			declared, covered,
-			"Mutations list for ${entityClass.simpleName} is out of sync with the @Serializable " +
-				"descriptor. Add a copy() mutation for each missing field, or add the field to " +
-				"EXEMPT_FIELDS if it cannot meaningfully be mutated."
+	// Synced per-project settings. NOT an ApiProjectEntity - it has its own [ProjectDataHasher],
+	// which is exactly why it needs its own structural guard (and recursion over theme/wordCountGoal).
+	private val projectDataSpec = run {
+		val base = ProjectData(
+			authorName = "base author",
+			theme = ProjectTheme(primary = "p", secondary = "s"),
+			wordCountGoal = WordCountGoal(cadence = WordCountGoal.Cadence.DAY, count = 100),
 		)
-
-		val baseHash = base.hash()
-		mutations.forEach { (fieldName, mutated) ->
-			val mutatedHash = mutated.hash()
-			assertNotEquals(
-				baseHash, mutatedHash,
-				"Hash of ${entityClass.simpleName} did not change when '$fieldName' changed - " +
-					"the hasher is silently dropping this field, so two clients with different " +
-					"values will never converge through sync."
-			)
-		}
+		Spec(
+			klass = ProjectData::class,
+			serializer = ProjectData.serializer(),
+			entityType = null,
+			base = base,
+			hashOf = { ProjectDataHasher.hash(it) },
+			mutations = mapOf(
+				"authorName" to base.copy(authorName = "different"),
+				"theme" to base.copy(theme = null),
+				"theme.primary" to base.copy(theme = base.theme!!.copy(primary = "different")),
+				"theme.secondary" to base.copy(theme = base.theme!!.copy(secondary = "different")),
+				"wordCountGoal" to base.copy(wordCountGoal = null),
+				"wordCountGoal.cadence" to base.copy(wordCountGoal = base.wordCountGoal!!.copy(cadence = WordCountGoal.Cadence.WEEK)),
+				"wordCountGoal.count" to base.copy(wordCountGoal = base.wordCountGoal!!.copy(count = 999)),
+			),
+		)
 	}
+
+	private val allSpecs: List<Spec<*>> = listOf(
+		sceneSpec, noteSpec, timelineSpec, encyclopediaSpec, draftSpec, projectDataSpec,
+	)
 
 	companion object {
-		// `type` is the polymorphic discriminator on ApiProjectEntity - it's effectively a
-		// constant for any instance of a given subclass and cannot be meaningfully mutated.
+		// `type` is the polymorphic discriminator on ApiProjectEntity - effectively constant for a
+		// given subclass and not meaningfully mutable.
 		private val EXEMPT_FIELDS = setOf("type")
+
+		// Recurse into nested classes only when they're our own DTOs; Instant, enums and
+		// collections must stay leaves.
+		private const val OWNED_PACKAGE = "com.darkrockstudios.apps.hammer"
 	}
 }


### PR DESCRIPTION
## Summary

Strengthens the `EntityHashSensitivityTest` tripwire so the bug class it exists for — *a new field added to a synced entity but not folded into its hash* — can no longer slip through silently. No production code changes; test-only.

## The holes that were open

The descriptor-driven test only inspected **top-level** fields:

1. **Nested DTOs weren't recursed.** `image`/`theme`/`wordCountGoal` were each a single element in the parent descriptor, so adding `ProjectTheme.tertiary` or `Image.caption` and forgetting to hash it **passed**.
2. **`ProjectData` had zero coverage** — it has its own `ProjectDataHasher` and no structural guard at all.
3. **New entity *types*** — a 6th `ApiProjectEntity` subtype could ship with a broken hasher and nothing failed.

## Changes ([EntityHashSensitivityTest.kt](server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/EntityHashSensitivityTest.kt))

- `leafPaths()` recurses into owned nested `@Serializable` DTOs, so `theme.tertiary` etc. are tracked field paths.
- Added a spec for `ProjectData` / `ProjectDataHasher`.
- Assert every `ApiProjectEntity.Type` has a sensitivity spec (reflection-free — the server has no `kotlin-reflect`).

## Verification

- `:server:test --tests EntityHashSensitivityTest` passes on `develop`.
- Proven to fire: temporarily adding `ProjectTheme.tertiary` without hashing it made the test go red (`Expected [..., theme.tertiary, ...]`), then reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
