### PR TITLE
Add configurable web analytics for the server web frontend (Umami)

### DIFF
--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -215,6 +215,18 @@ Otherwise, you can add individual users to the whitelist using the admin page.
 _**Note:** Disabling the whitelist is **strongly discouraged**. There are currently no moderation tools or even account
 verification. I expect any fully open server would become filled with spam very quickly._
 
+## Enable Community
+
+By default this is disabled. To enable it, add this line to your server config:
+
+```toml
+communityEnabled = true
+```
+
+This will enable several new pages on the website found at: `/community`
+
+Users will now be able to opt-in to the community if they have already selected a **Pen Name**.
+
 ## Setup Email Sending (_Optional_)
 
 Currently, we mainly use Email for password reset. Eventually we maybe have account verification, and potentially other
@@ -237,29 +249,15 @@ Then restart your server and navigate to the admin page to configure your email 
 
 Only SMTP has been thoroughly tested so far.
 
-## Enable Community
-
-By default this is disabled. To enable it, add this line to your server config:
-
-```toml
-communityEnabled = true
-```
-
-This will enable several new pages on the website found at: `/community`
-
-Users will now be able to opt-in to the community if they have already selected a **Pen Name**.
-
 ## Web Analytics (_Optional_)
 
 You can opt into a web analytics provider to measure traffic to your server's
-public web pages. The tracking script is injected automatically, and the server's
-Content Security Policy is widened to allow the configured provider — no manual
-changes needed.
+public web pages.
 
 Analytics is only served on **public (logged-out) pages**. It is never injected
 into the dashboard, story, or admin pages of signed-in users.
 
