### PR TITLE
Mac App Store: dry-run workflow + two-cert signing fix

### DIFF
--- a/.github/workflows/dry-run-mac-app-store.yml
+++ b/.github/workflows/dry-run-mac-app-store.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Set up signing keychain
         env:
           CERT_P12_BASE64: ${{ secrets.MAC_DISTRIBUTION_CERT_P12_BASE64 }}
+          INSTALLER_P12_BASE64: ${{ secrets.MAC_INSTALLER_CERT_P12_BASE64 }}
           CERT_PASSWORD: ${{ secrets.MAC_DISTRIBUTION_CERT_PASSWORD }}
         run: |
           KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
@@ -65,8 +66,13 @@ jobs:
             -o "$RUNNER_TEMP/AppleWWDRCAG3.cer"
           security import "$RUNNER_TEMP/AppleWWDRCAG3.cer" -k "$KEYCHAIN_PATH"
 
+          # Two separate single-identity .p12 files: macOS `security import`
+          # only ingests one identity from a combined multi-key .p12, so the
+          # Application and Installer certs are imported from their own files.
           echo -n "$CERT_P12_BASE64" | base64 --decode -o "$RUNNER_TEMP/cert.p12"
           security import "$RUNNER_TEMP/cert.p12" -P "$CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          echo -n "$INSTALLER_P12_BASE64" | base64 --decode -o "$RUNNER_TEMP/installer.p12"
+          security import "$RUNNER_TEMP/installer.p12" -P "$CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"' | xargs)
 

--- a/.github/workflows/dry-run-mac-app-store.yml
+++ b/.github/workflows/dry-run-mac-app-store.yml
@@ -4,6 +4,12 @@ name: Dry Run — Mac App Store
 # profile plumbing as the real publish workflow, then saves the .pkg as an
 # artifact. Safe to run on any branch — nothing is released.
 on:
+  # Temporary: lets the dry run trigger on pushes to this branch before the
+  # workflow exists on the default branch (workflow_dispatch requires that).
+  # Remove this `push` block once the workflow is merged to the default branch.
+  push:
+    branches:
+      - ci/mac-app-store-dry-run
   workflow_dispatch:
     inputs:
       build_number:

