### PR TITLE
Fix iOS archive: unzip compiles for Kotlin/Native

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/util/zip/ZipUtils.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/util/zip/ZipUtils.kt
@@ -6,7 +6,6 @@ import no.synth.kmpzip.zip.ZipInputStream
 import no.synth.kmpzip.zip.safeEntrySegments
 import okio.FileSystem
 import okio.Path
-import okio.buffer
 
 private const val COPY_BUFFER_SIZE = 8192
 
@@ -60,11 +59,11 @@ fun unzipBytesToDirectory(
 				fileSystem.createDirectories(target)
 			} else {
 				target.parent?.let { fileSystem.createDirectories(it) }
-				fileSystem.sink(target).buffer().use { sink ->
+				fileSystem.write(target) {
 					while (true) {
 						val n = zis.read(buffer, 0, buffer.size)
 						if (n == -1) break
-						sink.write(buffer, 0, n)
+						write(buffer, 0, n)
 					}
 				}
 			}


### PR DESCRIPTION
## What
`ZipUtils.unzipBytesToDirectory` used `fileSystem.sink(target).buffer().use { }`, where okio's `Sink.buffer()` fails to resolve for the iOS/native target (receiver type mismatch), cascading into a "cannot infer R" error on `.use` and failing the iOS archive. It compiled fine for JVM, so it only surfaced in the iOS publish workflow.

Switched to okio's multiplatform `FileSystem.write(target) { }` helper, which yields a `BufferedSink` directly and handles buffering + closing.

## Why this completes the iOS pipeline
`develop` already has the `Select Xcode 26` step (needed because App Store Connect now requires the iOS 26 SDK). Verified `macos-latest` (macOS 15) ships Xcode 26.3 at `/Applications/Xcode_26.3.app`, which that step selects. This compile fix was the only remaining gap.

## Verification
- `:common:compileKotlinIosArm64` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)