### PR TITLE
Fix IllegalStateException: closed race in FileLogger

### DIFF
--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/FileLogger.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/FileLogger.kt
@@ -30,6 +30,9 @@ class FileLogger(
 	private val logsDir = getLogsDirectory()
 	private val logFileName = getLogFilename()
 	private val appendBuffer: BufferedSink
+	private val writeLock = Any()
+	@Volatile
+	private var closed = false
 	private val messageChannel = Channel<String>(
 		capacity = Channel.UNLIMITED,
 		onUndeliveredElement = {
@@ -50,8 +53,12 @@ class FileLogger(
 
 	private suspend fun watchForLogs() {
 		messageChannel.consumeEach { message ->
-			appendBuffer.writeUtf8(message)
-			appendBuffer.flush()
+			synchronized(writeLock) {
+				if (!closed) {
+					appendBuffer.writeUtf8(message)
+					appendBuffer.flush()
+				}
+			}
 		}
 	}
 
@@ -73,7 +80,12 @@ class FileLogger(
 	}
 
 	fun close() {
-		appendBuffer.close()
+		synchronized(writeLock) {
+			if (closed) return
+			closed = true
+			messageChannel.close()
+			appendBuffer.close()
+		}
 	}
 
 	private fun createLogFile(): FileHandle = fileSystem.openReadWrite(logFileName)

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/FileLogger.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/FileLogger.kt
@@ -24,6 +24,9 @@ class FileLogger(
 	private val logsDir = getLogsDirectory()
 	private val logFileName = getLogFilename()
 	private val appendBuffer: BufferedSink
+	private val writeLock = Any()
+	@Volatile
+	private var closed = false
 	private val messageChannel = Channel<LogRecord>(
 		capacity = Channel.UNLIMITED,
 		onUndeliveredElement = {
@@ -59,19 +62,29 @@ class FileLogger(
 	}
 
 	private fun writeLogMessage(record: LogRecord) {
-		appendBuffer.writeUtf8(
-			"${record.instant} | ${record.message}\n"
-		)
+		synchronized(writeLock) {
+			if (closed) return
+			appendBuffer.writeUtf8(
+				"${record.instant} | ${record.message}\n"
+			)
+		}
 	}
 
 	override fun close() {
 		super.close()
-		appendBuffer.close()
+		synchronized(writeLock) {
+			if (closed) return
+			closed = true
+			messageChannel.close()
+			appendBuffer.close()
+		}
 	}
 
 	override fun flush() {
 		super.flush()
-		appendBuffer.flush()
+		synchronized(writeLock) {
+			if (!closed) appendBuffer.flush()
+		}
 	}
 
 	private fun createLogFile(): FileHandle = fileSystem.openReadWrite(logFileName)


### PR DESCRIPTION
@
## Problem

After saving and closing a scene, the app could crash a background worker thread with:

```
Exception in thread "DefaultDispatcher-worker-2" java.lang.IllegalStateException: closed
	at okio.RealBufferedSink.writeUtf8(RealBufferedSink.kt:159)
	at com.darkrockstudios.apps.hammer.desktop.FileLogger.writeLogMessage(FileLogger.kt:62)
	...
	Suppressed: ... [StandaloneCoroutine{Cancelling}@..., Dispatchers.Default]
```

## Cause

`FileLogger`s log-consumer coroutine (`watchForLogs`) writes to the shared `appendBuffer` while `close()` can close that same `BufferedSink` from another thread (e.g. during `CoroutineScope` cancellation on shutdown). Nothing serialized sink access, so a write could land after the sink was closed.

## Fix

- Guard all `appendBuffer` access (write/flush) and `close()` with a single lock plus a `@Volatile closed` flag, so a write can never hit the sink after it is closed.
- `close()` now also closes the `messageChannel`, letting the `consumeEach` consumer terminate cleanly instead of being killed mid-write, and is idempotent.

Applied to both the desktop and android `FileLogger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@