### PR TITLE
Fix iOS native compile + harden Mac App Store signing pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,73 +52,24 @@ jobs:
           path: |
             integrationTests/build/reports/tests/jvmTest/
             integrationTests/build/test-results/jvmTest/
-#  ios:
-#    runs-on: macos-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#
-#      - name: check Xcode version
-#        run: /usr/bin/xcodebuild -version
-#
-#      - name: Get swift version
-#        run: swift --version
-#
-#      - name: set up JDK 21
-#        uses: actions/setup-java@v4
-#        with:
-#          java-version: '21'
-#          distribution: 'temurin'
-#          cache: gradle
-#
-#      - name: Grant execute permission for gradlew
-#        run: chmod +x gradlew
-#
-#      - name: Install the Apple certificate and provisioning profile
-#        env:
-#          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-#          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-#          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-#          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-#        run: |
-#          # create variables
-#          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-#          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-#          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-#
-#          # import certificate and provisioning profile from secrets
-#          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERTIFICATE_PATH"
-#          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
-#
-#          # create temporary keychain
-#          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-#          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-#          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-#
-#          # import certificate to keychain
-#          security import "$CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-#          security list-keychain -d user -s "$KEYCHAIN_PATH"
-#
-#          # apply provisioning profile
-#          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-#          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles
-#
-#      - name: Set Default Scheme
-#        run: |
-#          cd ios
-#          default="ios"
-#          echo $default | cat >default
-#          echo Using default scheme: $default
-#
-#      - name: Build
-#        env:
-#          scheme: ${{ 'default' }}
-#          platform: ${{ 'iOS Simulator' }}
-#        run: |
-#          cd ios
-#          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
-#          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
-#          if [ $scheme = default ]; then scheme=$(cat default); fi
-#          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-#          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-#          xcodebuild build-for-testing -scheme "$scheme" -sdk iphoneos -allowProvisioningUpdates
+  # Compiles the shared Kotlin for both iOS targets. Kotlin/Native for Apple
+  # targets only builds on macOS, so the ubuntu `build` job never exercises it —
+  # commonMain code that breaks only on Native (e.g. an extension that resolves
+  # differently than on the JVM) would otherwise slip through to the release
+  # pipeline. Compiling composeUi transitively compiles base + common. No Xcode
+  # build and no signing — this is a pure compile gate, not a full app build.
+  ios-compile:
+    name: iOS compile check
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Compile iOS Kotlin targets
+        run: ./gradlew :composeUi:compileKotlinIosArm64 :composeUi:compileKotlinIosSimulatorArm64

--- a/.github/workflows/publish-mac-app-store.yml
+++ b/.github/workflows/publish-mac-app-store.yml
@@ -56,6 +56,12 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"' | xargs)
 
+          # Both the Application (signs .app) and Installer (signs .pkg) identities
+          # must be present, each with its private key. The .pkg step fails late if
+          # the Installer cert is missing — surface it here instead.
+          echo "=== identities in signing keychain ==="
+          security find-identity -v "$KEYCHAIN_PATH" || true
+
       - name: Place provisioning profiles
         env:
           EMBEDDED_PROFILE_B64: ${{ secrets.MAC_EMBEDDED_PROVISIONING_PROFILE_BASE64 }}

--- a/.github/workflows/publish-mac-app-store.yml
+++ b/.github/workflows/publish-mac-app-store.yml
@@ -74,6 +74,15 @@ jobs:
       - name: Upload to TestFlight 🍎
         run: bundle exec fastlane mac desktop_testflight
 
