### PR TITLE
Simplify FileLogger: channel-based sink ownership instead of a lock

### DIFF
--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/FileLogger.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/FileLogger.kt
@@ -30,9 +30,6 @@ class FileLogger(
 	private val logsDir = getLogsDirectory()
 	private val logFileName = getLogFilename()
 	private val appendBuffer: BufferedSink
-	private val writeLock = Any()
-	@Volatile
-	private var closed = false
 	private val messageChannel = Channel<String>(
 		capacity = Channel.UNLIMITED,
 		onUndeliveredElement = {
@@ -51,14 +48,16 @@ class FileLogger(
 		}
 	}
 
+	// The consumer coroutine is the sole owner of appendBuffer: it writes,
+	// flushes, and closes the sink so no other thread can race it.
 	private suspend fun watchForLogs() {
-		messageChannel.consumeEach { message ->
-			synchronized(writeLock) {
-				if (!closed) {
-					appendBuffer.writeUtf8(message)
-					appendBuffer.flush()
-				}
+		try {
+			messageChannel.consumeEach { message ->
+				appendBuffer.writeUtf8(message)
+				appendBuffer.flush()
 			}
+		} finally {
+			appendBuffer.close()
 		}
 	}
 
@@ -80,12 +79,8 @@ class FileLogger(
 	}
 
 	fun close() {
-		synchronized(writeLock) {
-			if (closed) return
-			closed = true
-			messageChannel.close()
-			appendBuffer.close()
-		}
+		// Closing the channel ends the consumer, which then closes the sink.
+		messageChannel.close()
 	}
 
 	private fun createLogFile(): FileHandle = fileSystem.openReadWrite(logFileName)

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/FileLogger.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/FileLogger.kt
@@ -24,9 +24,6 @@ class FileLogger(
 	private val logsDir = getLogsDirectory()
 	private val logFileName = getLogFilename()
 	private val appendBuffer: BufferedSink
-	private val writeLock = Any()
-	@Volatile
-	private var closed = false
 	private val messageChannel = Channel<LogRecord>(
 		capacity = Channel.UNLIMITED,
 		onUndeliveredElement = {
@@ -46,10 +43,16 @@ class FileLogger(
 		}
 	}
 
+	// The consumer coroutine is the sole owner of appendBuffer: it writes,
+	// flushes, and closes the sink so no other thread can race it.
 	private suspend fun watchForLogs() {
-		messageChannel.consumeEach { record ->
-			writeLogMessage(record)
-			flush()
+		try {
+			messageChannel.consumeEach { record ->
+				writeLogMessage(record)
+				appendBuffer.flush()
+			}
+		} finally {
+			appendBuffer.close()
 		}
 	}
 
@@ -62,29 +65,19 @@ class FileLogger(
 	}
 
 	private fun writeLogMessage(record: LogRecord) {
-		synchronized(writeLock) {
-			if (closed) return
-			appendBuffer.writeUtf8(
-				"${record.instant} | ${record.message}\n"
-			)
-		}
+		appendBuffer.writeUtf8(
+			"${record.instant} | ${record.message}\n"
+		)
 	}
 
 	override fun close() {
 		super.close()
-		synchronized(writeLock) {
-			if (closed) return
-			closed = true
-			messageChannel.close()
-			appendBuffer.close()
-		}
+		// Closing the channel ends the consumer, which then closes the sink.
+		messageChannel.close()
 	}
 
 	override fun flush() {
 		super.flush()
-		synchronized(writeLock) {
-			if (!closed) appendBuffer.flush()
-		}
 	}
 
 	private fun createLogFile(): FileHandle = fileSystem.openReadWrite(logFileName)


### PR DESCRIPTION
@
Follow-up to #519 (already merged), which fixed the `IllegalStateException: closed` crash with a lock + `closed` flag.

This replaces that lock with cleaner channel-based serialization. The single consumer coroutine becomes the **sole owner** of `appendBuffer`: it writes, flushes, and closes the sink (close in a `finally`, so it runs on normal channel close and on cancellation alike). `close()` now just closes the message channel — which ends the consumer — and `flush()`/`close()` no longer touch the sink from foreign threads. The channel is the serialization point, so no lock or `@Volatile` flag is needed.

Same crash-safety as #519, with less machinery. As a bonus, queued messages are drained before the sink closes instead of being dropped on an early `close()`.

Applies to both the desktop and android `FileLogger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@