--- a/.github/workflows/dry-run-mac-app-store.yml
+++ b/.github/workflows/dry-run-mac-app-store.yml
@@ -1,0 +1,102 @@
+name: Dry Run — Mac App Store
+# Builds, signs, and verifies the Mac App Store .pkg in CI without uploading
+# anything to App Store Connect. Exercises the same keychain + provisioning
+# profile plumbing as the real publish workflow, then saves the .pkg as an
+# artifact. Safe to run on any branch — nothing is released.
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: 'Build number to stamp (dry run only; not validated against TestFlight)'
+        required: false
+        default: '999'
+
+jobs:
+  dry-run-mac-app-store:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1.307.0
+        with:
+          ruby-version: '3.4.8'
+          bundler-cache: true
+
+      - name: Grant Permission to Execute
+        run: chmod +x gradlew desktop/scripts/build-appstore.sh
+
+      - name: Install bundle
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Set up signing keychain
+        env:
+          CERT_P12_BASE64: ${{ secrets.MAC_DISTRIBUTION_CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.MAC_DISTRIBUTION_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> $GITHUB_ENV
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # The leaf signing certs chain through Apple's WWDR intermediate. Without
+          # it in the keychain, `find-identity -v` (valid-only) silently hides them.
+          curl -fsSL https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer \
+            -o "$RUNNER_TEMP/AppleWWDRCAG3.cer"
+          security import "$RUNNER_TEMP/AppleWWDRCAG3.cer" -k "$KEYCHAIN_PATH"
+
+          echo -n "$CERT_P12_BASE64" | base64 --decode -o "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -P "$CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"' | xargs)
+
+      - name: Place provisioning profiles
+        env:
+          EMBEDDED_PROFILE_B64: ${{ secrets.MAC_EMBEDDED_PROVISIONING_PROFILE_BASE64 }}
+          RUNTIME_PROFILE_B64: ${{ secrets.MAC_RUNTIME_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          echo -n "$EMBEDDED_PROFILE_B64" | base64 --decode -o desktop/embedded.provisionprofile
+          echo -n "$RUNTIME_PROFILE_B64" | base64 --decode -o desktop/runtime.provisionprofile
+
+      - name: Build & verify (no upload) 🍎
+        env:
+          BUILD_NUMBER: ${{ github.event.inputs.build_number }}
+        run: bundle exec fastlane mac desktop_build_only
+
+      - name: Upload .pkg artifact
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mac-app-store-pkg-dry-run
+          path: desktop/build/installers/main-release/pkg/*.pkg
+          if-no-files-found: error
+
+      - name: Upload Gradle problems report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gradle-problems-report-macos-dry-run
+          path: build/reports/problems/problems-report.html
+          if-no-files-found: ignore
+
+      - name: Clean up signing material
+        if: always()
+        run: |
+          if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+          rm -f desktop/embedded.provisionprofile desktop/runtime.provisionprofile

--- a/.github/workflows/dry-run-mac-app-store.yml
+++ b/.github/workflows/dry-run-mac-app-store.yml
@@ -4,12 +4,6 @@ name: Dry Run — Mac App Store
 # profile plumbing as the real publish workflow, then saves the .pkg as an
 # artifact. Safe to run on any branch — nothing is released.
 on:
-  # Temporary: lets the dry run trigger on pushes to this branch before the
-  # workflow exists on the default branch (workflow_dispatch requires that).
-  # Remove this `push` block once the workflow is merged to the default branch.
-  push:
-    branches:
-      - ci/mac-app-store-dry-run
   workflow_dispatch:
     inputs:
       build_number:

--- a/.github/workflows/publish-mac-app-store.yml
+++ b/.github/workflows/publish-mac-app-store.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Set up signing keychain
         env:
           CERT_P12_BASE64: ${{ secrets.MAC_DISTRIBUTION_CERT_P12_BASE64 }}
+          INSTALLER_P12_BASE64: ${{ secrets.MAC_INSTALLER_CERT_P12_BASE64 }}
           CERT_PASSWORD: ${{ secrets.MAC_DISTRIBUTION_CERT_PASSWORD }}
         run: |
           KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
@@ -51,8 +52,13 @@ jobs:
             -o "$RUNNER_TEMP/AppleWWDRCAG3.cer"
           security import "$RUNNER_TEMP/AppleWWDRCAG3.cer" -k "$KEYCHAIN_PATH"
 
+          # Two separate single-identity .p12 files: macOS `security import`
+          # only ingests one identity from a combined multi-key .p12, so the
+          # Application and Installer certs are imported from their own files.
           echo -n "$CERT_P12_BASE64" | base64 --decode -o "$RUNNER_TEMP/cert.p12"
           security import "$RUNNER_TEMP/cert.p12" -P "$CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          echo -n "$INSTALLER_P12_BASE64" | base64 --decode -o "$RUNNER_TEMP/installer.p12"
+          security import "$RUNNER_TEMP/installer.p12" -P "$CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"' | xargs)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -60,6 +60,21 @@ platform :mac do
     )
   end
 
+  desc "Dry run: build, sign, and verify the .pkg without touching App Store Connect. No API key, no upload — for testing the pipeline. Build number defaults to 999; set BUILD_NUMBER to override."
+  lane :desktop_build_only do
+    build_number = ENV["BUILD_NUMBER"]
+    build_number = "999" if build_number.nil? || build_number.empty?
+    UI.message("Mac App Store DRY RUN build number: #{build_number}")
+
+    # build-appstore.sh builds the .pkg and runs codesign + pkgutil signature
+    # checks; it fails the lane if signing material is missing or invalid.
+    sh("cd \"#{File.expand_path('..', __dir__)}\" && ./desktop/scripts/build-appstore.sh #{build_number}")
+
+    pkg_path = Dir.glob(File.expand_path("../desktop/build/installers/main-release/pkg/*.pkg", __dir__)).first
+    UI.user_error!("Build produced no .pkg") unless pkg_path
+    UI.success("Dry run OK — built and verified #{pkg_path} (not uploaded)")
+  end
+
   desc "Submit the latest processed TestFlight build for App Store review. Metadata + screenshots stay in App Store Connect for now."
   lane :desktop_release do
     api_key = appstore_api_key


### PR DESCRIPTION
## What

Adds a way to verify the Mac App Store pipeline without releasing, and fixes a latent signing bug it uncovered.

### Dry-run workflow + lane
- New `fastlane mac desktop_build_only` lane: builds, signs, and verifies the `.pkg` (codesign + pkgutil) but skips the App Store Connect build-number lookup and upload — no API key, nothing released.
- New **Dry Run — Mac App Store** workflow (`workflow_dispatch`): mirrors the real publish workflow's keychain + provisioning-profile setup, runs the build-only lane, and uploads the `.pkg` as an artifact.

### Signing fix (found by the dry run)
- macOS `security import` only ingests **one** identity from a combined multi-key `.p12` (non-deterministic which one), so the single cert secret left the **Installer** cert missing from the CI keychain — the real `publish-mac-app-store.yml` would have failed too.
- Both the dry-run and real workflows now import the Application and Installer certs from **two separate single-identity `.p12` files**. Adds a new secret `MAC_INSTALLER_CERT_P12_BASE64`.

## Verification
- Local: `desktop_build_only` builds + passes codesign/pkgutil.
- CI: dry run is **green** end-to-end (keychain → build → sign → verify → artifact).

## Note for deployers
Requires the new repo secret `MAC_INSTALLER_CERT_P12_BASE64` (Installer cert as a single-identity `.p12`), and `MAC_DISTRIBUTION_CERT_P12_BASE64` should now hold the Application cert as its own single-identity `.p12`. Both decrypt with `MAC_DISTRIBUTION_CERT_PASSWORD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)