+      - name: Dump jpackage logs on failure
+        if: failure()
+        run: |
+          for f in desktop/build/compose/logs/packageReleasePkg/*.txt; do
+            [ -e "$f" ] || continue
+            echo "===== $f ====="
+            cat "$f"
+          done
+
       - name: Upload Gradle problems report on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -218,6 +218,7 @@
 
 	<string name="reauth_title">Reauthorize</string>
 	<string name="reauth_explanation">Your token has expired, please reauthorize with your sync server.</string>
+	<string name="reauth_token_expired">Token Expired</string>
 	<string name="reauth_server_url">Address</string>
 	<string name="reauth_server_email">E-Mail</string>
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
@@ -24,7 +24,6 @@ import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
 import com.darkrockstudios.apps.hammer.common.util.StrRes
-import io.github.aakira.napier.Napier
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -92,6 +91,8 @@ class AccountSettingsComponent(
 					_state.getAndUpdate {
 						it.copy(
 							uiTheme = settings.uiTheme,
+							syncAutomaticSync = settings.automaticSyncing,
+							syncAutoCloseDialog = settings.autoCloseSyncDialog,
 							syncAutomaticBackups = settings.automaticBackups,
 							maxBackups = settings.maxBackups,
 							initialProjectScreen = settings.initialProjectScreen,
@@ -331,7 +332,6 @@ class AccountSettingsComponent(
 							serverWorking = false,
 						)
 					}
-					Napier.d { "ABROWN: 1: $message" }
 					showToast(scope, Res.string.settings_server_setup_toast_failure, message)
 				}
 			}
@@ -347,7 +347,6 @@ class AccountSettingsComponent(
 				)
 			}
 		}
-		Napier.d { "ABROWN: 2: $message" }
 		showToast(Res.string.settings_server_setup_toast_failure, message)
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/EntitySynchronizers.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/EntitySynchronizers.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.projectInject
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.synchronizers.*
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import io.github.aakira.napier.Napier
 
 class EntitySynchronizers(projectDef: ProjectDef) : ProjectScoped {
 
@@ -65,7 +66,13 @@ class EntitySynchronizers(projectDef: ProjectDef) : ProjectScoped {
 
 	suspend fun reIdEntry(oldId: Int, newId: Int) {
 		val type = findEntityType(oldId)
-			?: throw IllegalArgumentException("Entity $oldId not found for reId")
+		if (type == null) {
+			// Phantom newId with no backing entity (created then deleted before a
+			// successful sync). Skip it so the sync can finish and clear newIds,
+			// instead of wedging every future sync.
+			Napier.w("reId skipped: no local entity owns $oldId")
+			return
+		}
 		when (type) {
 			EntityType.Scene -> sceneSynchronizer.reIdEntity(oldId = oldId, newId = newId)
 			EntityType.Note -> noteSynchronizer.reIdEntity(oldId = oldId, newId = newId)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataRepository.kt
@@ -50,8 +50,13 @@ class SyncDataRepository(
 		if (globalSettingsRepository.isServerSynchronized().not()) return
 
 		val syncData = datasource.loadSyncData()
-		val updated = syncData.deletedIds + deletedId
-		val newSyncData = syncData.copy(deletedIds = updated)
+		val newSyncData = if (syncData.newIds.contains(deletedId)) {
+			// Brand-new entity the server never saw: drop the claim so it can't
+			// become a phantom newId. Nothing to tell the server to delete.
+			syncData.copy(newIds = syncData.newIds - deletedId)
+		} else {
+			syncData.copy(deletedIds = syncData.deletedIds + deletedId)
+		}
 		datasource.saveSyncData(newSyncData)
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/IdConflictResolutionOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/IdConflictResolutionOperation.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import kotlinx.coroutines.yield
+import kotlin.math.max
 
 class IdConflictResolutionOperation(
 	projectDef: ProjectDef,
@@ -69,7 +70,24 @@ class IdConflictResolutionOperation(
 		val lastClientIdWithoutNew = calculateLastClientIdWithoutNewIds(clientSyncData)
 		return if (serverSyncData.lastId > lastClientIdWithoutNew) {
 			if (clientSyncData.newIds.isNotEmpty()) {
-				var serverLastId = serverSyncData.lastId
+				// New IDs must be assigned above both the server's last ID and any
+				// ID already present locally. If the server ever reports a lastId
+				// lower than a local entity's ID (e.g. server-side data loss),
+				// seeding only from serverLastId would hand out IDs that collide
+				// with - and clobber - existing local entities.
+				idRepository.findNextId()
+				val clientMaxId = idRepository.peekLastId()
+				if (serverSyncData.lastId < clientMaxId) {
+					onLog(
+						syncLogW(
+							"Server lastId ${serverSyncData.lastId} is below local max ID " +
+								"$clientMaxId; assigning new IDs above local max to avoid collision",
+							projectDef.name
+						)
+					)
+				}
+
+				var serverLastId = max(serverSyncData.lastId, clientMaxId)
 				val updatedNewIds = clientSyncData.newIds.toMutableList()
 				val updatedDirty = clientSyncData.dirty.toMutableList()
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/versioncheck/GithubVersionCheckDataSource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/versioncheck/GithubVersionCheckDataSource.kt
@@ -5,6 +5,7 @@ import io.github.aakira.napier.Napier
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -23,6 +24,10 @@ class GithubVersionCheckDataSource(
 	override suspend fun fetchLatestRelease(): GithubReleaseInfo? {
 		return try {
 			val response = http.get(VERSION_CHECK_URL)
+			if (!response.status.isSuccess()) {
+				Napier.w("Version check returned ${response.status} (likely GitHub rate limit)")
+				return null
+			}
 			val release = json.decodeFromString<GithubReleaseInfo>(response.bodyAsText())
 			if (release.body.isNullOrBlank()) {
 				release.copy(body = fetchAnnotatedTagMessage(release.tagName))

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/util/zip/ZipUtils.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/util/zip/ZipUtils.kt
@@ -6,7 +6,6 @@ import no.synth.kmpzip.zip.ZipInputStream
 import no.synth.kmpzip.zip.safeEntrySegments
 import okio.FileSystem
 import okio.Path
-import okio.buffer
 
 private const val COPY_BUFFER_SIZE = 8192
 
@@ -60,11 +59,11 @@ fun unzipBytesToDirectory(
 				fileSystem.createDirectories(target)
 			} else {
 				target.parent?.let { fileSystem.createDirectories(it) }
-				fileSystem.sink(target).buffer().use { sink ->
+				fileSystem.write(target) {
 					while (true) {
 						val n = zis.read(buffer, 0, buffer.size)
 						if (n == -1) break
-						sink.write(buffer, 0, n)
+						write(buffer, 0, n)
 					}
 				}
 			}

--- a/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
@@ -1,0 +1,107 @@
+package components.projectselection
+
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.resume
+import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettingsComponent
+import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.PlatformSettings
+import com.darkrockstudios.apps.hammer.common.data.ExampleProjectRepository
+import com.darkrockstudios.apps.hammer.common.data.account.AccountUseCase
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.SpellCheckerSettings
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
+import com.darkrockstudios.apps.hammer.common.util.StrRes
+import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.dsl.bind
+import org.koin.dsl.module
+import utils.BaseTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccountSettingsComponentTest : BaseTest() {
+
+	private lateinit var lifecycle: LifecycleRegistry
+	private lateinit var context: DefaultComponentContext
+
+	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsUpdates: MutableSharedFlow<GlobalSettings>
+	private lateinit var serverSettingsUpdates: SharedFlow<ServerSettings?>
+
+	private var globalSettings = GlobalSettings(
+		projectsDirectory = "",
+		spellCheckSettings = SpellCheckerSettings(locale = mockk()),
+		automaticSyncing = true,
+		autoCloseSyncDialog = true,
+		automaticBackups = true,
+	)
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+
+		lifecycle = LifecycleRegistry()
+		context = DefaultComponentContext(lifecycle = lifecycle)
+
+		globalSettingsRepository = mockk(relaxed = true)
+		globalSettingsUpdates = MutableSharedFlow(replay = 1)
+		every { globalSettingsRepository.globalSettingsUpdates } returns globalSettingsUpdates
+		every { globalSettingsRepository.globalSettings } answers { globalSettings }
+
+		serverSettingsUpdates = MutableSharedFlow(replay = 1)
+		every { globalSettingsRepository.serverSettingsUpdates } returns serverSettingsUpdates
+
+		val spellCheckerFactory = mockk<PlatformSpellCheckerFactory>(relaxed = true)
+		every { spellCheckerFactory.availableLocales() } returns emptyList()
+
+		val testModule = module {
+			single { globalSettingsRepository } bind GlobalSettingsRepository::class
+			single { mockk<ExampleProjectRepository>(relaxed = true) } bind ExampleProjectRepository::class
+			single { mockk<AccountUseCase>(relaxed = true) } bind AccountUseCase::class
+			single { mockk<ProjectsRepository>(relaxed = true) } bind ProjectsRepository::class
+			single { mockk<StrRes>(relaxed = true) } bind StrRes::class
+			single { spellCheckerFactory }
+			factory { mockk<PlatformSettings>(relaxed = true) } bind PlatformSettings::class
+		}
+		setupKoin(testModule)
+		lifecycle.resume()
+	}
+
+	private fun newComponent() = AccountSettingsComponent(componentContext = context)
+
+	@Test
+	fun `Auto-sync setting update is reflected in state`() = runTest {
+		val component = newComponent()
+		advanceUntilIdle()
+		assertTrue(component.state.value.syncAutomaticSync)
+
+		globalSettingsUpdates.emit(globalSettings.copy(automaticSyncing = false))
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.syncAutomaticSync)
+	}
+
+	@Test
+	fun `Auto-close sync dialog setting update is reflected in state`() = runTest {
+		val component = newComponent()
+		advanceUntilIdle()
+		assertTrue(component.state.value.syncAutoCloseDialog)
+
+		globalSettingsUpdates.emit(globalSettings.copy(autoCloseSyncDialog = false))
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.syncAutoCloseDialog)
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/syncdata/SyncDataRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/syncdata/SyncDataRepositoryTest.kt
@@ -343,6 +343,35 @@ class SyncDataRepositoryTest : BaseTest() {
 	}
 
 	@Test
+	fun `Record deleted ID prunes a brand-new entity from newIds`() = runTest {
+		// A never-synced entity (in newIds) that gets deleted must be dropped from
+		// newIds, not left behind as a phantom. The server never saw it, so there
+		// is nothing to add to deletedIds either. Leaving it in newIds is what
+		// wedged sync with "Entity X not found for reId".
+		createProject(ffs, PROJECT_2_NAME)
+		val projectDef = getProjectDef(PROJECT_2_NAME)
+		every { globalSettingsRepository.isServerSynchronized() } returns true
+		val repo = createRepository(projectDef)
+
+		repo.saveSyncData(
+			ProjectSynchronizationData(
+				currentSyncId = null,
+				lastId = 26,
+				newIds = listOf(26),
+				lastSync = Instant.DISTANT_PAST,
+				dirty = emptyList(),
+				deletedIds = emptySet(),
+			)
+		)
+
+		repo.recordIdDeletion(26)
+
+		val loadedData = ffs.readJson<ProjectSynchronizationData>(syncPath(projectDef), json)
+		assertEquals(emptyList<Int>(), loadedData?.newIds)
+		assertFalse(loadedData?.deletedIds?.contains(26) ?: true)
+	}
+
+	@Test
 	fun `Load sync data`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)

--- a/common/src/desktopTest/kotlin/synchronizer/operations/IdConflictResolutionOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/IdConflictResolutionOperationTest.kt
@@ -2,6 +2,7 @@ package synchronizer.operations
 
 import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.ProjectSynchronizationBegan
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
@@ -22,6 +23,7 @@ import utils.TestStrRes
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 class IdConflictResolutionOperationTest : BaseTest() {
 
@@ -105,5 +107,134 @@ class IdConflictResolutionOperationTest : BaseTest() {
 
 		coVerify { mockSynchronizers.sceneSynchronizer.deleteEntityLocal(11, any()) }
 		coVerify { mockSynchronizers.sceneSynchronizer.reIdEntity(11, 12) }
+	}
+
+	@Test
+	fun `Phantom newId owned by no synchronizer is skipped, not fatal`() = runTest {
+		// Reproduces the production "Entity X not found for reId" wedge: a newId
+		// that no local entity backs (created then deleted before a successful
+		// sync). Once the server's lastId climbs past it, the re-ID branch fires
+		// and used to throw, aborting every sync forever. It must instead skip
+		// the phantom so the sync can finish and clear it.
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		coEvery { idRepository.findNextId() } just Runs
+		coEvery { idRepository.peekLastId() } returns 50
+
+		// No synchronizer owns the phantom id.
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(any()) } returns false
+		coEvery { mockSynchronizers.noteSynchronizer.ownsEntity(any()) } returns false
+		coEvery { mockSynchronizers.timelineSynchronizer.ownsEntity(any()) } returns false
+		coEvery { mockSynchronizers.encyclopediaSynchronizer.ownsEntity(any()) } returns false
+		coEvery { mockSynchronizers.sceneDraftSynchronizer.ownsEntity(any()) } returns false
+
+		val phantomClientData = ProjectSynchronizationData(
+			lastId = 50,
+			newIds = listOf(50),
+			lastSync = Instant.fromEpochSeconds(123456),
+			dirty = emptyList(),
+			deletedIds = emptySet(),
+		)
+		// Server lastId is past the phantom, so the re-ID branch activates.
+		val serverBegan = ProjectSynchronizationBegan(
+			syncId = "sync-id",
+			lastSync = Instant.fromEpochSeconds(1234567),
+			lastId = 60,
+			idSequence = emptyList(),
+			deletedIds = emptySet(),
+		)
+		val emptyCollatedIds = CollateIdsState.CollatedIds(
+			combinedDeletions = emptySet(),
+			serverDeletedIds = emptySet(),
+			newlyDeletedIds = emptySet(),
+			dirtyEntities = mutableListOf(),
+		)
+
+		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
+		val onLog = mockk<OnSyncLog>(relaxed = true)
+		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
+		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+
+		val initialState = CollateIdsState(
+			onlyNew = false,
+			clientSyncData = phantomClientData,
+			entityState = entityState,
+			serverProjectId = projId,
+			serverSyncData = serverBegan,
+			collatedIds = emptyCollatedIds,
+		)
+
+		val result = op.execute(
+			state = initialState,
+			onProgress = onProgress,
+			onLog = onLog,
+			onConflict = onConflict,
+			onComplete = onComplete,
+		)
+
+		assertTrue(isSuccess(result))
+		coVerify(exactly = 0) { mockSynchronizers.sceneSynchronizer.reIdEntity(any(), any()) }
+		coVerify(exactly = 0) { mockSynchronizers.encyclopediaSynchronizer.reIdEntity(any(), any()) }
+	}
+
+	@Test
+	fun `New IDs are assigned above local max when server lastId regressed`() = runTest {
+		// Guards against server-side data loss: if the server reports a lastId
+		// lower than an existing local entity's ID, new IDs must still be assigned
+		// above the local max. Seeding only from serverLastId would hand out IDs
+		// that collide with - and clobber - real local entities.
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		coEvery { idRepository.findNextId() } just Runs
+		coEvery { idRepository.peekLastId() } returns 100 // local max entity id
+
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(30) } returns true
+		coEvery { mockSynchronizers.sceneSynchronizer.reIdEntity(any(), any()) } just Runs
+
+		val clientData = ProjectSynchronizationData(
+			lastId = 100,
+			newIds = listOf(30),
+			lastSync = Instant.fromEpochSeconds(123456),
+			dirty = emptyList(),
+			deletedIds = emptySet(),
+		)
+		// Server reports a lastId below the local max - the regression we guard against.
+		val serverBegan = ProjectSynchronizationBegan(
+			syncId = "sync-id",
+			lastSync = Instant.fromEpochSeconds(1234567),
+			lastId = 50,
+			idSequence = emptyList(),
+			deletedIds = emptySet(),
+		)
+		val emptyCollatedIds = CollateIdsState.CollatedIds(
+			combinedDeletions = emptySet(),
+			serverDeletedIds = emptySet(),
+			newlyDeletedIds = emptySet(),
+			dirtyEntities = mutableListOf(),
+		)
+
+		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
+		val onLog = mockk<OnSyncLog>(relaxed = true)
+		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
+		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+
+		val initialState = CollateIdsState(
+			onlyNew = false,
+			clientSyncData = clientData,
+			entityState = entityState,
+			serverProjectId = projId,
+			serverSyncData = serverBegan,
+			collatedIds = emptyCollatedIds,
+		)
+
+		val result = op.execute(
+			state = initialState,
+			onProgress = onProgress,
+			onLog = onLog,
+			onConflict = onConflict,
+			onComplete = onComplete,
+		)
+
+		assertTrue(isSuccess(result))
+		// Must land above the local max (101), not 51 which would clobber a real entity.
+		coVerify { mockSynchronizers.sceneSynchronizer.reIdEntity(30, 101) }
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCard.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCard.kt
@@ -35,8 +35,6 @@ import com.darkrockstudios.apps.hammer.project_select_card_rename_button
 import com.darkrockstudios.apps.hammer.projects_list_card_by_author
 import com.darkrockstudios.apps.hammer.projects_list_card_content_description
 import com.darkrockstudios.apps.hammer.projects_list_card_created
-import com.darkrockstudios.apps.hammer.projects_list_card_never_opened
-import com.darkrockstudios.apps.hammer.projects_list_card_opened
 import com.darkrockstudios.apps.hammer.projects_list_card_words
 import com.darkrockstudios.apps.hammer.projects_list_item_more_button
 import kotlinx.datetime.TimeZone
@@ -57,10 +55,12 @@ private val CompactNumberColumnWidth: Dp = 44.dp
  *     │ 01   Alice In Wonderland          29 JAN ’23   ⋮
  *     │      by Lewis Carroll · Created 29 JAN ’23
  *
- * Compact (drops the trailing mono cell, folds dates into the title column):
+ * Compact (drops the trailing mono cell, lays the dates + word count out as
+ * an aligned label/value greeble grid instead of one flowing mono line):
  *     │ 01  Alice In Wonderland           ⋮
  *     │     by Lewis Carroll
- *     │     CREATED 29 JAN ’23 · OPENED 04 MAR ’24
+ *     │     CREATED      OPENED      WORDS
+ *     │     29 JAN ’23   04 MAR ’24  26,351
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -89,21 +89,16 @@ fun ProjectIndexRow(
 	val wordsLabel = projectData.totalWords?.let {
 		Res.string.projects_list_card_words.get(it.formatDecimalSeparator())
 	}
+	val wordsValue = projectData.totalWords?.formatDecimalSeparator()
 	val byAuthor = author?.let { Res.string.projects_list_card_by_author.get(it) }
 	val createdText = Res.string.projects_list_card_created.get(createdDate)
-	val openedText = lastAccessedDate
-		?.let { Res.string.projects_list_card_opened.get(it) }
-		?: Res.string.projects_list_card_never_opened.get()
 	val cardContentDescription =
 		Res.string.projects_list_card_content_description.get(projectData.definition.name)
 	val rowNumber = remember(index) { (index + 1).toString().padStart(2, '0') }
-	val subline = remember(isWide, byAuthor, createdText, openedText, wordsLabel) {
-		val parts = if (isWide) {
-			listOfNotNull(byAuthor, createdText)
-		} else {
-			listOfNotNull(createdText, openedText, wordsLabel)
-		}
-		parts.joinToString(" · ")
+	// Wide keeps the single italic subline; Compact reflows the same facts into
+	// the aligned greeble grid below, so the subline is wide-only now.
+	val subline = remember(byAuthor, createdText) {
+		listOfNotNull(byAuthor, createdText).joinToString(" · ")
 	}
 
 	Row(
@@ -167,10 +162,11 @@ fun ProjectIndexRow(
 						color = MaterialTheme.colorScheme.onSurfaceVariant,
 					)
 				}
-				Spacer(modifier = Modifier.height(2.dp))
-				HdMonoLabel(
-					text = subline,
-					color = MaterialTheme.colorScheme.onSurfaceVariant,
+				Spacer(modifier = Modifier.height(8.dp))
+				CompactMetaGrid(
+					createdValue = createdDate,
+					openedValue = lastAccessedDate,
+					wordsValue = wordsValue,
 				)
 			}
 		}
@@ -219,6 +215,78 @@ fun ProjectIndexRow(
 		thickness = Dp.Hairline,
 		color = MaterialTheme.colorScheme.outlineVariant,
 	)
+}
+
+/**
+ * Compact label-over-value greeble grid. Equal-weight columns keep the dates
+ * and word count aligned down the whole list instead of flowing and wrapping
+ * at arbitrary points. The labels are faint captions; values stay at the same
+ * muted weight as the rest of the row so the project title is the only bright
+ * anchor per row.
+ *
+ *     CREATED      OPENED      WORDS
+ *     29 JAN ’23   04 MAR ’24  26,351
+ */
+@Composable
+private fun CompactMetaGrid(
+	createdValue: String,
+	openedValue: String?,
+	wordsValue: String?,
+) {
+	Row(
+		modifier = Modifier.fillMaxWidth(),
+		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
+	) {
+		MetaColumn(
+			label = "Created",
+			value = createdValue,
+			modifier = Modifier.weight(1f),
+		)
+		MetaColumn(
+			label = "Opened",
+			value = openedValue ?: "—",
+			muted = openedValue == null,
+			modifier = Modifier.weight(1f),
+		)
+		if (wordsValue != null) {
+			MetaColumn(
+				label = "Words",
+				value = wordsValue,
+				modifier = Modifier.weight(1f),
+			)
+		}
+	}
+}
+
+@Composable
+private fun MetaColumn(
+	label: String,
+	value: String,
+	modifier: Modifier = Modifier,
+	muted: Boolean = false,
+) {
+	Column(
+		modifier = modifier,
+		verticalArrangement = Arrangement.spacedBy(3.dp),
+	) {
+		HdMonoLabel(
+			text = label,
+			color = MaterialTheme.colorScheme.outline,
+			maxLines = 1,
+			softWrap = false,
+		)
+		HdMonoLabel(
+			text = value,
+			style = MaterialTheme.typography.labelMedium,
+			color = if (muted) {
+				MaterialTheme.colorScheme.outline
+			} else {
+				MaterialTheme.colorScheme.onSurfaceVariant
+			},
+			maxLines = 1,
+			softWrap = false,
+		)
+	}
 }
 
 @Composable

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/reauthentication/ReauthenticationUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/reauthentication/ReauthenticationUi.kt
@@ -1,166 +1,234 @@
 package com.darkrockstudios.apps.hammer.common.reauthentication
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.common.components.serverreauthentication.ServerReauthentication
-import com.darkrockstudios.apps.hammer.common.compose.SimpleDialog
-import com.darkrockstudios.apps.hammer.common.compose.SpacerXL
+import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialogContainer
 import com.darkrockstudios.apps.hammer.common.compose.Ui