-By default analytics is disabled (`type = "none"`). Currently the only supported
+By default analytics is disabled (`type = "none"`). Currently, the only supported
 provider is [Umami](https://umami.is).
 
 ### Umami

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -248,3 +248,35 @@ communityEnabled = true
 This will enable several new pages on the website found at: `/community`
 
 Users will now be able to opt-in to the community if they have already selected a **Pen Name**.
+
+## Web Analytics (_Optional_)
+
+You can opt into a web analytics provider to measure traffic to your server's
+public web pages. The tracking script is injected automatically, and the server's
+Content Security Policy is widened to allow the configured provider — no manual
+changes needed.
+
+Analytics is only served on **public (logged-out) pages**. It is never injected
+into the dashboard, story, or admin pages of signed-in users.
+
+By default analytics is disabled (`type = "none"`). Currently the only supported
+provider is [Umami](https://umami.is).
+
+### Umami
+
+Create a website in your Umami dashboard, copy its **Website ID**, and add:
+
+```toml
+[analytics]
+type = "umami"
+
+[analytics.umami]
+websiteId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+# scriptUrl defaults to Umami Cloud. To use a self-hosted Umami instance,
+# point it at your own script, e.g.:
+# scriptUrl = "https://umami.example.com/script.js"
+```
+
+The configuration is designed to grow: support for additional providers can be
+added under the `[analytics]` section in the future by selecting a different
+`type`.

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -55,6 +55,7 @@ fun main(args: Array<String>) {
 	} ?: ServerConfig()
 
 	config.storage.validate()
+	config.analytics.validate()
 
 	// Dry-run path exits before the server starts.
 	if (migrateDryRunArg == true) {

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -14,10 +14,43 @@ data class ServerConfig(
 	val emailProvider: String? = null,
 	val communityEnabled: Boolean = false,
 	val storage: StorageConfig = StorageConfig(),
+	val analytics: AnalyticsConfig = AnalyticsConfig(),
 ) {
 	@Transient
 	val emailProviderType: EmailProvider? = emailProvider?.let { provider ->
 		EmailProvider.entries.find { it.name.equals(provider, ignoreCase = true) }
+	}
+}
+
+@Serializable
+enum class AnalyticsProviderType { NONE, UMAMI }
+
+@Serializable
+data class AnalyticsConfig(
+	val type: AnalyticsProviderType = AnalyticsProviderType.NONE,
+	val umami: UmamiConfig? = null,
+) {
+	fun validate() {
+		when (type) {
+			AnalyticsProviderType.NONE -> Unit
+			AnalyticsProviderType.UMAMI -> {
+				requireNotNull(umami) { "analytics.type=umami requires an [analytics.umami] config block" }
+				umami.validate()
+			}
+		}
+	}
+}
+
+@Serializable
+data class UmamiConfig(
+	/** The Umami "website ID" (UUID) for this site. */
+	val websiteId: String,
+	/** Defaults to Umami Cloud; override with https://<your-host>/script.js for self-hosted Umami. */
+	val scriptUrl: String = "https://cloud.umami.is/script.js",
+) {
+	fun validate() {
+		require(websiteId.isNotBlank()) { "analytics.umami.websiteId must not be blank" }
+		require(scriptUrl.isNotBlank()) { "analytics.umami.scriptUrl must not be blank" }
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -1,8 +1,13 @@
 package com.darkrockstudios.apps.hammer
 
+import com.darkrockstudios.apps.hammer.analytics.AnalyticsProvider
+import com.darkrockstudios.apps.hammer.analytics.AnalyticsProviderFactory
 import com.darkrockstudios.apps.hammer.email.EmailProvider
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import java.net.URI
+import java.net.URISyntaxException
 
 @Serializable
 data class ServerConfig(
@@ -23,13 +28,25 @@ data class ServerConfig(
 }
 
 @Serializable
-enum class AnalyticsProviderType { NONE, UMAMI }
+enum class AnalyticsProviderType {
+	// Serial names are lowercase: tomlkt matches the TOML value to the enum's
+	// serial name exactly (case-sensitively), so e.g. `type = "umami"` maps here.
+	@SerialName("none")
+	NONE,
+
+	@SerialName("umami")
+	UMAMI,
+}
 
 @Serializable
 data class AnalyticsConfig(
 	val type: AnalyticsProviderType = AnalyticsProviderType.NONE,
 	val umami: UmamiConfig? = null,
 ) {
+	/** The active provider, resolved once when the config is loaded. Null when analytics is off. */
+	@Transient
+	val provider: AnalyticsProvider? = AnalyticsProviderFactory.create(this)
+
 	fun validate() {
 		when (type) {
 			AnalyticsProviderType.NONE -> Unit
@@ -51,11 +68,25 @@ data class UmamiConfig(
 	fun validate() {
 		require(websiteId.isNotBlank()) { "analytics.umami.websiteId must not be blank" }
 		require(scriptUrl.isNotBlank()) { "analytics.umami.scriptUrl must not be blank" }
+		val uri = try {
+			URI(scriptUrl)
+		} catch (e: URISyntaxException) {
+			throw IllegalArgumentException("analytics.umami.scriptUrl is not a valid URL: $scriptUrl", e)
+		}
+		require(uri.scheme?.lowercase() in setOf("http", "https") && uri.host != null) {
+			"analytics.umami.scriptUrl must be an absolute http(s) URL: $scriptUrl"
+		}
 	}
 }
 
 @Serializable
-enum class StorageMode { EMBEDDED, REMOTE }
+enum class StorageMode {
+	@SerialName("embedded")
+	EMBEDDED,
+
+	@SerialName("remote")
+	REMOTE,
+}
 
 @Serializable
 data class StorageConfig(

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProvider.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProvider.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.AnalyticsConfig
 import com.darkrockstudios.apps.hammer.AnalyticsProviderType
 import com.darkrockstudios.apps.hammer.UmamiConfig
 import java.net.URI
+import java.net.URISyntaxException
 
 /**
  * A configured web-analytics integration for the server's web frontend.
@@ -24,14 +25,18 @@ interface AnalyticsProvider {
 	fun connectSrcHosts(): List<String>
 }
 
-internal class UmamiAnalyticsProvider(private val config: UmamiConfig) : AnalyticsProvider {
-	override fun headSnippet(): String =
+internal class UmamiAnalyticsProvider(config: UmamiConfig) : AnalyticsProvider {
+	// Computed once at construction: the provider is built once per config load, not per request.
+	private val origin = originOf(config.scriptUrl)
+	private val snippet =
 		"""<script defer src="${escapeAttr(config.scriptUrl)}" data-website-id="${escapeAttr(config.websiteId)}"></script>"""
 
-	override fun scriptSrcHosts(): List<String> = listOf(originOf(config.scriptUrl))
+	override fun headSnippet(): String = snippet
+
+	override fun scriptSrcHosts(): List<String> = listOf(origin)
 
 	// Umami posts events to <origin>/api/send, i.e. the same origin the script is served from.
-	override fun connectSrcHosts(): List<String> = listOf(originOf(config.scriptUrl))
+	override fun connectSrcHosts(): List<String> = listOf(origin)
 }
 
 object AnalyticsProviderFactory {
@@ -42,12 +47,21 @@ object AnalyticsProviderFactory {
 	}
 }
 
-/** Extracts the CSP-source origin (scheme://host[:port], no path) from a URL. */
+/**
+ * Extracts the CSP-source origin (scheme://host[:port], no path) from a URL.
+ *
+ * Never throws: a malformed URL is rejected upfront by [UmamiConfig.validate], so this
+ * falls back to returning the raw string only as defense-in-depth.
+ */
 internal fun originOf(url: String): String {
-	val uri = URI(url)
-	val scheme = uri.scheme ?: return url
-	val host = uri.host ?: return url
-	return if (uri.port != -1) "$scheme://$host:${uri.port}" else "$scheme://$host"
+	return try {
+		val uri = URI(url)
+		val scheme = uri.scheme ?: return url
+		val host = uri.host ?: return url
+		if (uri.port != -1) "$scheme://$host:${uri.port}" else "$scheme://$host"
+	} catch (_: URISyntaxException) {
+		url
+	}
 }
 
 /** Minimal HTML-attribute escaping. Values are admin-controlled but rendered unescaped. */

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProvider.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProvider.kt
@@ -1,0 +1,58 @@
+package com.darkrockstudios.apps.hammer.analytics
+
+import com.darkrockstudios.apps.hammer.AnalyticsConfig
+import com.darkrockstudios.apps.hammer.AnalyticsProviderType
+import com.darkrockstudios.apps.hammer.UmamiConfig
+import java.net.URI
+
+/**
+ * A configured web-analytics integration for the server's web frontend.
+ *
+ * Implementations are pure (no I/O): they turn admin-provided config into the
+ * HTML to inject and the CSP origins that injection requires. Adding a new
+ * provider is a new [AnalyticsProviderType] entry, a new config block, a new
+ * implementation here, and one branch in [AnalyticsProviderFactory.create].
+ */
+interface AnalyticsProvider {
+	/** Raw HTML injected into `<head>`, rendered via Mustache triple-braces. */
+	fun headSnippet(): String
+
+	/** Origins (scheme://host[:port], no path) to add to the CSP `script-src`. */
+	fun scriptSrcHosts(): List<String>
+
+	/** Origins to add to the CSP `connect-src` (where the provider POSTs events). */
+	fun connectSrcHosts(): List<String>
+}
+
+internal class UmamiAnalyticsProvider(private val config: UmamiConfig) : AnalyticsProvider {
+	override fun headSnippet(): String =
+		"""<script defer src="${escapeAttr(config.scriptUrl)}" data-website-id="${escapeAttr(config.websiteId)}"></script>"""
+
+	override fun scriptSrcHosts(): List<String> = listOf(originOf(config.scriptUrl))
+
+	// Umami posts events to <origin>/api/send, i.e. the same origin the script is served from.
+	override fun connectSrcHosts(): List<String> = listOf(originOf(config.scriptUrl))
+}
+
+object AnalyticsProviderFactory {
+	/** Returns the active provider, or null when analytics is disabled/unconfigured. */
+	fun create(config: AnalyticsConfig): AnalyticsProvider? = when (config.type) {
+		AnalyticsProviderType.NONE -> null
+		AnalyticsProviderType.UMAMI -> config.umami?.let { UmamiAnalyticsProvider(it) }
+	}
+}
+
+/** Extracts the CSP-source origin (scheme://host[:port], no path) from a URL. */
+internal fun originOf(url: String): String {
+	val uri = URI(url)
+	val scheme = uri.scheme ?: return url
+	val host = uri.host ?: return url
+	return if (uri.port != -1) "$scheme://$host:${uri.port}" else "$scheme://$host"
+}
+
+/** Minimal HTML-attribute escaping. Values are admin-controlled but rendered unescaped. */
+internal fun escapeAttr(value: String): String =
+	value.replace("&", "&amp;")
+		.replace("\"", "&quot;")
+		.replace("<", "&lt;")
+		.replace(">", "&gt;")

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -8,7 +8,6 @@ import com.darkrockstudios.apps.hammer.account.PenNameService
 import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.admin.WhiteListRepository
-import com.darkrockstudios.apps.hammer.analytics.AnalyticsProviderFactory
 import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import com.darkrockstudios.apps.hammer.base.http.API_ROUTE_PREFIX
 import com.darkrockstudios.apps.hammer.email.EmailService
@@ -192,7 +191,7 @@ suspend fun ApplicationCall.withDefaults(data: Map<String, Any> = emptyMap()): M
 
 	// Inject web analytics on public (logged-out) pages only
 	if (session == null) {
-		AnalyticsProviderFactory.create(serverConfig.analytics)?.let { provider ->
+		serverConfig.analytics.provider?.let { provider ->
 			model["analyticsHead"] = provider.headSnippet()
 		}
 	}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.account.PenNameService
 import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.admin.WhiteListRepository
+import com.darkrockstudios.apps.hammer.analytics.AnalyticsProviderFactory
 import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import com.darkrockstudios.apps.hammer.base.http.API_ROUTE_PREFIX
 import com.darkrockstudios.apps.hammer.email.EmailService
@@ -187,6 +188,13 @@ suspend fun ApplicationCall.withDefaults(data: Map<String, Any> = emptyMap()): M
 	// Add development mode flag for header banner
 	if (application.developmentMode) {
 		model["isDev"] = true
+	}
+
+	// Inject web analytics on public (logged-out) pages only
+	if (session == null) {
+		AnalyticsProviderFactory.create(serverConfig.analytics)?.let { provider ->
+			model["analyticsHead"] = provider.headSnippet()
+		}
 	}
 
 	return model

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.plugins
 
 import com.darkrockstudios.apps.hammer.ServerConfig
+import com.darkrockstudios.apps.hammer.analytics.AnalyticsProviderFactory
 import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
 import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
@@ -13,6 +14,10 @@ import io.ktor.server.plugins.httpsredirect.*
 import io.ktor.server.routing.*
 
 fun Application.configureHTTP(config: ServerConfig) {
+	val analyticsProvider = AnalyticsProviderFactory.create(config.analytics)
+	val analyticsScriptHosts = analyticsProvider?.scriptSrcHosts().orEmpty()
+	val analyticsConnectHosts = analyticsProvider?.connectSrcHosts().orEmpty()
+
 	install(DefaultHeaders) {
 		header(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
 		header(HEADER_SERVER_VERSION, BuildMetadata.APP_VERSION)
@@ -27,13 +32,17 @@ fun Application.configureHTTP(config: ServerConfig) {
 		header("Referrer-Policy", "strict-origin-when-cross-origin")
 
 		// Content Security Policy - relaxed for compatibility
+		val scriptSrc = (listOf("'self'", "https://unpkg.com", "'unsafe-inline'", "'unsafe-eval'") + analyticsScriptHosts)
+			.joinToString(" ") // HTMX + inline scripts + dynamic eval + analytics
+		val connectSrc = (listOf("'self'") + analyticsConnectHosts)
+			.joinToString(" ") // HTMX requests stay on same origin + analytics event endpoint
 		val cspDirectives = listOf(
 			"default-src 'self'",
-			"script-src 'self' https://unpkg.com 'unsafe-inline' 'unsafe-eval'", // HTMX + inline scripts + dynamic eval
+			"script-src $scriptSrc",
 			"style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com 'unsafe-inline'", // Font Awesome + Google Fonts + inline styles
 			"font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com data:", // Custom fonts + Font Awesome + Google Fonts
 			"img-src 'self' data:", // Local images + data URIs
-			"connect-src 'self'", // HTMX requests stay on same origin
+			"connect-src $connectSrc",
 			"frame-ancestors 'self'" // Additional clickjacking protection
 		).joinToString("; ")
 		header("Content-Security-Policy", cspDirectives)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
@@ -1,7 +1,6 @@
 package com.darkrockstudios.apps.hammer.plugins
 
 import com.darkrockstudios.apps.hammer.ServerConfig
-import com.darkrockstudios.apps.hammer.analytics.AnalyticsProviderFactory
 import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
 import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
@@ -14,7 +13,7 @@ import io.ktor.server.plugins.httpsredirect.*
 import io.ktor.server.routing.*
 
 fun Application.configureHTTP(config: ServerConfig) {
-	val analyticsProvider = AnalyticsProviderFactory.create(config.analytics)
+	val analyticsProvider = config.analytics.provider
 	val analyticsScriptHosts = analyticsProvider?.scriptSrcHosts().orEmpty()
 	val analyticsConnectHosts = analyticsProvider?.connectSrcHosts().orEmpty()
 

--- a/server/src/main/resources/templates/header.mustache
+++ b/server/src/main/resources/templates/header.mustache
@@ -12,6 +12,9 @@
 	{{#page_stylesheet}}
 		<link rel="stylesheet" href="{{page_stylesheet}}">
 	{{/page_stylesheet}}
+	{{#analyticsHead}}
+		{{{analyticsHead}}}
+	{{/analyticsHead}}
 </head>
 <body>
 <header class="site-header">

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsConfigTest.kt
@@ -6,7 +6,9 @@ import net.peanuuutz.tomlkt.Toml
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 class AnalyticsConfigTest {
 
@@ -86,5 +88,54 @@ class AnalyticsConfigTest {
 			""".trimIndent()
 		)
 		assertThrows<IllegalArgumentException> { config.analytics.validate() }
+	}
+
+	@Test
+	fun `validate throws on a malformed script URL`() {
+		val config = parse(
+			"""
+			[analytics]
+			type = "umami"
+
+			[analytics.umami]
+			websiteId = "abc-123"
+			scriptUrl = "https://umami.is/bad script.js"
+			""".trimIndent()
+		)
+		assertThrows<IllegalArgumentException> { config.analytics.validate() }
+	}
+
+	@Test
+	fun `validate throws on a non-http script URL`() {
+		val config = parse(
+			"""
+			[analytics]
+			type = "umami"
+
+			[analytics.umami]
+			websiteId = "abc-123"
+			scriptUrl = "ftp://umami.is/script.js"
+			""".trimIndent()
+		)
+		assertThrows<IllegalArgumentException> { config.analytics.validate() }
+	}
+
+	@Test
+	fun `provider is resolved once when umami configured and absent otherwise`() {
+		val umami = parse(
+			"""
+			[analytics]
+			type = "umami"
+
+			[analytics.umami]
+			websiteId = "abc-123"
+			""".trimIndent()
+		)
+		val provider = umami.analytics.provider
+		assertNotNull(provider)
+		// Same precomputed instance is reused, not rebuilt per access.
+		assertSame(provider, umami.analytics.provider)
+
+		assertNull(parse("").analytics.provider)
 	}
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsConfigTest.kt
@@ -1,0 +1,90 @@
+package com.darkrockstudios.apps.hammer.analytics
+
+import com.darkrockstudios.apps.hammer.AnalyticsProviderType
+import com.darkrockstudios.apps.hammer.ServerConfig
+import net.peanuuutz.tomlkt.Toml
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AnalyticsConfigTest {
+
+	private val toml = Toml { ignoreUnknownKeys = true }
+
+	private fun parse(tomlString: String): ServerConfig =
+		toml.decodeFromString(ServerConfig.serializer(), tomlString)
+
+	@Test
+	fun `Omitted analytics section defaults to NONE`() {
+		val config = parse(
+			"""
+			host = "localhost"
+			port = 8080
+			""".trimIndent()
+		)
+		assertEquals(AnalyticsProviderType.NONE, config.analytics.type)
+		assertNull(config.analytics.umami)
+	}
+
+	@Test
+	fun `Umami block parses with default script URL`() {
+		val config = parse(
+			"""
+			[analytics]
+			type = "umami"
+
+			[analytics.umami]
+			websiteId = "abc-123"
+			""".trimIndent()
+		)
+		assertEquals(AnalyticsProviderType.UMAMI, config.analytics.type)
+		assertEquals("abc-123", config.analytics.umami?.websiteId)
+		assertEquals("https://cloud.umami.is/script.js", config.analytics.umami?.scriptUrl)
+	}
+
+	@Test
+	fun `Umami block honors a custom self-hosted script URL`() {
+		val config = parse(
+			"""
+			[analytics]
+			type = "umami"
+
+			[analytics.umami]
+			websiteId = "abc-123"
+			scriptUrl = "https://umami.example.com/script.js"
+			""".trimIndent()
+		)
+		assertEquals("https://umami.example.com/script.js", config.analytics.umami?.scriptUrl)
+	}
+
+	@Test
+	fun `validate succeeds for NONE`() {
+		parse("").analytics.validate()
+	}
+
+	@Test
+	fun `validate throws when umami selected without config block`() {
+		val config = parse(
+			"""
+			[analytics]
+			type = "umami"
+			""".trimIndent()
+		)
+		assertThrows<IllegalArgumentException> { config.analytics.validate() }
+	}
+
+	@Test
+	fun `validate throws on blank websiteId`() {
+		val config = parse(
+			"""
+			[analytics]
+			type = "umami"
+
+			[analytics.umami]
+			websiteId = ""
+			""".trimIndent()
+		)
+		assertThrows<IllegalArgumentException> { config.analytics.validate() }
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsCspTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsCspTest.kt
@@ -1,0 +1,54 @@
+package com.darkrockstudios.apps.hammer.analytics
+
+import com.darkrockstudios.apps.hammer.AnalyticsConfig
+import com.darkrockstudios.apps.hammer.AnalyticsProviderType
+import com.darkrockstudios.apps.hammer.ServerConfig
+import com.darkrockstudios.apps.hammer.UmamiConfig
+import com.darkrockstudios.apps.hammer.plugins.configureHTTP
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+
+class AnalyticsCspTest {
+
+	private suspend fun ApplicationTestBuilder.cspFor(config: ServerConfig): String {
+		application {
+			configureHTTP(config)
+			routing {
+				get("/") { call.respondText("ok") }
+			}
+		}
+		val response: HttpResponse = client.get("/")
+		return response.headers["Content-Security-Policy"] ?: ""
+	}
+
+	@Test
+	fun `umami host is added to script-src and connect-src`() = testApplication {
+		val config = ServerConfig(
+			analytics = AnalyticsConfig(
+				type = AnalyticsProviderType.UMAMI,
+				umami = UmamiConfig(websiteId = "abc-123"),
+			)
+		)
+		val csp = cspFor(config)
+		val scriptSrc = csp.split(";").first { it.trim().startsWith("script-src") }
+		val connectSrc = csp.split(";").first { it.trim().startsWith("connect-src") }
+		assertContains(scriptSrc, "https://cloud.umami.is")
+		assertContains(connectSrc, "https://cloud.umami.is")
+	}
+
+	@Test
+	fun `csp is unchanged when analytics disabled`() = testApplication {
+		val csp = cspFor(ServerConfig())
+		assertContains(csp, "script-src 'self' https://unpkg.com 'unsafe-inline' 'unsafe-eval'")
+		assertContains(csp, "connect-src 'self'")
+		assertFalse(csp.contains("umami"))
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProviderTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProviderTest.kt
@@ -1,0 +1,64 @@
+package com.darkrockstudios.apps.hammer.analytics
+
+import com.darkrockstudios.apps.hammer.AnalyticsConfig
+import com.darkrockstudios.apps.hammer.AnalyticsProviderType
+import com.darkrockstudios.apps.hammer.UmamiConfig
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class AnalyticsProviderTest {
+
+	@Test
+	fun `umami head snippet contains the website id and script url`() {
+		val provider = UmamiAnalyticsProvider(UmamiConfig(websiteId = "abc-123"))
+		val snippet = provider.headSnippet()
+		assertContains(snippet, "defer")
+		assertContains(snippet, """data-website-id="abc-123"""")
+		assertContains(snippet, """src="https://cloud.umami.is/script.js"""")
+	}
+
+	@Test
+	fun `umami head snippet escapes quotes in attribute values`() {
+		val provider = UmamiAnalyticsProvider(UmamiConfig(websiteId = """a"b"""))
+		val snippet = provider.headSnippet()
+		assertContains(snippet, "data-website-id=\"a&quot;b\"")
+	}
+
+	@Test
+	fun `umami csp hosts use the script origin only`() {
+		val cloud = UmamiAnalyticsProvider(UmamiConfig(websiteId = "x"))
+		assertEquals(listOf("https://cloud.umami.is"), cloud.scriptSrcHosts())
+		assertEquals(listOf("https://cloud.umami.is"), cloud.connectSrcHosts())
+
+		val selfHosted = UmamiAnalyticsProvider(
+			UmamiConfig(websiteId = "x", scriptUrl = "https://umami.example.com/script.js")
+		)
+		assertEquals(listOf("https://umami.example.com"), selfHosted.scriptSrcHosts())
+	}
+
+	@Test
+	fun `originOf keeps an explicit port and strips the path`() {
+		assertEquals("https://umami.example.com:3000", originOf("https://umami.example.com:3000/script.js"))
+	}
+
+	@Test
+	fun `factory returns null when analytics disabled`() {
+		assertNull(AnalyticsProviderFactory.create(AnalyticsConfig(type = AnalyticsProviderType.NONE)))
+	}
+
+	@Test
+	fun `factory returns null for umami type with no config block`() {
+		assertNull(AnalyticsProviderFactory.create(AnalyticsConfig(type = AnalyticsProviderType.UMAMI, umami = null)))
+	}
+
+	@Test
+	fun `factory returns a umami provider when configured`() {
+		val provider = AnalyticsProviderFactory.create(
+			AnalyticsConfig(type = AnalyticsProviderType.UMAMI, umami = UmamiConfig(websiteId = "x"))
+		)
+		assertIs<UmamiAnalyticsProvider>(provider)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an extensible web-analytics system that a self-hosting server admin can configure purely through the server config TOML — no rebuild required. The server then injects the provider's tracking `<script>` into the public web pages.

The first supported provider is **[Umami](https://docs.umami.is/docs)**. The design is intentionally extensible so other providers (Plausible, GA, etc.) can be added later **without touching the rendering or CSP wiring** — just a new enum entry, a config block, a provider implementation, and one `when` branch.

## How to use

```toml
[analytics]
type = "umami"

[analytics.umami]
websiteId = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
# scriptUrl defaults to Umami Cloud; override for self-hosted Umami:
# scriptUrl = "https://umami.example.com/script.js"
```

Default is `type = "none"` (analytics off), so existing configs are unaffected.

## Design

- **Config** (`ServerConfig.kt`): a new `[analytics]` section modeled on the existing `StorageConfig` pattern (enum `type` selector + nullable per-provider block + `validate()`). Validation runs at startup in `Application.kt`, alongside `storage.validate()`.
- **Provider abstraction** (`analytics/AnalyticsProvider.kt`): an `AnalyticsProvider` interface (`headSnippet()`, `scriptSrcHosts()`, `connectSrcHosts()`), a `UmamiAnalyticsProvider`, and a factory returning `null` when analytics is disabled.
- **Rendering**: the `<head>` snippet is injected via `withDefaults()` and rendered (guarded, unescaped) in `header.mustache`.
- **CSP**: `HTTP.kt` widens `script-src`/`connect-src` dynamically from the configured provider's origin. When analytics is off, the CSP is byte-identical to before.

## Behavior notes

- **Public pages only**: the tracking snippet is injected only when there is no logged-in session. It is never added to the dashboard, story, or admin pages of signed-in users.
- **Self-hosted Umami**: supported for free via the configurable `scriptUrl`; the CSP auto-adjusts to whatever host is set.

## Tests

- Config parsing + validation (TOML round-trip, default `scriptUrl`, failure cases)
- Provider snippet generation, attribute escaping, and CSP-origin extraction (cloud, self-hosted, explicit port)
- Factory behavior
- A Ktor `testApplication` test asserting the rendered `Content-Security-Policy` header includes the Umami host when enabled and is unchanged when disabled

## Docs

Added a "Web Analytics" section to `docs/HOW-TO-RUN-A-SERVER.md`.

## ⚠️ Not locally verified

I was unable to compile or run the test suite in my environment: a full Gradle build pulls the Android Gradle plugin (the `:server` module depends on the KMP `:base`/`:common` modules), and Google's Maven repo was blocked there (`dl.google.com` → 403). The code was reviewed by hand but has **not** been compiler/test-verified — please rely on CI here.

https://claude.ai/code/session_01UjaNa3HYs6TkGd4sk2KQ55

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjaNa3HYs6TkGd4sk2KQ55)_