### PR TITLE
Replace GlobalSearchRepository with SearchProjectUseCase + retained state

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/globalsearch/GlobalSearch.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/globalsearch/GlobalSearch.kt
@@ -3,6 +3,7 @@ package com.darkrockstudios.apps.hammer.common.components.globalsearch
 import com.arkivanov.decompose.value.Value
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import kotlinx.serialization.Serializable
 
 interface GlobalSearch {
 	val state: Value<State>
@@ -22,6 +23,7 @@ interface GlobalSearch {
 	)
 }
 
+@Serializable
 enum class GlobalSearchFilter {
 	All,
 	Scenes,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/globalsearch/GlobalSearchComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/globalsearch/GlobalSearchComponent.kt
@@ -4,34 +4,31 @@ import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsearchrepository.GlobalSearchRepository
-import com.darkrockstudios.apps.hammer.common.data.projectInject
 
 class GlobalSearchComponent(
 	componentContext: ComponentContext,
 	projectDef: ProjectDef,
+	private val searchState: GlobalSearchState,
 	private val onDismiss: () -> Unit,
 	private val navigateToResult: (SearchResult) -> Unit,
 	initialQuery: String? = null,
 ) : ProjectComponentBase(projectDef, componentContext), GlobalSearch {
 
-	private val searchRepository: GlobalSearchRepository by projectInject()
-
 	override val state: Value<GlobalSearch.State>
-		get() = searchRepository.state
+		get() = searchState.state
 
 	init {
 		if (!initialQuery.isNullOrBlank()) {
-			searchRepository.setQuery(initialQuery)
+			searchState.setQuery(initialQuery)
 		}
 	}
 
 	override fun onQueryChanged(query: String) {
-		searchRepository.setQuery(query)
+		searchState.setQuery(query)
 	}
 
 	override fun onFilterChanged(filter: GlobalSearchFilter) {
-		searchRepository.setFilter(filter)
+		searchState.setFilter(filter)
 	}
 
 	override fun onResultClicked(result: SearchResult) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/globalsearch/GlobalSearchState.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/globalsearch/GlobalSearchState.kt
@@ -1,0 +1,120 @@
+package com.darkrockstudios.apps.hammer.common.components.globalsearch
+
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.decompose.value.getAndUpdate
+import com.arkivanov.essenty.instancekeeper.InstanceKeeper
+import com.darkrockstudios.apps.hammer.common.data.globalsearch.ParsedQuery
+import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
+import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase.Companion.parseQuery
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlin.coroutines.CoroutineContext
+
+/** The slice of search state worth persisting across process death; results re-derive from these. */
+@Serializable
+data class GlobalSearchSavedState(
+	val query: String = "",
+	val filter: GlobalSearchFilter = GlobalSearchFilter.All,
+)
+
+/**
+ * Holds the global-search presentation state and drives the (stateless) [SearchProjectUseCase].
+ *
+ * Owned by a long-lived parent component (ProjectRoot) and observed by the transient search modal,
+ * so the query and results survive the modal being dismissed and reopened. The [scope] must outlive
+ * the modal. Process-death survival is handled by the owner persisting [query]/[filter] and passing
+ * them back in as the initial values.
+ */
+class GlobalSearchState(
+	private val searchProjectUseCase: SearchProjectUseCase,
+	mainContext: CoroutineContext,
+	initialQuery: String = "",
+	initialFilter: GlobalSearchFilter = GlobalSearchFilter.All,
+) : InstanceKeeper.Instance {
+
+	// Own scope so an in-flight search survives the modal being dismissed; cancelled in onDestroy.
+	// Runs on the main context so MutableValue updates stay on the main thread; the use case
+	// offloads its own heavy work.
+	private val scope = CoroutineScope(mainContext + SupervisorJob())
+
+	private val _state = MutableValue(buildInitialState(initialQuery, initialFilter))
+	val state: Value<GlobalSearch.State> = _state
+
+	private var searchJob: Job? = null
+
+	init {
+		val parsed = parseQuery(initialQuery)
+		if (parsed.isUsable()) {
+			startSearch(initialQuery, parsed, initialFilter, debounce = false)
+		}
+	}
+
+	fun setQuery(query: String) {
+		val parsed = parseQuery(query)
+		_state.getAndUpdate {
+			it.copy(query = query, parsedText = parsed.text, parsedTags = parsed.tags)
+		}
+		startSearch(query, parsed, _state.value.filter, debounce = true)
+	}
+
+	fun setFilter(filter: GlobalSearchFilter) {
+		if (_state.value.filter == filter) return
+		_state.getAndUpdate { it.copy(filter = filter) }
+		val query = _state.value.query
+		startSearch(query, parseQuery(query), filter, debounce = false)
+	}
+
+	private fun startSearch(
+		query: String,
+		parsed: ParsedQuery,
+		filter: GlobalSearchFilter,
+		debounce: Boolean,
+	) {
+		searchJob?.cancel()
+
+		if (!parsed.isUsable()) {
+			_state.getAndUpdate { it.copy(isSearching = false, results = emptyList()) }
+			return
+		}
+
+		searchJob = scope.launch {
+			try {
+				if (debounce) delay(DEBOUNCE_MS)
+				_state.getAndUpdate { it.copy(isSearching = true) }
+				val results = searchProjectUseCase.search(query, filter)
+				_state.getAndUpdate { it.copy(isSearching = false, results = results) }
+			} catch (e: CancellationException) {
+				throw e
+			} catch (e: Exception) {
+				Napier.e("Global search failed", e)
+				_state.getAndUpdate { it.copy(isSearching = false) }
+			}
+		}
+	}
+
+	override fun onDestroy() {
+		scope.cancel()
+	}
+
+	private fun buildInitialState(query: String, filter: GlobalSearchFilter): GlobalSearch.State {
+		val parsed = parseQuery(query)
+		return GlobalSearch.State(
+			query = query,
+			parsedText = parsed.text,
+			parsedTags = parsed.tags,
+			filter = filter,
+		)
+	}
+
+	companion object {
+		const val DEBOUNCE_MS = 250L
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
@@ -7,11 +7,16 @@ import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.getAndUpdate
 import com.arkivanov.decompose.value.update
+import com.arkivanov.essenty.instancekeeper.retainedInstance
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchFilter
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchSavedState
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchState
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.SearchResult
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
@@ -23,6 +28,8 @@ import io.github.aakira.napier.Napier
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.component.inject
+
+private const val GLOBAL_SEARCH_STATE_KEY = "global_search_state"
 
 class ProjectRootComponent(
 	componentContext: ComponentContext,
@@ -38,6 +45,25 @@ class ProjectRootComponent(
 	private val projectDataRepository: ProjectDataRepository by projectInject()
 	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
 	private val settingsRepository: GlobalSettingsRepository by inject()
+	private val searchProjectUseCase: SearchProjectUseCase by projectInject()
+
+	// Retained on this long-lived parent so search state survives the modal being dismissed/reopened
+	// and config changes; stateKeeper carries the query/filter slice across process death.
+	private val globalSearchState: GlobalSearchState = run {
+		val saved = stateKeeper.consume(GLOBAL_SEARCH_STATE_KEY, GlobalSearchSavedState.serializer())
+		retainedInstance {
+			GlobalSearchState(
+				searchProjectUseCase = searchProjectUseCase,
+				mainContext = dispatcherMain,
+				initialQuery = saved?.query ?: "",
+				initialFilter = saved?.filter ?: GlobalSearchFilter.All,
+			)
+		}
+	}.also { searchState ->
+		stateKeeper.register(GLOBAL_SEARCH_STATE_KEY, GlobalSearchSavedState.serializer()) {
+			GlobalSearchSavedState(searchState.state.value.query, searchState.state.value.filter)
+		}
+	}
 
 	private var pendingDeepLink: ProjectDeepLink? = initialDeepLink
 
@@ -80,6 +106,7 @@ class ProjectRootComponent(
 	private val modalRouter = ProjectRootModalRouter(
 		componentContext,
 		projectDef,
+		globalSearchState,
 		::navigateGlobalSearchResult,
 		::reopenSceneAfterFocusMode,
 	)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootModalRouter.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootModalRouter.kt
@@ -7,6 +7,7 @@ import com.arkivanov.decompose.router.slot.activate
 import com.arkivanov.decompose.router.slot.childSlot
 import com.arkivanov.decompose.value.Value
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchComponent
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchState
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.SearchResult
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot.ModalDestination.*
 import com.darkrockstudios.apps.hammer.common.components.projectsync.ProjectSynchronizationComponent
@@ -19,6 +20,7 @@ import kotlinx.serialization.Serializable
 class ProjectRootModalRouter(
 	componentContext: ComponentContext,
 	private val projectDef: ProjectDef,
+	private val globalSearchState: GlobalSearchState,
 	private val navigateGlobalSearchResult: (SearchResult) -> Unit,
 	private val onFocusModeDismissed: (SceneItem) -> Unit,
 ) : Router {
@@ -66,6 +68,7 @@ class ProjectRootModalRouter(
 				GlobalSearchComponent(
 					componentContext,
 					projectDef,
+					globalSearchState,
 					::dismissGlobalSearch,
 					navigateGlobalSearchResult,
 					initialQuery = config.initialQuery,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -1,14 +1,8 @@
-package com.darkrockstudios.apps.hammer.common.data.globalsearchrepository
+package com.darkrockstudios.apps.hammer.common.data.globalsearch
 
-import com.arkivanov.decompose.value.MutableValue
-import com.arkivanov.decompose.value.Value
-import com.arkivanov.decompose.value.getAndUpdate
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.AnnotatedSnippet
-import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearch
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchFilter
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.SearchResult
-import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
@@ -19,96 +13,67 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRe
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_IO
-import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
-import io.github.aakira.napier.Napier
-import kotlinx.coroutines.*
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.qualifier.named
-import org.koin.core.scope.Scope
-import org.koin.core.scope.ScopeCallback
 import kotlin.coroutines.CoroutineContext
 
-class GlobalSearchRepository(
-	projectDef: ProjectDef,
+/** Parsed search query: free text plus any `#tags` pulled out of it. */
+internal data class ParsedQuery(
+	val text: String,
+	val tags: List<String>,
+) {
+	fun isUsable(): Boolean {
+		val tagOk = tags.any { it.length >= SearchProjectUseCase.MIN_TAG_LENGTH }
+		val textOk = text.length >= SearchProjectUseCase.MIN_QUERY_LENGTH
+		return tagOk || textOk
+	}
+}
+
+/**
+ * Stateless cross-repo project search. Given a query and a filter it fans out across the
+ * scene/notes/encyclopedia/timeline repositories and returns the matched results. Holds no state.
+ */
+class SearchProjectUseCase(
 	private val sceneEditor: SceneRepository,
 	private val sceneMetadataRepository: SceneMetadataRepository,
 	private val sceneContentRepository: SceneContentRepository,
 	private val notes: NotesRepository,
 	private val encyclopedia: EncyclopediaRepository,
 	private val timeLine: TimeLineRepository,
-) : ScopeCallback, ProjectScoped, KoinComponent {
-
-	override val projectScope = ProjectDefScope(projectDef)
+) : KoinComponent {
 
 	private val dispatcherDefault: CoroutineContext by inject(named(DISPATCHER_DEFAULT))
 	private val dispatcherIo: CoroutineContext by inject(named(DISPATCHER_IO))
 
-	private val scope = CoroutineScope(dispatcherDefault)
-	private var searchJob: Job? = null
-
-	private val _state = MutableValue(GlobalSearch.State())
-	val state: Value<GlobalSearch.State> = _state
-
-	init {
-		projectScope.scope.registerCallback(this)
-	}
-
-	fun setQuery(query: String) {
+	suspend fun search(query: String, filter: GlobalSearchFilter): List<SearchResult> {
 		val parsed = parseQuery(query)
-		_state.getAndUpdate {
-			it.copy(query = query, parsedText = parsed.text, parsedTags = parsed.tags)
-		}
-		startSearch(parsed, _state.value.filter, debounce = true)
-	}
-
-	fun setFilter(filter: GlobalSearchFilter) {
-		if (_state.value.filter == filter) return
-		_state.getAndUpdate { it.copy(filter = filter) }
-		startSearch(parseQuery(_state.value.query), filter, debounce = false)
-	}
-
-	private fun startSearch(parsed: ParsedQuery, filter: GlobalSearchFilter, debounce: Boolean) {
-		searchJob?.cancel()
-
-		if (!parsed.isUsable()) {
-			_state.getAndUpdate { it.copy(isSearching = false, results = emptyList()) }
-			return
-		}
-
-		searchJob = scope.launch {
-			try {
-				if (debounce) delay(DEBOUNCE_MS)
-				_state.getAndUpdate { it.copy(isSearching = true) }
-				val results = runSearch(parsed, filter)
-				_state.getAndUpdate { it.copy(isSearching = false, results = results) }
-			} catch (e: CancellationException) {
-				throw e
-			} catch (e: Exception) {
-				Napier.e("Global search failed", e)
-				_state.getAndUpdate { it.copy(isSearching = false) }
-			}
-		}
+		if (!parsed.isUsable()) return emptyList()
+		return withContext(dispatcherDefault) { runSearch(parsed, filter) }
 	}
 
 	private suspend fun runSearch(parsed: ParsedQuery, filter: GlobalSearchFilter): List<SearchResult> =
 		coroutineScope {
-		val notesDeferred = async {
-			if (filter.includesNotes) searchNotes(parsed) else emptyList()
-		}
-		val timelineDeferred = async {
-			if (filter.includesTimeline) searchTimeline(parsed) else emptyList()
-		}
-		val encyclopediaDeferred = async {
-			if (filter.includesEncyclopedia) searchEncyclopedia(parsed) else emptyList()
-		}
-		val scenesDeferred = async {
-			if (filter.includesScenes) searchScenes(parsed) else emptyList()
-		}
+			val notesDeferred = async {
+				if (filter.includesNotes) searchNotes(parsed) else emptyList()
+			}
+			val timelineDeferred = async {
+				if (filter.includesTimeline) searchTimeline(parsed) else emptyList()
+			}
+			val encyclopediaDeferred = async {
+				if (filter.includesEncyclopedia) searchEncyclopedia(parsed) else emptyList()
+			}
+			val scenesDeferred = async {
+				if (filter.includesScenes) searchScenes(parsed) else emptyList()
+			}
 
-		awaitAll(notesDeferred, timelineDeferred, encyclopediaDeferred, scenesDeferred)
-			.flatten()
-	}
+			awaitAll(notesDeferred, timelineDeferred, encyclopediaDeferred, scenesDeferred)
+				.flatten()
+		}
 
 	private val GlobalSearchFilter.includesScenes: Boolean
 		get() = this == GlobalSearchFilter.All || this == GlobalSearchFilter.Scenes
@@ -289,29 +254,13 @@ class GlobalSearchRepository(
 		}
 	}
 
-	override fun onScopeClose(scope: Scope) {
-		this.scope.cancel("Closing GlobalSearchRepository")
-	}
-
 	companion object {
 		const val MIN_QUERY_LENGTH = 2
 		const val MIN_TAG_LENGTH = 1
-		const val DEBOUNCE_MS = 250L
 		const val PER_SOURCE_CAP = 25
 		const val TITLE_MAX = 60
 		const val SNIPPET_BEFORE = 40
 		const val SNIPPET_AFTER = 80
-
-		internal data class ParsedQuery(
-			val text: String,
-			val tags: List<String>,
-		) {
-			fun isUsable(): Boolean {
-				val tagOk = tags.any { it.length >= MIN_TAG_LENGTH }
-				val textOk = text.length >= MIN_QUERY_LENGTH
-				return tagOk || textOk
-			}
-		}
 
 		internal fun parseQuery(query: String): ParsedQuery {
 			val tags = mutableListOf<String>()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -11,7 +11,7 @@ import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.exampleProjectModule
-import com.darkrockstudios.apps.hammer.common.data.globalsearchrepository.GlobalSearchRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
@@ -172,7 +172,7 @@ val mainModule = module {
 		scopedOf(::TimeLineDatasource)
 		scopedOf(::TimeLineRepository)
 
-		scopedOf(::GlobalSearchRepository)
+		scopedOf(::SearchProjectUseCase)
 
 		scopedOf(::StatisticsDatasource)
 		scopedOf(::StatisticsRepository)

--- a/common/src/desktopTest/kotlin/components/globalsearch/GlobalSearchComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/globalsearch/GlobalSearchComponentTest.kt
@@ -8,17 +8,15 @@ import com.arkivanov.essenty.statekeeper.StateKeeper
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.AnnotatedSnippet
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearch
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchComponent
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchState
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.SearchResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsearchrepository.GlobalSearchRepository
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.koin.dsl.bind
-import org.koin.dsl.module
 import utils.BaseTest
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -38,28 +36,24 @@ class GlobalSearchComponentTest : BaseTest() {
 	private lateinit var context: ComponentContext
 
 	@MockK
-	private lateinit var searchRepository: GlobalSearchRepository
+	private lateinit var searchState: GlobalSearchState
 
 	private val projectDef = ProjectDef(name = "Test", path = HPath("/p", "Test", false))
-	private val repoState = MutableValue(GlobalSearch.State())
+	private val state = MutableValue(GlobalSearch.State())
 
 	@BeforeEach
 	override fun setup() {
 		super.setup()
 
 		MockKAnnotations.init(this, relaxUnitFun = true)
-
-		val testModule = module {
-			single { searchRepository } bind GlobalSearchRepository::class
-		}
-		setupKoin(testModule)
+		setupKoin()
 
 		every { lifecycle.state } returns Lifecycle.State.STARTED
 		every { context.lifecycle } returns lifecycle
 		every { context.backHandler } returns backHandler
 		every { context.stateKeeper } returns stateKeeper
 		every { backHandler.register(any()) } just Runs
-		every { searchRepository.state } returns repoState
+		every { searchState.state } returns state
 	}
 
 	private fun createComponent(
@@ -68,12 +62,13 @@ class GlobalSearchComponentTest : BaseTest() {
 	) = GlobalSearchComponent(
 		componentContext = context,
 		projectDef = projectDef,
+		searchState = searchState,
 		onDismiss = onDismiss,
 		navigateToResult = navigateToResult,
 	)
 
 	@Test
-	fun `state is sourced from repository - retains across construction`() = runTest {
+	fun `state is sourced from the holder`() = runTest {
 		val existingResults = listOf(
 			SearchResult.Note(
 				noteId = 1,
@@ -81,7 +76,7 @@ class GlobalSearchComponentTest : BaseTest() {
 				snippet = AnnotatedSnippet("matched text", 0, 7),
 			)
 		)
-		repoState.value = GlobalSearch.State(query = "previous", results = existingResults)
+		state.value = GlobalSearch.State(query = "previous", results = existingResults)
 
 		val component = createComponent()
 
@@ -90,13 +85,11 @@ class GlobalSearchComponentTest : BaseTest() {
 	}
 
 	@Test
-	fun `onQueryChanged delegates to repository`() = runTest {
-		every { searchRepository.setQuery(any()) } just Runs
-
+	fun `onQueryChanged delegates to the holder`() = runTest {
 		val component = createComponent()
 		component.onQueryChanged("dragon")
 
-		verify { searchRepository.setQuery("dragon") }
+		verify { searchState.setQuery("dragon") }
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/components/globalsearch/GlobalSearchStateTest.kt
+++ b/common/src/desktopTest/kotlin/components/globalsearch/GlobalSearchStateTest.kt
@@ -1,0 +1,86 @@
+package components.globalsearch
+
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.AnnotatedSnippet
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchFilter
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchState
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.SearchResult
+import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GlobalSearchStateTest : BaseTest() {
+
+	private lateinit var useCase: SearchProjectUseCase
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		setupKoin()
+		useCase = mockk(relaxed = true)
+		coEvery { useCase.search(any(), any()) } returns emptyList()
+	}
+
+	private fun note(id: Int) = SearchResult.Note(
+		noteId = id,
+		title = "Note $id",
+		snippet = AnnotatedSnippet("snippet", 0, 0),
+	)
+
+	@Test
+	fun `setQuery exposes parsed tags on state`() = runTest {
+		val state = GlobalSearchState(useCase, mainContext = StandardTestDispatcher(testScheduler))
+		state.setQuery("#a #b text")
+		advanceUntilIdle()
+
+		assertEquals(listOf("a", "b"), state.state.value.parsedTags)
+		assertEquals("text", state.state.value.parsedText)
+	}
+
+	@Test
+	fun `query shorter than min length clears results without searching`() = runTest {
+		val state = GlobalSearchState(useCase, mainContext = StandardTestDispatcher(testScheduler))
+		state.setQuery("a")
+		advanceUntilIdle()
+
+		assertEquals("a", state.state.value.query)
+		assertEquals(emptyList(), state.state.value.results)
+		assertTrue(!state.state.value.isSearching)
+	}
+
+	@Test
+	fun `setQuery debounces - only the latest query produces results`() = runTest {
+		coEvery { useCase.search("alpha", any()) } returns listOf(note(1))
+		coEvery { useCase.search("bravo", any()) } returns listOf(note(2))
+
+		val state = GlobalSearchState(useCase, mainContext = StandardTestDispatcher(testScheduler))
+		state.setQuery("alpha")
+		advanceTimeBy(100)
+		state.setQuery("bravo")
+		advanceUntilIdle()
+
+		val results = state.state.value.results.filterIsInstance<SearchResult.Note>()
+		assertEquals(1, results.size)
+		assertEquals(2, results.first().noteId)
+	}
+
+	@Test
+	fun `initial query runs a search on construction`() = runTest {
+		coEvery { useCase.search("dragon", any()) } returns listOf(note(7))
+
+		val state = GlobalSearchState(useCase, mainContext = StandardTestDispatcher(testScheduler), initialQuery = "dragon")
+		advanceUntilIdle()
+
+		val results = state.state.value.results.filterIsInstance<SearchResult.Note>()
+		assertEquals(1, results.size)
+		assertEquals(7, results.first().noteId)
+	}
+}

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -1,5 +1,6 @@
-package repositories.globalsearch
+package usecases.globalsearch
 
+import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchFilter
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.SearchResult
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
@@ -7,7 +8,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
-import com.darkrockstudios.apps.hammer.common.data.globalsearchrepository.GlobalSearchRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContainer
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
@@ -22,10 +23,6 @@ import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,7 +33,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 
-class GlobalSearchRepositoryTest : BaseTest() {
+class SearchProjectUseCaseTest : BaseTest() {
 
 	private val projectDef = ProjectDef(name = "Test", path = HPath("/projects/Test", "Test", false))
 
@@ -65,15 +62,10 @@ class GlobalSearchRepositoryTest : BaseTest() {
 		coEvery { sceneMetadataRepository.loadSceneMetadata(any()) } returns SceneMetadata()
 		every { notes.getNotes() } returns emptyList()
 		coEvery { timeLine.loadTimeline() } returns TimeLineContainer(emptyList())
-		every { encyclopedia.entryListFlow } returns MutableSharedFlow<List<EntryDef>>(
-			replay = 1,
-			extraBufferCapacity = 1,
-			onBufferOverflow = BufferOverflow.DROP_OLDEST,
-		).apply { tryEmit(emptyList()) }
+		coEvery { encyclopedia.ensureEntriesLoaded() } returns emptyList()
 	}
 
-	private fun createRepository() = GlobalSearchRepository(
-		projectDef = projectDef,
+	private fun createUseCase() = SearchProjectUseCase(
 		sceneEditor = sceneEditor,
 		sceneMetadataRepository = sceneMetadataRepository,
 		sceneContentRepository = sceneContentRepository,
@@ -84,18 +76,18 @@ class GlobalSearchRepositoryTest : BaseTest() {
 
 	@Test
 	fun `findMatch returns null for empty text or query`() {
-		assertNull(GlobalSearchRepository.findMatch("", "foo"))
-		assertNull(GlobalSearchRepository.findMatch("hello", ""))
+		assertNull(SearchProjectUseCase.findMatch("", "foo"))
+		assertNull(SearchProjectUseCase.findMatch("hello", ""))
 	}
 
 	@Test
 	fun `findMatch returns null when no match`() {
-		assertNull(GlobalSearchRepository.findMatch("hello world", "xyz"))
+		assertNull(SearchProjectUseCase.findMatch("hello world", "xyz"))
 	}
 
 	@Test
 	fun `findMatch is case insensitive`() {
-		val match = GlobalSearchRepository.findMatch("Hello WORLD", "world")
+		val match = SearchProjectUseCase.findMatch("Hello WORLD", "world")
 		assertNotNull(match)
 		assertEquals("Hello WORLD", match.text)
 	}
@@ -103,7 +95,7 @@ class GlobalSearchRepositoryTest : BaseTest() {
 	@Test
 	fun `buildSnippet trims a window around match with ellipses`() {
 		val text = "x".repeat(200) + "needle" + "y".repeat(200)
-		val match = GlobalSearchRepository.findMatch(text, "needle")
+		val match = SearchProjectUseCase.findMatch(text, "needle")
 		assertNotNull(match)
 		assertTrue(match.text.startsWith("…"))
 		assertTrue(match.text.endsWith("…"))
@@ -113,7 +105,7 @@ class GlobalSearchRepositoryTest : BaseTest() {
 	@Test
 	fun `buildSnippet does not add leading ellipsis when match is at start`() {
 		val text = "needle" + "y".repeat(200)
-		val match = GlobalSearchRepository.findMatch(text, "needle")
+		val match = SearchProjectUseCase.findMatch(text, "needle")
 		assertNotNull(match)
 		assertTrue(!match.text.startsWith("…"))
 		assertEquals(0, match.matchStart)
@@ -122,35 +114,45 @@ class GlobalSearchRepositoryTest : BaseTest() {
 	@Test
 	fun `buildSnippet collapses whitespace`() {
 		val text = "before\n\n\tneedle  after"
-		val match = GlobalSearchRepository.findMatch(text, "needle")
+		val match = SearchProjectUseCase.findMatch(text, "needle")
 		assertNotNull(match)
 		assertTrue(!match.text.contains("\n"))
 		assertTrue(!match.text.contains("\t"))
 	}
 
 	@Test
-	fun `setQuery shorter than min length clears results without searching`() = runTest {
-		val repo = createRepository()
-		repo.setQuery("a")
-		advanceUntilIdle()
-
-		assertEquals("a", repo.state.value.query)
-		assertEquals(emptyList(), repo.state.value.results)
-		assertTrue(!repo.state.value.isSearching)
+	fun `parseQuery extracts tags and free text in any order`() {
+		val parsed = SearchProjectUseCase.parseQuery("dragon #fantasy battle #adventure")
+		assertEquals(listOf("fantasy", "adventure"), parsed.tags)
+		assertEquals("dragon battle", parsed.text)
 	}
 
 	@Test
-	fun `setQuery searches notes content`() = runTest {
+	fun `parseQuery handles tag-only and stray hash`() {
+		val tagOnly = SearchProjectUseCase.parseQuery("#hero")
+		assertEquals(listOf("hero"), tagOnly.tags)
+		assertEquals("", tagOnly.text)
+
+		val strayHash = SearchProjectUseCase.parseQuery("# foo")
+		assertTrue(strayHash.tags.isEmpty())
+		assertEquals("foo", strayHash.text)
+	}
+
+	@Test
+	fun `search with query shorter than min length returns nothing`() = runTest {
+		val results = createUseCase().search("a", GlobalSearchFilter.All)
+		assertEquals(emptyList(), results)
+	}
+
+	@Test
+	fun `search finds notes content`() = runTest {
 		every { notes.getNotes() } returns listOf(
 			NoteContainer(NoteContent(id = 1, created = Clock.System.now(), content = "Once a hero rose")),
 			NoteContainer(NoteContent(id = 2, created = Clock.System.now(), content = "Random text")),
 		)
 
-		val repo = createRepository()
-		repo.setQuery("hero")
-		advanceUntilIdle()
+		val results = createUseCase().search("hero", GlobalSearchFilter.All)
 
-		val results = repo.state.value.results
 		assertEquals(1, results.size)
 		val note = results.first() as SearchResult.Note
 		assertEquals(1, note.noteId)
@@ -158,7 +160,7 @@ class GlobalSearchRepositoryTest : BaseTest() {
 	}
 
 	@Test
-	fun `setQuery prefers in-memory scene buffer over disk`() = runTest {
+	fun `search prefers in-memory scene buffer over disk`() = runTest {
 		val scene = SceneItem(
 			projectDef = projectDef,
 			type = SceneItem.Type.Scene,
@@ -174,17 +176,15 @@ class GlobalSearchRepositoryTest : BaseTest() {
 		// loadSceneMarkdownRaw should not be consulted because buffer wins
 		every { sceneEditor.loadSceneMarkdownRaw(scene, any()) } returns "On-disk text"
 
-		val repo = createRepository()
-		repo.setQuery("dragon")
-		advanceUntilIdle()
+		val results = createUseCase().search("dragon", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Scene>()
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.Scene>()
 		assertEquals(1, results.size)
 		assertTrue(results.first().snippet.text.contains("dragon"))
 	}
 
 	@Test
-	fun `setQuery includes archived scenes`() = runTest {
+	fun `search includes archived scenes`() = runTest {
 		val scene = SceneItem(
 			projectDef = projectDef,
 			type = SceneItem.Type.Scene,
@@ -195,42 +195,28 @@ class GlobalSearchRepositoryTest : BaseTest() {
 		)
 		every { sceneEditor.getScenes() } returns listOf(scene)
 
-		val repo = createRepository()
-		repo.setQuery("Forgotten")
-		advanceUntilIdle()
+		val results = createUseCase().search("Forgotten", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Scene>()
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.Scene>()
 		assertEquals(1, results.size)
 		assertEquals(9, results.first().sceneItem.id)
 	}
 
 	@Test
-	fun `setQuery matches encyclopedia entry name`() = runTest {
+	fun `search matches encyclopedia entry name`() = runTest {
 		val def = EntryDef(projectDef = projectDef, id = 11, type = EntryType.PERSON, name = "Aragorn")
-		every { encyclopedia.entryListFlow } returns MutableSharedFlow<List<EntryDef>>(
-			replay = 1,
-			extraBufferCapacity = 1,
-			onBufferOverflow = BufferOverflow.DROP_OLDEST,
-		).apply { tryEmit(listOf(def)) }
 		coEvery { encyclopedia.ensureEntriesLoaded() } returns listOf(def)
 
-		val repo = createRepository()
-		repo.setQuery("aragorn")
-		advanceUntilIdle()
+		val results = createUseCase().search("aragorn", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.EncyclopediaEntry>()
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.EncyclopediaEntry>()
 		assertEquals(1, results.size)
 		assertEquals(11, results.first().entryDef.id)
 	}
 
 	@Test
-	fun `setQuery matches encyclopedia entry body when name does not`() = runTest {
+	fun `search matches encyclopedia entry body when name does not`() = runTest {
 		val def = EntryDef(projectDef = projectDef, id = 12, type = EntryType.PLACE, name = "Mordor")
-		every { encyclopedia.entryListFlow } returns MutableSharedFlow<List<EntryDef>>(
-			replay = 1,
-			extraBufferCapacity = 1,
-			onBufferOverflow = BufferOverflow.DROP_OLDEST,
-		).apply { tryEmit(listOf(def)) }
 		coEvery { encyclopedia.ensureEntriesLoaded() } returns listOf(def)
 		every { encyclopedia.loadEntry(def) } returns EntryContainer(
 			EntryContent(
@@ -242,17 +228,15 @@ class GlobalSearchRepositoryTest : BaseTest() {
 			)
 		)
 
-		val repo = createRepository()
-		repo.setQuery("Sauron")
-		advanceUntilIdle()
+		val results = createUseCase().search("Sauron", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.EncyclopediaEntry>()
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.EncyclopediaEntry>()
 		assertEquals(1, results.size)
 		assertTrue(results.first().snippet.text.contains("Sauron"))
 	}
 
 	@Test
-	fun `setQuery matches timeline event content`() = runTest {
+	fun `search matches timeline event content`() = runTest {
 		coEvery { timeLine.loadTimeline() } returns TimeLineContainer(
 			listOf(
 				TimeLineEvent(id = 21, order = 0, date = "Year 3", content = "Coronation"),
@@ -260,35 +244,15 @@ class GlobalSearchRepositoryTest : BaseTest() {
 			)
 		)
 
-		val repo = createRepository()
-		repo.setQuery("coronation")
-		advanceUntilIdle()
+		val results = createUseCase().search("coronation", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.TimelineEvent>()
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.TimelineEvent>()
 		assertEquals(1, results.size)
 		assertEquals(21, results.first().eventId)
 	}
 
 	@Test
-	fun `parseQuery extracts tags and free text in any order`() {
-		val parsed = GlobalSearchRepository.parseQuery("dragon #fantasy battle #adventure")
-		assertEquals(listOf("fantasy", "adventure"), parsed.tags)
-		assertEquals("dragon battle", parsed.text)
-	}
-
-	@Test
-	fun `parseQuery handles tag-only and stray hash`() {
-		val tagOnly = GlobalSearchRepository.parseQuery("#hero")
-		assertEquals(listOf("hero"), tagOnly.tags)
-		assertEquals("", tagOnly.text)
-
-		val strayHash = GlobalSearchRepository.parseQuery("# foo")
-		assertTrue(strayHash.tags.isEmpty())
-		assertEquals("foo", strayHash.text)
-	}
-
-	@Test
-	fun `setQuery filters notes by tag when only a tag is specified`() = runTest {
+	fun `search filters notes by tag when only a tag is specified`() = runTest {
 		every { notes.getNotes() } returns listOf(
 			NoteContainer(
 				NoteContent(
@@ -308,17 +272,15 @@ class GlobalSearchRepositoryTest : BaseTest() {
 			),
 		)
 
-		val repo = createRepository()
-		repo.setQuery("#fantasy")
-		advanceUntilIdle()
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.Note>()
 		assertEquals(1, results.size)
 		assertEquals(1, results.first().noteId)
 	}
 
 	@Test
-	fun `setQuery combines tag filter with free text`() = runTest {
+	fun `search combines tag filter with free text`() = runTest {
 		every { notes.getNotes() } returns listOf(
 			NoteContainer(
 				NoteContent(
@@ -346,17 +308,15 @@ class GlobalSearchRepositoryTest : BaseTest() {
 			),
 		)
 
-		val repo = createRepository()
-		repo.setQuery("#fantasy dragon")
-		advanceUntilIdle()
+		val results = createUseCase().search("#fantasy dragon", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.Note>()
 		assertEquals(1, results.size)
 		assertEquals(1, results.first().noteId)
 	}
 
 	@Test
-	fun `setQuery with tag returns matching scenes by metadata`() = runTest {
+	fun `search with tag returns matching scenes by metadata`() = runTest {
 		val taggedScene = SceneItem(
 			projectDef = projectDef,
 			type = SceneItem.Type.Scene,
@@ -375,18 +335,16 @@ class GlobalSearchRepositoryTest : BaseTest() {
 		coEvery { sceneMetadataRepository.loadSceneMetadata(7) } returns SceneMetadata(tags = setOf("plot"))
 		coEvery { sceneMetadataRepository.loadSceneMetadata(8) } returns SceneMetadata(tags = setOf("misc"))
 
-		val repo = createRepository()
-		repo.setQuery("#plot")
-		advanceUntilIdle()
+		val results = createUseCase().search("#plot", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Scene>()
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.Scene>()
 		assertEquals(1, results.size)
 		assertEquals(7, results.first().sceneItem.id)
 		assertTrue(results.first().title.contains("#plot"))
 	}
 
 	@Test
-	fun `setQuery combines tag filter with free text for scenes`() = runTest {
+	fun `search combines tag filter with free text for scenes`() = runTest {
 		val matchingScene = SceneItem(
 			projectDef = projectDef,
 			type = SceneItem.Type.Scene,
@@ -405,40 +363,30 @@ class GlobalSearchRepositoryTest : BaseTest() {
 		coEvery { sceneMetadataRepository.loadSceneMetadata(7) } returns SceneMetadata(tags = setOf("fantasy"))
 		coEvery { sceneMetadataRepository.loadSceneMetadata(8) } returns SceneMetadata(tags = setOf("fantasy"))
 
-		val repo = createRepository()
-		repo.setQuery("#fantasy dragon")
-		advanceUntilIdle()
+		val results = createUseCase().search("#fantasy dragon", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Scene>()
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.Scene>()
 		assertEquals(1, results.size)
 		assertEquals(7, results.first().sceneItem.id)
 	}
 
 	@Test
-	fun `setQuery exposes parsed tags on state`() = runTest {
-		val repo = createRepository()
-		repo.setQuery("#a #b text")
-		advanceUntilIdle()
-
-		assertEquals(listOf("a", "b"), repo.state.value.parsedTags)
-		assertEquals("text", repo.state.value.parsedText)
-	}
-
-	@Test
-	fun `setQuery debounces - only the latest query produces results`() = runTest {
+	fun `search honors filter to a single source`() = runTest {
 		every { notes.getNotes() } returns listOf(
-			NoteContainer(NoteContent(id = 1, created = Clock.System.now(), content = "alpha line")),
-			NoteContainer(NoteContent(id = 2, created = Clock.System.now(), content = "bravo line")),
+			NoteContainer(NoteContent(id = 1, created = Clock.System.now(), content = "dragon note")),
 		)
+		val scene = SceneItem(
+			projectDef = projectDef,
+			type = SceneItem.Type.Scene,
+			id = 7,
+			name = "dragon scene",
+			order = 0,
+		)
+		every { sceneEditor.getScenes() } returns listOf(scene)
 
-		val repo = createRepository()
-		repo.setQuery("alpha")
-		advanceTimeBy(100)
-		repo.setQuery("bravo")
-		advanceUntilIdle()
+		val results = createUseCase().search("dragon", GlobalSearchFilter.Notes)
 
-		val results = repo.state.value.results.filterIsInstance<SearchResult.Note>()
 		assertEquals(1, results.size)
-		assertEquals(2, results.first().noteId)
+		assertTrue(results.first() is SearchResult.Note)
 	}
 }

--- a/docs/ARCHITECTURE_LAYERING.md
+++ b/docs/ARCHITECTURE_LAYERING.md
@@ -1,0 +1,172 @@
+# App Architecture
+
+This document describes the layered architecture used in this project. **Agents working in this codebase must follow
+these rules.** It is a Clean-style architecture with two orthogonal properties tracked per component: dependency
+direction and statefulness.
+
+Read the **Decision rules** section carefully — most mistakes come from adding layers that aren't needed, or putting
+logic in the wrong layer.
+
+---
+
+## Core model
+
+Layers are ordered from **lowest** (closest to data) to **highest** (closest to the UI):
+
+```
+Data Sources  →  Repositories  →  Services  →  Use Cases  →  ViewModels
+  (lowest)                                                     (highest)
+```
+
+"Lower" means closer to data; "higher" means closer to the UI. Dependencies always point **downward** (higher depends on
+lower), never upward.
+
+The **mandatory spine** is just:
+
+```
+Data Source  →  Repository  →  ViewModel
+```
+
+**Services** and **Use Cases** are *optional* layers, inserted only when a specific need arises (see Decision rules). Do
+not create them speculatively.
+
+---
+
+## Layer reference
+
+| Layer       | State     | Lifetime / DI         | May reference                                                  | Required? |
+|-------------|-----------|-----------------------|----------------------------------------------------------------|-----------|
+| Data Source | Stateless | Factory (new per use) | Nothing in these layers                                        | Yes       |
+| Repository  | Stateful  | Scoped singleton      | Data Sources                                                   | Yes       |
+| Service     | Stateful  | Scoped singleton      | Repositories, Data Sources                                     | No        |
+| Use Case    | Stateless | Factory (new per use) | Services, Repositories, Data Sources, other Use Cases (lazily) | No        |
+| ViewModel   | —         | Per screen/owner      | Use Cases, Services, Repositories                              | Yes       |
+
+---
+
+## Layer definitions
+
+### Data Sources — stateless
+
+Raw I/O and nothing else: network calls, database/DAO access, file/disk access, platform APIs (camera, sensors, key
+stores, etc.). A data source holds **no state** and contains **no business logic**. It does not combine or call other
+data sources. Factory-produced (a fresh instance per use).
+
+### Repositories — stateful
+
+Combine one or more **data sources** for a single domain area, and own the state for that area (caching, in-memory
+flows, dedup, the source-of-truth for that domain). A repository is the default home for "get/observe/save this kind of
+data." Scoped singleton.
+
+### Services — stateful, **optional**
+
+The sanctioned home for **stateful coordination across multiple repositories**. Because repositories may not reference
+each other (see Dependency rules), any logic that must orchestrate two or more repositories *and* carry state lives
+here. Scoped singleton.
+
+> Only add a Service when a single repository genuinely cannot do the job. If one repository already exposes what's
+> needed, skip this layer entirely.
+
+### Use Cases — stateless, **optional**
+
+**Stateless** business logic and composition over lower layers — a single, named operation ("RefreshFeed", "
+SignInWithBiometrics"). Use cases hold no state. They may combine repositories, services, data accessed through those,
+and other use cases.
+
+> Only add a Use Case when there is real stateless logic or composition to hold. Do **not** create a Use Case that
+> merely forwards one call to one repository — let the consumer call the repository directly instead.
+
+### ViewModels
+
+Consume Use Cases, Services, or Repositories. **ViewModels must never reference Data Sources directly.** Keep business
+logic out of ViewModels; if logic is accumulating here, extract a Use Case.
+
+---
+
+## Dependency rules (hard constraints)
+
+1. **Downward only.** A component may depend only on components in layers *below* it. Never reference a higher layer.
+2. **No sibling references**, with one exception below. Components in the same layer must not depend on each other. This
+   keeps the dependency graph acyclic by construction.
+3. **Sibling exception — stateless layers only.** Use Cases (stateless) *may* reference other Use Cases. Repositories
+   and Services (stateful) **may not** reference siblings under any circumstances.
+4. **Lazy injection for sibling Use Cases.** When one Use Case depends on another, inject it lazily — a `Provider<T>`, a
+   factory, or a `() -> T` lambda — never the constructed instance directly. Statelessness alone does **not** prevent a
+   construction cycle; lazy resolution is what breaks it.
+5. **ViewModels never touch Data Sources.** Always go through a Repository (or a Service/Use Case above it).
+
+---
+
+## DI conventions
+
+- **Stateless components** (Data Sources, Use Cases) are **factory-produced**: a new instance each time they're
+  requested.
+- **Stateful components** (Repositories, Services) are **scoped singletons**. The default scope is the application, but
+  choose a *narrower* scope when the state's natural lifetime is narrower — e.g. a user session or a navigation graph.
+  Do not park session-scoped or user-scoped state in an app-lifetime singleton.
+
+---
+
+## Decision rules (read before adding a layer)
+
+Start from the minimal spine and add layers only when a concrete need appears.
+
+**Do I need a Use Case?**
+
+- There is stateless business logic or composition that doesn't belong in a ViewModel → **yes, add a Use Case.**
+- A repository already exposes exactly what the consumer needs → **no.** The ViewModel (or a higher Use Case) calls the
+  repository directly. Do not add a pass-through.
+
+**Do I need a Service?**
+
+- I need to coordinate **two or more repositories** with shared/stateful logic → **yes, add a Service** (repos can't
+  talk to each other, so the coordination goes here).
+- A single repository can do the job → **no.**
+
+**Inserting a layer later (minimizing churn):**
+
+- Prefer depending on **interfaces** for lower layers, so a layer can be inserted later without rewriting every call
+  site.
+- If the new layer only *wraps existing behavior behind the same surface* (caching, retry, dedup), implement the lower
+  layer's interface (**decorator**) and swap the binding in DI — zero call-site churn.
+- If the new layer exposes genuinely new orchestration methods, call sites must change. That's expected and is the
+  honest signal you've crossed into a real coordination layer.
+
+---
+
+## Naming caveat
+
+"Service" here is an **architectural layer**, not an Android `Service` component. When generating code, do not confuse
+the two; an architectural Service is a plain stateful class coordinating repositories, with no relation to
+`android.app.Service`.
+
+---
+
+## Worked example
+
+A sign-in feature, fully expanded:
+
+```
+BiometricDataSource        (stateless: wraps platform biometric API)
+AuthApiDataSource          (stateless: network auth calls)
+TokenDataSource            (stateless: secure token storage)
+
+AuthRepository             (stateful: combines AuthApi + Token sources, holds session state)
+UserRepository             (stateful: combines a user API + local user cache)
+
+SessionService             (stateful, OPTIONAL: coordinates AuthRepository + UserRepository
+                            on login/logout — only exists because two repos must be orchestrated together)
+
+SignInUseCase              (stateless, OPTIONAL: orchestrates the sign-in flow via SessionService)
+
+LoginViewModel             (calls SignInUseCase)
+```
+
+A trivial read, by contrast, needs none of the optional layers:
+
+```
+SettingsRepository  →  SettingsViewModel
+```
+
+The ViewModel calls the repository directly because there is no cross-repo coordination and no stateless logic to
+extract.


### PR DESCRIPTION
Part of the layered-architecture refactor stack. **Base: `sceneeditor-refactor`** — review/merge that one first.

`GlobalSearchRepository` was a stateful class shaped like a Repository while fanning out across six repos. This splits it into:

- `SearchProjectUseCase` — stateless, owns the cross-repo search fan-out.
- `GlobalSearchState` — component-layer state holder, retained on `ProjectRootComponent` so results survive modal dismiss/reopen and process death.
- a thin `GlobalSearchComponent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)