-import com.darkrockstudios.apps.hammer.common.compose.moveFocusOnTab
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 
-@OptIn(ExperimentalMaterial3Api::class)
+private val DialogMaxWidth = 480.dp
+
 @Composable
 fun ReauthenticationUi(
 	component: ServerReauthentication,
 ) {
 	val state by component.state.subscribeAsState()
 
-	val focusManager = LocalFocusManager.current
+	var passwordVisible by rememberSaveable(state.showReauth) { mutableStateOf(false) }
 
-	var passwordVisible by rememberSaveable { mutableStateOf(false) }
-	var isOpen by remember { mutableStateOf(state.showReauth) }
-	LaunchedEffect(state.showReauth) { if (state.showReauth) isOpen = true }
+	var renderInternal by remember { mutableStateOf(state.showReauth) }
+	LaunchedEffect(state.showReauth) { if (state.showReauth) renderInternal = true }
 
-	SimpleDialog(
-		onCloseRequest = { isOpen = false },
-		onDismissed = component::cancelReauthentication,
-		visible = isOpen && state.showReauth,
-		title = Res.string.reauth_title.get(),
+	if (!renderInternal) return
+
+	AnimatedDialogContainer(
+		isOpen = state.showReauth,
+		onDismissRequest = { component.cancelReauthentication() },
+		onClosed = { renderInternal = false },
+		properties = DialogProperties(usePlatformDefaultWidth = false),
 	) {
-		Box(
-			modifier = Modifier.padding(Ui.Padding.XL),
-			contentAlignment = Alignment.Center
-		) {
+		ReauthenticationContent(
+			state = state,
+			passwordVisible = passwordVisible,
+			onPasswordVisibleChange = { passwordVisible = it },
+			onPasswordChange = { component.updateServerPassword(it) },
+			onClose = { component.cancelReauthentication() },
+			onLogin = { component.reauthenticate(password = state.serverPassword) },
+			modifier = Modifier.predictiveBackTransform(),
+		)
+	}
+}
+
+/**
+ * The visual body of the re-auth dialog — masthead, server identity, password field, and
+ * action row — split out from the [AnimatedDialogContainer] shell so it renders directly in
+ * `@Preview` (the dialog opens its own window, which preview tooling can't capture).
+ */
+@Composable
+internal fun ReauthenticationContent(
+	state: ServerReauthentication.State,
+	passwordVisible: Boolean,
+	onPasswordVisibleChange: (Boolean) -> Unit,
+	onPasswordChange: (String) -> Unit,
+	onClose: () -> Unit,
+	onLogin: () -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	Surface(
+		modifier = modifier
+			.padding(Ui.Padding.M)
+			.widthIn(max = DialogMaxWidth)
+			.fillMaxWidth(),
+		shape = RectangleShape,
+		color = MaterialTheme.colorScheme.surface,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+		border = BorderStroke(
+			width = Dp.Hairline,
+			color = MaterialTheme.colorScheme.outlineVariant,
+		),
+	) {
+		Column {
+			HdMasthead(
+				section = Res.string.reauth_title.get(),
+				leadingMeta = listOf(Res.string.reauth_token_expired.get()),
+				trailing = {
+					HdMastheadAction(
+						label = "× " + Res.string.close_dialog_button.get(),
+						onClick = onClose,
+					)
+				},
+			)
+			HdFolioDivider()
+
+			Header()
+
 			if (state.serverWorking) {
-				CircularProgressIndicator(
-					modifier = Modifier.align(Alignment.Center).size(128.dp)
+				LinearProgressIndicator(
+					modifier = Modifier
+						.fillMaxWidth()
+						.padding(horizontal = Ui.Padding.XL)
+						.height(2.dp),
+					color = MaterialTheme.colorScheme.primary,
 				)
 			}
 
-			Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+			Column(
+				modifier = Modifier
+					.fillMaxWidth()
+					.verticalScroll(rememberScrollState())
+					.padding(
+						start = Ui.Padding.XL,
+						end = Ui.Padding.XL,
+						top = Ui.Padding.L,
+						bottom = Ui.Padding.L,
+					),
+				verticalArrangement = Arrangement.spacedBy(Ui.Padding.L),
+			) {
 				Text(
-					Res.string.reauth_explanation.get(),
-					style = MaterialTheme.typography.bodyMedium
-				)
-
-				Spacer(modifier = Modifier.size(Ui.Padding.L))
-
-				Text(
-					Res.string.reauth_server_url.get(),
-					style = MaterialTheme.typography.bodyLarge,
-					fontWeight = FontWeight.Bold
-				)
-				Text(
-					state.serverUrl,
+					text = Res.string.reauth_explanation.get(),
 					style = MaterialTheme.typography.bodyMedium,
-					fontWeight = FontWeight.Thin
+					color = MaterialTheme.colorScheme.onSurfaceVariant,
 				)
 
-				Text(
-					Res.string.reauth_server_email.get(),
-					style = MaterialTheme.typography.bodyLarge,
-					fontWeight = FontWeight.Bold
-				)
-				Text(
-					state.serverEmail,
-					style = MaterialTheme.typography.bodyMedium,
-					fontWeight = FontWeight.Thin
+				HdMetadataItem(
+					label = Res.string.reauth_server_url.get(),
+					value = state.serverUrl,
+					selectable = true,
 				)
 
-				SpacerXL()
+				HdMetadataItem(
+					label = Res.string.reauth_server_email.get(),
+					value = state.serverEmail,
+					selectable = true,
+				)
 
-				OutlinedTextField(
+				HdHairlineField(
+					label = Res.string.settings_server_setup_password_hint.get(),
 					value = state.serverPassword,
-					onValueChange = { component.updateServerPassword(it) },
-					label = { Text(Res.string.settings_server_setup_password_hint.get()) },
+					onValueChange = onPasswordChange,
+					placeholder = Res.string.settings_server_setup_password_hint.get(),
 					singleLine = true,
-					placeholder = { Text(Res.string.settings_server_setup_password_hint.get()) },
-					visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-					modifier = Modifier.moveFocusOnTab(),
-					keyboardOptions = KeyboardOptions(
-						autoCorrect = false,
-						imeAction = ImeAction.Done,
-						keyboardType = KeyboardType.Password
-					),
-					keyboardActions = KeyboardActions(
-						onNext = { focusManager.moveFocus(FocusDirection.Down) },
-					),
-					trailingIcon = {
-						val image = if (passwordVisible)
-							Icons.Filled.Visibility
-						else Icons.Filled.VisibilityOff
+					imeAction = ImeAction.Done,
+					keyboardType = KeyboardType.Password,
+					visualTransformation = if (passwordVisible) VisualTransformation.None
+					else PasswordVisualTransformation(),
+					enabled = !state.serverWorking,
+				)
 
-						// Please provide localized description for accessibility services
-						val description = if (passwordVisible)
-							Res.string.settings_server_setup_password_hide.get()
-						else
-							Res.string.settings_server_setup_password_show.get()
-
-						IconButton(onClick = { passwordVisible = !passwordVisible }) {
-							Icon(imageVector = image, description)
-						}
+				HdHairlineToggleRow(
+					checked = passwordVisible,
+					onCheckedChange = onPasswordVisibleChange,
+					label = if (passwordVisible) {
+						Res.string.settings_server_setup_password_hide.get()
+					} else {
+						Res.string.settings_server_setup_password_show.get()
 					},
-					enabled = state.serverWorking.not()
 				)
 
 				state.serverError?.let { error ->
-					Text(
-						error,
+					HdMonoLabel(
+						text = "! $error",
 						color = MaterialTheme.colorScheme.error,
-						style = MaterialTheme.typography.bodySmall,
-						fontStyle = FontStyle.Italic
 					)
 				}
-
-				Spacer(modifier = Modifier.size(Ui.Padding.L))
-
-				Row(
-					horizontalArrangement = Arrangement.SpaceBetween
-				) {
-					Button(
-						onClick = {
-							component.reauthenticate(password = state.serverPassword)
-						},
-						enabled = state.serverWorking.not()
-					) {
-						Text(Res.string.settings_server_setup_login_button.get())
-					}
-
-					SpacerXL()
-
-					Button(
-						onClick = {
-							component.cancelReauthentication()
-						},
-						enabled = state.serverWorking.not()
-					) {
-						Text(Res.string.settings_server_setup_cancel_button.get())
-					}
-				}
 			}
+
+			HorizontalDivider(
+				thickness = Dp.Hairline,
+				color = MaterialTheme.colorScheme.outlineVariant,
+			)
+
+			ActionRow(
+				working = state.serverWorking,
+				onCancel = onClose,
+				onLogin = onLogin,
+			)
 		}
+	}
+}
+
+@Composable
+private fun Header() {
+	Text(
+		text = Res.string.reauth_title.get(),
+		style = MaterialTheme.typography.headlineSmall,
+		color = MaterialTheme.colorScheme.onSurface,
+		modifier = Modifier
+			.fillMaxWidth()
+			.padding(
+				start = Ui.Padding.XL,
+				end = Ui.Padding.XL,
+				top = Ui.Padding.L,
+				bottom = Ui.Padding.S,
+			),
+	)
+}
+
+@Composable
+private fun ActionRow(
+	working: Boolean,
+	onCancel: () -> Unit,
+	onLogin: () -> Unit,
+) {
+	Row(
+		modifier = Modifier
+			.fillMaxWidth()
+			.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.L),
+		verticalAlignment = Alignment.CenterVertically,
+		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
+	) {
+		HdHairlineButton(
+			label = Res.string.settings_server_setup_cancel_button.get(),
+			onClick = onCancel,
+			enabled = !working,
+		)
+
+		Spacer(modifier = Modifier.weight(1f))
+
+		HdHairlineButton(
+			label = Res.string.settings_server_setup_login_button.get(),
+			onClick = onLogin,
+			enabled = !working,
+			emphasised = true,
+		)
 	}
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/ProjectSelectionUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/ProjectSelectionUi.Preview.kt
@@ -3,6 +3,7 @@ package com.darkrockstudios.apps.hammer.common.preview
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -26,6 +27,22 @@ private fun ProjectCardPreview() {
 
 		AppTheme(globalSettingsPreview, true) {
 			ProjectIndexRow(true, 0, data, {}, {}, {})
+		}
+	}
+}
+
+@Preview
+@Composable
+private fun ProjectCardCompactPreview() {
+	val data = fakeProjectData()
+	Column(modifier = Modifier.width(360.dp)) {
+		Spacer(modifier = Modifier.size(32.dp))
+
+		AppTheme(globalSettingsPreview, true) {
+			Column {
+				ProjectIndexRow(false, 0, data, {}, {}, {})
+				ProjectIndexRow(false, 1, data, {}, {}, {})
+			}
 		}
 	}
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/ReauthenticationUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/ReauthenticationUi.Preview.kt
@@ -1,0 +1,92 @@
+package com.darkrockstudios.apps.hammer.common.preview
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.hammer.common.components.serverreauthentication.ServerReauthentication
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.reauthentication.ReauthenticationContent
+
+private fun previewState(
+	password: String = "",
+	working: Boolean = false,
+	error: String? = null,
+) = ServerReauthentication.State(
+	showReauth = true,
+	serverWorking = working,
+	serverUrl = "https://sync.darkrockstudios.com",
+	serverEmail = "writer@example.com",
+	serverPassword = password,
+	serverError = error,
+)
+
+/**
+ * Renders [ReauthenticationContent] on a scrim-like backdrop. The live re-auth dialog hangs in
+ * its own [androidx.compose.ui.window.Dialog] window, so we preview the extracted body directly.
+ */
+@Composable
+private fun ReauthPreviewScaffold(
+	state: ServerReauthentication.State,
+	darkTheme: Boolean,
+) {
+	var password by remember { mutableStateOf(state.serverPassword) }
+	var passwordVisible by remember { mutableStateOf(false) }
+
+	AppTheme(globalSettingsPreview, useDarkTheme = darkTheme) {
+		Box(
+			modifier = Modifier
+				.background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f))
+				.padding(24.dp),
+			contentAlignment = Alignment.Center,
+		) {
+			ReauthenticationContent(
+				state = state.copy(serverPassword = password),
+				passwordVisible = passwordVisible,
+				onPasswordVisibleChange = { passwordVisible = it },
+				onPasswordChange = { password = it },
+				onClose = {},
+				onLogin = {},
+				modifier = Modifier.widthIn(max = 480.dp).fillMaxWidth(),
+			)
+		}
+	}
+}
+
+@Preview
+@Composable
+private fun ReauthenticationPreview() {
+	ReauthPreviewScaffold(previewState(), darkTheme = false)
+}
+
+@Preview
+@Composable
+private fun ReauthenticationDarkPreview() {
+	ReauthPreviewScaffold(previewState(password = "hunter2"), darkTheme = true)
+}
+
+@Preview
+@Composable
+private fun ReauthenticationWorkingPreview() {
+	ReauthPreviewScaffold(previewState(password = "hunter2", working = true), darkTheme = false)
+}
+
+@Preview
+@Composable
+private fun ReauthenticationErrorPreview() {
+	ReauthPreviewScaffold(
+		previewState(error = "Invalid email or password."),
+		darkTheme = false,
+	)
+}


### PR DESCRIPTION
First run of the macOS/iOS App Store publishing pipeline surfaced several issues. This fixes the code bug and hardens the signing workflow, and adds a CI guard so the iOS compile break can't recur silently.

## Changes

- **`ZipUtils.kt`** — `unzipBytesToDirectory` used `sink.buffer().use { }`, which only resolves on the JVM (okio's `Closeable` maps to `java.io.Closeable`, an `AutoCloseable`). On Kotlin/Native the only `use` candidate is `kotlin.AutoCloseable.use`, which okio's `BufferedSink` doesn't satisfy → the iOS archive failed to compile. Switched to `FileSystem.write { }`, which buffers and closes on all targets. Desktop `ZipUtilsTest` still passes.

- **`build.yml`** — added an `ios-compile` job (macOS runner) that compiles `:composeUi` for `iosArm64` + `iosSimulatorArm64`, transitively compiling `base` + `common`. Pure compile gate (no Xcode, no signing). This would have caught the bug above on PR instead of at release time. Removed the stale, signing-heavy commented-out Xcode job it supersedes.

- **`publish-mac-app-store.yml`** — import the Apple WWDR intermediate before the leaf cert (otherwise `find-identity -v` hides chain-incomplete certs); print the signing-keychain identities up front; dump the `jpackage` `*-err.txt`/`*-out.txt` on failure (the real packaging error is otherwise never surfaced in CI).

## Note (operational, not in this PR)
The `MAC_DISTRIBUTION_CERT_P12_BASE64` secret must contain **both** the `3rd Party Mac Developer Application` and `3rd Party Mac Developer Installer` identities (each with its private key). The current secret is missing the Installer cert, so `.pkg` signing still fails until that's re-exported.