### PR TITLE
CI: compile the Android instrumented tests (catch androidTest rot)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew buildDebug
+      # Compiles + packages the Android instrumented (androidTest) source set without a device.
+      # buildDebug does not touch androidTest, so stale instrumented tests rot silently otherwise.
+      - name: Compile Android instrumented tests
+        run: ./gradlew :android:assembleDebugAndroidTest
       - name: Run Kover
         run: ./gradlew koverXmlReport
       - name: Upload coverage reports to Codecov

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -102,7 +102,9 @@ android {
 		resources {
 			excludes += setOf(
 				"/META-INF/{AL2.0,LGPL2.1}",
-				"/META-INF/versions/9/previous-compilation-data.bin"
+				"/META-INF/versions/9/previous-compilation-data.bin",
+				"/META-INF/LICENSE.md",
+				"/META-INF/LICENSE-notice.md"
 			)
 		}
 	}

--- a/android/src/androidTest/kotlin/HashTest.kt
+++ b/android/src/androidTest/kotlin/HashTest.kt
@@ -9,14 +9,13 @@ class HashTest {
 	@Test
 	fun EntityHashTest() {
 		val hash = EntityHasher.hashNote(
-			id = 1,
-			created = Instant.fromEpochSeconds(123),
-			content = "this is some tet text"
+			id = 2,
+			created = Instant.fromEpochMilliseconds(0),
+			content = "Content",
+			tags = emptySet(),
 		)
 
-		println("hash: $hash")
-
-		val expected = "IAvvisZNMehI-2mBnczrnw"
+		val expected = "NKZ2n0XDoHLagRABzkb8Yg"
 		assert(expected == hash)
 	}
 }


### PR DESCRIPTION
## Summary

CI ran every JVM/desktop unit test but **never compiled the Android instrumented (`androidTest`) source set** — `buildDebug` doesn't touch it. So a stale instrumented test rotted unnoticed: `HashTest` stopped compiling after `tags` was added to `EntityHasher.hashNote`, and nothing caught it.

This adds a fast, emulator-free gate so that can't happen again.

## Changes

- **[build.yml](.github/workflows/build.yml):** new `:android:assembleDebugAndroidTest` step in the build job — compiles + packages the `androidTest` source set on every PR. No device required.
- **[HashTest.kt](android/src/androidTest/kotlin/HashTest.kt):** fixed to match the current `hashNote(tags = ...)` signature, aligned to the verified golden vector from `EntityHasherTest`.
- **[android/build.gradle.kts](android/build.gradle.kts):** exclude the duplicate `META-INF/LICENSE*.md` files the test deps ship, so the `androidTest` APK packages.

## Verification

`./gradlew :android:assembleDebugAndroidTest` passes locally (exit 0).

## Note

This is the **compile gate** only. Actually *running* the instrumented suite on an emulator (the `android-emulator-runner` job) is a separate change that rides with the e2e-test PR, since it's only green once those tests are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
