### PR TITLE
Expand Android instrumented UI test coverage across editor screens

### DIFF
--- a/android/src/androidTest/kotlin/EditorNavigationTest.kt
+++ b/android/src/androidTest/kotlin/EditorNavigationTest.kt
@@ -1,0 +1,57 @@
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_ENCYCLOPEDIA_TAG
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_EDITOR_TAG
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_HOME_TAG
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_NOTES_TAG
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_TIMELINE_TAG
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Smoke-tests every top-level editor destination by seeding a project, launching straight into
+ * the editor, and clicking through each nav item. Composing a screen that throws fails the test.
+ */
+@RunWith(AndroidJUnit4::class)
+class EditorNavigationTest {
+
+	@get:Rule
+	val composeRule = createEmptyComposeRule()
+
+	private lateinit var projectDef: ProjectDef
+	private lateinit var scenario: ActivityScenario<ProjectRootActivity>
+
+	@Before
+	fun setup() {
+		projectDef = EditorTestHarness.seedProject("E2E Nav")
+		scenario = EditorTestHarness.launchEditor(projectDef)
+	}
+
+	@Test
+	fun visitsEveryTopLevelDestination() {
+		// Editor opens on Home; the bottom bar must show all five destinations.
+		composeRule.waitUntil(timeoutMillis = 10_000) {
+			composeRule.onAllNodesWithTag(NAV_HOME_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+
+		listOf(NAV_EDITOR_TAG, NAV_NOTES_TAG, NAV_ENCYCLOPEDIA_TAG, NAV_TIMELINE_TAG, NAV_HOME_TAG)
+			.forEach { tag ->
+				composeRule.navigateTo(tag)
+				composeRule.onNodeWithTag(tag).assertIsDisplayed()
+			}
+	}
+
+	@After
+	fun tearDown() {
+		EditorTestHarness.teardown(scenario, projectDef)
+	}
+}

--- a/android/src/androidTest/kotlin/EditorTestHarness.kt
+++ b/android/src/androidTest/kotlin/EditorTestHarness.kt
@@ -1,0 +1,71 @@
+import android.content.Context
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.common.data.ClientResult
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
+import org.koin.java.KoinJavaComponent.getKoin
+
+/**
+ * Shared helpers for editor instrumented tests: seed a project through the real Koin graph,
+ * launch straight into [ProjectRootActivity] (no click-through), navigate, and tear down
+ * without racing the project-scope buffer flush.
+ */
+object EditorTestHarness {
+
+	fun repository(): ProjectsRepository = getKoin().get()
+
+	private fun context(): Context =
+		InstrumentationRegistry.getInstrumentation().targetContext
+
+	/** Create a uniquely-named project so re-runs don't collide; returns its def. */
+	fun seedProject(baseName: String): ProjectDef {
+		val result = repository().createProject("$baseName ${System.currentTimeMillis()}")
+		check(result is ClientResult.Success) { "Failed to seed project: $result" }
+		return result.data
+	}
+
+	fun launchEditor(projectDef: ProjectDef): ActivityScenario<ProjectRootActivity> =
+		ActivityScenario.launch(ProjectRootActivity.createIntent(context(), projectDef))
+
+	/** Finish + idle before deleting: the project-scope close flushes scene buffers and racing it crashes. */
+	fun teardown(scenario: ActivityScenario<ProjectRootActivity>, projectDef: ProjectDef) {
+		scenario.onActivity { it.finish() }
+		InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+		scenario.close()
+		repository().deleteProject(projectDef)
+	}
+}
+
+/** Matches nodes whose testTag starts with [prefix] - for list items keyed by an unknown id. */
+fun hasTestTagPrefix(prefix: String) = SemanticsMatcher("testTag starts with '$prefix'") { node ->
+	node.config.getOrNull(SemanticsProperties.TestTag)?.startsWith(prefix) == true
+}
+
+/** Wait for a nav destination tag to render, then click it. */
+fun ComposeTestRule.navigateTo(navTag: String) {
+	waitUntil(timeoutMillis = 10_000) {
+		onAllNodesWithTag(navTag).fetchSemanticsNodes().isNotEmpty()
+	}
+	onNodeWithTag(navTag).performClick()
+}
+
+/**
+ * Type into the tagged markdown/scene editor. It consumes hardware key events rather than
+ * exposing Compose SetText semantics, so performTextInput can't drive it - focus it, then
+ * inject real keystrokes via the instrumentation.
+ */
+fun ComposeTestRule.typeIntoEditor(tag: String, text: String) {
+	onNodeWithTag(tag).performClick()
+	waitForIdle()
+	InstrumentationRegistry.getInstrumentation().sendStringSync(text)
+	waitForIdle()
+}

--- a/android/src/androidTest/kotlin/EncyclopediaWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/EncyclopediaWorkflowTest.kt
@@ -1,0 +1,79 @@
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.encyclopedia.ENCYCLOPEDIA_CREATE_CONFIRM_TAG
+import com.darkrockstudios.apps.hammer.common.encyclopedia.ENCYCLOPEDIA_CREATE_FAB_TAG
+import com.darkrockstudios.apps.hammer.common.encyclopedia.ENCYCLOPEDIA_CREATE_NAME_TAG
+import com.darkrockstudios.apps.hammer.common.encyclopedia.ENCYCLOPEDIA_CREATE_TAGS_TAG
+import com.darkrockstudios.apps.hammer.common.encyclopedia.encyclopediaTypeCellTag
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_ENCYCLOPEDIA_TAG
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Encyclopedia happy path: navigate to encyclopedia, create an entry (name + type + tag; description
+ * optional), see it land in the browse grid, and open it.
+ */
+@RunWith(AndroidJUnit4::class)
+class EncyclopediaWorkflowTest {
+
+	@get:Rule
+	val composeRule = createEmptyComposeRule()
+
+	private lateinit var projectDef: ProjectDef
+	private lateinit var scenario: ActivityScenario<ProjectRootActivity>
+
+	@Before
+	fun setup() {
+		projectDef = EditorTestHarness.seedProject("E2E Encyclopedia")
+		scenario = EditorTestHarness.launchEditor(projectDef)
+	}
+
+	@Test
+	fun createEntryThenOpenIt() {
+		composeRule.navigateTo(NAV_ENCYCLOPEDIA_TAG)
+
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(ENCYCLOPEDIA_CREATE_FAB_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(ENCYCLOPEDIA_CREATE_FAB_TAG).performClick()
+
+		// Name is required; type defaults to PERSON, pick PLACE. Trailing comma commits the tag.
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(ENCYCLOPEDIA_CREATE_NAME_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(ENCYCLOPEDIA_CREATE_NAME_TAG).performTextInput("Smoke Entry")
+		composeRule.onNodeWithTag(encyclopediaTypeCellTag(EntryType.PLACE)).performClick()
+		composeRule.onNodeWithTag(ENCYCLOPEDIA_CREATE_TAGS_TAG).performTextInput("hero,")
+		composeRule.onNodeWithTag(ENCYCLOPEDIA_CREATE_CONFIRM_TAG).performClick()
+
+		// Back on the browse grid, the new entry card appears (id unknown, match by tag prefix).
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodes(hasTestTagPrefix("encyclopedia-entry-")).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onAllNodes(hasTestTagPrefix("encyclopedia-entry-")).onFirst().assertIsDisplayed()
+
+		// Opening it leaves the browse list - the create FAB only shows there.
+		composeRule.onAllNodes(hasTestTagPrefix("encyclopedia-entry-")).onFirst().performClick()
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(ENCYCLOPEDIA_CREATE_FAB_TAG).fetchSemanticsNodes().isEmpty()
+		}
+	}
+
+	@After
+	fun tearDown() {
+		EditorTestHarness.teardown(scenario, projectDef)
+	}
+}

--- a/android/src/androidTest/kotlin/GlobalSearchTest.kt
+++ b/android/src/androidTest/kotlin/GlobalSearchTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.globalsearch.GLOBAL_SEARCH_INPUT_TAG
@@ -53,14 +52,15 @@ class GlobalSearchTest {
 		composeRule.onNodeWithTag(GLOBAL_SEARCH_INPUT_TAG).assertIsDisplayed()
 	}
 
-	// ProjectRootActivity.dispatchKeyEvent opens search on Ctrl+Shift+F (key down).
+	// ProjectRootActivity.dispatchKeyEvent opens search on Ctrl+Shift+F (key down). Dispatch it
+	// directly on the activity so it doesn't depend on the emulator's hardware-keyboard config.
 	private fun sendGlobalSearchShortcut() {
 		val now = SystemClock.uptimeMillis()
 		val event = KeyEvent(
 			now, now, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_F, 0,
 			KeyEvent.META_CTRL_ON or KeyEvent.META_SHIFT_ON,
 		)
-		InstrumentationRegistry.getInstrumentation().sendKeySync(event)
+		scenario.onActivity { it.dispatchKeyEvent(event) }
 	}
 
 	@After

--- a/android/src/androidTest/kotlin/GlobalSearchTest.kt
+++ b/android/src/androidTest/kotlin/GlobalSearchTest.kt
@@ -1,0 +1,70 @@
+import android.os.SystemClock
+import android.view.KeyEvent
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.globalsearch.GLOBAL_SEARCH_INPUT_TAG
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_HOME_TAG
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Global-search happy path: on Android the search modal is opened with the Ctrl+Shift+F chord
+ * (no on-screen trigger), so inject that key event, then confirm the search field renders and accepts a query.
+ */
+@RunWith(AndroidJUnit4::class)
+class GlobalSearchTest {
+
+	@get:Rule
+	val composeRule = createEmptyComposeRule()
+
+	private lateinit var projectDef: ProjectDef
+	private lateinit var scenario: ActivityScenario<ProjectRootActivity>
+
+	@Before
+	fun setup() {
+		projectDef = EditorTestHarness.seedProject("E2E Search")
+		scenario = EditorTestHarness.launchEditor(projectDef)
+	}
+
+	@Test
+	fun openGlobalSearchAndType() {
+		// Wait for the editor chrome before sending the shortcut.
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(NAV_HOME_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+
+		sendGlobalSearchShortcut()
+
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(GLOBAL_SEARCH_INPUT_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(GLOBAL_SEARCH_INPUT_TAG).performTextInput("smoke")
+		composeRule.onNodeWithTag(GLOBAL_SEARCH_INPUT_TAG).assertIsDisplayed()
+	}
+
+	// ProjectRootActivity.dispatchKeyEvent opens search on Ctrl+Shift+F (key down).
+	private fun sendGlobalSearchShortcut() {
+		val now = SystemClock.uptimeMillis()
+		val event = KeyEvent(
+			now, now, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_F, 0,
+			KeyEvent.META_CTRL_ON or KeyEvent.META_SHIFT_ON,
+		)
+		InstrumentationRegistry.getInstrumentation().sendKeySync(event)
+	}
+
+	@After
+	fun tearDown() {
+		EditorTestHarness.teardown(scenario, projectDef)
+	}
+}

--- a/android/src/androidTest/kotlin/NotesWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/NotesWorkflowTest.kt
@@ -1,0 +1,72 @@
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.notes.NOTES_CREATE_BODY_TAG
+import com.darkrockstudios.apps.hammer.common.notes.NOTES_CREATE_CONFIRM_TAG
+import com.darkrockstudios.apps.hammer.common.notes.NOTES_CREATE_FAB_TAG
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_NOTES_TAG
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Notes happy path: navigate to notes, create a note (body required) via the FAB + create screen,
+ * which returns to the browse list, then confirm the new note card appears and open it.
+ */
+@RunWith(AndroidJUnit4::class)
+class NotesWorkflowTest {
+
+	@get:Rule
+	val composeRule = createEmptyComposeRule()
+
+	private lateinit var projectDef: ProjectDef
+	private lateinit var scenario: ActivityScenario<ProjectRootActivity>
+
+	@Before
+	fun setup() {
+		projectDef = EditorTestHarness.seedProject("E2E Notes")
+		scenario = EditorTestHarness.launchEditor(projectDef)
+	}
+
+	@Test
+	fun createNoteThenOpenIt() {
+		composeRule.navigateTo(NAV_NOTES_TAG)
+
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(NOTES_CREATE_FAB_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(NOTES_CREATE_FAB_TAG).performClick()
+
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(NOTES_CREATE_BODY_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.typeIntoEditor(NOTES_CREATE_BODY_TAG, "E2E smoke note body")
+		composeRule.onNodeWithTag(NOTES_CREATE_CONFIRM_TAG).performClick()
+
+		// Creating returns to the browse grid; the new note card appears (id unknown, match by prefix).
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodes(hasTestTagPrefix("note-card-")).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onAllNodes(hasTestTagPrefix("note-card-")).onFirst().assertIsDisplayed()
+
+		// Opening it leaves the browse list - the create FAB only shows there.
+		composeRule.onAllNodes(hasTestTagPrefix("note-card-")).onFirst().performClick()
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(NOTES_CREATE_FAB_TAG).fetchSemanticsNodes().isEmpty()
+		}
+	}
+
+	@After
+	fun tearDown() {
+		EditorTestHarness.teardown(scenario, projectDef)
+	}
+}

--- a/android/src/androidTest/kotlin/ProjectHomeTest.kt
+++ b/android/src/androidTest/kotlin/ProjectHomeTest.kt
@@ -1,0 +1,52 @@
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.projecthome.PROJECT_STATS_TAG
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_HOME_TAG
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Project-home happy path: the editor opens on the Home destination, which must render the project
+ * stats dashboard. Re-navigating Home keeps it stable.
+ */
+@RunWith(AndroidJUnit4::class)
+class ProjectHomeTest {
+
+	@get:Rule
+	val composeRule = createEmptyComposeRule()
+
+	private lateinit var projectDef: ProjectDef
+	private lateinit var scenario: ActivityScenario<ProjectRootActivity>
+
+	@Before
+	fun setup() {
+		projectDef = EditorTestHarness.seedProject("E2E Home")
+		scenario = EditorTestHarness.launchEditor(projectDef)
+	}
+
+	@Test
+	fun homeShowsProjectStats() {
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(PROJECT_STATS_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(PROJECT_STATS_TAG).assertIsDisplayed()
+
+		// Re-selecting Home keeps the stats dashboard stable.
+		composeRule.navigateTo(NAV_HOME_TAG)
+		composeRule.onNodeWithTag(PROJECT_STATS_TAG).assertIsDisplayed()
+	}
+
+	@After
+	fun tearDown() {
+		EditorTestHarness.teardown(scenario, projectDef)
+	}
+}

--- a/android/src/androidTest/kotlin/SceneEditorWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/SceneEditorWorkflowTest.kt
@@ -1,0 +1,78 @@
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_EDITOR_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.CREATE_ITEM_NAME_FIELD_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SCENE_LIST_ADD_BUTTON_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SCENE_LIST_ADD_SCENE_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.SCENE_EDITOR_SAVE_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.SCENE_EDITOR_TEXT_TAG
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Scene-editor happy path: create+select a scene, type into the editor, and save. The save action
+ * only appears when the buffer is dirty, so its appearance/disappearance confirms the edit + save.
+ */
+@RunWith(AndroidJUnit4::class)
+class SceneEditorWorkflowTest {
+
+	@get:Rule
+	val composeRule = createEmptyComposeRule()
+
+	private lateinit var projectDef: ProjectDef
+	private lateinit var scenario: ActivityScenario<ProjectRootActivity>
+
+	@Before
+	fun setup() {
+		projectDef = EditorTestHarness.seedProject("E2E SceneEditor")
+		scenario = EditorTestHarness.launchEditor(projectDef)
+	}
+
+	@Test
+	fun editSceneTextThenSave() {
+		composeRule.navigateTo(NAV_EDITOR_TAG)
+
+		// Create a scene and open it.
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(SCENE_LIST_ADD_BUTTON_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(SCENE_LIST_ADD_BUTTON_TAG).performClick()
+		composeRule.onNodeWithTag(SCENE_LIST_ADD_SCENE_TAG).performClick()
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(CREATE_ITEM_NAME_FIELD_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(CREATE_ITEM_NAME_FIELD_TAG).performTextInput("Opening")
+		composeRule.onNodeWithTag(CREATE_ITEM_NAME_FIELD_TAG).performImeAction()
+
+		// Creating a scene auto-opens it in the editor.
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(SCENE_EDITOR_TEXT_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.typeIntoEditor(SCENE_EDITOR_TEXT_TAG, "Once upon a time")
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(SCENE_EDITOR_SAVE_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+
+		// Saving clears the dirty buffer, so the save action disappears.
+		composeRule.onNodeWithTag(SCENE_EDITOR_SAVE_TAG).performClick()
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(SCENE_EDITOR_SAVE_TAG).fetchSemanticsNodes().isEmpty()
+		}
+	}
+
+	@After
+	fun tearDown() {
+		EditorTestHarness.teardown(scenario, projectDef)
+	}
+}

--- a/android/src/androidTest/kotlin/SceneListWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/SceneListWorkflowTest.kt
@@ -1,0 +1,84 @@
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_EDITOR_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.CREATE_ITEM_NAME_FIELD_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SCENE_LIST_ADD_BUTTON_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SCENE_LIST_ADD_GROUP_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SCENE_LIST_ADD_SCENE_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.SCENE_EDITOR_TEXT_TAG
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Scene-list happy path: create a group (stays in the list) and a scene (auto-opens the editor),
+ * exercising the add menu + create dialog for both.
+ */
+@RunWith(AndroidJUnit4::class)
+class SceneListWorkflowTest {
+
+	@get:Rule
+	val composeRule = createEmptyComposeRule()
+
+	private lateinit var projectDef: ProjectDef
+	private lateinit var scenario: ActivityScenario<ProjectRootActivity>
+
+	@Before
+	fun setup() {
+		projectDef = EditorTestHarness.seedProject("E2E SceneList")
+		scenario = EditorTestHarness.launchEditor(projectDef)
+	}
+
+	@Test
+	fun createGroupAndSceneFromAddMenu() {
+		composeRule.navigateTo(NAV_EDITOR_TAG)
+
+		// A group has no editor, so it lands in the tree and the list stays put.
+		addItem(SCENE_LIST_ADD_GROUP_TAG, "Act One")
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodes(hasTestTagPrefix("scene-group-")).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onAllNodes(hasTestTagPrefix("scene-group-")).onFirst().assertIsDisplayed()
+
+		// Creating a scene auto-selects it and opens the editor.
+		addItem(SCENE_LIST_ADD_SCENE_TAG, "Chapter One")
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(SCENE_EDITOR_TEXT_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(SCENE_EDITOR_TEXT_TAG).assertIsDisplayed()
+	}
+
+	// Open the add menu, pick scene/group, type a name, submit via the IME action.
+	private fun addItem(menuItemTag: String, name: String) {
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(SCENE_LIST_ADD_BUTTON_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(SCENE_LIST_ADD_BUTTON_TAG).performClick()
+		composeRule.onNodeWithTag(menuItemTag).performClick()
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(CREATE_ITEM_NAME_FIELD_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(CREATE_ITEM_NAME_FIELD_TAG).performTextInput(name)
+		composeRule.onNodeWithTag(CREATE_ITEM_NAME_FIELD_TAG).performImeAction()
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(CREATE_ITEM_NAME_FIELD_TAG).fetchSemanticsNodes().isEmpty()
+		}
+	}
+
+	@After
+	fun tearDown() {
+		EditorTestHarness.teardown(scenario, projectDef)
+	}
+}

--- a/android/src/androidTest/kotlin/TimelineWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/TimelineWorkflowTest.kt
@@ -1,0 +1,75 @@
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.darkrockstudios.apps.hammer.android.ProjectRootActivity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.projectroot.NAV_TIMELINE_TAG
+import com.darkrockstudios.apps.hammer.common.timeline.EVENT_CARD_TAG
+import com.darkrockstudios.apps.hammer.common.timeline.TIME_LINE_CREATE_CONFIRM_TAG
+import com.darkrockstudios.apps.hammer.common.timeline.TIME_LINE_CREATE_DATE_TAG
+import com.darkrockstudios.apps.hammer.common.timeline.TIME_LINE_CREATE_TAG
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Timeline happy path: navigate to the timeline, create an event via the FAB + create screen,
+ * see it land in the overview list, and open it. Reference template for the other feature tests.
+ */
+@RunWith(AndroidJUnit4::class)
+class TimelineWorkflowTest {
+
+	@get:Rule
+	val composeRule = createEmptyComposeRule()
+
+	private lateinit var projectDef: ProjectDef
+	private lateinit var scenario: ActivityScenario<ProjectRootActivity>
+
+	@Before
+	fun setup() {
+		projectDef = EditorTestHarness.seedProject("E2E Timeline")
+		scenario = EditorTestHarness.launchEditor(projectDef)
+	}
+
+	@Test
+	fun createEventThenOpenIt() {
+		composeRule.navigateTo(NAV_TIMELINE_TAG)
+
+		// Open the create screen via the FAB.
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(TIME_LINE_CREATE_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(TIME_LINE_CREATE_TAG).performClick()
+
+		// Content is optional, so a date alone persists an event.
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(TIME_LINE_CREATE_DATE_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onNodeWithTag(TIME_LINE_CREATE_DATE_TAG).performTextInput("Year One")
+		composeRule.onNodeWithTag(TIME_LINE_CREATE_CONFIRM_TAG).performClick()
+
+		// Back on the overview, the new event card appears.
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(EVENT_CARD_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.onAllNodesWithTag(EVENT_CARD_TAG)[0].assertIsDisplayed()
+
+		// Opening the event leaves the overview - the create FAB only shows there.
+		composeRule.onAllNodesWithTag(EVENT_CARD_TAG)[0].performClick()
+		composeRule.waitUntil(10_000) {
+			composeRule.onAllNodesWithTag(TIME_LINE_CREATE_TAG).fetchSemanticsNodes().isEmpty()
+		}
+	}
+
+	@After
+	fun tearDown() {
+		EditorTestHarness.teardown(scenario, projectDef)
+	}
+}

--- a/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/EditorTopBar.kt
+++ b/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/EditorTopBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.SceneEditor
@@ -52,12 +53,15 @@ actual fun EditorTopBar(
 
 				Spacer(modifier = Modifier.weight(1f))
 
-				IconButton(onClick = {
-					scope.launch {
-						component.storeSceneContent()
-						scope.launch { rootSnackbar.showSnackbar(strRes.get(Res.string.scene_editor_toast_save_successful)) }
-					}
-				}) {
+				IconButton(
+					onClick = {
+						scope.launch {
+							component.storeSceneContent()
+							scope.launch { rootSnackbar.showSnackbar(strRes.get(Res.string.scene_editor_toast_save_successful)) }
+						}
+					},
+					modifier = Modifier.testTag(SCENE_EDITOR_SAVE_TAG),
+				) {
 					Icon(
 						Icons.Filled.Save,
 						contentDescription = Res.string.scene_editor_save_button.get(),
@@ -145,6 +149,7 @@ private fun RenameSceneDialog(
 			autoFocus = true,
 			error = if (editSceneNameValue.isNotEmpty() && !isValid) errorMessage else null,
 			onImeAction = ::submit,
+			testTag = RENAME_SCENE_FIELD_TAG,
 		)
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/FormDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/FormDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -233,6 +234,7 @@ fun FormField(
 	singleLine: Boolean = true,
 	imeAction: ImeAction = ImeAction.Done,
 	onImeAction: (() -> Unit)? = null,
+	testTag: String? = null,
 ) {
 	val isError = !error.isNullOrEmpty()
 	val underlineColor = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.outline
@@ -279,7 +281,8 @@ fun FormField(
 				modifier = Modifier
 					.fillMaxWidth()
 					.padding(vertical = 6.dp)
-					.focusRequester(focusRequester),
+					.focusRequester(focusRequester)
+					.then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
 				decorationBox = { inner ->
 					if (value.isEmpty() && !placeholder.isNullOrEmpty()) {
 						Text(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdBottomBar.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdBottomBar.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
@@ -74,6 +75,7 @@ fun <T> HdBottomBar(
 	onSelect: (T) -> Unit,
 	modifier: Modifier = Modifier,
 	contentHeight: Dp = BarHeight,
+	itemTestTag: ((T) -> String)? = null,
 ) {
 	val selectedIndex = destinations.indexOfFirst { it.id == selectedId }.coerceAtLeast(0)
 	var barWidthPx by remember { mutableIntStateOf(0) }
@@ -109,6 +111,7 @@ fun <T> HdBottomBar(
 						destination = destination,
 						selected = destination.id == selectedId,
 						onClick = { onSelect(destination.id) },
+						testTag = itemTestTag?.invoke(destination.id),
 					)
 				}
 			}
@@ -132,6 +135,7 @@ private fun <T> RowScope.HdBottomBarItem(
 	destination: HdBottomBarDestination<T>,
 	selected: Boolean,
 	onClick: () -> Unit,
+	testTag: String? = null,
 ) {
 	val iconColor = if (selected) MaterialTheme.colorScheme.secondary
 	else MaterialTheme.colorScheme.onSurfaceVariant
@@ -143,7 +147,8 @@ private fun <T> RowScope.HdBottomBarItem(
 			.weight(1f)
 			.fillMaxHeight()
 			.clickable(onClick = onClick)
-			.semantics { contentDescription = destination.label },
+			.semantics { contentDescription = destination.label }
+			.then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
 		horizontalAlignment = Alignment.CenterHorizontally,
 		verticalArrangement = Arrangement.Center,
 	) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineField.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -51,6 +52,7 @@ fun HdHairlineField(
 	enabled: Boolean = true,
 	onFocusChanged: (Boolean) -> Unit = {},
 	trailing: (@Composable () -> Unit)? = null,
+	testTag: String? = null,
 ) {
 	Column(modifier = modifier.fillMaxWidth()) {
 		Row(
@@ -93,7 +95,8 @@ fun HdHairlineField(
 					onValueChange = onValueChange,
 					modifier = Modifier
 						.fillMaxWidth()
-						.onFocusChanged { onFocusChanged(it.isFocused) },
+						.onFocusChanged { onFocusChanged(it.isFocused) }
+						.then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
 					enabled = enabled,
 					singleLine = singleLine,
 					minLines = minLines,

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.input.key.*
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.Dp
@@ -40,6 +41,7 @@ fun HdHairlineTagField(
 	hint: String? = null,
 	placeholder: String? = null,
 	suggestTags: (prefix: String) -> List<String> = { emptyList() },
+	testTag: String? = null,
 ) {
 	var draft by remember { mutableStateOf("") }
 
@@ -134,6 +136,7 @@ fun HdHairlineTagField(
 							.fillMaxWidth()
 							.heightIn(min = 24.dp)
 							.onFocusChanged { tagsFocused = it.isFocused }
+							.then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
 							.onPreviewKeyEvent { event ->
 								if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
 								when (event.key) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTypePicker.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTypePicker.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -45,6 +46,7 @@ fun HdHairlineTypePicker(
 		EntryType.EVENT,
 		EntryType.IDEA,
 	),
+	cellTestTag: ((EntryType) -> String)? = null,
 ) {
 	val ruleColor = MaterialTheme.colorScheme.outlineVariant
 	Row(
@@ -69,6 +71,7 @@ fun HdHairlineTypePicker(
 				modifier = Modifier
 					.weight(1f)
 					.fillMaxHeight(),
+				testTag = cellTestTag?.invoke(type),
 			)
 		}
 	}
@@ -80,6 +83,7 @@ private fun HdTypePickerCell(
 	active: Boolean,
 	onClick: () -> Unit,
 	modifier: Modifier = Modifier,
+	testTag: String? = null,
 ) {
 	val typeColor = LocalHammerColors.current.colorFor(type)
 	val outlineVariant = MaterialTheme.colorScheme.outlineVariant
@@ -98,7 +102,8 @@ private fun HdTypePickerCell(
 	Column(
 		modifier = modifier
 			.background(background)
-			.clickable(onClick = onClick),
+			.clickable(onClick = onClick)
+			.then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
 		horizontalAlignment = Alignment.CenterHorizontally,
 	) {
 		Box(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdNavRail.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdNavRail.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
@@ -97,6 +98,7 @@ fun <T> HdNavRail(
 	onToggleExpanded: () -> Unit,
 	modifier: Modifier = Modifier,
 	footer: @Composable (ColumnScope.() -> Unit)? = null,
+	itemTestTag: ((T) -> String)? = null,
 ) {
 	val width by animateDpAsState(
 		targetValue = if (expanded) ExpandedWidth else CollapsedWidth,
@@ -135,6 +137,7 @@ fun <T> HdNavRail(
 						selected = destination.id == selectedId,
 						expanded = expanded,
 						onClick = { onSelect(destination.id) },
+						testTag = itemTestTag?.invoke(destination.id),
 					)
 				}
 			}
@@ -173,6 +176,7 @@ private fun <T> HdNavRailRow(
 	selected: Boolean,
 	expanded: Boolean,
 	onClick: () -> Unit,
+	testTag: String? = null,
 ) {
 	val iconColor = if (selected) MaterialTheme.colorScheme.secondary
 	else MaterialTheme.colorScheme.onSurfaceVariant
@@ -184,7 +188,8 @@ private fun <T> HdNavRailRow(
 			.fillMaxWidth()
 			.height(ItemHeight)
 			.clickable(onClick = onClick)
-			.semantics { contentDescription = destination.label },
+			.semantics { contentDescription = destination.label }
+			.then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
 		verticalAlignment = Alignment.CenterVertically,
 	) {
 		AnimatedContent(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdSearchField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdSearchField.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -45,6 +46,7 @@ fun HdSearchField(
 	onClear: (() -> Unit)? = null,
 	clearContentDescription: String? = null,
 	focusRequester: FocusRequester? = null,
+	testTag: String? = null,
 ) {
 	val ruleColor = MaterialTheme.colorScheme.outlineVariant
 	val onSurface = MaterialTheme.colorScheme.onSurface
@@ -78,7 +80,8 @@ fun HdSearchField(
 				keyboardActions = KeyboardActions(onSearch = { onSearch?.invoke(value) }),
 				modifier = Modifier
 					.fillMaxWidth()
-					.then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier),
+					.then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
+					.then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
 			)
 			if (value.isEmpty()) {
 				Text(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditField.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextIndent
 import androidx.compose.ui.unit.Dp
@@ -43,6 +44,7 @@ fun MarkdownEditField(
 	autoFocus: Boolean = false,
 	contentPadding: PaddingValues = PaddingValues(),
 	minEditorHeight: Dp = 200.dp,
+	testTag: String? = null,
 ) {
 	val markdownConfig = LocalMarkdownConfig.current
 
@@ -86,7 +88,8 @@ fun MarkdownEditField(
 			modifier = Modifier
 				.fillMaxWidth()
 				.weight(1f)
-				.heightIn(min = minEditorHeight),
+				.heightIn(min = minEditorHeight)
+				.then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
 		)
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/BrowseEntriesUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/BrowseEntriesUi.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
@@ -32,6 +33,8 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import kotlinx.coroutines.CoroutineScope
 import kotlin.math.roundToInt
+
+const val ENCYCLOPEDIA_CREATE_FAB_TAG = "encyclopedia-create-fab"
 
 @OptIn(ExperimentalSharedTransitionApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -436,7 +439,7 @@ fun BrowseEntriesFab(
 				onClick = component::showCreateEntry,
 				icon = Icons.Default.Create,
 				contentDescription = Res.string.encyclopedia_create_button.get(),
-				modifier = modifier,
+				modifier = modifier.testTag(ENCYCLOPEDIA_CREATE_FAB_TAG),
 			)
 		}
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -34,6 +35,11 @@ import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+
+const val ENCYCLOPEDIA_CREATE_NAME_TAG = "encyclopedia-create-name"
+const val ENCYCLOPEDIA_CREATE_TAGS_TAG = "encyclopedia-create-tags"
+const val ENCYCLOPEDIA_CREATE_CONFIRM_TAG = "encyclopedia-create-confirm"
+fun encyclopediaTypeCellTag(type: EntryType) = "encyclopedia-type-${type.name}"
 
 @Composable
 internal fun CreateEntryUi(
@@ -95,11 +101,13 @@ internal fun CreateEntryUi(
 					onValueChange = { name = it.take(EncyclopediaRepository.MAX_NAME_SIZE) },
 					placeholder = Res.string.encyclopedia_create_entry_name_placeholder.get(),
 					counter = "${name.length}/${EncyclopediaRepository.MAX_NAME_SIZE}",
+					testTag = ENCYCLOPEDIA_CREATE_NAME_TAG,
 				)
 
 				HdHairlineTypePicker(
 					selected = selectedType,
 					onSelect = { selectedType = it },
+					cellTestTag = ::encyclopediaTypeCellTag,
 				)
 
 				HdHairlineTagField(
@@ -112,6 +120,7 @@ internal fun CreateEntryUi(
 					hint = Res.string.encyclopedia_create_entry_tags_hint.get(),
 					placeholder = Res.string.encyclopedia_create_entry_tags_placeholder.get(),
 					suggestTags = component::suggestTags,
+					testTag = ENCYCLOPEDIA_CREATE_TAGS_TAG,
 				)
 
 				Text(
@@ -301,6 +310,7 @@ private fun HairlineModalFooter(
 				label = Res.string.encyclopedia_create_entry_create_button.get(),
 				onClick = onCreate,
 				emphasised = true,
+				modifier = Modifier.testTag(ENCYCLOPEDIA_CREATE_CONFIRM_TAG),
 			)
 		}
 	}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/EncyclopediaEntryItem.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/EncyclopediaEntryItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -46,6 +47,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 private val HeroHeight = 200.dp
+
+fun encyclopediaEntryTag(id: Int) = "encyclopedia-entry-$id"
 
 internal fun getEntryTypeIcon(type: EntryType): ImageVector {
 	return when (type) {
@@ -116,6 +119,7 @@ internal fun EncyclopediaEntryItem(
 					),
 					animatedVisibilityScope = animatedVisibilityScope,
 				)
+				.testTag(encyclopediaEntryTag(entryDef.id))
 				.clickable { viewEntry(entryDef) },
 		) {
 			// Hero zone — image (full-bleed with palette gradient) or

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/globalsearch/GlobalSearchUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/globalsearch/GlobalSearchUi.kt
@@ -40,6 +40,8 @@ import org.jetbrains.compose.resources.vectorResource
 
 private val DialogMaxWidth = 720.dp
 
+const val GLOBAL_SEARCH_INPUT_TAG = "global-search-input"
+
 @Composable
 fun GlobalSearchUi(component: GlobalSearch) {
 	val state by component.state.subscribeAsState()
@@ -89,6 +91,7 @@ fun GlobalSearchUi(component: GlobalSearch) {
 						onClear = { component.onQueryChanged("") },
 						clearContentDescription = Res.string.global_search_clear.get(),
 						focusRequester = focusRequester,
+						testTag = GLOBAL_SEARCH_INPUT_TAG,
 						modifier = Modifier.fillMaxWidth(),
 					)
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/BrowseNotesUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/BrowseNotesUi.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
@@ -44,6 +45,9 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import kotlin.math.roundToInt
 import androidx.compose.foundation.lazy.staggeredgrid.items as staggeredItems
+
+const val NOTES_CREATE_FAB_TAG = "notes-create-fab"
+fun noteCardTag(id: Int) = "note-card-$id"
 
 private enum class NotesSortMode(
 	override val labelRes: StringResource,
@@ -394,6 +398,7 @@ private fun NoteCard(
 					sharedContentState = rememberSharedContentState(key = "note-card-${note.id}"),
 					animatedVisibilityScope = animatedVisibilityScope,
 				)
+				.testTag(noteCardTag(note.id))
 				.clickable(onClick = onClick),
 		) {
 			val date = remember(note.created) {
@@ -611,6 +616,6 @@ fun BrowseNotesFab(
 		onClick = { component.showCreate() },
 		icon = Icons.Filled.Create,
 		contentDescription = Res.string.notes_create_note_button.get(),
-		modifier = modifier,
+		modifier = modifier.testTag(NOTES_CREATE_FAB_TAG),
 	)
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/CreateNoteUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/CreateNoteUi.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
@@ -26,6 +27,10 @@ import com.darkrockstudios.apps.hammer.common.data.notesrepository.NoteError
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+const val NOTES_CREATE_BODY_TAG = "notes-create-body"
+const val NOTES_CREATE_CONFIRM_TAG = "notes-create-confirm"
+const val NOTES_CREATE_CANCEL_TAG = "notes-create-cancel"
 
 @Composable
 fun CreateNoteUi(
@@ -110,6 +115,7 @@ fun CreateNoteUi(
 						initialMarkdown = noteText,
 						onMarkdownChanged = { component.onTextChanged(it) },
 						contentPadding = PaddingValues(Ui.Padding.XL),
+						testTag = NOTES_CREATE_BODY_TAG,
 						modifier = Modifier
 							.fillMaxWidth()
 							.widthIn(max = TextEditorDefaults.MAX_WIDTH),
@@ -135,10 +141,12 @@ fun CreateNoteUi(
 				HdHairlineButton(
 					label = Res.string.notes_create_cancel_button.get(),
 					onClick = { component.closeCreate() },
+					modifier = Modifier.testTag(NOTES_CREATE_CANCEL_TAG),
 				)
 				HdHairlineButton(
 					label = Res.string.notes_create_create_button.get(),
 					emphasised = canCreate,
+					modifier = Modifier.testTag(NOTES_CREATE_CONFIRM_TAG),
 					onClick = {
 						scope.launch {
 							val result = component.createNote(noteText, tags.toSet())

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -56,6 +57,8 @@ import org.jetbrains.compose.resources.stringResource
 import kotlin.random.Random
 import kotlin.time.Clock
 
+const val PROJECT_STATS_TAG = "project-stats"
+
 @Composable
 fun ProjectStatsUi(
 	modifier: Modifier,
@@ -67,6 +70,7 @@ fun ProjectStatsUi(
 
 	Column(
 		modifier = modifier
+			.testTag(PROJECT_STATS_TAG)
 			.fillMaxSize()
 			.verticalScroll(rememberScrollState())
 			.padding(horizontal = 24.dp, vertical = 16.dp),

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootScaffold.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootScaffold.kt
@@ -25,6 +25,13 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
 import com.darkrockstudios.apps.hammer.common.compose.theme.ProjectThemeOverride
 import com.darkrockstudios.apps.hammer.common.util.getAppVersionString
 
+// Locale-independent nav testTags; values match "nav-${DestinationTypes.name}".
+const val NAV_HOME_TAG = "nav-Home"
+const val NAV_EDITOR_TAG = "nav-Editor"
+const val NAV_NOTES_TAG = "nav-Notes"
+const val NAV_ENCYCLOPEDIA_TAG = "nav-Encyclopedia"
+const val NAV_TIMELINE_TAG = "nav-TimeLine"
+
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun ProjectRootScaffold(
@@ -80,6 +87,7 @@ private fun CompactNavigation(
 				destinations = destinations,
 				selectedId = router.active.instance.getLocationType(),
 				onSelect = { component.showDestination(it) },
+				itemTestTag = { "nav-${it.name}" },
 			)
 		},
 		floatingActionButton = {
@@ -111,6 +119,7 @@ private fun RailNavigation(
 					onSelect = { component.showDestination(it) },
 					expanded = navRailState.expanded,
 					onToggleExpanded = { component.toggleNavRailExpanded() },
+					itemTestTag = { "nav-${it.name}" },
 					modifier = Modifier.onSizeChanged {
 						navRailWidth = density.run { it.width.toDp() }
 					},

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextIndent
 import androidx.compose.ui.unit.Dp
@@ -34,6 +35,10 @@ import com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor
 import com.darkrockstudios.texteditor.spellcheck.markdown.withMarkdown
 import com.darkrockstudios.texteditor.spellcheck.rememberSpellCheckState
 import kotlinx.coroutines.launch
+
+const val SCENE_EDITOR_TEXT_TAG = "scene-editor-text"
+const val SCENE_EDITOR_SAVE_TAG = "scene-editor-save"
+const val RENAME_SCENE_FIELD_TAG = "rename-scene-field"
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalComposeApi::class)
 @Composable
@@ -160,6 +165,7 @@ fun SceneEditorUi(
 							unfocusedBorderColor = Color.Transparent,
 						),
 						modifier = Modifier
+							.testTag(SCENE_EDITOR_TEXT_TAG)
 							.background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
 							.fillMaxHeight()
 							.widthIn(128.dp, TextEditorDefaults.MAX_WIDTH),

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/CreateDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/CreateDialog.kt
@@ -64,6 +64,7 @@ internal fun CreateDialog(
 			autoFocus = true,
 			error = if (nameText.isNotEmpty() && !isValid) errorMessage else null,
 			onImeAction = ::submit,
+			testTag = CREATE_ITEM_NAME_FIELD_TAG,
 		)
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneGroupItem.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneGroupItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -24,6 +25,8 @@ import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeValue
 import com.darkrockstudios.apps.hammer.scene_group_item_collapsed
 import com.darkrockstudios.apps.hammer.scene_group_item_expanded
+
+fun sceneGroupTag(id: Int) = "scene-group-$id"
 
 @Composable
 internal fun SceneGroupItem(
@@ -43,6 +46,7 @@ internal fun SceneGroupItem(
 
 	val groupModifier = draggable
 		.fillMaxWidth()
+		.testTag(sceneGroupTag(scene.id))
 		.clickable { toggleExpand(scene.id) }
 
 	SceneGroupActionContainer(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneItem.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneItem.kt
@@ -10,12 +10,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.leftBorder
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
+
+fun sceneItemTag(id: Int) = "scene-item-$id"
 
 @ExperimentalFoundationApi
 @Composable
@@ -38,6 +41,7 @@ internal fun SceneItem(
 		Box(
 			modifier = draggable
 				.fillMaxWidth()
+				.testTag(sceneItemTag(scene.id))
 				.background(bg)
 				.leftBorder(2.dp, accent)
 				.combinedClickable(onClick = { onSceneSelected(scene) })

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneListUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneListUi.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
@@ -39,6 +40,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.random.Random
+
+const val SCENE_LIST_ADD_BUTTON_TAG = "scene-list-add"
+const val SCENE_LIST_ADD_SCENE_TAG = "scene-list-add-scene"
+const val SCENE_LIST_ADD_GROUP_TAG = "scene-list-add-group"
+const val CREATE_ITEM_NAME_FIELD_TAG = "create-item-name-field"
 
 @OptIn(
 	ExperimentalMaterialApi::class,
@@ -185,7 +191,10 @@ fun SceneListUi(
 							modifier = Modifier.weight(1f),
 						)
 						Box {
-							IconButton(onClick = { addMenuOpen = true }) {
+							IconButton(
+								onClick = { addMenuOpen = true },
+								modifier = Modifier.testTag(SCENE_LIST_ADD_BUTTON_TAG),
+							) {
 								Icon(
 									imageVector = Icons.Filled.Add,
 									contentDescription = Res.string.scene_list_add_button.get(),
@@ -197,6 +206,7 @@ fun SceneListUi(
 								onDismissRequest = { addMenuOpen = false },
 							) {
 								DropdownMenuItem(
+									modifier = Modifier.testTag(SCENE_LIST_ADD_SCENE_TAG),
 									text = { Text(Res.string.scene_list_create_menu_scene.get()) },
 									leadingIcon = {
 										Icon(
@@ -210,6 +220,7 @@ fun SceneListUi(
 									},
 								)
 								DropdownMenuItem(
+									modifier = Modifier.testTag(SCENE_LIST_ADD_GROUP_TAG),
 									text = { Text(Res.string.scene_list_create_menu_group.get()) },
 									leadingIcon = {
 										Icon(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/CreateTimeLineEventUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/CreateTimeLineEventUi.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
@@ -23,6 +24,11 @@ import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEv
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+
+const val TIME_LINE_CREATE_DATE_TAG = "timeline-create-date"
+const val TIME_LINE_CREATE_TAGS_TAG = "timeline-create-tags"
+const val TIME_LINE_CREATE_CONTENT_TAG = "timeline-create-content"
+const val TIME_LINE_CREATE_CONFIRM_TAG = "timeline-create-confirm"
 
 @Composable
 fun CreateTimeLineEventUi(
@@ -97,6 +103,7 @@ fun CreateTimeLineEventUi(
 						hint = Res.string.timeline_create_date_hint.get(),
 						placeholder = Res.string.timeline_create_date_placeholder.get(),
 						onFocusChanged = { dateFocused = it },
+						testTag = TIME_LINE_CREATE_DATE_TAG,
 					)
 				}
 
@@ -110,6 +117,7 @@ fun CreateTimeLineEventUi(
 					hint = Res.string.timeline_create_tags_hint.get(),
 					placeholder = Res.string.timeline_create_tags_placeholder.get(),
 					suggestTags = component::suggestTags,
+					testTag = TIME_LINE_CREATE_TAGS_TAG,
 				)
 			}
 
@@ -130,6 +138,7 @@ fun CreateTimeLineEventUi(
 						initialMarkdown = contentText,
 						onMarkdownChanged = { component.onContentChanged(it) },
 						contentPadding = PaddingValues(Ui.Padding.XL),
+						testTag = TIME_LINE_CREATE_CONTENT_TAG,
 						modifier = Modifier
 							.fillMaxWidth()
 							.widthIn(max = TextEditorDefaults.MAX_WIDTH),
@@ -158,6 +167,7 @@ fun CreateTimeLineEventUi(
 				HdHairlineButton(
 					label = Res.string.timeline_create_create_button.get(),
 					emphasised = contentText.isNotBlank(),
+					modifier = Modifier.testTag(TIME_LINE_CREATE_CONFIRM_TAG),
 					onClick = {
 						scope.launch {
 							when (component.createEvent(dateText, contentText, tags.toSet())) {


### PR DESCRIPTION
Builds on the e2e harness from #516 to exercise nearly every editor screen with a happy-path instrumented test.

## What's here

**Reusable harness** (`EditorTestHarness.kt`): seeds a project through the real Koin graph, launches straight into `ProjectRootActivity` (no click-through), navigates, and tears down without racing the project-scope buffer flush. Adds a `hasTestTagPrefix` matcher (for list cards keyed by unknown ids) and a `typeIntoEditor` helper — the third-party text editor consumes key events rather than Compose `SetText` semantics, so it's driven via injected keystrokes.

**9 new instrumented tests** (all green on an api-34 emulator):

| Test | Flow |
|---|---|
| `EditorNavigationTest` | Visits all 5 top-level destinations, composing each screen |
| `SceneListWorkflowTest` | Add menu → create group (lands in tree) + scene (auto-opens editor) |
| `SceneEditorWorkflowTest` | Create scene → type → save appears → save clears |
| `NotesWorkflowTest` | Create note → returns to browse → card appears → open |
| `EncyclopediaWorkflowTest` | Create entry (name/type/tag) → card appears → open |
| `TimelineWorkflowTest` | FAB → create event → card in list → open |
| `ProjectHomeTest` | Home renders the stats dashboard, stable across re-nav |
| `GlobalSearchTest` | Ctrl+Shift+F chord opens the search modal, accepts a query |

**Addressability**: optional `testTag` params added to shared design-system components (`FormField`, `MarkdownEditField`, the `Hd*` fields, `HdBottomBar`/`HdNavRail`) and colocated `testTag` consts on each screen. All changes are additive; existing desktop UI tests still pass.

## Excluded (need external infra)
Server sync + conflict resolution, SAF import/export, server-backed backup/restore, Glance widgets, and Expanded-only focus mode.

## Verification
- `./gradlew :android:connectedDebugAndroidTest` — 10/10 pass on emulator (9 new + existing)
- `./gradlew :composeUi:desktopTest` — green
- CI's `android-instrumented-tests` job runs the suite automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)