### PR TITLE
Add Foundation primitives tier; rename Id/Sync/Settings repos

### DIFF
--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
@@ -35,7 +35,7 @@ import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.closeProjectScope
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.data.openProjectScope
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
@@ -55,12 +55,12 @@ import kotlin.time.Clock
 class ProjectRootActivity : AppCompatActivity() {
 
 	private val settings: Settings by inject()
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
+	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val shortcutsManager: ProjectShortcutsManager by inject()
 	private val projectsRepository: ProjectsRepository by inject()
 	private val projectMetadataDatasource: ProjectMetadataDatasource by inject()
 	private val mainDispatcher by injectMainDispatcher()
-	private val globalSettings = MutableValue(globalSettingsRepository.globalSettings)
+	private val globalSettings = MutableValue(globalSettingsStore.globalSettings)
 	private var settingsUpdateJob: Job? = null
 
 	private val viewModel: ProjectRootViewModel by viewModels()
@@ -148,7 +148,7 @@ class ProjectRootActivity : AppCompatActivity() {
 		super.onStart()
 
 		settingsUpdateJob = lifecycleScope.launch {
-			globalSettingsRepository.globalSettingsUpdates.collect { settings ->
+			globalSettingsStore.globalSettingsUpdates.collect { settings ->
 				withContext(mainDispatcher) {
 					globalSettings.getAndUpdate { settings }
 				}

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectSelectActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectSelectActivity.kt
@@ -23,7 +23,7 @@ import com.darkrockstudios.apps.hammer.android.widgets.AddNoteActivity
 import com.darkrockstudios.apps.hammer.common.components.projectselection.ProjectSelectionComponent
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.platformMainDispatcher
 import com.darkrockstudios.apps.hammer.common.projectselection.ProjectSelectScaffold
@@ -36,8 +36,8 @@ import org.koin.android.ext.android.inject
 @ExperimentalComposeApi
 class ProjectSelectActivity : AppCompatActivity() {
 
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
-	private val globalSettings = MutableValue(globalSettingsRepository.globalSettings)
+	private val globalSettingsStore: GlobalSettingsStore by inject()
+	private val globalSettings = MutableValue(globalSettingsStore.globalSettings)
 	private var settingsUpdateJob: Job? = null
 
 	override fun onCreate(savedInstanceState: Bundle?) {
@@ -95,7 +95,7 @@ class ProjectSelectActivity : AppCompatActivity() {
 		super.onStart()
 
 		settingsUpdateJob = lifecycleScope.launch {
-			globalSettingsRepository.globalSettingsUpdates.collect { settings ->
+			globalSettingsStore.globalSettingsUpdates.collect { settings ->
 				withContext(platformMainDispatcher) {
 					globalSettings.getAndUpdate { settings }
 				}

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteActivity.kt
@@ -9,20 +9,8 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -43,15 +31,11 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.value.MutableValue
 import com.darkrockstudios.apps.hammer.android.R
 import com.darkrockstudios.apps.hammer.common.compose.Ui
-import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
-import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
-import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineField
-import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMasthead
-import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.serializableStateSaver
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
@@ -64,8 +48,8 @@ class AddNoteActivity : ComponentActivity(), KoinComponent {
 
 	private val projectsRepository: ProjectsRepository by inject()
 	private val projectsMetadataRepository: ProjectMetadataDatasource by inject()
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
-	private val globalSettings = MutableValue(globalSettingsRepository.globalSettings)
+	private val globalSettingsStore: GlobalSettingsStore by inject()
+	private val globalSettings = MutableValue(globalSettingsStore.globalSettings)
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteWidgetConfigActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteWidgetConfigActivity.kt
@@ -9,22 +9,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -48,7 +36,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMasthead
 import com.darkrockstudios.apps.hammer.common.compose.serializableStateSaver
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.data.projectdata.loadStoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
@@ -61,8 +49,8 @@ import org.koin.android.ext.android.inject
 private val ContentMaxWidth = 480.dp
 
 class AddNoteWidgetConfigActivity : ComponentActivity() {
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
-	private val globalSettings = MutableValue(globalSettingsRepository.globalSettings)
+	private val globalSettingsStore: GlobalSettingsStore by inject()
+	private val globalSettings = MutableValue(globalSettingsStore.globalSettings)
 	private val projectsRepository: ProjectsRepository by inject()
 	private val fileSystem: FileSystem by inject()
 	private val toml: Toml by inject()

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteWorker.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteWorker.kt
@@ -8,7 +8,7 @@ import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ClientProjectSynchronizer
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.temporaryProjectTask
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.sync.Mutex
@@ -48,9 +48,9 @@ class AddNoteWorker(
 				Napier.d { "Note create in proj: ${projectDef.name} result: $result" }
 
 				if (isSuccess(result) && isInternetConnected(context)) {
-					val syncDataRepository: SyncDataRepository = projectScope.get()
+					val syncJournal: SyncJournal = projectScope.get()
 					val synchronizer: ClientProjectSynchronizer = projectScope.get()
-					if (syncDataRepository.isServerSynchronized()) {
+					if (syncJournal.isServerSynchronized()) {
 						val success = synchronizer.sync(
 							onProgress = { _, log ->
 								log?.let {

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/StoryInfoWidgetConfigActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/StoryInfoWidgetConfigActivity.kt
@@ -9,22 +9,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -47,7 +35,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMasthead
 import com.darkrockstudios.apps.hammer.common.compose.serializableStateSaver
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.data.projectdata.loadStoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
@@ -60,8 +48,8 @@ import org.koin.android.ext.android.inject
 private val ContentMaxWidth = 480.dp
 
 class StoryInfoWidgetConfigActivity : ComponentActivity() {
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
-	private val globalSettings = MutableValue(globalSettingsRepository.globalSettings)
+	private val globalSettingsStore: GlobalSettingsStore by inject()
+	private val globalSettings = MutableValue(globalSettingsStore.globalSettings)
 	private val projectsRepository: ProjectsRepository by inject()
 	private val fileSystem: FileSystem by inject()
 	private val toml: Toml by inject()

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/PlatformSettingsComponent.android.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/PlatformSettingsComponent.android.kt
@@ -14,7 +14,7 @@ import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.getAndUpdate
 import com.darkrockstudios.apps.hammer.common.components.SavableComponent
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.migrator.DataMigrator
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
@@ -48,7 +48,7 @@ class AndroidPlatformSettingsComponent(
 
 	private val mainDispatcher by injectMainDispatcher()
 
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
+	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val projectsRepository: ProjectsRepository by inject()
 
 	val permissionsController = PermissionsController(context)
@@ -67,7 +67,7 @@ class AndroidPlatformSettingsComponent(
 			val internalStorage =
 				settings.getBoolean(AndroidSettingsKeys.KEY_USE_INTERNAL_STORAGE, true)
 			val externalStorageAccess = isExternalStorageGranted()
-			val dndSelected = globalSettingsRepository.globalSettings.enableDndInFocusMode
+			val dndSelected = globalSettingsStore.globalSettings.enableDndInFocusMode
 			val dndGranted = isNotificationPolicyGranted()
 
 			_state.getAndUpdate {
@@ -122,7 +122,7 @@ class AndroidPlatformSettingsComponent(
 
 	fun updateEnableDndInFocusMode(enabled: Boolean) {
 		scope.launch {
-			globalSettingsRepository.updateSettings {
+			globalSettingsStore.updateSettings {
 				it.copy(enableDndInFocusMode = enabled)
 			}
 			_state.getAndUpdate {
@@ -167,9 +167,9 @@ class AndroidPlatformSettingsComponent(
 	fun setInternalStorage() = setStorage(internal = true)
 
 	private fun setStorage(internal: Boolean) {
-		val oldPath = globalSettingsRepository.globalSettings.projectsDirectory.toPath()
+		val oldPath = globalSettingsStore.globalSettings.projectsDirectory.toPath()
 		if (internal) setInternalDirectories(context) else setExternalDirectories(context)
-		val newPath = globalSettingsRepository.defaultProjectDir()
+		val newPath = globalSettingsStore.defaultProjectDir()
 		moveProjectDirectory(oldPath = oldPath, newPath = newPath.toOkioPath())
 
 		settings[AndroidSettingsKeys.KEY_USE_INTERNAL_STORAGE] = internal
@@ -216,7 +216,7 @@ class AndroidPlatformSettingsComponent(
 		)
 
 		scope.launch {
-			globalSettingsRepository.updateSettings {
+			globalSettingsStore.updateSettings {
 				it.copy(
 					projectsDirectory = path
 				)

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusModeService.android.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusModeService.android.kt
@@ -11,11 +11,11 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import com.darkrockstudios.apps.hammer.common.R
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 
 actual class FocusModeService(
 	private val appContext: Context,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 ) {
 
 	private val notificationManager =
@@ -32,7 +32,7 @@ actual class FocusModeService(
 	 * Handles legacy global toggle for API < 35 and ZenRules for API 35+.
 	 */
 	actual fun enterFocusMode() {
-		if (!globalSettingsRepository.globalSettings.enableDndInFocusMode) return
+		if (!globalSettingsStore.globalSettings.enableDndInFocusMode) return
 		if (!notificationManager.isNotificationPolicyAccessGranted) return
 
 		if (Build.VERSION.SDK_INT >= 35) {

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryAndroid.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryAndroid.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data
 
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.zip.unzipBytesToDirectory
 import io.github.aakira.napier.Napier
 import net.peanuuutz.tomlkt.Toml
@@ -16,11 +16,11 @@ actual val exampleProjectModule = module {
 }
 
 class ExampleProjectRepositoryAndroid(
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	fileSystem: FileSystem,
 	toml: Toml,
 	clock: Clock,
-) : ExampleProjectRepository(globalSettingsRepository, fileSystem, toml, clock) {
+) : ExampleProjectRepository(globalSettingsStore, fileSystem, toml, clock) {
 
 	private fun loadExampleProjectZip(): ByteArray {
 		val path = "/raw/$EXAMPLE_PROJECT_FILE_NAME"

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
@@ -14,7 +14,7 @@ import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.importer.ImportPreview
 import com.darkrockstudios.apps.hammer.common.data.importer.StoryImporter
 import com.darkrockstudios.apps.hammer.common.data.projectbackup.ProjectBackupDef
@@ -52,7 +52,7 @@ class ProjectHomeComponent(
 
 	private val mainDispatcher by injectMainDispatcher()
 
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
+	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val projectBackupRepository: ProjectBackupRepository by inject()
 	private val sceneEditorRepository: SceneEditorService by projectInject()
 	private val exportStoryUseCase: ExportStoryUseCase by projectInject()
@@ -305,7 +305,7 @@ class ProjectHomeComponent(
 							totalEntryConnections = stats.totalEntryConnections,
 							wordCountGoal = stats.wordCountGoal,
 							writingActivity = derived,
-							hasServer = globalSettingsRepository.serverSettings != null,
+							hasServer = globalSettingsStore.serverSettings != null,
 							isLoadingStats = false
 						)
 					}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
@@ -21,7 +21,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.sync_menu_group
 import com.darkrockstudios.apps.hammer.sync_menu_item
 import io.github.aakira.napier.Napier
@@ -40,7 +40,7 @@ class ProjectRootComponent(
 	initialDeepLink: ProjectDeepLink? = null,
 ) : ProjectComponentBase(projectDef, componentContext), ProjectRoot {
 
-	private val syncDataRepository: SyncDataRepository by projectInject()
+	private val syncJournal: SyncJournal by projectInject()
 	private val sceneEditor: SceneEditorService by projectInject()
 	private val projectDataRepository: ProjectDataRepository by projectInject()
 	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
@@ -318,7 +318,7 @@ class ProjectRootComponent(
 
 			list.addAll(router.shouldConfirmClose())
 
-			if (syncDataRepository.shouldAutoSync()) {
+			if (syncJournal.shouldAutoSync()) {
 				list.add(CloseConfirm.Sync)
 			}
 
@@ -344,7 +344,7 @@ class ProjectRootComponent(
 	}
 
 	private fun addMenuItems() {
-		if (syncDataRepository.isServerSynchronized()) {
+		if (syncJournal.isServerSynchronized()) {
 			addMenu(
 				MenuDescriptor(
 					id = "project-root-sync",
@@ -364,7 +364,7 @@ class ProjectRootComponent(
 	}
 
 	private fun removeMenuItems() {
-		if (syncDataRepository.isServerSynchronized()) {
+		if (syncJournal.isServerSynchronized()) {
 			removeMenu("project-root-sync")
 		}
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
@@ -16,9 +16,9 @@ import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSear
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.SearchResult
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
-import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
@@ -44,7 +44,7 @@ class ProjectRootComponent(
 	private val sceneEditor: SceneEditorService by projectInject()
 	private val projectDataRepository: ProjectDataRepository by projectInject()
 	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
-	private val settingsRepository: GlobalSettingsRepository by inject()
+	private val settingsRepository: GlobalSettingsStore by inject()
 	private val searchProjectUseCase: SearchProjectUseCase by projectInject()
 
 	// Retained on this long-lived parent so search state survives the modal being dismissed/reopened

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/ProjectSelectionComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/ProjectSelectionComponent.kt
@@ -14,7 +14,7 @@ import com.darkrockstudios.apps.hammer.common.components.projectselection.accoun
 import com.darkrockstudios.apps.hammer.common.components.projectselection.projectslist.ProjectsListComponent
 import com.darkrockstudios.apps.hammer.common.data.ExampleProjectRepository
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.versioncheck.GithubReleaseInfo
 import com.darkrockstudios.apps.hammer.common.data.versioncheck.ShouldNotifyOfUpdateUseCase
 import com.darkrockstudios.apps.hammer.common.data.versioncheck.VersionCheckRepository
@@ -30,7 +30,7 @@ class ProjectSelectionComponent(
 
 	private val exampleProjectRepository: ExampleProjectRepository by inject()
 	private val urlLauncher: UrlLauncher by inject()
-	private val settingsRepository: GlobalSettingsRepository by inject()
+	private val settingsRepository: GlobalSettingsStore by inject()
 	private val versionCheckRepository: VersionCheckRepository by inject()
 	private val shouldNotifyOfUpdate: ShouldNotifyOfUpdateUseCase by inject()
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
@@ -17,7 +17,7 @@ import com.darkrockstudios.apps.hammer.common.components.spellchecksettings.Spel
 import com.darkrockstudios.apps.hammer.common.data.ExampleProjectRepository
 import com.darkrockstudios.apps.hammer.common.data.account.AccountUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.InitialProjectScreen
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
@@ -40,7 +40,7 @@ class AccountSettingsComponent(
 	private val mainDispatcher by injectMainDispatcher()
 	private val strRes: StrRes by inject()
 
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
+	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val exampleProjectRepository: ExampleProjectRepository by inject()
 	private val accountUseCase: AccountUseCase by inject()
 	private val projectsRepository: ProjectsRepository by inject()
@@ -64,12 +64,12 @@ class AccountSettingsComponent(
 
 	private val _state by savableState {
 		AccountSettings.State(
-			uiTheme = globalSettingsRepository.globalSettings.uiTheme,
-			syncAutomaticSync = globalSettingsRepository.globalSettings.automaticSyncing,
-			syncAutoCloseDialog = globalSettingsRepository.globalSettings.autoCloseSyncDialog,
-			syncAutomaticBackups = globalSettingsRepository.globalSettings.automaticBackups,
-			maxBackups = globalSettingsRepository.globalSettings.maxBackups,
-			initialProjectScreen = globalSettingsRepository.globalSettings.initialProjectScreen,
+			uiTheme = globalSettingsStore.globalSettings.uiTheme,
+			syncAutomaticSync = globalSettingsStore.globalSettings.automaticSyncing,
+			syncAutoCloseDialog = globalSettingsStore.globalSettings.autoCloseSyncDialog,
+			syncAutomaticBackups = globalSettingsStore.globalSettings.automaticBackups,
+			maxBackups = globalSettingsStore.globalSettings.maxBackups,
+			initialProjectScreen = globalSettingsStore.globalSettings.initialProjectScreen,
 		)
 	}
 	override val state: Value<AccountSettings.State> = _state
@@ -86,7 +86,7 @@ class AccountSettingsComponent(
 
 	private fun watchSettingsUpdates() {
 		scope.launch {
-			globalSettingsRepository.globalSettingsUpdates.collect { settings ->
+			globalSettingsStore.globalSettingsUpdates.collect { settings ->
 				withContext(dispatcherMain) {
 					_state.getAndUpdate {
 						it.copy(
@@ -103,7 +103,7 @@ class AccountSettingsComponent(
 		}
 
 		scope.launch {
-			globalSettingsRepository.serverSettingsUpdates.collect { settings ->
+			globalSettingsStore.serverSettingsUpdates.collect { settings ->
 				withContext(dispatcherMain) {
 					_state.getAndUpdate {
 						it.copy(
@@ -121,7 +121,7 @@ class AccountSettingsComponent(
 
 	override fun setUiTheme(theme: UiTheme) {
 		scope.launch {
-			globalSettingsRepository.updateSettings {
+			globalSettingsStore.updateSettings {
 				it.copy(
 					uiTheme = theme
 				)
@@ -131,7 +131,7 @@ class AccountSettingsComponent(
 
 	override fun setInitialProjectScreen(value: InitialProjectScreen) {
 		scope.launch {
-			globalSettingsRepository.updateSettings {
+			globalSettingsStore.updateSettings {
 				it.copy(
 					initialProjectScreen = value
 				)
@@ -186,14 +186,14 @@ class AccountSettingsComponent(
 	}
 
 	override fun removeServer() {
-		globalSettingsRepository.deleteServerSettings()
+		globalSettingsStore.deleteServerSettings()
 		projectsRepository.getProjects().forEach { projectDef ->
 			projectsRepository.removeProjectId(projectDef = projectDef)
 		}
 	}
 
 	override suspend fun setAutomaticBackups(value: Boolean) {
-		globalSettingsRepository.updateSettings {
+		globalSettingsStore.updateSettings {
 			it.copy(
 				automaticBackups = value
 			)
@@ -201,7 +201,7 @@ class AccountSettingsComponent(
 	}
 
 	override suspend fun setAutoCloseDialogs(value: Boolean) {
-		globalSettingsRepository.updateSettings {
+		globalSettingsStore.updateSettings {
 			it.copy(
 				autoCloseSyncDialog = value
 			)
@@ -209,7 +209,7 @@ class AccountSettingsComponent(
 	}
 
 	override suspend fun setAutoSyncing(value: Boolean) {
-		globalSettingsRepository.updateSettings {
+		globalSettingsStore.updateSettings {
 			it.copy(
 				automaticSyncing = value
 			)
@@ -218,7 +218,7 @@ class AccountSettingsComponent(
 
 	override suspend fun setMaxBackups(value: Int): Boolean {
 		return if (value in 1..GlobalSettings.MAX_BACKUPS) {
-			globalSettingsRepository.updateSettings {
+			globalSettingsStore.updateSettings {
 				it.copy(
 					maxBackups = value
 				)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
@@ -13,7 +13,7 @@ import com.darkrockstudios.apps.hammer.common.components.savableState
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SyncedProjectDefinition
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflictBroker
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
@@ -51,7 +51,7 @@ class ProjectsListComponent(
 	ComponentToaster by ComponentToasterImpl() {
 	private val mainDispatcher by injectMainDispatcher()
 
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
+	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val projectsRepository: ProjectsRepository by inject()
 	private val projectsSynchronizer: ClientAccountSynchronizer by inject()
 	private val networkConnectivity: NetworkConnectivity by inject()
@@ -72,7 +72,7 @@ class ProjectsListComponent(
 	private val _state by savableState {
 		ProjectsList.State(
 			projects = emptyList(),
-			projectsPath = HPath(globalSettingsRepository.globalSettings.projectsDirectory, "", true),
+			projectsPath = HPath(globalSettingsStore.globalSettings.projectsDirectory, "", true),
 			isServerSynced = projectsSynchronizer.isServerSynchronized(),
 		)
 	}
@@ -81,7 +81,7 @@ class ProjectsListComponent(
 
 	private fun watchSettingsUpdates() {
 		scope.launch {
-			globalSettingsRepository.globalSettingsUpdates.collect { settings ->
+			globalSettingsStore.globalSettingsUpdates.collect { settings ->
 				withContext(dispatcherMain) {
 					val oldPath = state.value.projectsPath
 					_state.getAndUpdate {
@@ -99,7 +99,7 @@ class ProjectsListComponent(
 		}
 
 		scope.launch {
-			globalSettingsRepository.serverSettingsUpdates.collect { settings ->
+			globalSettingsStore.serverSettingsUpdates.collect { settings ->
 				withContext(dispatcherMain) {
 					_state.getAndUpdate {
 						it.copy(
@@ -124,7 +124,7 @@ class ProjectsListComponent(
 
 	private fun initialProjectSync() {
 		scope.launch {
-			globalSettingsRepository.globalSettingsUpdates.first().let { settings ->
+			globalSettingsStore.globalSettingsUpdates.first().let { settings ->
 				if (
 					projectsSynchronizer.isServerSynchronized() &&
 					settings.automaticSyncing &&
@@ -145,7 +145,7 @@ class ProjectsListComponent(
 
 		_state.getAndUpdate {
 			it.copy(
-				projectsPath = HPath(globalSettingsRepository.globalSettings.projectsDirectory, "", true),
+				projectsPath = HPath(globalSettingsStore.globalSettings.projectsDirectory, "", true),
 				isServerSynced = projectsSynchronizer.isServerSynchronized()
 			)
 		}
@@ -153,7 +153,7 @@ class ProjectsListComponent(
 
 	override fun loadProjectList() {
 		val projectsDir = HPath(
-			path = globalSettingsRepository.globalSettings.projectsDirectory,
+			path = globalSettingsStore.globalSettings.projectsDirectory,
 			name = "",
 			isAbsolute = true
 		)
@@ -462,7 +462,7 @@ class ProjectsListComponent(
 
 					loadProjectList()
 
-					if (allSuccess && globalSettingsRepository.globalSettings.autoCloseSyncDialog) {
+					if (allSuccess && globalSettingsStore.globalSettings.autoCloseSyncDialog) {
 						hideProjectsSync()
 					}
 				}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectsync/ProjectSynchronizationComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectsync/ProjectSynchronizationComponent.kt
@@ -12,7 +12,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NoteError
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
@@ -41,7 +41,7 @@ class ProjectSynchronizationComponent(
 
 	private val mainDispatcher by injectMainDispatcher()
 
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
+	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val sceneEditorRepository: SceneEditorService by projectInject()
 	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
 	private val notesRepository: NotesRepository by projectInject()
@@ -123,7 +123,7 @@ class ProjectSynchronizationComponent(
 			}
 
 			// Auto-close dialog on success
-			if (success && globalSettingsRepository.globalSettings.autoCloseSyncDialog) {
+			if (success && globalSettingsStore.globalSettings.autoCloseSyncDialog) {
 				endSync()
 			} else {
 				if (!success) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/serverreauthentication/ServerReauthenticationComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/serverreauthentication/ServerReauthenticationComponent.kt
@@ -6,7 +6,7 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.getAndUpdate
 import com.darkrockstudios.apps.hammer.common.components.ComponentBase
 import com.darkrockstudios.apps.hammer.common.data.account.AccountReauthUseCase
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
 import com.darkrockstudios.apps.hammer.common.util.StrRes
@@ -23,15 +23,15 @@ class ServerReauthenticationComponent(
 
 	private val strRes: StrRes by inject()
 	private val mainDispatcher by injectMainDispatcher()
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
+	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val reauthUseCase: AccountReauthUseCase by inject()
 
 	private var authenticateJob: Job? = null
 
 	private val _state = MutableValue(
 		ServerReauthentication.State(
-			serverUrl = globalSettingsRepository.serverSettings?.url ?: "",
-			serverEmail = globalSettingsRepository.serverSettings?.email ?: "",
+			serverUrl = globalSettingsStore.serverSettings?.url ?: "",
+			serverEmail = globalSettingsStore.serverSettings?.email ?: "",
 		)
 	)
 	override val state: Value<ServerReauthentication.State> = _state

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/spellchecksettings/SpellCheckSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/spellchecksettings/SpellCheckSettingsComponent.kt
@@ -5,7 +5,7 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.getAndUpdate
 import com.darkrockstudios.apps.hammer.common.components.SavableComponent
 import com.darkrockstudios.apps.hammer.common.components.savableState
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.HammerComponent
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
 import com.darkrockstudios.apps.hammer.common.spellcheck.toLocale
@@ -20,14 +20,14 @@ class SpellCheckSettingsComponent(
 ) : SpellCheckSettings, HammerComponent, SavableComponent<SpellCheckSettings.State>(componentContext) {
 
 	private val mainDispatcher by injectMainDispatcher()
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
+	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val platformSpellCheckerFactory: PlatformSpellCheckerFactory by inject()
 
 	private val _state by savableState {
 		SpellCheckSettings.State(
-			spellCheckingEnabled = globalSettingsRepository.globalSettings.spellCheckSettings.enabled,
-			spellCheckingInFocusEnabled = globalSettingsRepository.globalSettings.spellCheckSettings.enabledInFocusMode,
-			spellCheckingLanguage = globalSettingsRepository.globalSettings.spellCheckSettings.locale,
+			spellCheckingEnabled = globalSettingsStore.globalSettings.spellCheckSettings.enabled,
+			spellCheckingInFocusEnabled = globalSettingsStore.globalSettings.spellCheckSettings.enabledInFocusMode,
+			spellCheckingLanguage = globalSettingsStore.globalSettings.spellCheckSettings.locale,
 			spellCheckLanguages = platformSpellCheckerFactory.availableLocales().map { it.toLocale() },
 		)
 	}
@@ -41,7 +41,7 @@ class SpellCheckSettingsComponent(
 
 	private fun watchSettingsUpdates() {
 		scope.launch {
-			globalSettingsRepository.globalSettingsUpdates.collect { settings ->
+			globalSettingsStore.globalSettingsUpdates.collect { settings ->
 				withContext(mainDispatcher) {
 					_state.getAndUpdate {
 						it.copy(
@@ -56,7 +56,7 @@ class SpellCheckSettingsComponent(
 	}
 
 	override suspend fun setSpellcheckEnable(enable: Boolean) {
-		globalSettingsRepository.updateSettings {
+		globalSettingsStore.updateSettings {
 			it.copy(
 				spellCheckSettings = it.spellCheckSettings.copy(
 					enabled = enable
@@ -66,7 +66,7 @@ class SpellCheckSettingsComponent(
 	}
 
 	override suspend fun setSpellCheckingInFocusEnabled(enable: Boolean) {
-		globalSettingsRepository.updateSettings {
+		globalSettingsStore.updateSettings {
 			it.copy(
 				spellCheckSettings = it.spellCheckSettings.copy(
 					enabledInFocusMode = enable
@@ -76,7 +76,7 @@ class SpellCheckSettingsComponent(
 	}
 
 	override suspend fun setSpellCheckLanguage(locale: Locale) {
-		globalSettingsRepository.updateSettings {
+		globalSettingsStore.updateSettings {
 			it.copy(
 				spellCheckSettings = it.spellCheckSettings.copy(
 					locale = locale

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusModeComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusModeComponent.kt
@@ -9,7 +9,7 @@ import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.increaseEditorTextSize
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import com.darkrockstudios.apps.hammer.common.spellcheck.SpellCheckRepository
 import io.github.aakira.napier.Napier
@@ -26,7 +26,7 @@ class FocusModeComponent(
 	private val closeFocusMode: () -> Unit
 ) : ProjectComponentBase(projectDef, componentContext), FocusMode {
 
-	private val settingsRepository: GlobalSettingsRepository by inject()
+	private val settingsRepository: GlobalSettingsStore by inject()
 	private val spellCheckRepository: SpellCheckRepository by inject()
 	private val focusModeService: FocusModeService by inject()
 	private val sceneEditor: SceneEditorService by projectInject()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditorComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditorComponent.kt
@@ -17,7 +17,7 @@ import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings.Companion.DEFAULT_FONT_SIZE
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.AutoConfirmReferencesUseCase
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
@@ -43,7 +43,7 @@ class SceneEditorComponent(
 	ComponentToaster by ComponentToasterImpl(),
 	SceneEditor {
 
-	private val settingsRepository: GlobalSettingsRepository by inject()
+	private val settingsRepository: GlobalSettingsStore by inject()
 	private val sceneEditor: SceneEditorService by projectInject()
 	private val draftsRepository: SceneDraftRepository by projectInject()
 	private val autoConfirmReferences: AutoConfirmReferencesUseCase by projectInject()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepository.kt
@@ -3,7 +3,8 @@ package com.darkrockstudios.apps.hammer.common.data
 import com.darkrockstudios.apps.hammer.base.http.writeToml
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingSession
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.ExampleProjectRepository.Companion.EXAMPLE_DAYS
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityDatasource
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectDefaultDispatcher
@@ -11,14 +12,7 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDisp
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.LocalTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atTime
-import kotlinx.datetime.minus
-import kotlinx.datetime.toInstant
-import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.*
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
 import okio.Path
@@ -34,7 +28,7 @@ import kotlin.time.Instant
 expect val exampleProjectModule: Module
 
 abstract class ExampleProjectRepository(
-	protected val globalSettingsRepository: GlobalSettingsRepository,
+	protected val globalSettingsStore: GlobalSettingsStore,
 	protected val fileSystem: FileSystem,
 	private val toml: Toml,
 	private val clock: Clock,
@@ -44,7 +38,7 @@ abstract class ExampleProjectRepository(
 	private val scope = CoroutineScope(dispatcherDefault)
 
 	fun shouldInstallFirstTime(): Boolean =
-		!globalSettingsRepository.globalSettings.nux.exampleProjectCreated
+		!globalSettingsStore.globalSettings.nux.exampleProjectCreated
 
 	fun install() {
 		removeExampleProject()
@@ -52,9 +46,9 @@ abstract class ExampleProjectRepository(
 
 		scope.launch {
 			fabricateExampleActivity()
-			globalSettingsRepository.updateSettings {
+			globalSettingsStore.updateSettings {
 				it.copy(
-					nux = globalSettingsRepository.globalSettings.nux.copy(
+					nux = globalSettingsStore.globalSettings.nux.copy(
 						exampleProjectCreated = true
 					)
 				)
@@ -67,7 +61,7 @@ abstract class ExampleProjectRepository(
 	protected abstract fun platformInstall()
 
 	protected fun projectsDir(): Path =
-		globalSettingsRepository.globalSettings.projectsDirectory.toPath()
+		globalSettingsStore.globalSettings.projectsDirectory.toPath()
 
 	private fun fabricateExampleActivity() {
 		val activityDir = projectsDir() / PROJECT_NAME /

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/account/AccountReauthUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/account/AccountReauthUseCase.kt
@@ -2,7 +2,7 @@ package com.darkrockstudios.apps.hammer.common.data.account
 
 import com.darkrockstudios.apps.hammer.base.http.Token
 import com.darkrockstudios.apps.hammer.common.data.CResult
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.updateCredentials
 import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
@@ -11,13 +11,13 @@ import io.ktor.client.*
 import io.ktor.client.plugins.auth.providers.*
 
 class AccountReauthUseCase(
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val accountApi: ServerAccountApi,
 	private val httpClient: HttpClient,
 ) {
 	suspend fun reauthenticate(password: String): CResult<Unit> {
-		val server = globalSettingsRepository.serverSettings ?: error("No server info is present")
-		val installId = globalSettingsRepository.ensureInstallId()
+		val server = globalSettingsStore.serverSettings ?: error("No server info is present")
+		val installId = globalSettingsStore.ensureInstallId()
 
 		val result = accountApi.login(
 			email = server.email,
@@ -39,7 +39,7 @@ class AccountReauthUseCase(
 				bearerToken = token.auth,
 				refreshToken = token.refresh,
 			)
-			globalSettingsRepository.updateServerSettings(authedSettings)
+			globalSettingsStore.updateServerSettings(authedSettings)
 
 			CResult.success()
 		} else {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/account/AccountUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/account/AccountUseCase.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.common.data.account
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.base.http.Token
 import com.darkrockstudios.apps.hammer.common.data.CResult
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.toMsg
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.updateCredentials
@@ -15,7 +15,7 @@ import io.ktor.client.*
 import io.ktor.client.plugins.auth.providers.*
 
 class AccountUseCase(
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val accountApi: ServerAccountApi,
 	private val httpClient: HttpClient,
 	private val strRes: StrRes,
@@ -27,7 +27,7 @@ class AccountUseCase(
 		password: String,
 		create: Boolean
 	): CResult<Unit> {
-		val installId = globalSettingsRepository.ensureInstallId()
+		val installId = globalSettingsStore.ensureInstallId()
 		val newSettings = ServerSettings(
 			userId = -1,
 			ssl = ssl,
@@ -37,7 +37,7 @@ class AccountUseCase(
 			refreshToken = null,
 		)
 
-		globalSettingsRepository.updateServerSettings(newSettings)
+		globalSettingsStore.updateServerSettings(newSettings)
 
 		val result = if (create) {
 			accountApi.createAccount(
@@ -64,11 +64,11 @@ class AccountUseCase(
 
 			val bearerTokens = BearerTokens(accessToken = token.auth, refreshToken = token.refresh)
 			httpClient.updateCredentials(bearerTokens)
-			globalSettingsRepository.updateServerSettings(authedSettings)
+			globalSettingsStore.updateServerSettings(authedSettings)
 
 			CResult.success()
 		} else {
-			globalSettingsRepository.deleteServerSettings()
+			globalSettingsStore.deleteServerSettings()
 
 			val exception = result.exceptionOrNull() as? HttpFailureException
 			val displayMessage = exception?.error?.displayMessage

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftRepository.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.common.data.drafts
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.*
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
@@ -18,7 +18,7 @@ class SceneDraftRepository(
 ) : ProjectScoped {
 	override val projectScope = ProjectDefScope(projectDef)
 
-	private val idRepository: IdRepository by projectInject()
+	private val idAllocator: IdAllocator by projectInject()
 	private val syncDataRepository: SyncDataRepository by projectInject()
 
 	suspend fun getAllDrafts(): Set<DraftDef> = datasource.getAllDrafts()
@@ -42,7 +42,7 @@ class SceneDraftRepository(
 			return null
 		}
 
-		val newId = idRepository.claimNextId()
+		val newId = idAllocator.claimNextId()
 		val newDraftTimestamp = clock.now()
 		val newDef = DraftDef(
 			id = newId,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftRepository.kt
@@ -5,7 +5,7 @@ import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import io.github.aakira.napier.Napier
 import kotlin.time.Clock
@@ -19,7 +19,7 @@ class SceneDraftRepository(
 	override val projectScope = ProjectDefScope(projectDef)
 
 	private val idAllocator: IdAllocator by projectInject()
-	private val syncDataRepository: SyncDataRepository by projectInject()
+	private val syncJournal: SyncJournal by projectInject()
 
 	suspend fun getAllDrafts(): Set<DraftDef> = datasource.getAllDrafts()
 	fun getSceneIdsThatHaveDrafts(): List<Int> = datasource.getSceneIdsThatHaveDrafts()
@@ -64,7 +64,7 @@ class SceneDraftRepository(
 	 * But I'm leaving it here just in case we need it at some point.
 	 */
 	protected suspend fun markForSynchronization(originalDef: DraftDef, originalContent: String) {
-		if (syncDataRepository.isServerSynchronized() && !syncDataRepository.isEntityDirty(
+		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(
 				originalDef.id
 			)
 		) {
@@ -75,7 +75,7 @@ class SceneDraftRepository(
 				name = originalDef.draftName,
 				content = originalContent,
 			)
-			syncDataRepository.markEntityAsDirty(originalDef.id, hash)
+			syncJournal.markEntityAsDirty(originalDef.id, hash)
 		}
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
@@ -12,7 +12,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
@@ -35,7 +35,7 @@ class EncyclopediaRepository(
 	private val projectDef: ProjectDef,
 	private val idAllocator: IdAllocator,
 	private val datasource: EncyclopediaDatasource,
-	private val syncDataRepository: SyncDataRepository,
+	private val syncJournal: SyncJournal,
 	private val statisticsRepository: StatisticsRepository,
 	private val referenceIndexRepository: ReferenceIndexRepository,
 ) : ScopeCallback, ProjectScoped, KoinComponent {
@@ -147,7 +147,7 @@ class EncyclopediaRepository(
 	}
 
 	private suspend fun markForSynchronization(entryDef: EntryDef) {
-		if (syncDataRepository.isServerSynchronized() && !syncDataRepository.isEntityDirty(
+		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(
 				entryDef.id
 			)
 		) {
@@ -173,7 +173,7 @@ class EncyclopediaRepository(
 				image = image,
 				aliases = entry.aliases,
 			)
-			syncDataRepository.markEntityAsDirty(entryDef.id, hash)
+			syncJournal.markEntityAsDirty(entryDef.id, hash)
 		}
 	}
 
@@ -218,7 +218,7 @@ class EncyclopediaRepository(
 
 	suspend fun deleteEntry(entryDef: EntryDef): Boolean {
 		datasource.deleteEntry(entryDef)
-		syncDataRepository.recordIdDeletion(entryDef.id)
+		syncJournal.recordIdDeletion(entryDef.id)
 		statisticsRepository.markDirty()
 		referenceIndexRepository.markEntryDeleted(entryDef.id)
 		_entryContentChangedFlow.emit(Unit)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
@@ -9,7 +9,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
@@ -33,7 +33,7 @@ import kotlin.coroutines.CoroutineContext
 
 class EncyclopediaRepository(
 	private val projectDef: ProjectDef,
-	private val idRepository: IdRepository,
+	private val idAllocator: IdAllocator,
 	private val datasource: EncyclopediaDatasource,
 	private val syncDataRepository: SyncDataRepository,
 	private val statisticsRepository: StatisticsRepository,
@@ -192,7 +192,7 @@ class EncyclopediaRepository(
 		val cleanedTags = cleanTags(tags)
 		val cleanedAliases = cleanAliases(aliases, name)
 
-		val newId = forceId ?: idRepository.claimNextId()
+		val newId = forceId ?: idAllocator.claimNextId()
 		val entry = EntryContent(
 			id = newId,
 			name = name.trim(),

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/GlobalSettingsStore.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/GlobalSettingsStore.kt
@@ -7,7 +7,6 @@ import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.getDefaultRootDocumentDirectory
 import com.darkrockstudios.apps.hammer.common.getPlatformName
 import com.darkrockstudios.apps.hammer.common.spellcheck.LanguageUtil
-import kotlin.uuid.Uuid
 import com.darkrockstudios.apps.hammer.common.spellcheck.findBestMatchingLanguage
 import com.darkrockstudios.apps.hammer.common.spellcheck.findBestMatchingLanguageOrNull
 import com.darkrockstudios.apps.hammer.common.spellcheck.toLocale
@@ -20,8 +19,9 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.first
 import okio.Path.Companion.toPath
 import org.koin.core.component.KoinComponent
+import kotlin.uuid.Uuid
 
-class GlobalSettingsRepository(
+class GlobalSettingsStore(
 	private val globalSettingsDatasource: GlobalSettingsDatasource,
 	private val serverSettingsDatasource: ServerSettingsDatasource,
 ) : KoinComponent {
@@ -85,7 +85,7 @@ class GlobalSettingsRepository(
 
 	fun serverIsSetup(): Boolean = serverSettingsDatasource.serverIsSetup(projectsDir())
 
-	fun defaultProjectDir() = GlobalSettingsRepository.defaultProjectDir().toHPath()
+	fun defaultProjectDir() = GlobalSettingsStore.defaultProjectDir().toHPath()
 
 	fun deleteServerSettings() {
 		serverSettingsDatasource.removeServerSettings(projectsDir())

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/GlobalSettingsFilesystemDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/GlobalSettingsFilesystemDatasource.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
 
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository.Companion.createDefault
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore.Companion.createDefault
 import com.darkrockstudios.apps.hammer.common.getConfigDirectory
 import com.darkrockstudios.apps.hammer.common.spellcheck.LanguageUtil
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/id/IdAllocator.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/id/IdAllocator.kt
@@ -5,7 +5,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.id.datasources.*
 import com.darkrockstudios.apps.hammer.common.data.projectInject
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
@@ -14,7 +14,7 @@ import kotlin.math.max
 
 class IdAllocator(private val projectDef: ProjectDef) : ProjectScoped {
 	override val projectScope = ProjectDefScope(projectDef)
-	private val syncDataRepository: SyncDataRepository by projectInject()
+	private val syncJournal: SyncJournal by projectInject()
 
 	private val idDatasources: Set<IdDatasource> by lazy {
 		EntityType.entries
@@ -45,8 +45,8 @@ class IdAllocator(private val projectDef: ProjectDef) : ProjectScoped {
 				lastId = max(lastId, highestId)
 			}
 
-			if (syncDataRepository.isServerSynchronized()) {
-				syncDataRepository.deletedIds().maxOrNull()?.let { maxDeletedId ->
+			if (syncJournal.isServerSynchronized()) {
+				syncJournal.deletedIds().maxOrNull()?.let { maxDeletedId ->
 					lastId = max(lastId, maxDeletedId)
 				}
 			}
@@ -60,8 +60,8 @@ class IdAllocator(private val projectDef: ProjectDef) : ProjectScoped {
 	}
 
 	private suspend fun recordNewId(claimedId: Int) {
-		if (syncDataRepository.isServerSynchronized()) {
-			syncDataRepository.recordNewId(claimedId)
+		if (syncJournal.isServerSynchronized()) {
+			syncJournal.recordNewId(claimedId)
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/id/IdAllocator.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/id/IdAllocator.kt
@@ -12,7 +12,7 @@ import kotlinx.atomicfu.locks.withLock
 import org.koin.core.component.get
 import kotlin.math.max
 
-class IdRepository(private val projectDef: ProjectDef) : ProjectScoped {
+class IdAllocator(private val projectDef: ProjectDef) : ProjectScoped {
 	override val projectScope = ProjectDefScope(projectDef)
 	private val syncDataRepository: SyncDataRepository by projectInject()
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/migrator/DataMigrator.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/migrator/DataMigrator.kt
@@ -2,7 +2,7 @@ package com.darkrockstudios.apps.hammer.common.data.migrator
 
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
@@ -12,7 +12,7 @@ import org.koin.mp.KoinPlatform.getKoin
 
 // This is only open for testing purposes
 open class DataMigrator(
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val projectsRepository: ProjectsRepository,
 	private val projectMetadataDatasource: ProjectMetadataDatasource,
 ) {
@@ -31,7 +31,7 @@ open class DataMigrator(
 	)
 
 	private fun getProjects(): List<ProjectData> {
-		val projDir = globalSettingsRepository.globalSettings.projectsDirectory.toPath()
+		val projDir = globalSettingsStore.globalSettings.projectsDirectory.toPath()
 		val projects = projectsRepository.getProjects(projDir.toHPath()).map { projDef ->
 			val metadata = projectMetadataDatasource.loadMetadata(projDef)
 			ProjectData(projDef, metadata)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/migrator/MigrateInstallIdToGlobal.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/migrator/MigrateInstallIdToGlobal.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data.migrator
 
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import io.github.aakira.napier.Napier
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -22,15 +22,15 @@ import okio.Path.Companion.toPath
  * time has passed that any user upgrading would already have run it.
  */
 class MigrateInstallIdToGlobal(
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val fileSystem: FileSystem,
 	private val json: Json,
 ) : GlobalMigration {
 
 	override suspend fun migrate() {
-		if (globalSettingsRepository.globalSettings.installId != null) return
+		if (globalSettingsStore.globalSettings.installId != null) return
 
-		val projectsDir = globalSettingsRepository.globalSettings.projectsDirectory.toPath()
+		val projectsDir = globalSettingsStore.globalSettings.projectsDirectory.toPath()
 		val legacyPath = projectsDir / LEGACY_SERVER_FILE_NAME
 		if (!fileSystem.exists(legacyPath)) return
 
@@ -43,7 +43,7 @@ class MigrateInstallIdToGlobal(
 		} ?: return
 
 		Napier.i("Migrating installId from server.json to GlobalSettings")
-		globalSettingsRepository.updateSettings { it.copy(installId = legacyInstallId) }
+		globalSettingsStore.updateSettings { it.copy(installId = legacyInstallId) }
 	}
 
 	@Serializable

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesRepository.kt
@@ -4,7 +4,7 @@ import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContainer
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
@@ -27,7 +27,7 @@ import kotlin.time.Clock
 
 class NotesRepository(
 	projectDef: ProjectDef,
-	private val idRepository: IdRepository,
+	private val idAllocator: IdAllocator,
 	private val syncDataRepository: SyncDataRepository,
 	private val notesDatasource: NotesDatasource,
 ) : ScopeCallback, ProjectScoped {
@@ -104,7 +104,7 @@ class NotesRepository(
 		return if (result != NoteError.NONE) {
 			CResult.failure(InvalidNote(result))
 		} else {
-			val newId = idRepository.claimNextId()
+			val newId = idAllocator.claimNextId()
 			val newNote = NoteContainer(
 				NoteContent(
 					id = newId,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesRepository.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContainer
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
@@ -28,7 +28,7 @@ import kotlin.time.Clock
 class NotesRepository(
 	projectDef: ProjectDef,
 	private val idAllocator: IdAllocator,
-	private val syncDataRepository: SyncDataRepository,
+	private val syncJournal: SyncJournal,
 	private val notesDatasource: NotesDatasource,
 ) : ScopeCallback, ProjectScoped {
 
@@ -80,7 +80,7 @@ class NotesRepository(
 	}
 
 	private suspend fun markForSync(id: Int, originalHash: String? = null) {
-		if (syncDataRepository.isServerSynchronized() && !syncDataRepository.isEntityDirty(id)) {
+		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(id)) {
 			val hash = if (originalHash != null) {
 				originalHash
 			} else {
@@ -92,7 +92,7 @@ class NotesRepository(
 					tags = noteContainer.note.tags,
 				)
 			}
-			syncDataRepository.markEntityAsDirty(id, hash)
+			syncJournal.markEntityAsDirty(id, hash)
 		}
 	}
 
@@ -128,7 +128,7 @@ class NotesRepository(
 
 	suspend fun deleteNote(id: Int) {
 		notesDatasource.deleteNote(id)
-		syncDataRepository.recordIdDeletion(id)
+		syncJournal.recordIdDeletion(id)
 		_noteContentChangedFlow.emit(Unit)
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectbackup/ProjectBackupRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectbackup/ProjectBackupRepository.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.projectbackup
 
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
@@ -21,7 +21,7 @@ import kotlin.time.Instant
 open class ProjectBackupRepository(
 	protected val fileSystem: FileSystem,
 	protected val projectsRepository: ProjectsRepository,
-	protected val globalSettingsRepository: GlobalSettingsRepository,
+	protected val globalSettingsStore: GlobalSettingsStore,
 	protected val clock: Clock
 ) : KoinComponent {
 
@@ -100,7 +100,7 @@ open class ProjectBackupRepository(
 	}
 
 	fun cullBackups(project: ProjectDef) {
-		val settings = globalSettingsRepository.globalSettings
+		val settings = globalSettingsStore.globalSettings
 
 		val backups = getBackups(project).toMutableList()
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectsrepository/ProjectsRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectsrepository/ProjectsRepository.kt
@@ -5,7 +5,7 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.Info
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.*
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.migrator.PROJECT_DATA_VERSION
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository.Companion.MAX_FILENAME_LENGTH
@@ -30,17 +30,17 @@ import kotlin.time.Clock
 
 class ProjectsRepository(
 	private val fileSystem: FileSystem,
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	private val projectsMetadataDatasource: ProjectMetadataDatasource
 ) : KoinComponent {
 
 	private val dispatcherDefault: CoroutineContext by inject(named(DISPATCHER_DEFAULT))
 	private val projectsScope = CoroutineScope(dispatcherDefault)
 
-	private var globalSettings = globalSettingsRepository.globalSettings
+	private var globalSettings = globalSettingsStore.globalSettings
 
 	init {
-		watchSettings(globalSettingsRepository)
+		watchSettings(globalSettingsStore)
 
 		val projectsDir = getProjectsDirectory().toOkioPath()
 		if (!fileSystem.exists(projectsDir)) {
@@ -48,9 +48,9 @@ class ProjectsRepository(
 		}
 	}
 
-	private fun watchSettings(globalSettingsRepository: GlobalSettingsRepository) {
+	private fun watchSettings(globalSettingsStore: GlobalSettingsStore) {
 		projectsScope.launch {
-			globalSettingsRepository.globalSettingsUpdates.collect { newSettings ->
+			globalSettingsStore.globalSettingsUpdates.collect { newSettings ->
 				globalSettings = newSettings
 			}
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
@@ -6,7 +6,7 @@ import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.toApiType
 import com.darkrockstudios.apps.hammer.common.data.tree.ImmutableTree
 import com.darkrockstudios.apps.hammer.common.data.tree.Tree
@@ -33,7 +33,7 @@ import kotlin.time.Clock
 class SceneRepository(
 	val projectDef: ProjectDef,
 	private val idAllocator: IdAllocator,
-	private val syncDataRepository: SyncDataRepository,
+	private val syncJournal: SyncJournal,
 	private val sceneMetadataRepository: SceneMetadataRepository,
 	private val sceneContentRepository: SceneContentRepository,
 	private val sceneMetadataDatasource: SceneMetadataDatasource,
@@ -65,7 +65,7 @@ class SceneRepository(
 		get() = sceneTree
 
 	private suspend fun markForSynchronization(scene: SceneItem) {
-		if (syncDataRepository.isServerSynchronized() && !syncDataRepository.isEntityDirty(scene.id)) {
+		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(scene.id)) {
 			val metadata = sceneMetadataDatasource.loadMetadata(scene.id)
 			val pathSegments = getPathSegments(scene)
 
@@ -94,7 +94,7 @@ class SceneRepository(
 				created = metadata?.created,
 				lastEdited = metadata?.lastEdited,
 			)
-			syncDataRepository.markEntityAsDirty(scene.id, hash)
+			syncJournal.markEntityAsDirty(scene.id, hash)
 		}
 	}
 
@@ -423,7 +423,7 @@ class SceneRepository(
 	}
 
 	private suspend fun markForSynchronization(scene: SceneItem, content: String) {
-		if (syncDataRepository.isServerSynchronized() && !syncDataRepository.isEntityDirty(scene.id)) {
+		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(scene.id)) {
 			val metadata = sceneMetadataDatasource.loadMetadata(scene.id)
 			val pathSegments = getPathSegments(scene)
 			val hash = EntityHasher.hashScene(
@@ -442,7 +442,7 @@ class SceneRepository(
 				created = metadata?.created,
 				lastEdited = metadata?.lastEdited,
 			)
-			syncDataRepository.markEntityAsDirty(scene.id, hash)
+			syncJournal.markEntityAsDirty(scene.id, hash)
 		}
 	}
 
@@ -571,7 +571,7 @@ class SceneRepository(
 		// Must grab a copy of the children before they are modified
 		// we'll need this if we need to calculate their original hash
 		// down below for markForSynchronization()
-		val originalChildren = if (syncDataRepository.isServerSynchronized()) {
+		val originalChildren = if (syncJournal.isServerSynchronized()) {
 			parent.children().map { child -> child.value.copy() }
 		} else {
 			null
@@ -761,8 +761,8 @@ class SceneRepository(
 				updateSceneOrder(parentId)
 				Napier.w("Scene ${scene.id} deleted")
 
-				if (syncDataRepository.isServerSynchronized()) {
-					syncDataRepository.recordIdDeletion(scene.id)
+				if (syncJournal.isServerSynchronized()) {
+					syncJournal.recordIdDeletion(scene.id)
 				}
 
 				reloadScenes()
@@ -781,8 +781,8 @@ class SceneRepository(
 		val deleted = sceneDatasource.deleteGroup(scene)
 
 		return if (deleted) {
-			if (syncDataRepository.isServerSynchronized()) {
-				syncDataRepository.recordIdDeletion(scene.id)
+			if (syncJournal.isServerSynchronized()) {
+				syncJournal.recordIdDeletion(scene.id)
 			}
 
 			val sceneNode = getSceneNodeFromId(scene.id)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
@@ -2,7 +2,7 @@ package com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository
 
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.*
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
@@ -18,10 +18,13 @@ import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.util.numDigits
 import io.github.aakira.napier.Napier
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okio.IOException
 import okio.Path
 import org.koin.core.component.KoinComponent
@@ -29,7 +32,7 @@ import kotlin.time.Clock
 
 class SceneRepository(
 	val projectDef: ProjectDef,
-	private val idRepository: IdRepository,
+	private val idAllocator: IdAllocator,
 	private val syncDataRepository: SyncDataRepository,
 	private val sceneMetadataRepository: SceneMetadataRepository,
 	private val sceneContentRepository: SceneContentRepository,
@@ -143,7 +146,7 @@ class SceneRepository(
 
 		cleanupSceneOrder()
 
-		idRepository.findNextId()
+		idAllocator.findNextId()
 
 		// Loads any existing temp buffers and starts the content debounce/autosave engine.
 		sceneContentRepository.initialize()
@@ -693,7 +696,7 @@ class SceneRepository(
 		} else {
 			val lastOrder = getLastOrderNumber(parent?.id)
 			val nextOrder = forceOrder ?: (lastOrder + 1)
-			val sceneId = forceId ?: idRepository.claimNextId()
+			val sceneId = forceId ?: idAllocator.claimNextId()
 			val type = if (isGroup) SceneItem.Type.Group else SceneItem.Type.Scene
 
 			val newSceneItem = SceneItem(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -6,7 +6,7 @@ import com.darkrockstudios.apps.hammer.base.http.ApiProjectDefinition
 import com.darkrockstudios.apps.hammer.base.http.BeginProjectsSyncResponse
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SyncedProjectDefinition
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
@@ -28,7 +28,7 @@ import kotlin.uuid.Uuid
 
 class ClientAccountSynchronizer(
 	private val fileSystem: FileSystem,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val projectsRepository: ProjectsRepository,
 	private val serverProjectsApi: ServerProjectsApi,
 	private val networkConnectivity: NetworkConnectivity,
@@ -38,11 +38,11 @@ class ClientAccountSynchronizer(
 	var initialSync = false
 
 	fun isServerSynchronized(): Boolean {
-		return (globalSettingsRepository.serverSettings?.userId ?: -1) > -1
+		return (globalSettingsStore.serverSettings?.userId ?: -1) > -1
 	}
 
 	suspend fun shouldAutoSync(): Boolean =
-		globalSettingsRepository.globalSettings.automaticSyncing &&
+		globalSettingsStore.globalSettings.automaticSyncing &&
 			networkConnectivity.hasActiveConnection()
 
 	suspend fun syncProjects(onLog: OnSyncLog, onUnauthorized: suspend () -> Unit): Boolean {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
@@ -27,7 +27,7 @@ class ClientProjectSynchronizer(
 	private val projectDef: ProjectDef,
 	private val entitySynchronizers: EntitySynchronizers,
 	private val strRes: StrRes,
-	private val syncDataRepository: SyncDataRepository,
+	private val syncJournal: SyncJournal,
 	private val globalSettingsRepository: GlobalSettingsRepository,
 	private val projectMetadataDatasource: ProjectMetadataDatasource,
 	private val serverProjectApi: ServerProjectApi,
@@ -149,7 +149,7 @@ class ClientProjectSynchronizer(
 
 	private suspend fun endSync() {
 		try {
-			val syncId = syncDataRepository.loadSyncData().currentSyncId
+			val syncId = syncJournal.loadSyncData().currentSyncId
 				?: throw IllegalStateException("No sync ID")
 			val serverProjectId = projectMetadataDatasource.requireProjectId(projectDef)
 
@@ -165,8 +165,8 @@ class ClientProjectSynchronizer(
 			if (endSyncResult.isFailure) {
 				Napier.e("Failed to end sync", endSyncResult.exceptionOrNull())
 			} else {
-				val finalSyncData = syncDataRepository.loadSyncData().copy(currentSyncId = null)
-				syncDataRepository.saveSyncData(finalSyncData)
+				val finalSyncData = syncJournal.loadSyncData().copy(currentSyncId = null)
+				syncJournal.saveSyncData(finalSyncData)
 			}
 		} catch (e: IOException) {
 			Napier.e("Sync failed", e)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
@@ -5,7 +5,7 @@ import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.*
@@ -28,7 +28,7 @@ class ClientProjectSynchronizer(
 	private val entitySynchronizers: EntitySynchronizers,
 	private val strRes: StrRes,
 	private val syncJournal: SyncJournal,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val projectMetadataDatasource: ProjectMetadataDatasource,
 	private val serverProjectApi: ServerProjectApi,
 ) : ProjectScoped {
@@ -154,7 +154,7 @@ class ClientProjectSynchronizer(
 			val serverProjectId = projectMetadataDatasource.requireProjectId(projectDef)
 
 			val endSyncResult = serverProjectApi.endProjectSync(
-				globalSettingsRepository.userIdOrThrow(),
+				globalSettingsStore.userIdOrThrow(),
 				projectDef.name,
 				serverProjectId,
 				syncId,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataDatasource.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.sync.projectsync
 
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -13,7 +13,7 @@ class SyncDataDatasource(
 	private val projectDef: ProjectDef,
 	private val fileSystem: FileSystem,
 	private val json: Json,
-	private val idRepository: IdRepository,
+	private val idAllocator: IdAllocator,
 	private val entitySynchronizers: EntitySynchronizers
 ) {
 	suspend fun loadSyncDataOrNull(): ProjectSynchronizationData? {
@@ -58,7 +58,7 @@ class SyncDataDatasource(
 	}
 
 	suspend fun createSyncData(): ProjectSynchronizationData {
-		val lastId = idRepository.peekLastId()
+		val lastId = idAllocator.peekLastId()
 
 		val missingIds = mutableSetOf<Int>()
 		for (id in 1..lastId) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.common.data.sync.projectsync
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
 import com.darkrockstudios.apps.hammer.common.util.NetworkConnectivity
 
-class SyncDataRepository(
+class SyncJournal(
 	private val globalSettingsRepository: GlobalSettingsRepository,
 	private val networkConnectivity: NetworkConnectivity,
 	private val datasource: SyncDataDatasource,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
@@ -1,10 +1,10 @@
 package com.darkrockstudios.apps.hammer.common.data.sync.projectsync
 
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.NetworkConnectivity
 
 class SyncJournal(
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val networkConnectivity: NetworkConnectivity,
 	private val datasource: SyncDataDatasource,
 ) {
@@ -18,8 +18,8 @@ class SyncJournal(
 		return datasource.loadSyncDataOrNull()?.deletedIds ?: emptySet()
 	}
 
-	suspend fun shouldAutoSync(): Boolean = globalSettingsRepository.serverIsSetup() &&
-		globalSettingsRepository.globalSettings.automaticSyncing &&
+	suspend fun shouldAutoSync(): Boolean = globalSettingsStore.serverIsSetup() &&
+		globalSettingsStore.globalSettings.automaticSyncing &&
 		networkConnectivity.hasActiveConnection() &&
 		needsSync()
 
@@ -29,7 +29,7 @@ class SyncJournal(
 	}
 
 	suspend fun markEntityAsDirty(id: Int, oldHash: String) {
-		if (globalSettingsRepository.isServerSynchronized().not()) return
+		if (globalSettingsStore.isServerSynchronized().not()) return
 
 		val syncData = datasource.loadSyncData()
 		val newSyncData = syncData.copy(
@@ -39,7 +39,7 @@ class SyncJournal(
 	}
 
 	suspend fun recordNewId(claimedId: Int) {
-		if (globalSettingsRepository.isServerSynchronized().not()) return
+		if (globalSettingsStore.isServerSynchronized().not()) return
 
 		val syncData = datasource.loadSyncData()
 		val newSyncData = syncData.copy(newIds = syncData.newIds + claimedId)
@@ -47,7 +47,7 @@ class SyncJournal(
 	}
 
 	suspend fun recordIdDeletion(deletedId: Int) {
-		if (globalSettingsRepository.isServerSynchronized().not()) return
+		if (globalSettingsStore.isServerSynchronized().not()) return
 
 		val syncData = datasource.loadSyncData()
 		val newSyncData = if (syncData.newIds.contains(deletedId)) {
@@ -61,7 +61,7 @@ class SyncJournal(
 	}
 
 	fun isServerSynchronized(): Boolean {
-		return globalSettingsRepository.serverSettings != null
+		return globalSettingsStore.serverSettings != null
 	}
 
 	suspend fun createSyncData(): Boolean {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/BackupOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/BackupOperation.kt
@@ -4,7 +4,7 @@ import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectbackup.ProjectBackupRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.util.StrRes
@@ -12,7 +12,7 @@ import com.darkrockstudios.apps.hammer.sync_log_backup_made
 
 class BackupOperation(
 	projectDef: ProjectDef,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val backupRepository: ProjectBackupRepository,
 	private val strRes: StrRes,
 ) : SyncOperation(projectDef) {
@@ -24,7 +24,7 @@ class BackupOperation(
 		onComplete: suspend () -> Unit
 	): CResult<SyncOperationState> {
 		if (
-			globalSettingsRepository.globalSettings.automaticBackups &&
+			globalSettingsStore.globalSettings.automaticBackups &&
 			backupRepository.supportsBackup()
 		) {
 			val backupDef = backupRepository.createBackup(projectDef)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchLocalDataOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchLocalDataOperation.kt
@@ -14,7 +14,7 @@ class FetchLocalDataOperation(
 	projectDef: ProjectDef,
 	private val projectMetadataDatasource: ProjectMetadataDatasource,
 	private val entitySynchronizers: EntitySynchronizers,
-	private val syncDataRepository: SyncDataRepository,
+	private val syncJournal: SyncJournal,
 	private val strRes: StrRes,
 ) : SyncOperation(projectDef) {
 
@@ -34,7 +34,7 @@ class FetchLocalDataOperation(
 				return CResult.failure(MissingProjectIdException(projectDef.name))
 			}
 
-			val clientSyncData = syncDataRepository.loadSyncData()
+			val clientSyncData = syncJournal.loadSyncData()
 			val entityState = if (state.onlyNew) {
 				null
 			} else {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchServerDataOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchServerDataOperation.kt
@@ -4,7 +4,7 @@ import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.first
 
 class FetchServerDataOperation(
 	projectDef: ProjectDef,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val serverProjectApi: ServerProjectApi,
 	private val projectMetadataDatasource: ProjectMetadataDatasource,
 	private val strRes: StrRes,
@@ -63,7 +63,7 @@ class FetchServerDataOperation(
 	}
 
 	private suspend fun userId(): Long {
-		return globalSettingsRepository.serverSettingsUpdates.first()?.userId
+		return globalSettingsStore.serverSettingsUpdates.first()?.userId
 			?: throw IllegalStateException("Server settings missing")
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
@@ -4,7 +4,7 @@ import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
@@ -20,7 +20,7 @@ class FinalizeSyncOperation(
 	private val strRes: StrRes,
 	private val clock: Clock,
 	private val serverProjectApi: ServerProjectApi,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val syncDataDatasource: SyncDataDatasource,
 ) : SyncOperation(projectDef) {
 
@@ -117,7 +117,7 @@ class FinalizeSyncOperation(
 	}
 
 	private suspend fun userId(): Long {
-		return globalSettingsRepository.serverSettingsUpdates.first()?.userId
+		return globalSettingsStore.serverSettingsUpdates.first()?.userId
 			?: throw IllegalStateException("Server settings missing")
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/IdConflictResolutionOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/IdConflictResolutionOperation.kt
@@ -4,14 +4,14 @@ import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.base.http.ProjectSynchronizationBegan
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import kotlinx.coroutines.yield
 import kotlin.math.max
 
 class IdConflictResolutionOperation(
 	projectDef: ProjectDef,
-	private val idRepository: IdRepository,
+	private val idAllocator: IdAllocator,
 	private val entitySynchronizers: EntitySynchronizers,
 ) : SyncOperation(projectDef) {
 	override suspend fun execute(
@@ -27,7 +27,7 @@ class IdConflictResolutionOperation(
 		// Resolve ID conflicts
 		val resolvedClientSyncData =
 			handleIdConflicts(state.clientSyncData, state.serverSyncData, onLog)
-		val currentMaxId: Int = idRepository.let {
+		val currentMaxId: Int = idAllocator.let {
 			it.findNextId()
 			it.peekLastId()
 		}
@@ -75,8 +75,8 @@ class IdConflictResolutionOperation(
 				// lower than a local entity's ID (e.g. server-side data loss),
 				// seeding only from serverLastId would hand out IDs that collide
 				// with - and clobber - existing local entities.
-				idRepository.findNextId()
-				val clientMaxId = idRepository.peekLastId()
+				idAllocator.findNextId()
+				val clientMaxId = idAllocator.peekLastId()
 				if (serverSyncData.lastId < clientMaxId) {
 					onLog(
 						syncLogW(
@@ -123,7 +123,7 @@ class IdConflictResolutionOperation(
 				}
 
 				// Tell ID Repository to re-find the max ID
-				idRepository.findNextId()
+				idAllocator.findNextId()
 
 				clientSyncData.copy(
 					newIds = updatedNewIds,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/PrepareForSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/PrepareForSyncOperation.kt
@@ -11,7 +11,7 @@ class PrepareForSyncOperation(
 	projectDef: ProjectDef,
 	private val entitySynchronizers: EntitySynchronizers,
 	private val idAllocator: IdAllocator,
-	private val syncDataRepository: SyncDataRepository,
+	private val syncJournal: SyncJournal,
 ) : SyncOperation(projectDef) {
 	override suspend fun execute(
 		state: SyncOperationState,
@@ -25,7 +25,7 @@ class PrepareForSyncOperation(
 		entitySynchronizers.synchronizers.values.forEach { it.prepareForSync() }
 
 		// Create the sync data if it doesnt exist yet
-		if (syncDataRepository.createSyncData()) {
+		if (syncJournal.createSyncData()) {
 			Napier.i("New sync data file created.")
 		}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/PrepareForSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/PrepareForSyncOperation.kt
@@ -3,14 +3,14 @@ package com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import io.github.aakira.napier.Napier
 
 class PrepareForSyncOperation(
 	projectDef: ProjectDef,
 	private val entitySynchronizers: EntitySynchronizers,
-	private val idRepository: IdRepository,
+	private val idAllocator: IdAllocator,
 	private val syncDataRepository: SyncDataRepository,
 ) : SyncOperation(projectDef) {
 	override suspend fun execute(
@@ -20,7 +20,7 @@ class PrepareForSyncOperation(
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
 		onComplete: suspend () -> Unit
 	): CResult<SyncOperationState> {
-		idRepository.findNextId()
+		idAllocator.findNextId()
 
 		entitySynchronizers.synchronizers.values.forEach { it.prepareForSync() }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
@@ -8,7 +8,7 @@ import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataConflic
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflict
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflictBroker
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
@@ -25,7 +25,7 @@ class ProjectDataSyncOperation(
 	private val repository: ProjectDataRepository,
 	private val api: ProjectDataApi,
 	private val broker: ProjectDataConflictBroker,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 ) : SyncOperation(projectDef) {
 
 	override suspend fun execute(
@@ -37,7 +37,7 @@ class ProjectDataSyncOperation(
 	): CResult<SyncOperationState> {
 		state as IdConflictResolutionState
 
-		val userId = globalSettingsRepository.userIdOrThrow()
+		val userId = globalSettingsStore.userIdOrThrow()
 		val projectId = state.serverProjectId
 
 		val getResult = api.getProjectData(userId, projectDef.name, projectId)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/WritingActivitySyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/WritingActivitySyncOperation.kt
@@ -4,14 +4,8 @@ import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityConflictHandler
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityTransferState
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogMessage
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncOperationState
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogI
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogW
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityRepository
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.mergeOwnSlotSessions
@@ -42,7 +36,7 @@ class WritingActivitySyncOperation(
 	private val repository: WritingActivityRepository,
 	private val tracker: WritingSessionTracker,
 	private val api: WritingActivityApi,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 ) : SyncOperation(projectDef) {
 
 	override suspend fun execute(
@@ -55,7 +49,7 @@ class WritingActivitySyncOperation(
 		state as EntityTransferState
 
 		try {
-			val userId = globalSettingsRepository.userIdOrThrow()
+			val userId = globalSettingsStore.userIdOrThrow()
 			val projectId = state.serverProjectId
 			val ownDeviceId = repository.ownDeviceId()
 
@@ -78,7 +72,7 @@ class WritingActivitySyncOperation(
 			repository.saveOwnLog(mergedSessions)
 
 			val payload = DeviceLog(
-				deviceLabel = globalSettingsRepository.deviceLabelOrDefault(),
+				deviceLabel = globalSettingsStore.deviceLabelOrDefault(),
 				sessions = mergedSessions,
 			)
 			val postResult = api.uploadDeviceLog(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineRepository.kt
@@ -5,7 +5,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectInject
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectDefaultDispatcher
@@ -30,7 +30,7 @@ class TimeLineRepository(
 ) : ProjectScoped, ScopeCallback {
 	override val projectScope = ProjectDefScope(projectDef)
 
-	private val syncDataRepository: SyncDataRepository by projectInject()
+	private val syncJournal: SyncJournal by projectInject()
 	private val dispatcherDefault: CoroutineContext by injectDefaultDispatcher()
 
 	// Get this one eagerly, it's used during Koin teardown when we can't get it from the scope
@@ -139,7 +139,7 @@ class TimeLineRepository(
 		events.removeAt(index)
 		storeAndEmitTimeline(timeline.copy(events = events))
 
-		syncDataRepository.recordIdDeletion(event.id)
+		syncJournal.recordIdDeletion(event.id)
 
 		return true
 	}
@@ -249,7 +249,7 @@ class TimeLineRepository(
 	}
 
 	private suspend fun markForSynchronization(originalEvent: TimeLineEvent, originalOrder: Int) {
-		if (syncDataRepository.isServerSynchronized() && !syncDataRepository.isEntityDirty(
+		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(
 				originalEvent.id
 			)
 		) {
@@ -260,7 +260,7 @@ class TimeLineRepository(
 				date = originalEvent.date,
 				tags = originalEvent.tags,
 			)
-			syncDataRepository.markEntityAsDirty(originalEvent.id, hash)
+			syncJournal.markEntityAsDirty(originalEvent.id, hash)
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineRepository.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.common.data.timelinerepository
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectInject
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
@@ -25,7 +25,7 @@ import kotlin.coroutines.CoroutineContext
 
 class TimeLineRepository(
 	private val projectDef: ProjectDef,
-	private val idRepository: IdRepository,
+	private val idAllocator: IdAllocator,
 	private val datasource: TimeLineDatasource,
 ) : ProjectScoped, ScopeCallback {
 	override val projectScope = ProjectDefScope(projectDef)
@@ -70,7 +70,7 @@ class TimeLineRepository(
 		order: Int? = null,
 		tags: Set<String> = emptySet(),
 	): TimeLineEvent {
-		val eventId = id ?: idRepository.claimNextId()
+		val eventId = id ?: idAllocator.claimNextId()
 		val timeline = timelineFlow.first()
 
 		val event = TimeLineEvent(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/writingactivity/WritingActivityRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/writingactivity/WritingActivityRepository.kt
@@ -4,7 +4,7 @@ import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingSession
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 
 /**
@@ -14,14 +14,14 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScop
  */
 class WritingActivityRepository(
 	private val datasource: WritingActivityDatasource,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	val projectDef: ProjectDef,
 ) : ProjectScoped {
 
 	override val projectScope = ProjectDefScope(projectDef)
 
 	/** Returns this device's id, generating and persisting it on first call. */
-	suspend fun ownDeviceId(): String = globalSettingsRepository.ensureInstallId()
+	suspend fun ownDeviceId(): String = globalSettingsStore.ensureInstallId()
 
 	/**
 	 * Loads this device's slot, returning an empty log labeled with the current
@@ -31,7 +31,7 @@ class WritingActivityRepository(
 	suspend fun loadOwnLog(): DeviceLog {
 		val deviceId = ownDeviceId()
 		return datasource.loadDeviceLog(deviceId)
-			?: DeviceLog(deviceLabel = globalSettingsRepository.deviceLabelOrDefault())
+			?: DeviceLog(deviceLabel = globalSettingsStore.deviceLabelOrDefault())
 	}
 
 	/**
@@ -41,7 +41,7 @@ class WritingActivityRepository(
 	suspend fun saveOwnLog(sessions: List<WritingSession>) {
 		val deviceId = ownDeviceId()
 		val log = DeviceLog(
-			deviceLabel = globalSettingsRepository.deviceLabelOrDefault(),
+			deviceLabel = globalSettingsStore.deviceLabelOrDefault(),
 			sessions = sessions,
 		)
 		datasource.saveDeviceLog(deviceId, log)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
@@ -215,7 +215,7 @@ fun HttpClient.updateCredentials(credentials: BearerTokens) {
 		// This clears the internal cache, forcing `loadTokens` to run again on the next request.
 		authProvider<BearerAuthProvider>()?.clearToken()
 	} else {
-		Napier.e("Failed to update credentials: GlobalSettingsRepository not attached to HttpClient")
+		Napier.e("Failed to update credentials: GlobalSettingsStore not attached to HttpClient")
 	}
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
@@ -2,7 +2,7 @@ package com.darkrockstudios.apps.hammer.common.dependencyinjection
 
 import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import com.darkrockstudios.apps.hammer.base.http.*
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import io.github.aakira.napier.Napier
 import io.ktor.client.*
@@ -20,10 +20,10 @@ import io.ktor.serialization.kotlinx.json.*
 import io.ktor.util.*
 import okio.IOException
 
-private val GlobalSettingsKey = AttributeKey<GlobalSettingsRepository>("GlobalSettings")
+private val GlobalSettingsKey = AttributeKey<GlobalSettingsStore>("GlobalSettings")
 
 fun createHttpClient(
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 ): HttpClient {
 	val tokenRefreshClient = createRefreshClient()
 	val client = HttpClient(getHttpPlatformEngine()) {
@@ -54,23 +54,23 @@ fun createHttpClient(
 			bearer {
 				realm = AUTH_REALM
 				loadTokens {
-					loadTokens(globalSettingsRepository)
+					loadTokens(globalSettingsStore)
 				}
 				refreshTokens {
-					refreshToken(globalSettingsRepository, tokenRefreshClient)
+					refreshToken(globalSettingsStore, tokenRefreshClient)
 				}
 			}
 		}
 	}
 
-	client.attributes.put(GlobalSettingsKey, globalSettingsRepository)
+	client.attributes.put(GlobalSettingsKey, globalSettingsStore)
 
 	return client
 }
 
-private fun loadTokens(globalSettingsRepository: GlobalSettingsRepository): BearerTokens? {
-	val accessToken = globalSettingsRepository.serverSettings?.bearerToken
-	val refreshToken = globalSettingsRepository.serverSettings?.refreshToken
+private fun loadTokens(globalSettingsStore: GlobalSettingsStore): BearerTokens? {
+	val accessToken = globalSettingsStore.serverSettings?.bearerToken
+	val refreshToken = globalSettingsStore.serverSettings?.refreshToken
 	Napier.d { "loadTokens" }
 	return if (accessToken != null && refreshToken != null) {
 		BearerTokens(
@@ -96,14 +96,14 @@ private fun createRefreshClient(): HttpClient {
 }
 
 private suspend fun refreshToken(
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	client: HttpClient
 ): BearerTokens? {
 
-	val refreshToken = globalSettingsRepository.serverSettings?.refreshToken
+	val refreshToken = globalSettingsStore.serverSettings?.refreshToken
 	val serverSettings =
-		globalSettingsRepository.serverSettings ?: throw IllegalStateException("No server URL")
-	val installId = globalSettingsRepository.ensureInstallId()
+		globalSettingsStore.serverSettings ?: throw IllegalStateException("No server URL")
+	val installId = globalSettingsStore.ensureInstallId()
 	return if (refreshToken != null) {
 		val result = refreshTokenRequest(
 			httpClient = client,
@@ -115,12 +115,12 @@ private suspend fun refreshToken(
 		if (result.isSuccess) {
 			val newTokens = result.getOrThrow()
 
-			globalSettingsRepository.serverSettings?.let { oldSettings ->
+			globalSettingsStore.serverSettings?.let { oldSettings ->
 				val newSettings = oldSettings.copy(
 					bearerToken = newTokens.auth,
 					refreshToken = newTokens.refresh
 				)
-				globalSettingsRepository.updateServerSettings(newSettings)
+				globalSettingsStore.updateServerSettings(newSettings)
 			}
 
 			BearerTokens(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -16,7 +16,7 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsFilesystemDatasource
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.id.datasources.*
 import com.darkrockstudios.apps.hammer.common.data.importer.MarkdownStoryImporter
 import com.darkrockstudios.apps.hammer.common.data.importer.StoryImporter
@@ -33,11 +33,7 @@ import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsD
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsService
 import com.darkrockstudios.apps.hammer.common.data.references.*
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.accountsync.ClientAccountSynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ClientProjectSynchronizer
@@ -161,7 +157,7 @@ val mainModule = module {
 		factoryOf(::EncyclopediaIdDatasource)
 		factoryOf(::TimeLineEventIdDatasource)
 		factoryOf(::SceneDraftIdDatasource)
-		scopedOf(::IdRepository)
+		scopedOf(::IdAllocator)
 
 		scopedOf(::NotesDatasource)
 		scopedOf(::NotesRepository)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -39,7 +39,7 @@ import com.darkrockstudios.apps.hammer.common.data.sync.accountsync.ClientAccoun
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ClientProjectSynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizers
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.synchronizers.*
 import com.darkrockstudios.apps.hammer.common.data.tagindex.BuildTagIndexUseCase
@@ -215,7 +215,7 @@ val mainModule = module {
 		factoryOf(::ProjectDataSyncOperation)
 		factoryOf(::FinalizeSyncOperation)
 
-		scopedOf(::SyncDataRepository)
+		scopedOf(::SyncJournal)
 		scopedOf(::ClientProjectSynchronizer)
 
 		scopedOf(::EntitySynchronizers)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -12,7 +12,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.exampleProjectModule
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsFilesystemDatasource
@@ -105,7 +105,7 @@ val mainModule = module {
 
 	singleOf(::ServerSettingsFilesystemDatasource) bind ServerSettingsDatasource::class
 	singleOf(::GlobalSettingsFilesystemDatasource)
-	singleOf(::GlobalSettingsRepository) bind GlobalSettingsRepository::class
+	singleOf(::GlobalSettingsStore) bind GlobalSettingsStore::class
 
 	singleOf(::GithubVersionCheckDataSource) bind VersionCheckDataSource::class
 	singleOf(::VersionCheckRepository)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
@@ -2,7 +2,7 @@ package com.darkrockstudios.apps.hammer.common.server
 
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispatcher
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.url
 import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
@@ -23,11 +23,11 @@ import org.koin.core.component.inject
 
 abstract class Api(
 	private val httpClient: HttpClient,
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val strRes: StrRes,
 ) : KoinComponent {
 	protected val userId: Long?
-		get() = globalSettingsRepository.serverSettings?.userId
+		get() = globalSettingsStore.serverSettings?.userId
 
 	private val ioDispatcher by injectIoDispatcher()
 	private val localeResolver: DeviceLocaleResolver by inject()
@@ -39,7 +39,7 @@ abstract class Api(
 		failureHandler: FailureHandler = { defaultFailureHandler(it, strRes) },
 		parse: suspend (HttpResponse) -> T,
 	): Result<T> = withContext(ioDispatcher) {
-		val server = globalSettingsRepository.serverSettings ?: return@withContext Result.failure<T>(
+		val server = globalSettingsStore.serverSettings ?: return@withContext Result.failure<T>(
 			IllegalStateException("Server not configured")
 		)
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ProjectDataApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ProjectDataApi.kt
@@ -6,23 +6,21 @@ import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataConflict
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataDto
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataUploadRequest
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataConflictException
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.StrRes
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import kotlinx.serialization.json.Json
 
 class ProjectDataApi(
 	httpClient: HttpClient,
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	private val json: Json,
 	private val strRes: StrRes,
-) : Api(httpClient, globalSettingsRepository, strRes) {
+) : Api(httpClient, globalSettingsStore, strRes) {
 
 	suspend fun getProjectData(
 		userId: Long,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerAccountApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerAccountApi.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.server
 
 import com.darkrockstudios.apps.hammer.base.http.Token
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -11,9 +11,9 @@ import io.ktor.http.*
 
 class ServerAccountApi(
 	httpClient: HttpClient,
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	strRes: StrRes
-) : Api(httpClient, globalSettingsRepository, strRes) {
+) : Api(httpClient, globalSettingsStore, strRes) {
 
 	suspend fun createAccount(
 		email: String,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerAdminApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerAdminApi.kt
@@ -1,15 +1,15 @@
 package com.darkrockstudios.apps.hammer.common.server
 
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
 
 class ServerAdminApi(
 	httpClient: HttpClient,
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	strRes: StrRes,
-) : Api(httpClient, globalSettingsRepository, strRes) {
+) : Api(httpClient, globalSettingsStore, strRes) {
 
 	suspend fun getWhiteList(): Result<List<String>> {
 		return get(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectApi.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.common.server
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.*
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityConflictException
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -19,10 +19,10 @@ import kotlin.time.Instant
 
 class ServerProjectApi(
 	httpClient: HttpClient,
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	private val json: Json,
 	private val strRes: StrRes,
-) : Api(httpClient, globalSettingsRepository, strRes) {
+) : Api(httpClient, globalSettingsStore, strRes) {
 
 	suspend fun beginProjectSync(
 		userId: Long,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
@@ -4,7 +4,7 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.BeginProjectsSyncResponse
 import com.darkrockstudios.apps.hammer.base.http.CreateProjectResponse
 import com.darkrockstudios.apps.hammer.base.http.HEADER_SYNC_ID
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -12,9 +12,9 @@ import io.ktor.client.request.*
 
 class ServerProjectsApi(
 	httpClient: HttpClient,
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	strRes: StrRes,
-) : Api(httpClient, globalSettingsRepository, strRes) {
+) : Api(httpClient, globalSettingsStore, strRes) {
 
 	suspend fun beginProjectsSync(): Result<BeginProjectsSyncResponse> {
 		return get(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/WritingActivityApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/WritingActivityApi.kt
@@ -3,13 +3,12 @@ package com.darkrockstudios.apps.hammer.common.server
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingActivityResponse
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.StrRes
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
 
 /**
  * Client API for the project's writing-activity sync endpoints. The server
@@ -19,9 +18,9 @@ import io.ktor.http.contentType
  */
 class WritingActivityApi(
 	httpClient: HttpClient,
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	private val strRes: StrRes,
-) : Api(httpClient, globalSettingsRepository, strRes) {
+) : Api(httpClient, globalSettingsStore, strRes) {
 
 	/** Fetch every device's slot for this project. */
 	suspend fun getWritingActivity(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/SpellCheckRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/SpellCheckRepository.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.spellcheck
 
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectDefaultDispatcher
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellChecker
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 
 class SpellCheckRepository(
-	private val globalSettingsRepository: GlobalSettingsRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
 	private val spellCheckFactory: PlatformSpellCheckerFactory,
 ) : KoinComponent {
 
@@ -48,11 +48,11 @@ class SpellCheckRepository(
 	init {
 		scope.launch {
 			val initialLocale =
-				globalSettingsRepository.globalSettings.spellCheckSettings.locale
+				globalSettingsStore.globalSettings.spellCheckSettings.locale
 			requestSpellChecker(initialLocale)
 			Napier.i("Spell Check: Initial language set: $initialLocale")
 
-			globalSettingsRepository.globalSettingsUpdates.collect { settings ->
+			globalSettingsStore.globalSettingsUpdates.collect { settings ->
 				val newLanguage = settings.spellCheckSettings.locale
 				if (currentLanguage != settings.spellCheckSettings.locale) {
 					Napier.i("Updating Spell Check Language: $newLanguage")

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/PlatformSettingsComponent.desktop.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/PlatformSettingsComponent.desktop.kt
@@ -5,7 +5,7 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.getAndUpdate
 import com.darkrockstudios.apps.hammer.common.components.SavableComponent
 import com.darkrockstudios.apps.hammer.common.components.savableState
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.migrator.DataMigrator
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
@@ -24,7 +24,7 @@ class DesktopPlatformSettingsComponent(componentContext: ComponentContext) : Des
 
 	private val mainDispatcher by injectMainDispatcher()
 
-	private val globalSettingsRepository: GlobalSettingsRepository by inject()
+	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val projectsRepository: ProjectsRepository by inject()
 	private val sandboxFileAccess: SandboxFileAccess by inject()
 
@@ -44,7 +44,7 @@ class DesktopPlatformSettingsComponent(componentContext: ComponentContext) : Des
 
 	private fun watchSettingsUpdates() {
 		scope.launch {
-			globalSettingsRepository.globalSettingsUpdates.collect { settings ->
+			globalSettingsStore.globalSettingsUpdates.collect { settings ->
 				withContext(dispatcherMain) {
 					_state.getAndUpdate {
 						val projectsPath = settings.projectsDirectory.toPath().toHPath()
@@ -70,7 +70,7 @@ class DesktopPlatformSettingsComponent(componentContext: ComponentContext) : Des
 				return@launch
 			}
 
-			globalSettingsRepository.updateSettings {
+			globalSettingsStore.updateSettings {
 				it.copy(projectsDirectory = path)
 			}
 

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryDesktop.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryDesktop.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data
 
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.zip.unzipBytesToDirectory
 import io.github.aakira.napier.Napier
 import net.peanuuutz.tomlkt.Toml
@@ -17,11 +17,11 @@ actual val exampleProjectModule = module {
 }
 
 class ExampleProjectRepositoryDesktop(
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	fileSystem: FileSystem,
 	toml: Toml,
 	clock: Clock,
-) : ExampleProjectRepository(globalSettingsRepository, fileSystem, toml, clock) {
+) : ExampleProjectRepository(globalSettingsStore, fileSystem, toml, clock) {
 
 	private fun loadExampleProjectZip(): ByteArray {
 		val path = "/raw/$EXAMPLE_PROJECT_FILE_NAME"

--- a/common/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/data/projectbackup/ProjectBackupRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/data/projectbackup/ProjectBackupRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.projectbackup
 
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
@@ -19,15 +19,15 @@ class ProjectBackupRepositoryTest {
 
 	private val fileSystem = FakeFileSystem()
 	private val projectsRepository = mockk<ProjectsRepository>()
-	private val globalSettingsRepository = mockk<GlobalSettingsRepository>()
+	private val globalSettingsStore = mockk<GlobalSettingsStore>()
 	private val clock = mockk<Clock>()
 
 	private class TestRepo(
 		fileSystem: FileSystem,
 		projectsRepository: ProjectsRepository,
-		globalSettingsRepository: GlobalSettingsRepository,
+		globalSettingsStore: GlobalSettingsStore,
 		clock: Clock
-	) : ProjectBackupRepository(fileSystem, projectsRepository, globalSettingsRepository, clock) {
+	) : ProjectBackupRepository(fileSystem, projectsRepository, globalSettingsStore, clock) {
 		override fun supportsBackup(): Boolean = true
 		override suspend fun createBackup(projectDef: ProjectDef): ProjectBackupDef? = null
 		override suspend fun restoreBackup(backupDef: ProjectBackupDef, targetDir: HPath): Boolean = true
@@ -43,7 +43,7 @@ class ProjectBackupRepositoryTest {
 		every { projectsRepository.getProjectsDirectory() } returns "/projects".toPath().toHPath()
 
 		val projectDef = ProjectDef("Test Project", "/projects/Test Project".toPath().toHPath())
-		val repo = TestRepo(fileSystem, projectsRepository, globalSettingsRepository, clock)
+		val repo = TestRepo(fileSystem, projectsRepository, globalSettingsStore, clock)
 		val backupDef = repo.testCreateNewProjectBackupDef(projectDef)
 
 		val filename = backupDef.path.name
@@ -63,7 +63,7 @@ class ProjectBackupRepositoryTest {
 		every { projectsRepository.getProjectDirectory("Test Project") } returns "/projects/Test Project".toPath()
 			.toHPath()
 
-		val repo = TestRepo(fileSystem, projectsRepository, globalSettingsRepository, clock)
+		val repo = TestRepo(fileSystem, projectsRepository, globalSettingsStore, clock)
 		val backups = repo.getBackups(projectDef)
 
 		assertEquals(1, backups.size)

--- a/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
@@ -8,13 +8,12 @@ import com.darkrockstudios.apps.hammer.common.components.projectselection.accoun
 import com.darkrockstudios.apps.hammer.common.data.ExampleProjectRepository
 import com.darkrockstudios.apps.hammer.common.data.account.AccountUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.SpellCheckerSettings
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -36,7 +35,7 @@ class AccountSettingsComponentTest : BaseTest() {
 	private lateinit var lifecycle: LifecycleRegistry
 	private lateinit var context: DefaultComponentContext
 
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 	private lateinit var globalSettingsUpdates: MutableSharedFlow<GlobalSettings>
 	private lateinit var serverSettingsUpdates: SharedFlow<ServerSettings?>
 
@@ -55,19 +54,19 @@ class AccountSettingsComponentTest : BaseTest() {
 		lifecycle = LifecycleRegistry()
 		context = DefaultComponentContext(lifecycle = lifecycle)
 
-		globalSettingsRepository = mockk(relaxed = true)
+		globalSettingsStore = mockk(relaxed = true)
 		globalSettingsUpdates = MutableSharedFlow(replay = 1)
-		every { globalSettingsRepository.globalSettingsUpdates } returns globalSettingsUpdates
-		every { globalSettingsRepository.globalSettings } answers { globalSettings }
+		every { globalSettingsStore.globalSettingsUpdates } returns globalSettingsUpdates
+		every { globalSettingsStore.globalSettings } answers { globalSettings }
 
 		serverSettingsUpdates = MutableSharedFlow(replay = 1)
-		every { globalSettingsRepository.serverSettingsUpdates } returns serverSettingsUpdates
+		every { globalSettingsStore.serverSettingsUpdates } returns serverSettingsUpdates
 
 		val spellCheckerFactory = mockk<PlatformSpellCheckerFactory>(relaxed = true)
 		every { spellCheckerFactory.availableLocales() } returns emptyList()
 
 		val testModule = module {
-			single { globalSettingsRepository } bind GlobalSettingsRepository::class
+			single { globalSettingsStore } bind GlobalSettingsStore::class
 			single { mockk<ExampleProjectRepository>(relaxed = true) } bind ExampleProjectRepository::class
 			single { mockk<AccountUseCase>(relaxed = true) } bind AccountUseCase::class
 			single { mockk<ProjectsRepository>(relaxed = true) } bind ProjectsRepository::class

--- a/common/src/desktopTest/kotlin/components/projectselection/ProjectSelectionComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/ProjectSelectionComponentTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.components.projectselection.ProjectSelectionComponent
 import com.darkrockstudios.apps.hammer.common.data.ExampleProjectRepository
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.SpellCheckerSettings
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
@@ -45,7 +45,7 @@ class ProjectSelectionComponentTest : BaseTest() {
 	lateinit var lifecycle: LifecycleRegistry
 	lateinit var context: DefaultComponentContext
 
-	lateinit var globalSettingsRepository: GlobalSettingsRepository
+	lateinit var globalSettingsStore: GlobalSettingsStore
 	lateinit var globalSettingsUpdates: SharedFlow<GlobalSettings>
 	lateinit var serverSettingsUpdates: SharedFlow<ServerSettings?>
 	lateinit var projectsRepository: ProjectsRepository
@@ -71,7 +71,7 @@ class ProjectSelectionComponentTest : BaseTest() {
 		lifecycle = LifecycleRegistry()
 		context = DefaultComponentContext(lifecycle = lifecycle)
 
-		globalSettingsRepository = mockk(relaxed = true)
+		globalSettingsStore = mockk(relaxed = true)
 		projectsRepository = mockk()
 		exampleProjectRepository = mockk()
 		projectsSynchronizer = mockk()
@@ -86,7 +86,7 @@ class ProjectSelectionComponentTest : BaseTest() {
 		every { versionCheckRepository.updates } returns versionCheckUpdates
 
 		val testModule = module {
-			single { globalSettingsRepository } bind GlobalSettingsRepository::class
+			single { globalSettingsStore } bind GlobalSettingsStore::class
 			single { projectsRepository } bind ProjectsRepository::class
 			single { exampleProjectRepository } bind ExampleProjectRepository::class
 			single { projectsSynchronizer }
@@ -105,18 +105,18 @@ class ProjectSelectionComponentTest : BaseTest() {
 
 		globalSettingsUpdates = mockk()
 		coEvery { globalSettingsUpdates.collect(any()) } just Awaits
-		every { globalSettingsRepository.globalSettingsUpdates } returns globalSettingsUpdates
+		every { globalSettingsStore.globalSettingsUpdates } returns globalSettingsUpdates
 
 		globalSettings = GlobalSettings(
 			projectsDirectory = projectsDir.toString(),
 			spellCheckSettings = SpellCheckerSettings(locale = mockk())
 		)
-		every { globalSettingsRepository.globalSettings } answers { globalSettings }
+		every { globalSettingsStore.globalSettings } answers { globalSettings }
 
 		serverSettingsUpdates = mockk()
 		coEvery { serverSettingsUpdates.collect(any()) } just Awaits
 		coEvery { serverSettingsUpdates.first() } returns null
-		every { globalSettingsRepository.serverSettingsUpdates } returns serverSettingsUpdates
+		every { globalSettingsStore.serverSettingsUpdates } returns serverSettingsUpdates
 
 		every { projectsRepository.getProjects(any()) } returns emptyList()
 		every { exampleProjectRepository.shouldInstallFirstTime() } returns false
@@ -196,7 +196,7 @@ class ProjectSelectionComponentTest : BaseTest() {
 				currentVersion = "v1.0.0",
 			)
 		val captured = slot<(GlobalSettings) -> GlobalSettings>()
-		coEvery { globalSettingsRepository.updateSettings(capture(captured)) } just Runs
+		coEvery { globalSettingsStore.updateSettings(capture(captured)) } just Runs
 
 		val component = newComponent()
 		advanceUntilIdle()
@@ -223,7 +223,7 @@ class ProjectSelectionComponentTest : BaseTest() {
 		advanceUntilIdle()
 
 		assertFalse(component.updateNotification.value.visible)
-		coVerify(exactly = 0) { globalSettingsRepository.updateSettings(any()) }
+		coVerify(exactly = 0) { globalSettingsStore.updateSettings(any()) }
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/components/timeline/TimeLineOverviewComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/timeline/TimeLineOverviewComponentTest.kt
@@ -6,7 +6,7 @@ import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.components.timeline.TimeLineOverviewComponent
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.tagindex.TagIndex
 import com.darkrockstudios.apps.hammer.common.data.tagindex.TagIndexService
@@ -50,7 +50,7 @@ class TimeLineOverviewComponentTest : BaseTest() {
 	lateinit var lifecycleCallbacks: MutableList<Lifecycle.Callbacks>
 	lateinit var timelineRepoCollectCallback: CapturingSlot<FlowCollector<TimeLineContainer>>
 	lateinit var timelineRepo: TimeLineRepository
-	lateinit var globalSettingsRepo: GlobalSettingsRepository
+	lateinit var globalSettingsRepo: GlobalSettingsStore
 	lateinit var globalSettingsFlow: SharedFlow<GlobalSettings>
 	lateinit var tagIndexService: TagIndexService
 

--- a/common/src/desktopTest/kotlin/components/timeline/TimeLineOverviewComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/timeline/TimeLineOverviewComponentTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.components.timeline.TimeLineOverviewComponent
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.tagindex.TagIndex
 import com.darkrockstudios.apps.hammer.common.data.tagindex.TagIndexService
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineContainer
@@ -44,7 +44,7 @@ class TimeLineOverviewComponentTest : BaseTest() {
 	lateinit var ffs: FakeFileSystem
 	lateinit var toml: Toml
 	lateinit var json: Json
-	lateinit var idRepo: IdRepository
+	lateinit var idRepo: IdAllocator
 	lateinit var context: ComponentContext
 	lateinit var lifecycle: Lifecycle
 	lateinit var lifecycleCallbacks: MutableList<Lifecycle.Callbacks>
@@ -78,7 +78,7 @@ class TimeLineOverviewComponentTest : BaseTest() {
 
 		val testModule = module {
 			single { timelineRepo } bind TimeLineRepository::class
-			single { idRepo } bind IdRepository::class
+			single { idRepo } bind IdAllocator::class
 			single { globalSettingsRepo }
 			single { tagIndexService } bind TagIndexService::class
 		}

--- a/common/src/desktopTest/kotlin/datamigrator/DataMigratorTest.kt
+++ b/common/src/desktopTest/kotlin/datamigrator/DataMigratorTest.kt
@@ -5,13 +5,8 @@ import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.Info
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
-import com.darkrockstudios.apps.hammer.common.data.migrator.DataMigrator
-import com.darkrockstudios.apps.hammer.common.data.migrator.MigrateInstallIdToGlobal
-import com.darkrockstudios.apps.hammer.common.data.migrator.Migration
-import com.darkrockstudios.apps.hammer.common.data.migrator.Migration0_1
-import com.darkrockstudios.apps.hammer.common.data.migrator.Migration1_2
-import com.darkrockstudios.apps.hammer.common.data.migrator.PROJECT_DATA_VERSION
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.migrator.*
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import getProjectDef
@@ -30,7 +25,7 @@ import kotlin.time.Clock
 class DataMigratorTest : BaseTest() {
 
 	@MockK(relaxed = true)
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 
 	@MockK(relaxed = true)
 	private lateinit var projectsRepository: ProjectsRepository
@@ -71,7 +66,7 @@ class DataMigratorTest : BaseTest() {
 		)
 
 		val migrator = DataMigrator(
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			projectsRepository = projectsRepository,
 			projectMetadataDatasource = projectMetadataDatasource,
 		)
@@ -107,7 +102,7 @@ class DataMigratorTest : BaseTest() {
 		)
 
 		val migrator = DataMigrator(
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			projectsRepository = projectsRepository,
 			projectMetadataDatasource = projectMetadataDatasource,
 		)
@@ -151,7 +146,7 @@ class DataMigratorTest : BaseTest() {
 		)
 
 		val migrator = DataMigrator(
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			projectsRepository = projectsRepository,
 			projectMetadataDatasource = projectMetadataDatasource,
 		)
@@ -211,7 +206,7 @@ class DataMigratorTest : BaseTest() {
 		// Pin latestProjectDataVersion to 1 so this test stays focused on a single 0→1
 		// hop regardless of the global PROJECT_DATA_VERSION value.
 		val migrator = object : DataMigrator(
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			projectsRepository = projectsRepository,
 			projectMetadataDatasource = projectMetadataDatasource,
 		) {
@@ -289,7 +284,7 @@ class DataMigratorTest : BaseTest() {
 		})
 
 		val migrator = object : DataMigrator(
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			projectsRepository = projectsRepository,
 			projectMetadataDatasource = projectMetadataDatasource,
 		) {
@@ -377,7 +372,7 @@ class DataMigratorTest : BaseTest() {
 		})
 
 		val migrator = object : DataMigrator(
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			projectsRepository = projectsRepository,
 			projectMetadataDatasource = projectMetadataDatasource,
 		) {

--- a/common/src/desktopTest/kotlin/integration/BaseIntegrationTest.kt
+++ b/common/src/desktopTest/kotlin/integration/BaseIntegrationTest.kt
@@ -1,18 +1,14 @@
 package integration
 
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
-import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
@@ -56,7 +52,7 @@ abstract class BaseIntegrationTest : BaseTest() {
 
 	// Mocked external dependencies (things we don't want to test here)
 	protected lateinit var syncDataRepository: SyncDataRepository
-	protected lateinit var idRepository: IdRepository
+	protected lateinit var idAllocator: IdAllocator
 	protected lateinit var statisticsRepository: StatisticsRepository
 
 	// Project state
@@ -96,9 +92,9 @@ abstract class BaseIntegrationTest : BaseTest() {
 
 	private fun setupMockedDependencies() {
 		// ID repository - just provides incrementing IDs
-		idRepository = mockk()
-		coEvery { idRepository.claimNextId() } answers { nextId++ }
-		coEvery { idRepository.findNextId() } returns Unit
+		idAllocator = mockk()
+		coEvery { idAllocator.claimNextId() } answers { nextId++ }
+		coEvery { idAllocator.findNextId() } returns Unit
 
 		// Statistics repository - we don't care about stats in integration tests
 		statisticsRepository = mockk(relaxed = true)
@@ -148,7 +144,7 @@ abstract class BaseIntegrationTest : BaseTest() {
 		sceneEditorRepository = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,

--- a/common/src/desktopTest/kotlin/integration/BaseIntegrationTest.kt
+++ b/common/src/desktopTest/kotlin/integration/BaseIntegrationTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsR
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
@@ -51,7 +51,7 @@ abstract class BaseIntegrationTest : BaseTest() {
 	protected lateinit var projectMetadataDatasource: ProjectMetadataDatasource
 
 	// Mocked external dependencies (things we don't want to test here)
-	protected lateinit var syncDataRepository: SyncDataRepository
+	protected lateinit var syncJournal: SyncJournal
 	protected lateinit var idAllocator: IdAllocator
 	protected lateinit var statisticsRepository: StatisticsRepository
 
@@ -101,8 +101,8 @@ abstract class BaseIntegrationTest : BaseTest() {
 
 		// Sync data repository - controls whether sync is active
 		// Default to NOT synchronized so we don't trigger sync marking
-		syncDataRepository = mockk()
-		every { syncDataRepository.isServerSynchronized() } returns false
+		syncJournal = mockk()
+		every { syncJournal.isServerSynchronized() } returns false
 	}
 
 	/**
@@ -143,7 +143,7 @@ abstract class BaseIntegrationTest : BaseTest() {
 		// Create real repository with real datasources
 		sceneEditorRepository = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,
@@ -167,9 +167,9 @@ abstract class BaseIntegrationTest : BaseTest() {
 	 * This will cause markForSynchronization to actually run.
 	 */
 	protected fun enableServerSync() {
-		every { syncDataRepository.isServerSynchronized() } returns true
-		coEvery { syncDataRepository.isEntityDirty(any()) } returns false
-		coEvery { syncDataRepository.markEntityAsDirty(any(), any()) } returns Unit
+		every { syncJournal.isServerSynchronized() } returns true
+		coEvery { syncJournal.isEntityDirty(any()) } returns false
+		coEvery { syncJournal.markEntityAsDirty(any(), any()) } returns Unit
 	}
 
 	/**

--- a/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
@@ -13,7 +13,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
@@ -43,7 +43,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 	lateinit var externalFileIo: ExternalFileIo
 
 	@MockK
-	lateinit var syncDataRepository: SyncDataRepository
+	lateinit var syncJournal: SyncJournal
 
 	@MockK
 	lateinit var statisticsRepository: StatisticsRepository
@@ -64,7 +64,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 
 		setupKoin()
 
-		every { syncDataRepository.isServerSynchronized() } returns false
+		every { syncJournal.isServerSynchronized() } returns false
 		fileSystem = FakeFileSystem()
 		toml = createTomlSerializer()
 		createProject(fileSystem, ENCYCLOPEDIA_ONLY_PROJECT_NAME)
@@ -85,7 +85,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 			projectDef = projDef,
 			idAllocator = idAllocator,
 			datasource = datasource,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			statisticsRepository = statisticsRepository,
 			referenceIndexRepository = referenceIndexRepository,
 		)
@@ -280,7 +280,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 	@Test
 	fun `Delete Entry`() = runTest {
 		val deletionIdSlot = slot<Int>()
-		coEvery { syncDataRepository.recordIdDeletion(capture(deletionIdSlot)) } just Runs
+		coEvery { syncJournal.recordIdDeletion(capture(deletionIdSlot)) } just Runs
 
 		val repo = createRepository()
 		val deleted = repo.deleteEntry(entry1().toDef(projDef))
@@ -289,12 +289,12 @@ class EncyclopediaRepositoryTest : BaseTest() {
 		val path = datasource.getEntryPath(entry1().toDef(projDef)).toOkioPath()
 		assertFalse(fileSystem.exists(path))
 		assertEquals(entry1().id, deletionIdSlot.captured)
-		coVerify { syncDataRepository.recordIdDeletion(any()) }
+		coVerify { syncJournal.recordIdDeletion(any()) }
 	}
 
 	@Test
 	fun `Delete Entry purges that entry id from the reference index`() = runTest {
-		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
 
 		val repo = createRepository()
 		referenceIndexDatasource.saveIndex(
@@ -375,7 +375,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 	@Test
 	fun `entryContentChangedFlow emits on create update and delete`() = runTest {
 		coEvery { idAllocator.claimNextId() } returns 50
-		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
 
 		val repo = createRepository()
 

--- a/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
@@ -1,6 +1,7 @@
 package repositories.encyclopedia
 
 import ENCYCLOPEDIA_ONLY_PROJECT_NAME
+import app.cash.turbine.test
 import com.darkrockstudios.apps.hammer.base.http.readToml
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
@@ -10,13 +11,12 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryR
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContainer
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
-import app.cash.turbine.test
 import createProject
 import getProjectDef
 import io.mockk.*
@@ -37,7 +37,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 	private val projDef = getProjectDef(ENCYCLOPEDIA_ONLY_PROJECT_NAME)
 
 	@MockK
-	lateinit var idRepository: IdRepository
+	lateinit var idAllocator: IdAllocator
 
 	@MockK
 	lateinit var externalFileIo: ExternalFileIo
@@ -83,7 +83,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 			.ReferenceIndexRepository(projDef, referenceIndexDatasource)
 		return EncyclopediaRepository(
 			projectDef = projDef,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			datasource = datasource,
 			syncDataRepository = syncDataRepository,
 			statisticsRepository = statisticsRepository,
@@ -176,7 +176,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 
 	@Test
 	fun `Create Entry`() = runTest {
-		coEvery { idRepository.claimNextId() } returns 3
+		coEvery { idAllocator.claimNextId() } returns 3
 
 		val container = EntryContainer(
 			entry = EntryContent(
@@ -209,7 +209,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 
 	@Test
 	fun `Create Entry round-trips aliases`() = runTest {
-		coEvery { idRepository.claimNextId() } returns 4
+		coEvery { idAllocator.claimNextId() } returns 4
 
 		val repo = createRepository()
 		val result = repo.createEntry(
@@ -233,7 +233,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 
 	@Test
 	fun `Create Entry cleans aliases - trims, dedupes, drops blanks and entry name`() = runTest {
-		coEvery { idRepository.claimNextId() } returns 5
+		coEvery { idAllocator.claimNextId() } returns 5
 
 		val repo = createRepository()
 		val result = repo.createEntry(
@@ -253,7 +253,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 
 	@Test
 	fun `Create Entry rejects alias exceeding max length`() = runTest {
-		coEvery { idRepository.claimNextId() } returns 6
+		coEvery { idAllocator.claimNextId() } returns 6
 
 		val repo = createRepository()
 		val tooLong = "x".repeat(MAX_NAME_SIZE + 1)
@@ -374,7 +374,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 
 	@Test
 	fun `entryContentChangedFlow emits on create update and delete`() = runTest {
-		coEvery { idRepository.claimNextId() } returns 50
+		coEvery { idAllocator.claimNextId() } returns 50
 		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
 
 		val repo = createRepository()

--- a/common/src/desktopTest/kotlin/repositories/globalsettings/GlobalSettingsDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/globalsettings/GlobalSettingsDatasourceTest.kt
@@ -2,7 +2,7 @@ package repositories.globalsettings
 
 import com.darkrockstudios.apps.hammer.base.http.writeToml
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.InitialProjectScreen
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
@@ -49,7 +49,7 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 	@Test
 	fun `Load Global Settings when non exists`() = runTest {
 		val datasource = createDatasource()
-		val default = GlobalSettingsRepository.createDefault(languageUtil, platformSpellCheckerFactory)
+		val default = GlobalSettingsStore.createDefault(languageUtil, platformSpellCheckerFactory)
 
 		val loaded: GlobalSettings = datasource.loadSettings()
 
@@ -59,7 +59,7 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 	@Test
 	fun `Load Global Settings when one already exists`() = runTest {
 		val datasource = createDatasource()
-		val settings = GlobalSettingsRepository.createDefault(languageUtil, platformSpellCheckerFactory).copy(
+		val settings = GlobalSettingsStore.createDefault(languageUtil, platformSpellCheckerFactory).copy(
 			uiTheme = UiTheme.Dark,
 			automaticBackups = false,
 			automaticSyncing = false,
@@ -84,7 +84,7 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 
 		val loaded: GlobalSettings = datasource.loadSettings()
 
-		assertEquals(GlobalSettingsRepository.createDefault(languageUtil, platformSpellCheckerFactory), loaded)
+		assertEquals(GlobalSettingsStore.createDefault(languageUtil, platformSpellCheckerFactory), loaded)
 	}
 
 	@Test
@@ -107,7 +107,7 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 	@Test
 	fun `Store and load preserves initialProjectScreen`() = runTest {
 		val datasource = createDatasource()
-		val settings = GlobalSettingsRepository.createDefault(languageUtil, platformSpellCheckerFactory).copy(
+		val settings = GlobalSettingsStore.createDefault(languageUtil, platformSpellCheckerFactory).copy(
 			initialProjectScreen = InitialProjectScreen.Editor,
 		)
 
@@ -120,7 +120,7 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 	@Test
 	fun `Store Global Settings`() = runTest {
 		val datasource = createDatasource()
-		val newSettings = GlobalSettingsRepository.createDefault(languageUtil, platformSpellCheckerFactory).copy(
+		val newSettings = GlobalSettingsStore.createDefault(languageUtil, platformSpellCheckerFactory).copy(
 			automaticBackups = false,
 			uiTheme = UiTheme.Light,
 		)

--- a/common/src/desktopTest/kotlin/repositories/globalsettings/GlobalSettingsStoreTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/globalsettings/GlobalSettingsStoreTest.kt
@@ -1,7 +1,7 @@
 package repositories.globalsettings
 
 import app.cash.turbine.test
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
@@ -21,7 +21,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class GlobalSettingsRepositoryTest : BaseTest() {
+class GlobalSettingsStoreTest : BaseTest() {
 
 	private lateinit var serverSettings: ServerSettingsDatasource
 	private lateinit var globalSettings: GlobalSettingsDatasource
@@ -37,22 +37,22 @@ class GlobalSettingsRepositoryTest : BaseTest() {
 		every { languageUtil.getCurrentLocale() } returns Locale.forLanguageTag("en")
 	}
 
-	private fun createDefaultRepository(): GlobalSettingsRepository {
-		coEvery { globalSettings.loadSettings() } returns GlobalSettingsRepository.createDefault(
+	private fun createDefaultRepository(): GlobalSettingsStore {
+		coEvery { globalSettings.loadSettings() } returns GlobalSettingsStore.createDefault(
 			languageUtil,
 			mockk(relaxed = true)
 		)
 		coEvery { serverSettings.loadServerSettings(any()) } returns null
 
-		return GlobalSettingsRepository(
+		return GlobalSettingsStore(
 			globalSettings,
 			serverSettings,
 		)
 	}
 
-	private fun defaultGlobalSettings() = GlobalSettingsRepository.createDefault(languageUtil, mockk(relaxed = true))
+	private fun defaultGlobalSettings() = GlobalSettingsStore.createDefault(languageUtil, mockk(relaxed = true))
 
-	private fun projectsDir() = GlobalSettingsRepository.defaultProjectDir().toHPath()
+	private fun projectsDir() = GlobalSettingsStore.defaultProjectDir().toHPath()
 
 	private fun createServerConfig() = ServerSettings(
 		ssl = true,
@@ -68,7 +68,7 @@ class GlobalSettingsRepositoryTest : BaseTest() {
 		coEvery { globalSettings.loadSettings() } returns defaultGlobalSettings()
 		coEvery { serverSettings.loadServerSettings(any()) } returns createServerConfig()
 
-		val repo = GlobalSettingsRepository(
+		val repo = GlobalSettingsStore(
 			globalSettings,
 			serverSettings,
 		)
@@ -134,7 +134,7 @@ class GlobalSettingsRepositoryTest : BaseTest() {
 	@Test
 	fun `Change projects directory, no server config in new dir`() = runTest {
 		val newDirName = "NewProjectDir"
-		val newProjDir = GlobalSettingsRepository.defaultProjectDir().parent!! / newDirName
+		val newProjDir = GlobalSettingsStore.defaultProjectDir().parent!! / newDirName
 
 		val defaultSettings = defaultGlobalSettings()
 		coEvery { globalSettings.loadSettings() } returns defaultSettings
@@ -150,7 +150,7 @@ class GlobalSettingsRepositoryTest : BaseTest() {
 			projectsDirectory = newProjDir.toHPath().path
 		)
 
-		val repo = GlobalSettingsRepository(
+		val repo = GlobalSettingsStore(
 			globalSettings,
 			serverSettings,
 		)
@@ -214,14 +214,14 @@ class GlobalSettingsRepositoryTest : BaseTest() {
 
 	@Test
 	fun `Delete server settings successfully`() = runTest {
-		coEvery { globalSettings.loadSettings() } returns GlobalSettingsRepository.createDefault(
+		coEvery { globalSettings.loadSettings() } returns GlobalSettingsStore.createDefault(
 			mockk(relaxed = true),
 			mockk(relaxed = true)
 		)
 		coEvery { serverSettings.loadServerSettings(any()) } returns createServerConfig()
 		coEvery { serverSettings.removeServerSettings(any()) } just Runs
 
-		val repo = GlobalSettingsRepository(
+		val repo = GlobalSettingsStore(
 			globalSettings,
 			serverSettings,
 		)

--- a/common/src/desktopTest/kotlin/repositories/id/IdAllocatorTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/id/IdAllocatorTest.kt
@@ -8,7 +8,7 @@ import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.id.datasources.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import createProject
@@ -31,7 +31,7 @@ import kotlin.test.assertEquals
 class IdAllocatorTest : BaseTest() {
 	private lateinit var ffs: FakeFileSystem
 	private lateinit var idAllocator: IdAllocator
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 	private lateinit var toml: Toml
 
 	private lateinit var sceneIdDatasource: SceneIdDatasource
@@ -46,7 +46,7 @@ class IdAllocatorTest : BaseTest() {
 
 		ffs = FakeFileSystem()
 		toml = createTomlSerializer()
-		syncDataRepository = mockk(relaxed = true)
+		syncJournal = mockk(relaxed = true)
 
 		sceneIdDatasource = SceneIdDatasource(ffs)
 		notesIdDatasource = NotesIdDatasource(ffs)
@@ -59,7 +59,7 @@ class IdAllocatorTest : BaseTest() {
 		sceneDraftIdDatasource = SceneDraftIdDatasource(SceneDraftsDatasource(ffs, sceneDatasource))
 
 		val testModule = module {
-			single { syncDataRepository }
+			single { syncJournal }
 			single { sceneIdDatasource }
 			single { notesIdDatasource }
 			single { encyclopediaIdDatasource }
@@ -81,7 +81,7 @@ class IdAllocatorTest : BaseTest() {
 		createProject(ffs, PROJECT_EMPTY_NAME)
 		setupForProject(getProjectDef(PROJECT_EMPTY_NAME))
 
-		every { syncDataRepository.isServerSynchronized() } returns false
+		every { syncJournal.isServerSynchronized() } returns false
 
 		idAllocator = IdAllocator(getProjectDef(PROJECT_EMPTY_NAME))
 		idAllocator.findNextId()
@@ -94,7 +94,7 @@ class IdAllocatorTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 		setupForProject(getProjectDef(PROJECT_1_NAME))
 
-		every { syncDataRepository.isServerSynchronized() } returns false
+		every { syncJournal.isServerSynchronized() } returns false
 
 		idAllocator = IdAllocator(getProject1Def())
 		idAllocator.findNextId()
@@ -108,8 +108,8 @@ class IdAllocatorTest : BaseTest() {
 		setupForProject(getProjectDef(PROJECT_1_NAME))
 
 		// Last real ID is 7 in "Test Project 1"
-		every { syncDataRepository.isServerSynchronized() } returns true
-		coEvery { syncDataRepository.deletedIds() } returns setOf(8)
+		every { syncJournal.isServerSynchronized() } returns true
+		coEvery { syncJournal.deletedIds() } returns setOf(8)
 
 		idAllocator = IdAllocator(getProject1Def())
 		idAllocator.findNextId()
@@ -123,7 +123,7 @@ class IdAllocatorTest : BaseTest() {
 		setupForProject(getProjectDef(PROJECT_EMPTY_NAME))
 
 		val projectPath = getProjectsDirectory().div(PROJECT_EMPTY_NAME).toHPath()
-		every { syncDataRepository.isServerSynchronized() } returns false
+		every { syncJournal.isServerSynchronized() } returns false
 
 		val projectDef = ProjectDef(
 			name = PROJECT_EMPTY_NAME,
@@ -142,7 +142,7 @@ class IdAllocatorTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		setupForProject(projDef)
 
-		every { syncDataRepository.isServerSynchronized() } returns true
+		every { syncJournal.isServerSynchronized() } returns true
 
 		idAllocator = IdAllocator(projDef)
 		idAllocator.findNextId()

--- a/common/src/desktopTest/kotlin/repositories/id/IdAllocatorTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/id/IdAllocatorTest.kt
@@ -5,7 +5,7 @@ import PROJECT_2_NAME
 import PROJECT_EMPTY_NAME
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.id.datasources.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
@@ -28,9 +28,9 @@ import org.koin.dsl.module
 import utils.BaseTest
 import kotlin.test.assertEquals
 
-class IdRepositoryTest : BaseTest() {
+class IdAllocatorTest : BaseTest() {
 	private lateinit var ffs: FakeFileSystem
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 	private lateinit var syncDataRepository: SyncDataRepository
 	private lateinit var toml: Toml
 
@@ -83,10 +83,10 @@ class IdRepositoryTest : BaseTest() {
 
 		every { syncDataRepository.isServerSynchronized() } returns false
 
-		idRepository = IdRepository(getProjectDef(PROJECT_EMPTY_NAME))
-		idRepository.findNextId()
+		idAllocator = IdAllocator(getProjectDef(PROJECT_EMPTY_NAME))
+		idAllocator.findNextId()
 
-		assertEquals(idRepository.claimNextId(), 1, "First claimed ID should be 1 in empty project")
+		assertEquals(idAllocator.claimNextId(), 1, "First claimed ID should be 1 in empty project")
 	}
 
 	@Test
@@ -96,10 +96,10 @@ class IdRepositoryTest : BaseTest() {
 
 		every { syncDataRepository.isServerSynchronized() } returns false
 
-		idRepository = IdRepository(getProject1Def())
-		idRepository.findNextId()
+		idAllocator = IdAllocator(getProject1Def())
+		idAllocator.findNextId()
 
-		assertEquals(8, idRepository.claimNextId(), "Failed to find last scene ID")
+		assertEquals(8, idAllocator.claimNextId(), "Failed to find last scene ID")
 	}
 
 	@Test
@@ -111,10 +111,10 @@ class IdRepositoryTest : BaseTest() {
 		every { syncDataRepository.isServerSynchronized() } returns true
 		coEvery { syncDataRepository.deletedIds() } returns setOf(8)
 
-		idRepository = IdRepository(getProject1Def())
-		idRepository.findNextId()
+		idAllocator = IdAllocator(getProject1Def())
+		idAllocator.findNextId()
 
-		assertEquals(9, idRepository.claimNextId(), "Failed to find last entity ID")
+		assertEquals(9, idAllocator.claimNextId(), "Failed to find last entity ID")
 	}
 
 	@Test
@@ -130,10 +130,10 @@ class IdRepositoryTest : BaseTest() {
 			path = projectPath
 		)
 
-		idRepository = IdRepository(projectDef)
-		idRepository.findNextId()
+		idAllocator = IdAllocator(projectDef)
+		idAllocator.findNextId()
 
-		assertEquals(1, idRepository.claimNextId(), "Failed to find last scene ID")
+		assertEquals(1, idAllocator.claimNextId(), "Failed to find last scene ID")
 	}
 
 	@Test
@@ -144,9 +144,9 @@ class IdRepositoryTest : BaseTest() {
 
 		every { syncDataRepository.isServerSynchronized() } returns true
 
-		idRepository = IdRepository(projDef)
-		idRepository.findNextId()
+		idAllocator = IdAllocator(projDef)
+		idAllocator.findNextId()
 
-		assertEquals(24, idRepository.claimNextId(), "Failed to find last entity ID")
+		assertEquals(24, idAllocator.claimNextId(), "Failed to find last entity ID")
 	}
 }

--- a/common/src/desktopTest/kotlin/repositories/notes/NotesRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/notes/NotesRepositoryTest.kt
@@ -3,7 +3,7 @@ package repositories.notes
 import PROJECT_2_NAME
 import app.cash.turbine.test
 import com.darkrockstudios.apps.hammer.base.http.readToml
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.isFailure
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.InvalidNote
@@ -45,7 +45,7 @@ class NotesRepositoryTest : BaseTest() {
 
 	private val projectDef = getProjectDef(PROJECT_2_NAME)
 
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 	private lateinit var syncDataRepository: SyncDataRepository
 	private lateinit var datasource: NotesDatasource
 	private lateinit var ffs: FakeFileSystem
@@ -56,14 +56,14 @@ class NotesRepositoryTest : BaseTest() {
 		super.setup()
 		ffs = FakeFileSystem()
 		toml = createTomlSerializer()
-		idRepository = mockk()
+		idAllocator = mockk()
 		syncDataRepository = mockk()
 		setupKoin()
 	}
 
 	private fun createRepository(): NotesRepository {
 		datasource = NotesDatasource(projectDef, ffs, toml)
-		return NotesRepository(projectDef, idRepository, syncDataRepository, datasource)
+		return NotesRepository(projectDef, idAllocator, syncDataRepository, datasource)
 	}
 
 	@Test
@@ -154,7 +154,7 @@ class NotesRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
 		coEvery { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { idRepository.claimNextId() } returns 15
+		coEvery { idAllocator.claimNextId() } returns 15
 
 		val noteText = "New note content"
 
@@ -178,7 +178,7 @@ class NotesRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
 		coEvery { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { idRepository.claimNextId() } returns 15
+		coEvery { idAllocator.claimNextId() } returns 15
 
 		val repo = createRepository()
 		val result = repo.createNote(
@@ -199,7 +199,7 @@ class NotesRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
 		coEvery { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { idRepository.claimNextId() } returns 15
+		coEvery { idAllocator.claimNextId() } returns 15
 
 		val repo = createRepository()
 		val result = repo.createNote(
@@ -237,7 +237,7 @@ class NotesRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
 		coEvery { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { idRepository.claimNextId() } returns 15
+		coEvery { idAllocator.claimNextId() } returns 15
 
 		val repo = createRepository()
 		val result = repo.createNote(noteText)
@@ -285,7 +285,7 @@ class NotesRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
 		coEvery { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { idRepository.claimNextId() } returns 20
+		coEvery { idAllocator.claimNextId() } returns 20
 
 		val repo = createRepository()
 		advanceUntilIdle()

--- a/common/src/desktopTest/kotlin/repositories/notes/NotesRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/notes/NotesRepositoryTest.kt
@@ -14,7 +14,7 @@ import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesReposito
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository.Companion.MAX_TAG_SIZE
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContainer
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import createProject
@@ -46,7 +46,7 @@ class NotesRepositoryTest : BaseTest() {
 	private val projectDef = getProjectDef(PROJECT_2_NAME)
 
 	private lateinit var idAllocator: IdAllocator
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 	private lateinit var datasource: NotesDatasource
 	private lateinit var ffs: FakeFileSystem
 	private lateinit var toml: Toml
@@ -57,13 +57,13 @@ class NotesRepositoryTest : BaseTest() {
 		ffs = FakeFileSystem()
 		toml = createTomlSerializer()
 		idAllocator = mockk()
-		syncDataRepository = mockk()
+		syncJournal = mockk()
 		setupKoin()
 	}
 
 	private fun createRepository(): NotesRepository {
 		datasource = NotesDatasource(projectDef, ffs, toml)
-		return NotesRepository(projectDef, idAllocator, syncDataRepository, datasource)
+		return NotesRepository(projectDef, idAllocator, syncJournal, datasource)
 	}
 
 	@Test
@@ -101,7 +101,7 @@ class NotesRepositoryTest : BaseTest() {
 	@Test
 	fun `Delete note`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
-		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
 		val noteId = 12
 
 		val repo = createRepository()
@@ -122,7 +122,7 @@ class NotesRepositoryTest : BaseTest() {
 	@Test
 	fun `Update note`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
+		coEvery { syncJournal.isServerSynchronized() } returns false
 		val noteId = 12
 
 		val noteContainer = NoteContainer(
@@ -152,8 +152,8 @@ class NotesRepositoryTest : BaseTest() {
 	@Test
 	fun `Create note`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
-		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
+		coEvery { syncJournal.isServerSynchronized() } returns false
 		coEvery { idAllocator.claimNextId() } returns 15
 
 		val noteText = "New note content"
@@ -176,8 +176,8 @@ class NotesRepositoryTest : BaseTest() {
 	@Test
 	fun `Create note with tags persists cleaned tags`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
-		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
+		coEvery { syncJournal.isServerSynchronized() } returns false
 		coEvery { idAllocator.claimNextId() } returns 15
 
 		val repo = createRepository()
@@ -197,8 +197,8 @@ class NotesRepositoryTest : BaseTest() {
 	@Test
 	fun `Create note rejects tag exceeding MAX_TAG_SIZE`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
-		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
+		coEvery { syncJournal.isServerSynchronized() } returns false
 		coEvery { idAllocator.claimNextId() } returns 15
 
 		val repo = createRepository()
@@ -214,7 +214,7 @@ class NotesRepositoryTest : BaseTest() {
 	@Test
 	fun `Update note round-trips tags through TOML`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
+		coEvery { syncJournal.isServerSynchronized() } returns false
 		val noteId = 12
 
 		val updated = NoteContent(
@@ -235,8 +235,8 @@ class NotesRepositoryTest : BaseTest() {
 	@MethodSource("provideCreateFailureTestData")
 	fun `Create note failure for invalid name`(noteText: String, error: NoteError) = runTest {
 		createProject(ffs, PROJECT_2_NAME)
-		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
+		coEvery { syncJournal.isServerSynchronized() } returns false
 		coEvery { idAllocator.claimNextId() } returns 15
 
 		val repo = createRepository()
@@ -283,8 +283,8 @@ class NotesRepositoryTest : BaseTest() {
 	@Test
 	fun `noteContentChangedFlow emits on create update and delete`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
-		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
+		coEvery { syncJournal.isServerSynchronized() } returns false
 		coEvery { idAllocator.claimNextId() } returns 20
 
 		val repo = createRepository()

--- a/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryBaseTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryBaseTest.kt
@@ -1,7 +1,7 @@
 package repositories.projectsrepository
 
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import createRootDirectory
@@ -19,7 +19,7 @@ import utils.BaseTest
 
 abstract class ProjectsRepositoryBaseTest : BaseTest() {
 	protected lateinit var ffs: FakeFileSystem
-	protected lateinit var settingsRepo: GlobalSettingsRepository
+	protected lateinit var settingsRepo: GlobalSettingsStore
 	protected lateinit var projectsMetaDatasource: ProjectMetadataDatasource
 	protected lateinit var settings: GlobalSettings
 	protected lateinit var toml: Toml

--- a/common/src/desktopTest/kotlin/repositories/scenedraft/SceneDraftRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/scenedraft/SceneDraftRepositoryTest.kt
@@ -9,9 +9,9 @@ import com.darkrockstudios.apps.hammer.common.data.UpdateSource
 import com.darkrockstudios.apps.hammer.common.data.drafts.DraftDef
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import createProject
@@ -41,7 +41,7 @@ class SceneDraftRepositoryTest : BaseTest() {
 	private lateinit var toml: Toml
 	private lateinit var datasource: SceneDraftsDatasource
 	private lateinit var sceneDatasource: SceneDatasource
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 	private lateinit var clock: Clock
 
 	@BeforeEach
@@ -50,7 +50,7 @@ class SceneDraftRepositoryTest : BaseTest() {
 
 		sceneContentRepository = mockk<SceneContentRepository>()
 
-		idRepository = mockk<IdRepository>()
+		idAllocator = mockk<IdAllocator>()
 		clock = mockk<Clock>()
 
 		ffs = FakeFileSystem()
@@ -58,7 +58,7 @@ class SceneDraftRepositoryTest : BaseTest() {
 
 		setupKoin(
 			module {
-				single { idRepository }
+				single { idAllocator }
 				single { clock }
 			}
 		)
@@ -185,7 +185,7 @@ class SceneDraftRepositoryTest : BaseTest() {
 		val draftName = "New Draft"
 		val draftId = 11
 
-		coEvery { idRepository.claimNextId() } returns draftId
+		coEvery { idAllocator.claimNextId() } returns draftId
 		every { sceneContentRepository.getCurrentSceneContent(any()) } returns buffer.content.coerceMarkdown()
 		every { clock.now() } returns fakeNow
 
@@ -231,7 +231,7 @@ class SceneDraftRepositoryTest : BaseTest() {
 		val draftName = "New Draft"
 		val draftId = 11
 
-		coEvery { idRepository.claimNextId() } returns draftId
+		coEvery { idAllocator.claimNextId() } returns draftId
 		every { sceneContentRepository.getCurrentSceneContent(any()) } returns buffer.content.coerceMarkdown()
 		every { clock.now() } returns fakeNow
 

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneContentRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneContentRepositoryTest.kt
@@ -3,21 +3,12 @@ package repositories.sceneeditor
 import PROJECT_1_NAME
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.Info
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
-import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
-import com.darkrockstudios.apps.hammer.common.data.SceneContent
-import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.SceneSummary
-import com.darkrockstudios.apps.hammer.common.data.UpdateSource
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.*
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
@@ -57,7 +48,7 @@ class SceneContentRepositoryTest : BaseTest() {
 	private lateinit var syncDataRepository: SyncDataRepository
 
 	@MockK
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 
 	@MockK
 	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
@@ -107,7 +98,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = contentRepo,
 			sceneMetadataDatasource = sceneMetadataDatasource,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneContentRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneContentRepositoryTest.kt
@@ -10,7 +10,7 @@ import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsR
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
@@ -45,7 +45,7 @@ class SceneContentRepositoryTest : BaseTest() {
 	private lateinit var toml: Toml
 
 	@MockK
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 
 	@MockK
 	private lateinit var idAllocator: IdAllocator
@@ -77,9 +77,9 @@ class SceneContentRepositoryTest : BaseTest() {
 				dataVersion = 1,
 			)
 		)
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { syncDataRepository.isEntityDirty(any()) } returns false
-		coEvery { syncDataRepository.markEntityAsDirty(any(), any()) } just Runs
+		coEvery { syncJournal.isServerSynchronized() } returns false
+		coEvery { syncJournal.isEntityDirty(any()) } returns false
+		coEvery { syncJournal.markEntityAsDirty(any(), any()) } just Runs
 	}
 
 	private fun createStack(projectDef: ProjectDef) {
@@ -97,7 +97,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		val writingSessionTracker = mockk<WritingSessionTracker>(relaxed = true)
 		repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = contentRepo,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryArchiveTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryArchiveTest.kt
@@ -5,15 +5,15 @@ import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.In
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.migrator.PROJECT_DATA_VERSION
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
@@ -44,7 +44,7 @@ class SceneEditorRepositoryArchiveTest : BaseTest() {
 	private lateinit var syncDataRepository: SyncDataRepository
 	private lateinit var projectDef: ProjectDef
 	private lateinit var repo: SceneRepository
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 	private lateinit var metadataRepository: ProjectMetadataDatasource
 	private lateinit var metadataDatasource: SceneMetadataDatasource
 	private lateinit var sceneDatasource: SceneDatasource
@@ -67,9 +67,9 @@ class SceneEditorRepositoryArchiveTest : BaseTest() {
 		ffs.createDirectories(rootDir.toPath())
 
 		nextId = 100
-		idRepository = mockk()
-		coEvery { idRepository.claimNextId() } answers { claimId() }
-		coEvery { idRepository.findNextId() } answers { }
+		idAllocator = mockk()
+		coEvery { idAllocator.claimNextId() } answers { claimId() }
+		coEvery { idAllocator.findNextId() } answers { }
 
 		metadataRepository = mockk()
 		every { metadataRepository.loadMetadata(any()) } returns
@@ -121,7 +121,7 @@ class SceneEditorRepositoryArchiveTest : BaseTest() {
 		repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,
 				sceneMetadataDatasource = metadataDatasource,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryArchiveTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryArchiveTest.kt
@@ -15,7 +15,7 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDa
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
@@ -41,7 +41,7 @@ class SceneEditorRepositoryArchiveTest : BaseTest() {
 	private lateinit var ffs: FakeFileSystem
 	private lateinit var projectPath: HPath
 	private lateinit var projectsRepo: ProjectsRepository
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 	private lateinit var projectDef: ProjectDef
 	private lateinit var repo: SceneRepository
 	private lateinit var idAllocator: IdAllocator
@@ -84,8 +84,8 @@ class SceneEditorRepositoryArchiveTest : BaseTest() {
 		metadataDatasource = mockk(relaxed = true)
 		statisticsRepository = mockk(relaxed = true)
 
-		syncDataRepository = mockk()
-		every { syncDataRepository.isServerSynchronized() } returns false
+		syncJournal = mockk()
+		every { syncJournal.isServerSynchronized() } returns false
 
 		projectsRepo = mockk()
 		every { projectsRepo.getProjectsDirectory() } returns
@@ -120,7 +120,7 @@ class SceneEditorRepositoryArchiveTest : BaseTest() {
 		)
 		repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLastEditedSceneTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLastEditedSceneTest.kt
@@ -11,7 +11,7 @@ import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsR
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import createProject
@@ -43,7 +43,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 	private lateinit var clock: TestClock
 
 	@MockK
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 
 	@MockK
 	private lateinit var idAllocator: IdAllocator
@@ -65,9 +65,9 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 		statisticsRepository = mockk(relaxed = true)
 		projectMetadataDatasource = ProjectMetadataDatasource(ffs, toml)
 
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { syncDataRepository.isEntityDirty(any()) } returns false
-		coEvery { syncDataRepository.markEntityAsDirty(any(), any()) } just Runs
+		coEvery { syncJournal.isServerSynchronized() } returns false
+		coEvery { syncJournal.isEntityDirty(any()) } returns false
+		coEvery { syncJournal.markEntityAsDirty(any(), any()) } just Runs
 	}
 
 	private fun createRepository(projectDef: ProjectDef): SceneRepository {
@@ -88,7 +88,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 		val referenceIndexRepository = mockk<com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository>(relaxed = true)
 		val repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLastEditedSceneTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLastEditedSceneTest.kt
@@ -5,14 +5,10 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneContent
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
@@ -50,7 +46,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 	private lateinit var syncDataRepository: SyncDataRepository
 
 	@MockK
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 
 	private lateinit var sceneMetadataDatasource: SceneMetadataDatasource
 	private lateinit var sceneDatasource: SceneDatasource
@@ -93,7 +89,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 		val repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLoadTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLoadTest.kt
@@ -14,7 +14,7 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDa
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
@@ -42,7 +42,7 @@ class SceneEditorRepositoryLoadTest : BaseTest() {
 	private lateinit var projectsRepo: ProjectsRepository
 	private lateinit var projectDef: ProjectDef
 	private lateinit var repo: SceneRepository
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 	private lateinit var idAllocator: IdAllocator
 	private lateinit var metadataRepository: ProjectMetadataDatasource
 	private lateinit var metadataDatasource: SceneMetadataDatasource
@@ -78,8 +78,8 @@ class SceneEditorRepositoryLoadTest : BaseTest() {
 
 		statisticsRepository = mockk()
 
-		syncDataRepository = mockk()
-		every { syncDataRepository.isServerSynchronized() } returns false
+		syncJournal = mockk()
+		every { syncJournal.isServerSynchronized() } returns false
 
 		projectsRepo = mockk()
 		every { projectsRepo.getProjectsDirectory() } returns
@@ -113,7 +113,7 @@ class SceneEditorRepositoryLoadTest : BaseTest() {
 		)
 		repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLoadTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLoadTest.kt
@@ -5,14 +5,14 @@ import PROJECT_1_NAME
 import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
@@ -43,7 +43,7 @@ class SceneEditorRepositoryLoadTest : BaseTest() {
 	private lateinit var projectDef: ProjectDef
 	private lateinit var repo: SceneRepository
 	private lateinit var syncDataRepository: SyncDataRepository
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 	private lateinit var metadataRepository: ProjectMetadataDatasource
 	private lateinit var metadataDatasource: SceneMetadataDatasource
 	private lateinit var sceneDatasource: SceneDatasource
@@ -70,8 +70,8 @@ class SceneEditorRepositoryLoadTest : BaseTest() {
 		toml = createTomlSerializer()
 
 		nextId = -1
-		idRepository = mockk()
-		coEvery { idRepository.claimNextId() } answers { claimId() }
+		idAllocator = mockk()
+		coEvery { idAllocator.claimNextId() } answers { claimId() }
 
 		metadataRepository = mockk()
 		metadataDatasource = mockk()
@@ -114,7 +114,7 @@ class SceneEditorRepositoryLoadTest : BaseTest() {
 		repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,
 				sceneMetadataDatasource = metadataDatasource,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryMoveTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryMoveTest.kt
@@ -11,7 +11,7 @@ import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRe
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.tree.NodeCoordinates
 import com.darkrockstudios.apps.hammer.common.data.tree.Tree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
@@ -45,7 +45,7 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 	private lateinit var ffs: FakeFileSystem
 	private lateinit var projectPath: HPath
 	private lateinit var projectsRepo: ProjectsRepository
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 	private lateinit var projectDef: ProjectDef
 	private lateinit var repo: SceneRepository
 	private lateinit var idAllocator: IdAllocator
@@ -106,8 +106,8 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 		val rootDir = getDefaultRootDocumentDirectory()
 		ffs.createDirectories(rootDir.toPath())
 
-		syncDataRepository = mockk()
-		every { syncDataRepository.isServerSynchronized() } returns false
+		syncJournal = mockk()
+		every { syncJournal.isServerSynchronized() } returns false
 
 		metadataRepository = mockk(relaxed = true)
 		metadataDatasource = mockk(relaxed = true)
@@ -143,7 +143,7 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 		)
 		repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,
@@ -354,7 +354,7 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 		)
 		repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryMoveTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryMoveTest.kt
@@ -5,15 +5,11 @@ import com.darkrockstudios.apps.hammer.common.data.InsertPosition
 import com.darkrockstudios.apps.hammer.common.data.MoveRequest
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.filterScenePathsOkio
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.data.tree.NodeCoordinates
@@ -52,7 +48,7 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 	private lateinit var syncDataRepository: SyncDataRepository
 	private lateinit var projectDef: ProjectDef
 	private lateinit var repo: SceneRepository
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 	private lateinit var metadataRepository: ProjectMetadataDatasource
 	private lateinit var metadataDatasource: SceneMetadataDatasource
 	private lateinit var sceneDatasource: SceneDatasource
@@ -133,9 +129,9 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 		toml = createTomlSerializer()
 
 		nextId = -1
-		idRepository = mockk()
-		coEvery { idRepository.claimNextId() } answers { claimId() }
-		coEvery { idRepository.findNextId() } answers {}
+		idAllocator = mockk()
+		coEvery { idAllocator.claimNextId() } answers { claimId() }
+		coEvery { idAllocator.findNextId() } answers {}
 
 		createProject(ffs, PROJECT_1_NAME)
 
@@ -148,7 +144,7 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 		repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,
 				sceneMetadataDatasource = metadataDatasource,
@@ -359,7 +355,7 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 		repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,
 				sceneMetadataDatasource = metadataDatasource,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryOtherTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryOtherTest.kt
@@ -9,16 +9,16 @@ import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.Pr
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.migrator.PROJECT_DATA_VERSION
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ValidationFailedException
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.data.tree.Tree
@@ -55,7 +55,7 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 	private lateinit var syncDataRepository: SyncDataRepository
 	private lateinit var projectDef: ProjectDef
 	private lateinit var repo: SceneRepository
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 	private lateinit var metadataRepository: ProjectMetadataDatasource
 	private lateinit var metadataDatasource: SceneMetadataDatasource
 	private lateinit var sceneDatasource: SceneDatasource
@@ -108,9 +108,9 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 		toml = createTomlSerializer()
 
 		nextId = 8
-		idRepository = mockk()
-		coEvery { idRepository.claimNextId() } answers { claimId() }
-		coEvery { idRepository.findNextId() } answers { }
+		idAllocator = mockk()
+		coEvery { idAllocator.claimNextId() } answers { claimId() }
+		coEvery { idAllocator.findNextId() } answers { }
 
 		metadataRepository = mockk(relaxUnitFun = true)
 		every { metadataRepository.loadMetadata(any()) } returns
@@ -164,7 +164,7 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 		repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,
 				sceneMetadataDatasource = metadataDatasource,
@@ -258,7 +258,7 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 		repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,
 				sceneMetadataDatasource = metadataDatasource,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryOtherTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryOtherTest.kt
@@ -20,7 +20,7 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDa
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.tree.Tree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
@@ -52,7 +52,7 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 	private lateinit var ffs: FakeFileSystem
 	private lateinit var projectPath: HPath
 	private lateinit var projectsRepo: ProjectsRepository
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 	private lateinit var projectDef: ProjectDef
 	private lateinit var repo: SceneRepository
 	private lateinit var idAllocator: IdAllocator
@@ -125,8 +125,8 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 		metadataDatasource = mockk(relaxed = true)
 		statisticsRepository = mockk(relaxed = true)
 
-		syncDataRepository = mockk()
-		every { syncDataRepository.isServerSynchronized() } returns false
+		syncJournal = mockk()
+		every { syncJournal.isServerSynchronized() } returns false
 		//coEvery { projectSynchronizer.recordIdDeletion(any()) } just Runs
 
 		projectsRepo = mockk()
@@ -163,7 +163,7 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 		)
 		repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,
@@ -257,7 +257,7 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 		)
 		repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = SceneMetadataRepository(
 				projectDef = projectDef,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryTestSimple.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryTestSimple.kt
@@ -14,7 +14,7 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDa
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
@@ -42,7 +42,7 @@ class SceneEditorRepositoryTestSimple : BaseTest() {
 	private lateinit var projectPath: HPath
 	private lateinit var scenesPath: HPath
 	private lateinit var projectsRepo: ProjectsRepository
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 	private lateinit var projectDef: ProjectDef
 	private lateinit var idAllocator: IdAllocator
 	private lateinit var projectMetadataRepository: ProjectMetadataDatasource
@@ -126,8 +126,8 @@ class SceneEditorRepositoryTestSimple : BaseTest() {
 			path = projectPath
 		)
 
-		syncDataRepository = mockk()
-		every { syncDataRepository.isServerSynchronized() } returns false
+		syncJournal = mockk()
+		every { syncJournal.isServerSynchronized() } returns false
 
 		setupKoin()
 		sceneDatasource = SceneDatasource(projectDef, ffs)
@@ -154,7 +154,7 @@ class SceneEditorRepositoryTestSimple : BaseTest() {
 		)
 		return SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryTestSimple.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryTestSimple.kt
@@ -4,15 +4,15 @@ import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.In
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.migrator.PROJECT_DATA_VERSION
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
@@ -44,7 +44,7 @@ class SceneEditorRepositoryTestSimple : BaseTest() {
 	private lateinit var projectsRepo: ProjectsRepository
 	private lateinit var syncDataRepository: SyncDataRepository
 	private lateinit var projectDef: ProjectDef
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 	private lateinit var projectMetadataRepository: ProjectMetadataDatasource
 	private lateinit var sceneMetadataDatasource: SceneMetadataDatasource
 	private lateinit var sceneMetadataRepository: SceneMetadataRepository
@@ -115,9 +115,9 @@ class SceneEditorRepositoryTestSimple : BaseTest() {
 		toml = createTomlSerializer()
 
 		nextId = -1
-		idRepository = mockk()
-		coEvery { idRepository.claimNextId() } answers { claimId() }
-		coEvery { idRepository.findNextId() } answers {}
+		idAllocator = mockk()
+		coEvery { idAllocator.claimNextId() } answers { claimId() }
+		coEvery { idAllocator.findNextId() } answers {}
 
 		populateProject(ffs)
 
@@ -155,7 +155,7 @@ class SceneEditorRepositoryTestSimple : BaseTest() {
 		return SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
@@ -12,7 +12,7 @@ import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepo
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.toApiType
 import com.darkrockstudios.apps.hammer.common.data.tree.NodeCoordinates
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
@@ -51,7 +51,7 @@ class SceneEditorServiceTest : BaseTest() {
 	private lateinit var toml: Toml
 
 	@MockK
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 
 	@MockK
 	private lateinit var idAllocator: IdAllocator
@@ -94,10 +94,10 @@ class SceneEditorServiceTest : BaseTest() {
 		coEvery { idAllocator.claimNextId() } answers { nextId++ }
 		coEvery { idAllocator.findNextId() } just Runs
 
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { syncDataRepository.isEntityDirty(any()) } returns false
-		coEvery { syncDataRepository.markEntityAsDirty(any(), any()) } just Runs
-		coEvery { syncDataRepository.recordIdDeletion(any()) } just Runs
+		coEvery { syncJournal.isServerSynchronized() } returns false
+		coEvery { syncJournal.isEntityDirty(any()) } returns false
+		coEvery { syncJournal.markEntityAsDirty(any(), any()) } just Runs
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
 	}
 
 	private fun createService(projectDef: ProjectDef): SceneEditorService {
@@ -118,7 +118,7 @@ class SceneEditorServiceTest : BaseTest() {
 		)
 		repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,
@@ -522,8 +522,8 @@ class SceneEditorServiceTest : BaseTest() {
 	@Test
 	fun `Marking for synchronization hashes the exact persisted scene identity`() =
 		runTest(mainTestDispatcher) {
-			coEvery { syncDataRepository.isServerSynchronized() } returns true
-			coEvery { syncDataRepository.isEntityDirty(1) } returns false
+			coEvery { syncJournal.isServerSynchronized() } returns true
+			coEvery { syncJournal.isEntityDirty(1) } returns false
 
 			val service = initializedService()
 			val scene = service.getSceneItemFromId(1)!!
@@ -548,12 +548,12 @@ class SceneEditorServiceTest : BaseTest() {
 			)
 
 			val hashSlot = slot<String>()
-			coEvery { syncDataRepository.markEntityAsDirty(1, capture(hashSlot)) } just Runs
+			coEvery { syncJournal.markEntityAsDirty(1, capture(hashSlot)) } just Runs
 
 			// Any mutation marks the scene for sync before changing it.
 			service.renameScene(scene, "Renamed")
 
-			coVerify { syncDataRepository.markEntityAsDirty(1, any()) }
+			coVerify { syncJournal.markEntityAsDirty(1, any()) }
 			assertEquals(expectedHash, hashSlot.captured)
 		}
 

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
@@ -4,23 +4,12 @@ import PROJECT_1_NAME
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.Info
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
-import com.darkrockstudios.apps.hammer.common.data.InsertPosition
-import com.darkrockstudios.apps.hammer.common.data.MoveRequest
-import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
-import com.darkrockstudios.apps.hammer.common.data.SceneContent
-import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.SceneSummary
-import com.darkrockstudios.apps.hammer.common.data.UpdateSource
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.*
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
@@ -65,7 +54,7 @@ class SceneEditorServiceTest : BaseTest() {
 	private lateinit var syncDataRepository: SyncDataRepository
 
 	@MockK
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 
 	@MockK
 	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
@@ -102,8 +91,8 @@ class SceneEditorServiceTest : BaseTest() {
 		)
 
 		nextId = 100
-		coEvery { idRepository.claimNextId() } answers { nextId++ }
-		coEvery { idRepository.findNextId() } just Runs
+		coEvery { idAllocator.claimNextId() } answers { nextId++ }
+		coEvery { idAllocator.findNextId() } just Runs
 
 		coEvery { syncDataRepository.isServerSynchronized() } returns false
 		coEvery { syncDataRepository.isEntityDirty(any()) } returns false
@@ -130,7 +119,7 @@ class SceneEditorServiceTest : BaseTest() {
 		repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneMetadataRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneMetadataRepositoryTest.kt
@@ -14,7 +14,7 @@ import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepo
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import createProject
@@ -46,7 +46,7 @@ class SceneMetadataRepositoryTest : BaseTest() {
 	private lateinit var toml: Toml
 
 	@MockK
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 
 	@MockK
 	private lateinit var idAllocator: IdAllocator
@@ -78,9 +78,9 @@ class SceneMetadataRepositoryTest : BaseTest() {
 				dataVersion = 1,
 			)
 		)
-		coEvery { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { syncDataRepository.isEntityDirty(any()) } returns false
-		coEvery { syncDataRepository.markEntityAsDirty(any(), any()) } just Runs
+		coEvery { syncJournal.isServerSynchronized() } returns false
+		coEvery { syncJournal.isEntityDirty(any()) } returns false
+		coEvery { syncJournal.markEntityAsDirty(any(), any()) } just Runs
 
 		setupKoin()
 	}
@@ -106,7 +106,7 @@ class SceneMetadataRepositoryTest : BaseTest() {
 		val writingSessionTracker = mockk<WritingSessionTracker>(relaxed = true)
 		repo = SceneRepository(
 			projectDef = projectDef,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,
@@ -155,7 +155,7 @@ class SceneMetadataRepositoryTest : BaseTest() {
 			)
 		)
 		coEvery { projectMetadataDatasource.loadMetadata(any()) } returns projectMetadata
-		coEvery { syncDataRepository.isServerSynchronized() } returns true
+		coEvery { syncJournal.isServerSynchronized() } returns true
 
 		val projDef = getProject1Def()
 		createProject(ffs, PROJECT_1_NAME)
@@ -170,7 +170,7 @@ class SceneMetadataRepositoryTest : BaseTest() {
 		service.storeMetadata(newMetadata, sceneId)
 
 		assertEquals(newMetadata, sceneMetadataRepository.loadSceneMetadata(sceneId))
-		coVerify { syncDataRepository.markEntityAsDirty(sceneId, any()) }
+		coVerify { syncJournal.markEntityAsDirty(sceneId, any()) }
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneMetadataRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneMetadataRepositoryTest.kt
@@ -5,17 +5,13 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.Info
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndex
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexDatasource
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
@@ -53,7 +49,7 @@ class SceneMetadataRepositoryTest : BaseTest() {
 	private lateinit var syncDataRepository: SyncDataRepository
 
 	@MockK
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 
 	@MockK
 	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
@@ -111,7 +107,7 @@ class SceneMetadataRepositoryTest : BaseTest() {
 		repo = SceneRepository(
 			projectDef = projectDef,
 			syncDataRepository = syncDataRepository,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			sceneMetadataRepository = sceneMetadataRepository,
 			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,

--- a/common/src/desktopTest/kotlin/repositories/syncdata/SyncDataRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/syncdata/SyncDataRepositoryTest.kt
@@ -8,7 +8,7 @@ import com.darkrockstudios.apps.hammer.base.http.readJson
 import com.darkrockstudios.apps.hammer.base.http.writeJson
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataDatasource.Companion.SYNC_FILE_NAME
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
@@ -40,7 +40,7 @@ class SyncDataRepositoryTest : BaseTest() {
 	lateinit var datasource: SyncDataDatasource
 
 	@MockK
-	lateinit var idRepository: IdRepository
+	lateinit var idAllocator: IdAllocator
 
 	@MockK
 	lateinit var entitySynchronizers: EntitySynchronizers
@@ -65,7 +65,7 @@ class SyncDataRepositoryTest : BaseTest() {
 			projectDef = projectDef,
 			fileSystem = ffs,
 			json = json,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			entitySynchronizers = entitySynchronizers,
 		)
 		return SyncDataRepository(
@@ -102,7 +102,7 @@ class SyncDataRepositoryTest : BaseTest() {
 		val projectDef = getProject1Def()
 
 		every { globalSettingsRepository.serverSettings } returns null
-		every { idRepository.peekLastId() } returns 4
+		every { idAllocator.peekLastId() } returns 4
 		val idSlot = slot<Int>()
 		coEvery { entitySynchronizers.findEntityType(capture(idSlot)) } answers {
 			when (idSlot.captured) {
@@ -141,7 +141,7 @@ class SyncDataRepositoryTest : BaseTest() {
 		val projectDef = getProjectDef(PROJECT_2_NAME)
 
 		every { globalSettingsRepository.serverSettings } returns null
-		every { idRepository.peekLastId() } returns 4
+		every { idAllocator.peekLastId() } returns 4
 		coEvery { entitySynchronizers.findEntityType(any()) } returns null
 
 		val repo = createRepository(projectDef)
@@ -263,7 +263,7 @@ class SyncDataRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
 		writeDirtyData(syncPath(projectDef))
-		every { idRepository.peekLastId() } returns 25
+		every { idAllocator.peekLastId() } returns 25
 		every { globalSettingsRepository.serverIsSetup() } returns false
 		every { globalSettingsRepository.globalSettings.automaticSyncing } returns true
 		coEvery { networkConnectivity.hasActiveConnection() } returns true

--- a/common/src/desktopTest/kotlin/repositories/syncdata/SyncJournalTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/syncdata/SyncJournalTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.base.http.readJson
 import com.darkrockstudios.apps.hammer.base.http.writeJson
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataDatasource.Companion.SYNC_FILE_NAME
@@ -46,7 +46,7 @@ class SyncJournalTest : BaseTest() {
 	lateinit var entitySynchronizers: EntitySynchronizers
 
 	@MockK
-	lateinit var globalSettingsRepository: GlobalSettingsRepository
+	lateinit var globalSettingsStore: GlobalSettingsStore
 
 	@MockK
 	lateinit var networkConnectivity: NetworkConnectivity
@@ -69,7 +69,7 @@ class SyncJournalTest : BaseTest() {
 			entitySynchronizers = entitySynchronizers,
 		)
 		return SyncJournal(
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			networkConnectivity = networkConnectivity,
 			datasource = datasource,
 		)
@@ -82,7 +82,7 @@ class SyncJournalTest : BaseTest() {
 
 	@Test
 	fun `Check if server is synchronized`() {
-		every { globalSettingsRepository.serverSettings } returns mockk()
+		every { globalSettingsStore.serverSettings } returns mockk()
 
 		val repo = createRepository(getProject1Def())
 		assertTrue(repo.isServerSynchronized())
@@ -90,7 +90,7 @@ class SyncJournalTest : BaseTest() {
 
 	@Test
 	fun `Check that server is not synchronized`() {
-		every { globalSettingsRepository.serverSettings } returns null
+		every { globalSettingsStore.serverSettings } returns null
 
 		val repo = createRepository(getProject1Def())
 		assertFalse(repo.isServerSynchronized())
@@ -101,7 +101,7 @@ class SyncJournalTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 		val projectDef = getProject1Def()
 
-		every { globalSettingsRepository.serverSettings } returns null
+		every { globalSettingsStore.serverSettings } returns null
 		every { idAllocator.peekLastId() } returns 4
 		val idSlot = slot<Int>()
 		coEvery { entitySynchronizers.findEntityType(capture(idSlot)) } answers {
@@ -140,7 +140,7 @@ class SyncJournalTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
 
-		every { globalSettingsRepository.serverSettings } returns null
+		every { globalSettingsStore.serverSettings } returns null
 		every { idAllocator.peekLastId() } returns 4
 		coEvery { entitySynchronizers.findEntityType(any()) } returns null
 
@@ -159,7 +159,7 @@ class SyncJournalTest : BaseTest() {
 		runTest {
 			createProject(ffs, PROJECT_2_NAME)
 			val projectDef = getProjectDef(PROJECT_2_NAME)
-			every { globalSettingsRepository.serverSettings } returns mockk()
+			every { globalSettingsStore.serverSettings } returns mockk()
 
 			val repo = createRepository(projectDef)
 			val path = syncPath(projectDef)
@@ -173,7 +173,7 @@ class SyncJournalTest : BaseTest() {
 	fun `Check if Entity is Dirty`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
-		every { globalSettingsRepository.serverSettings } returns mockk()
+		every { globalSettingsStore.serverSettings } returns mockk()
 
 		val repo = createRepository(projectDef)
 		val path = syncPath(projectDef)
@@ -198,8 +198,8 @@ class SyncJournalTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
 		writeDirtyData(syncPath(projectDef))
-		every { globalSettingsRepository.serverIsSetup() } returns true
-		every { globalSettingsRepository.globalSettings.automaticSyncing } returns true
+		every { globalSettingsStore.serverIsSetup() } returns true
+		every { globalSettingsStore.globalSettings.automaticSyncing } returns true
 		coEvery { networkConnectivity.hasActiveConnection() } returns true
 
 		val repo = createRepository(projectDef)
@@ -221,8 +221,8 @@ class SyncJournalTest : BaseTest() {
 				deletedIds = setOf(2, 4)
 			)
 		)
-		every { globalSettingsRepository.serverIsSetup() } returns true
-		every { globalSettingsRepository.globalSettings.automaticSyncing } returns true
+		every { globalSettingsStore.serverIsSetup() } returns true
+		every { globalSettingsStore.globalSettings.automaticSyncing } returns true
 		coEvery { networkConnectivity.hasActiveConnection() } returns true
 
 		val repo = createRepository(projectDef)
@@ -235,8 +235,8 @@ class SyncJournalTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
 		writeDirtyData(syncPath(projectDef))
-		every { globalSettingsRepository.serverIsSetup() } returns true
-		every { globalSettingsRepository.globalSettings.automaticSyncing } returns true
+		every { globalSettingsStore.serverIsSetup() } returns true
+		every { globalSettingsStore.globalSettings.automaticSyncing } returns true
 		coEvery { networkConnectivity.hasActiveConnection() } returns false
 
 		val repo = createRepository(projectDef)
@@ -249,8 +249,8 @@ class SyncJournalTest : BaseTest() {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
 		writeDirtyData(syncPath(projectDef))
-		every { globalSettingsRepository.serverIsSetup() } returns true
-		every { globalSettingsRepository.globalSettings.automaticSyncing } returns false
+		every { globalSettingsStore.serverIsSetup() } returns true
+		every { globalSettingsStore.globalSettings.automaticSyncing } returns false
 		coEvery { networkConnectivity.hasActiveConnection() } returns true
 
 		val repo = createRepository(projectDef)
@@ -264,8 +264,8 @@ class SyncJournalTest : BaseTest() {
 		val projectDef = getProjectDef(PROJECT_2_NAME)
 		writeDirtyData(syncPath(projectDef))
 		every { idAllocator.peekLastId() } returns 25
-		every { globalSettingsRepository.serverIsSetup() } returns false
-		every { globalSettingsRepository.globalSettings.automaticSyncing } returns true
+		every { globalSettingsStore.serverIsSetup() } returns false
+		every { globalSettingsStore.globalSettings.automaticSyncing } returns true
 		coEvery { networkConnectivity.hasActiveConnection() } returns true
 
 		val repo = createRepository(projectDef)
@@ -290,7 +290,7 @@ class SyncJournalTest : BaseTest() {
 	fun `Mark Entity Dirty`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
-		every { globalSettingsRepository.isServerSynchronized() } returns true
+		every { globalSettingsStore.isServerSynchronized() } returns true
 		val repo = createRepository(projectDef)
 
 		repo.markEntityAsDirty(1, "old-hash")
@@ -306,7 +306,7 @@ class SyncJournalTest : BaseTest() {
 	fun `Record new ID`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
-		every { globalSettingsRepository.isServerSynchronized() } returns true
+		every { globalSettingsStore.isServerSynchronized() } returns true
 		val newId1 = 26
 		val newId2 = 27
 
@@ -326,7 +326,7 @@ class SyncJournalTest : BaseTest() {
 	fun `Record deleted ID`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
-		every { globalSettingsRepository.isServerSynchronized() } returns true
+		every { globalSettingsStore.isServerSynchronized() } returns true
 		val newId1 = 14
 		val newId2 = 16
 
@@ -350,7 +350,7 @@ class SyncJournalTest : BaseTest() {
 		// wedged sync with "Entity X not found for reId".
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
-		every { globalSettingsRepository.isServerSynchronized() } returns true
+		every { globalSettingsStore.isServerSynchronized() } returns true
 		val repo = createRepository(projectDef)
 
 		repo.saveSyncData(
@@ -375,7 +375,7 @@ class SyncJournalTest : BaseTest() {
 	fun `Load sync data`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
-		every { globalSettingsRepository.isServerSynchronized() } returns true
+		every { globalSettingsStore.isServerSynchronized() } returns true
 		val repo = createRepository(projectDef)
 
 		val loadedData = repo.loadSyncData()
@@ -397,7 +397,7 @@ class SyncJournalTest : BaseTest() {
 	fun `Save sync data`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
-		every { globalSettingsRepository.isServerSynchronized() } returns true
+		every { globalSettingsStore.isServerSynchronized() } returns true
 		val repo = createRepository(projectDef)
 
 		val newData = ProjectSynchronizationData(
@@ -421,7 +421,7 @@ class SyncJournalTest : BaseTest() {
 	fun `Get Deleted IDs`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
-		every { globalSettingsRepository.isServerSynchronized() } returns true
+		every { globalSettingsStore.isServerSynchronized() } returns true
 		val repo = createRepository(projectDef)
 
 		val deletedIds = repo.deletedIds()

--- a/common/src/desktopTest/kotlin/repositories/syncdata/SyncJournalTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/syncdata/SyncJournalTest.kt
@@ -33,7 +33,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Instant
 
-class SyncDataRepositoryTest : BaseTest() {
+class SyncJournalTest : BaseTest() {
 
 	lateinit var ffs: FakeFileSystem
 	lateinit var json: Json
@@ -60,7 +60,7 @@ class SyncDataRepositoryTest : BaseTest() {
 		MockKAnnotations.init(this)
 	}
 
-	private fun createRepository(projectDef: ProjectDef): SyncDataRepository {
+	private fun createRepository(projectDef: ProjectDef): SyncJournal {
 		datasource = SyncDataDatasource(
 			projectDef = projectDef,
 			fileSystem = ffs,
@@ -68,7 +68,7 @@ class SyncDataRepositoryTest : BaseTest() {
 			idAllocator = idAllocator,
 			entitySynchronizers = entitySynchronizers,
 		)
-		return SyncDataRepository(
+		return SyncJournal(
 			globalSettingsRepository = globalSettingsRepository,
 			networkConnectivity = networkConnectivity,
 			datasource = datasource,

--- a/common/src/desktopTest/kotlin/repositories/syncdata/SyncJournalTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/syncdata/SyncJournalTest.kt
@@ -76,7 +76,7 @@ class SyncJournalTest : BaseTest() {
 	}
 
 	@Test
-	fun `SyncDataRepository Init`() {
+	fun `SyncJournal Init`() {
 		val repo = createRepository(getProject1Def())
 	}
 

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryMoveTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryMoveTest.kt
@@ -8,7 +8,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineDatasource
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
@@ -47,7 +47,7 @@ class TimeLineRepositoryMoveTest : BaseTest() {
 	lateinit var lifecycle: Lifecycle
 	lateinit var datasource: TimeLineDatasource
 	lateinit var lifecycleCallbacks: MutableList<Lifecycle.Callbacks>
-	lateinit var syncDataRepository: SyncDataRepository
+	lateinit var syncJournal: SyncJournal
 	lateinit var globalSettingsRepo: GlobalSettingsRepository
 	lateinit var globalSettingsFlow: SharedFlow<GlobalSettings>
 
@@ -67,15 +67,15 @@ class TimeLineRepositoryMoveTest : BaseTest() {
 		globalSettingsFlow = mockk()
 		every { globalSettingsRepo.globalSettingsUpdates } returns globalSettingsFlow
 
-		syncDataRepository = mockk()
-		every { syncDataRepository.isServerSynchronized() } returns false
+		syncJournal = mockk()
+		every { syncJournal.isServerSynchronized() } returns false
 
 		lifecycleCallbacks = mutableListOf()
 
 		val testModule = module {
 			single { idRepo } bind IdAllocator::class
 			single { globalSettingsRepo }
-			single { syncDataRepository }
+			single { syncJournal }
 		}
 		setupKoin(testModule)
 

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryMoveTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryMoveTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineDatasource
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
@@ -42,7 +42,7 @@ class TimeLineRepositoryMoveTest : BaseTest() {
 	lateinit var ffs: FakeFileSystem
 	lateinit var toml: Toml
 	lateinit var json: Json
-	lateinit var idRepo: IdRepository
+	lateinit var idRepo: IdAllocator
 	lateinit var context: ComponentContext
 	lateinit var lifecycle: Lifecycle
 	lateinit var datasource: TimeLineDatasource
@@ -73,7 +73,7 @@ class TimeLineRepositoryMoveTest : BaseTest() {
 		lifecycleCallbacks = mutableListOf()
 
 		val testModule = module {
-			single { idRepo } bind IdRepository::class
+			single { idRepo } bind IdAllocator::class
 			single { globalSettingsRepo }
 			single { syncDataRepository }
 		}
@@ -113,7 +113,7 @@ class TimeLineRepositoryMoveTest : BaseTest() {
 		val repo = TimeLineRepository(
 			projectDef = projectDef,
 			datasource = datasource,
-			idRepository = idRepo,
+			idAllocator = idRepo,
 		)
 		repo.initialize()
 

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryMoveTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryMoveTest.kt
@@ -6,7 +6,7 @@ import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineDatasource
@@ -48,7 +48,7 @@ class TimeLineRepositoryMoveTest : BaseTest() {
 	lateinit var datasource: TimeLineDatasource
 	lateinit var lifecycleCallbacks: MutableList<Lifecycle.Callbacks>
 	lateinit var syncJournal: SyncJournal
-	lateinit var globalSettingsRepo: GlobalSettingsRepository
+	lateinit var globalSettingsRepo: GlobalSettingsStore
 	lateinit var globalSettingsFlow: SharedFlow<GlobalSettings>
 
 	@BeforeEach

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryTest.kt
@@ -5,7 +5,7 @@ import app.cash.turbine.test
 import com.darkrockstudios.apps.hammer.base.http.readToml
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.*
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository.Companion.MAX_TAG_SIZE
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
@@ -38,7 +38,7 @@ class TimeLineRepositoryTest : BaseTest() {
 
 	lateinit var ffs: FakeFileSystem
 	lateinit var toml: Toml
-	lateinit var syncDataRepository: SyncDataRepository
+	lateinit var syncJournal: SyncJournal
 	lateinit var datasource: TimeLineDatasource
 
 	@BeforeEach
@@ -47,11 +47,11 @@ class TimeLineRepositoryTest : BaseTest() {
 
 		ffs = FakeFileSystem()
 		toml = createTomlSerializer()
-		syncDataRepository = mockk()
+		syncJournal = mockk()
 		datasource = TimeLineDatasource(ffs, toml)
 
 		val testModule = module {
-			single { syncDataRepository }
+			single { syncJournal }
 		}
 		setupKoin(testModule)
 	}
@@ -140,7 +140,7 @@ class TimeLineRepositoryTest : BaseTest() {
 
 	@Test
 	fun `Update timeline with new event`() = runTest {
-		every { syncDataRepository.isServerSynchronized() } returns false
+		every { syncJournal.isServerSynchronized() } returns false
 
 		createProject(ffs, PROJECT_EMPTY_NAME)
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)
@@ -196,7 +196,7 @@ class TimeLineRepositoryTest : BaseTest() {
 
 	@Test
 	fun `Update timeline with updated event`() = runTest {
-		every { syncDataRepository.isServerSynchronized() } returns false
+		every { syncJournal.isServerSynchronized() } returns false
 
 		createProject(ffs, PROJECT_EMPTY_NAME)
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)
@@ -250,7 +250,7 @@ class TimeLineRepositoryTest : BaseTest() {
 
 	@Test
 	fun `Create event with tags persists cleaned tags`() = runTest {
-		every { syncDataRepository.isServerSynchronized() } returns false
+		every { syncJournal.isServerSynchronized() } returns false
 
 		createProject(ffs, PROJECT_EMPTY_NAME)
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)
@@ -282,7 +282,7 @@ class TimeLineRepositoryTest : BaseTest() {
 
 	@Test
 	fun `Update event with tags persists cleaned tags`() = runTest {
-		every { syncDataRepository.isServerSynchronized() } returns false
+		every { syncJournal.isServerSynchronized() } returns false
 
 		createProject(ffs, PROJECT_EMPTY_NAME)
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)
@@ -327,8 +327,8 @@ class TimeLineRepositoryTest : BaseTest() {
 
 	@Test
 	fun `eventContentChangedFlow emits on create update and delete`() = runTest {
-		every { syncDataRepository.isServerSynchronized() } returns false
-		coEvery { syncDataRepository.recordIdDeletion(any()) } returns Unit
+		every { syncJournal.isServerSynchronized() } returns false
+		coEvery { syncJournal.recordIdDeletion(any()) } returns Unit
 
 		createProject(ffs, PROJECT_EMPTY_NAME)
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineRepositoryTest.kt
@@ -4,7 +4,7 @@ import PROJECT_EMPTY_NAME
 import app.cash.turbine.test
 import com.darkrockstudios.apps.hammer.base.http.readToml
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataRepository
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.*
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository.Companion.MAX_TAG_SIZE
@@ -80,11 +80,11 @@ class TimeLineRepositoryTest : BaseTest() {
 	fun `Get Timeline Dir creates Dir`() = runTest {
 		createProject(ffs, PROJECT_EMPTY_NAME)
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)
-		val idRepo = mockk<IdRepository>()
+		val idRepo = mockk<IdAllocator>()
 
 		val repo = TimeLineRepository(
 			projectDef = projDef,
-			idRepository = idRepo,
+			idAllocator = idRepo,
 			datasource = datasource,
 		).initialize()
 
@@ -98,11 +98,11 @@ class TimeLineRepositoryTest : BaseTest() {
 	fun `Get timeline when none exists`() = runTest {
 		createProject(ffs, PROJECT_EMPTY_NAME)
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)
-		val idRepo = mockk<IdRepository>()
+		val idRepo = mockk<IdAllocator>()
 
 		val repo = TimeLineRepository(
 			projectDef = projDef,
-			idRepository = idRepo,
+			idAllocator = idRepo,
 			datasource = datasource,
 		).initialize()
 
@@ -116,10 +116,10 @@ class TimeLineRepositoryTest : BaseTest() {
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)
 		setupTimelne(projDef)
 
-		val idRepo = mockk<IdRepository>()
+		val idRepo = mockk<IdAllocator>()
 		val repo = TimeLineRepository(
 			projectDef = projDef,
-			idRepository = idRepo,
+			idAllocator = idRepo,
 			datasource = datasource,
 		).initialize()
 
@@ -147,10 +147,10 @@ class TimeLineRepositoryTest : BaseTest() {
 		val oldEvents = fakeEvents()
 		setupTimelne(projDef, oldEvents)
 
-		val idRepo = mockk<IdRepository>()
+		val idRepo = mockk<IdAllocator>()
 		val repo = TimeLineRepository(
 			projectDef = projDef,
-			idRepository = idRepo,
+			idAllocator = idRepo,
 			datasource = datasource,
 		).initialize()
 
@@ -205,7 +205,7 @@ class TimeLineRepositoryTest : BaseTest() {
 
 		val repo = TimeLineRepository(
 			projectDef = projDef,
-			idRepository = mockk(),
+			idAllocator = mockk(),
 			datasource = datasource,
 		).initialize()
 
@@ -256,12 +256,12 @@ class TimeLineRepositoryTest : BaseTest() {
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)
 		setupTimelne(projDef, emptyList())
 
-		val idRepo = mockk<IdRepository>()
+		val idRepo = mockk<IdAllocator>()
 		coEvery { idRepo.claimNextId() } returns 42
 
 		val repo = TimeLineRepository(
 			projectDef = projDef,
-			idRepository = idRepo,
+			idAllocator = idRepo,
 			datasource = datasource,
 		).initialize()
 
@@ -291,7 +291,7 @@ class TimeLineRepositoryTest : BaseTest() {
 
 		val repo = TimeLineRepository(
 			projectDef = projDef,
-			idRepository = mockk(),
+			idAllocator = mockk(),
 			datasource = datasource,
 		).initialize()
 
@@ -311,7 +311,7 @@ class TimeLineRepositoryTest : BaseTest() {
 	fun `Validate tags rejects tag exceeding MAX_TAG_SIZE`() {
 		val repo = TimeLineRepository(
 			projectDef = getProjectDef(PROJECT_EMPTY_NAME),
-			idRepository = mockk(),
+			idAllocator = mockk(),
 			datasource = datasource,
 		)
 
@@ -334,12 +334,12 @@ class TimeLineRepositoryTest : BaseTest() {
 		val projDef = getProjectDef(PROJECT_EMPTY_NAME)
 		setupTimelne(projDef, fakeEvents())
 
-		val idRepo = mockk<IdRepository>()
+		val idRepo = mockk<IdAllocator>()
 		coEvery { idRepo.claimNextId() } returns 99
 
 		val repo = TimeLineRepository(
 			projectDef = projDef,
-			idRepository = idRepo,
+			idAllocator = idRepo,
 			datasource = datasource,
 		).initialize()
 		advanceUntilIdle()

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineTestBase.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineTestBase.kt
@@ -6,7 +6,7 @@ import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.statekeeper.StateKeeperDispatcher
 import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineContainer
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
@@ -32,7 +32,7 @@ abstract class TimeLineTestBase : BaseTest() {
 	lateinit var toml: Toml
 	lateinit var json: Json
 	lateinit var timelineRepo: TimeLineRepository
-	lateinit var globalSettingsRepo: GlobalSettingsRepository
+	lateinit var globalSettingsRepo: GlobalSettingsStore
 	lateinit var globalSettingsUpdates: SharedFlow<GlobalSettings>
 	lateinit var idRepo: IdAllocator
 	lateinit var context: ComponentContext

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineTestBase.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineTestBase.kt
@@ -7,7 +7,7 @@ import com.arkivanov.essenty.statekeeper.StateKeeperDispatcher
 import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineContainer
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
@@ -34,7 +34,7 @@ abstract class TimeLineTestBase : BaseTest() {
 	lateinit var timelineRepo: TimeLineRepository
 	lateinit var globalSettingsRepo: GlobalSettingsRepository
 	lateinit var globalSettingsUpdates: SharedFlow<GlobalSettings>
-	lateinit var idRepo: IdRepository
+	lateinit var idRepo: IdAllocator
 	lateinit var context: ComponentContext
 	lateinit var lifecycle: Lifecycle
 	lateinit var backHandler: BackHandler
@@ -117,7 +117,7 @@ abstract class TimeLineTestBase : BaseTest() {
 			//single { globalSettingsRepo } bind GlobalSettingsRepository::class
 			scope<ProjectDefScope> {
 				scoped { timelineRepo } bind TimeLineRepository::class
-				scoped { idRepo } bind IdRepository::class
+				scoped { idRepo } bind IdAllocator::class
 			}
 		}
 		setupKoin(testModule)

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineTestBase.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineTestBase.kt
@@ -114,7 +114,7 @@ abstract class TimeLineTestBase : BaseTest() {
 		}
 
 		val testModule = module {
-			//single { globalSettingsRepo } bind GlobalSettingsRepository::class
+			//single { globalSettingsRepo } bind GlobalSettingsStore::class
 			scope<ProjectDefScope> {
 				scoped { timelineRepo } bind TimeLineRepository::class
 				scoped { idRepo } bind IdAllocator::class

--- a/common/src/desktopTest/kotlin/repositories/writingactivity/WritingActivitySyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/writingactivity/WritingActivitySyncOperationTest.kt
@@ -5,7 +5,7 @@ import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingActivityResponse
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingSession
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityConflictHandler
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityTransferState
@@ -17,23 +17,14 @@ import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessio
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.server.WritingActivityApi
-import io.mockk.MockKAnnotations
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.dsl.module
-import synchronizer.operations.beganResponse
-import synchronizer.operations.collatedIds
-import synchronizer.operations.entityState
-import synchronizer.operations.projId
-import synchronizer.operations.projectData
+import synchronizer.operations.*
 import utils.BaseTest
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -51,7 +42,7 @@ class WritingActivitySyncOperationTest : BaseTest() {
 	private lateinit var api: WritingActivityApi
 
 	@MockK(relaxed = true)
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 
 	private val projectDef = ProjectDef(
 		name = "Test Project",
@@ -77,8 +68,8 @@ class WritingActivitySyncOperationTest : BaseTest() {
 			}
 		})
 
-		coEvery { globalSettingsRepository.userIdOrThrow() } returns userId
-		every { globalSettingsRepository.deviceLabelOrDefault() } returns deviceLabel
+		coEvery { globalSettingsStore.userIdOrThrow() } returns userId
+		every { globalSettingsStore.deviceLabelOrDefault() } returns deviceLabel
 		coEvery { repository.ownDeviceId() } returns ownDeviceId
 	}
 
@@ -87,7 +78,7 @@ class WritingActivitySyncOperationTest : BaseTest() {
 		repository = repository,
 		tracker = tracker,
 		api = api,
-		globalSettingsRepository = globalSettingsRepository,
+		globalSettingsStore = globalSettingsStore,
 	)
 
 	private fun startState() = EntityTransferState(

--- a/common/src/desktopTest/kotlin/repositories/writingactivity/WritingSessionTrackerTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/writingactivity/WritingSessionTrackerTest.kt
@@ -2,7 +2,7 @@ package repositories.writingactivity
 
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityDatasource
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityRepository
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
@@ -30,7 +30,7 @@ class WritingSessionTrackerTest : BaseTest() {
 	private lateinit var toml: Toml
 	private lateinit var datasource: WritingActivityDatasource
 	private lateinit var repository: WritingActivityRepository
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 	private lateinit var clock: TestClock
 	private lateinit var tracker: WritingSessionTracker
 
@@ -50,11 +50,11 @@ class WritingSessionTrackerTest : BaseTest() {
 
 		datasource = WritingActivityDatasource(fileSystem, toml, projectDef)
 
-		globalSettingsRepository = mockk(relaxed = true)
-		coEvery { globalSettingsRepository.ensureInstallId() } returns "device-test"
-		every { globalSettingsRepository.deviceLabelOrDefault() } returns "Test Device"
+		globalSettingsStore = mockk(relaxed = true)
+		coEvery { globalSettingsStore.ensureInstallId() } returns "device-test"
+		every { globalSettingsStore.deviceLabelOrDefault() } returns "Test Device"
 
-		repository = WritingActivityRepository(datasource, globalSettingsRepository, projectDef)
+		repository = WritingActivityRepository(datasource, globalSettingsStore, projectDef)
 		clock = TestClock(Clock.System)
 		tracker = WritingSessionTracker(repository, clock, projectDef)
 	}

--- a/common/src/desktopTest/kotlin/synchronizer/ClientProjectSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientProjectSynchronizerTest.kt
@@ -35,7 +35,7 @@ class ClientProjectSynchronizerTest : BaseTest() {
 	private lateinit var strRes: StrRes
 
 	@MockK(relaxed = true)
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 
 	@MockK(relaxed = true)
 	private lateinit var entitySynchronizers: EntitySynchronizers
@@ -125,7 +125,7 @@ class ClientProjectSynchronizerTest : BaseTest() {
 			projectDef = projectDef,
 			entitySynchronizers = entitySynchronizers,
 			strRes = strRes,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			globalSettingsRepository = globalSettingsRepository,
 			projectMetadataDatasource = projectMetadataDatasource,
 			serverProjectApi = serverProjectApi,

--- a/common/src/desktopTest/kotlin/synchronizer/ClientProjectSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientProjectSynchronizerTest.kt
@@ -6,7 +6,7 @@ import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.*
@@ -41,7 +41,7 @@ class ClientProjectSynchronizerTest : BaseTest() {
 	private lateinit var entitySynchronizers: EntitySynchronizers
 
 	@MockK(relaxed = true)
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 
 	@MockK(relaxed = true)
 	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
@@ -126,7 +126,7 @@ class ClientProjectSynchronizerTest : BaseTest() {
 			entitySynchronizers = entitySynchronizers,
 			strRes = strRes,
 			syncJournal = syncJournal,
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			projectMetadataDatasource = projectMetadataDatasource,
 			serverProjectApi = serverProjectApi,
 		)

--- a/common/src/desktopTest/kotlin/synchronizer/operations/BackupOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/BackupOperationTest.kt
@@ -3,7 +3,7 @@ package synchronizer.operations
 import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectbackup.ProjectBackupRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.CollateIdsState
@@ -28,7 +28,7 @@ import kotlin.test.assertTrue
 class BackupOperationTest : BaseTest() {
 
 	@MockK(relaxed = true)
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 
 	@MockK(relaxed = true)
 	private lateinit var backupRepository: ProjectBackupRepository
@@ -47,14 +47,14 @@ class BackupOperationTest : BaseTest() {
 		return BackupOperation(
 			projectDef = projectDef,
 			strRes = strRes,
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			backupRepository = backupRepository,
 		)
 	}
 
 	@Test
 	fun `Golden Path`() = runTest {
-		coEvery { globalSettingsRepository.globalSettings.automaticBackups } returns true
+		coEvery { globalSettingsStore.globalSettings.automaticBackups } returns true
 		coEvery { backupRepository.supportsBackup() } returns true
 		coEvery { backupRepository.createBackup(any()) } returns mockk(relaxed = true)
 
@@ -91,7 +91,7 @@ class BackupOperationTest : BaseTest() {
 
 	@Test
 	fun `Backups disabled`() = runTest {
-		coEvery { globalSettingsRepository.globalSettings.automaticBackups } returns false
+		coEvery { globalSettingsStore.globalSettings.automaticBackups } returns false
 		coEvery { backupRepository.supportsBackup() } returns true
 		coEvery { backupRepository.createBackup(any()) } returns mockk(relaxed = true)
 
@@ -128,7 +128,7 @@ class BackupOperationTest : BaseTest() {
 
 	@Test
 	fun `Platform does not support backups`() = runTest {
-		coEvery { globalSettingsRepository.globalSettings.automaticBackups } returns true
+		coEvery { globalSettingsStore.globalSettings.automaticBackups } returns true
 		coEvery { backupRepository.supportsBackup() } returns false
 		coEvery { backupRepository.createBackup(any()) } returns mockk(relaxed = true)
 

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FetchLocalDataOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FetchLocalDataOperationTest.kt
@@ -39,7 +39,7 @@ class FetchLocalDataOperationTest : BaseTest() {
 	private lateinit var mockSynchronizers: MockSynchronizers
 
 	@MockK(relaxed = true)
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 
 	@MockK(relaxed = true)
 	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
@@ -71,7 +71,7 @@ class FetchLocalDataOperationTest : BaseTest() {
 			projectDef = projectDef,
 			entitySynchronizers = EntitySynchronizers(projectDef),
 			strRes = strRes,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 			projectMetadataDatasource = projectMetadataDatasource,
 		)
 	}
@@ -81,7 +81,7 @@ class FetchLocalDataOperationTest : BaseTest() {
 		val op = createOperation(getProjectDef(PROJECT_2_NAME))
 
 		coEvery { projectMetadataDatasource.loadMetadata(any()) } returns metadata
-		coEvery { syncDataRepository.loadSyncData() } returns projectData
+		coEvery { syncJournal.loadSyncData() } returns projectData
 
 		mockSynchronizers.synchronizers.forEach { synchronizer ->
 			when (synchronizer) {

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FetchServerDataOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FetchServerDataOperationTest.kt
@@ -3,7 +3,7 @@ package synchronizer.operations
 import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
@@ -39,7 +39,7 @@ class FetchServerDataOperationTest : BaseTest() {
 	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
 
 	@MockK(relaxed = true)
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 
 	@MockK(relaxed = true)
 	private lateinit var serverProjectApi: ServerProjectApi
@@ -71,7 +71,7 @@ class FetchServerDataOperationTest : BaseTest() {
 			projectDef = projectDef,
 			strRes = strRes,
 			projectMetadataDatasource = projectMetadataDatasource,
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			serverProjectApi = serverProjectApi,
 		)
 	}
@@ -89,7 +89,7 @@ class FetchServerDataOperationTest : BaseTest() {
 				any()
 			)
 		} returns Result.success(beganResponse)
-		coEvery { globalSettingsRepository.serverSettingsUpdates } returns sharedFlow {
+		coEvery { globalSettingsStore.serverSettingsUpdates } returns sharedFlow {
 			emit(
 				mockk<ServerSettings>().apply {
 					every { userId } returns 1L
@@ -137,7 +137,7 @@ class FetchServerDataOperationTest : BaseTest() {
 	fun `Handle Failure`() = runTest {
 		val op = createOperation(getProjectDef(PROJECT_2_NAME))
 
-		coEvery { globalSettingsRepository.serverSettingsUpdates } returns sharedFlow {
+		coEvery { globalSettingsStore.serverSettingsUpdates } returns sharedFlow {
 			emit(
 				mockk<ServerSettings>().apply {
 					every { userId } returns 1L

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FinalizeSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FinalizeSyncOperationTest.kt
@@ -3,7 +3,7 @@ package synchronizer.operations
 import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
@@ -32,7 +32,7 @@ class FinalizeSyncOperationTest : BaseTest() {
 	private lateinit var mockSynchronizers: MockSynchronizers
 
 	@MockK(relaxed = true)
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 
 	@MockK(relaxed = true)
 	private lateinit var serverProjectApi: ServerProjectApi
@@ -72,7 +72,7 @@ class FinalizeSyncOperationTest : BaseTest() {
 			strRes = strRes,
 			entitySynchronizers = EntitySynchronizers(projectDef),
 			clock = clock,
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 			syncDataDatasource = syncDataDatasource,
 		)
 	}
@@ -81,7 +81,7 @@ class FinalizeSyncOperationTest : BaseTest() {
 	fun `Golden Path`() = runTest {
 		val op = createOperation(getProjectDef(PROJECT_2_NAME))
 
-		coEvery { globalSettingsRepository.serverSettingsUpdates } returns sharedFlow {
+		coEvery { globalSettingsStore.serverSettingsUpdates } returns sharedFlow {
 			emit(
 				mockk<ServerSettings>().apply {
 					every { userId } returns 1L

--- a/common/src/desktopTest/kotlin/synchronizer/operations/IdConflictResolutionOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/IdConflictResolutionOperationTest.kt
@@ -4,7 +4,7 @@ import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.base.http.ProjectSynchronizationBegan
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.IdConflictResolutionOperation
@@ -30,7 +30,7 @@ class IdConflictResolutionOperationTest : BaseTest() {
 	private lateinit var mockSynchronizers: MockSynchronizers
 
 	@MockK(relaxed = true)
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 
 	private lateinit var strRes: TestStrRes
 
@@ -57,7 +57,7 @@ class IdConflictResolutionOperationTest : BaseTest() {
 		configureKoin(projectDef)
 		return IdConflictResolutionOperation(
 			projectDef = projectDef,
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			entitySynchronizers = EntitySynchronizers(projectDef),
 		)
 	}
@@ -65,8 +65,8 @@ class IdConflictResolutionOperationTest : BaseTest() {
 	@Test
 	fun `Golden Path`() = runTest {
 		val op = createOperation(getProjectDef(PROJECT_2_NAME))
-		coEvery { idRepository.findNextId() } just Runs
-		coEvery { idRepository.peekLastId() } returns 11
+		coEvery { idAllocator.findNextId() } just Runs
+		coEvery { idAllocator.peekLastId() } returns 11
 
 		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(11) } returns true
 		coEvery { mockSynchronizers.sceneSynchronizer.deleteEntityLocal(any(), any()) } just Runs
@@ -117,8 +117,8 @@ class IdConflictResolutionOperationTest : BaseTest() {
 		// and used to throw, aborting every sync forever. It must instead skip
 		// the phantom so the sync can finish and clear it.
 		val op = createOperation(getProjectDef(PROJECT_2_NAME))
-		coEvery { idRepository.findNextId() } just Runs
-		coEvery { idRepository.peekLastId() } returns 50
+		coEvery { idAllocator.findNextId() } just Runs
+		coEvery { idAllocator.peekLastId() } returns 50
 
 		// No synchronizer owns the phantom id.
 		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(any()) } returns false
@@ -183,8 +183,8 @@ class IdConflictResolutionOperationTest : BaseTest() {
 		// above the local max. Seeding only from serverLastId would hand out IDs
 		// that collide with - and clobber - real local entities.
 		val op = createOperation(getProjectDef(PROJECT_2_NAME))
-		coEvery { idRepository.findNextId() } just Runs
-		coEvery { idRepository.peekLastId() } returns 100 // local max entity id
+		coEvery { idAllocator.findNextId() } just Runs
+		coEvery { idAllocator.peekLastId() } returns 100 // local max entity id
 
 		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(30) } returns true
 		coEvery { mockSynchronizers.sceneSynchronizer.reIdEntity(any(), any()) } just Runs

--- a/common/src/desktopTest/kotlin/synchronizer/operations/PrepareForSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/PrepareForSyncOperationTest.kt
@@ -29,7 +29,7 @@ class PrepareForSyncOperationTest : BaseTest() {
 	private lateinit var idAllocator: IdAllocator
 
 	@MockK(relaxed = true)
-	private lateinit var syncDataRepository: SyncDataRepository
+	private lateinit var syncJournal: SyncJournal
 
 	@BeforeEach
 	override fun setup() {
@@ -55,7 +55,7 @@ class PrepareForSyncOperationTest : BaseTest() {
 			projectDef = projectDef,
 			entitySynchronizers = EntitySynchronizers(projectDef),
 			idAllocator = idAllocator,
-			syncDataRepository = syncDataRepository,
+			syncJournal = syncJournal,
 		)
 	}
 
@@ -85,7 +85,7 @@ class PrepareForSyncOperationTest : BaseTest() {
 		assertIs<SyncOperationState>(result.data)
 
 		coVerify { idAllocator.findNextId() }
-		coVerify { syncDataRepository.createSyncData() }
+		coVerify { syncJournal.createSyncData() }
 
 		mockSynchronizers.synchronizers.forEach { synchronizer ->
 			coVerify { synchronizer.prepareForSync() }

--- a/common/src/desktopTest/kotlin/synchronizer/operations/PrepareForSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/PrepareForSyncOperationTest.kt
@@ -3,7 +3,7 @@ package synchronizer.operations
 import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.id.IdRepository
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.PrepareForSyncOperation
@@ -26,7 +26,7 @@ class PrepareForSyncOperationTest : BaseTest() {
 	private lateinit var mockSynchronizers: MockSynchronizers
 
 	@MockK
-	private lateinit var idRepository: IdRepository
+	private lateinit var idAllocator: IdAllocator
 
 	@MockK(relaxed = true)
 	private lateinit var syncDataRepository: SyncDataRepository
@@ -54,7 +54,7 @@ class PrepareForSyncOperationTest : BaseTest() {
 		return PrepareForSyncOperation(
 			projectDef = projectDef,
 			entitySynchronizers = EntitySynchronizers(projectDef),
-			idRepository = idRepository,
+			idAllocator = idAllocator,
 			syncDataRepository = syncDataRepository,
 		)
 	}
@@ -62,7 +62,7 @@ class PrepareForSyncOperationTest : BaseTest() {
 	@Test
 	fun `Golden Path`() = runTest {
 		val op = createOperation(getProjectDef(PROJECT_2_NAME))
-		coEvery { idRepository.findNextId() } just Runs
+		coEvery { idAllocator.findNextId() } just Runs
 		mockSynchronizers.synchronizers.forEach { synchronizer ->
 			coEvery { synchronizer.prepareForSync() } just Runs
 		}
@@ -84,7 +84,7 @@ class PrepareForSyncOperationTest : BaseTest() {
 		assertTrue(isSuccess(result))
 		assertIs<SyncOperationState>(result.data)
 
-		coVerify { idRepository.findNextId() }
+		coVerify { idAllocator.findNextId() }
 		coVerify { syncDataRepository.createSyncData() }
 
 		mockSynchronizers.synchronizers.forEach { synchronizer ->

--- a/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
@@ -6,7 +6,7 @@ import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataConflict
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataDto
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataConflictException
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflictBroker
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflictUnresolvedException
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
@@ -39,7 +39,7 @@ class ProjectDataSyncOperationTest : BaseTest() {
 	private lateinit var api: ProjectDataApi
 
 	@MockK(relaxed = true)
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 
 	@BeforeEach
 	override fun setup() {
@@ -65,7 +65,7 @@ class ProjectDataSyncOperationTest : BaseTest() {
 			repository = repository,
 			api = api,
 			broker = broker,
-			globalSettingsRepository = globalSettingsRepository,
+			globalSettingsStore = globalSettingsStore,
 		)
 	}
 
@@ -86,7 +86,7 @@ class ProjectDataSyncOperationTest : BaseTest() {
 		val broker = ProjectDataConflictBroker(projectDef)
 		val op = createOperation(projectDef, broker)
 
-		coEvery { globalSettingsRepository.userIdOrThrow() } returns 1L
+		coEvery { globalSettingsStore.userIdOrThrow() } returns 1L
 		coEvery { repository.load() } returns StoredProjectData(
 			data = ProjectData(authorName = "local"),
 			lastSyncedHash = "old-hash",

--- a/common/src/desktopTest/kotlin/usecases/AccountUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/AccountUseCaseTest.kt
@@ -2,7 +2,7 @@ package usecases
 
 import com.darkrockstudios.apps.hammer.base.http.Token
 import com.darkrockstudios.apps.hammer.common.data.account.AccountUseCase
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.isFailure
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
@@ -25,7 +25,7 @@ import kotlin.test.assertTrue
 class AccountUseCaseTest : BaseTest() {
 
 	@MockK
-	private lateinit var globalSettingsRepository: GlobalSettingsRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
 
 	@MockK
 	private lateinit var accountApi: ServerAccountApi
@@ -51,8 +51,8 @@ class AccountUseCaseTest : BaseTest() {
 	}
 
 	private fun createSut(installId: String = "test-uuid"): AccountUseCase {
-		coEvery { globalSettingsRepository.ensureInstallId() } returns installId
-		return AccountUseCase(globalSettingsRepository, accountApi, httpClient, strRes)
+		coEvery { globalSettingsStore.ensureInstallId() } returns installId
+		return AccountUseCase(globalSettingsStore, accountApi, httpClient, strRes)
 	}
 
 	@Test
@@ -74,7 +74,7 @@ class AccountUseCaseTest : BaseTest() {
 		every { httpClient.updateCredentials(credentials = capture(bearerTokenSlot)) } just Runs
 
 		val settingsSlot = slot<ServerSettings>()
-		every { globalSettingsRepository.updateServerSettings(settings = capture(settingsSlot)) } just Runs
+		every { globalSettingsStore.updateServerSettings(settings = capture(settingsSlot)) } just Runs
 
 		val usecase = createSut()
 
@@ -90,7 +90,7 @@ class AccountUseCaseTest : BaseTest() {
 		coVerify { accountApi.createAccount(any(), any(), any()) }
 		coVerify(exactly = 0) { accountApi.login(any(), any(), any()) }
 
-		coVerify { globalSettingsRepository.updateServerSettings(any()) }
+		coVerify { globalSettingsStore.updateServerSettings(any()) }
 		assertEquals(
 			token.auth,
 			settingsSlot.captured.bearerToken
@@ -143,7 +143,7 @@ class AccountUseCaseTest : BaseTest() {
 		coVerify { accountApi.createAccount(any(), any(), any()) }
 		coVerify(exactly = 0) { accountApi.login(any(), any(), any()) }
 		coVerify(exactly = 0) { httpClient.updateCredentials(any()) }
-		coVerify { globalSettingsRepository.deleteServerSettings() }
+		coVerify { globalSettingsStore.deleteServerSettings() }
 	}
 
 	@Test
@@ -165,7 +165,7 @@ class AccountUseCaseTest : BaseTest() {
 		every { httpClient.updateCredentials(credentials = capture(bearerTokenSlot)) } just Runs
 
 		val settingsSlot = slot<ServerSettings>()
-		every { globalSettingsRepository.updateServerSettings(settings = capture(settingsSlot)) } just Runs
+		every { globalSettingsStore.updateServerSettings(settings = capture(settingsSlot)) } just Runs
 
 		val usecase = createSut()
 
@@ -181,7 +181,7 @@ class AccountUseCaseTest : BaseTest() {
 		coVerify(exactly = 0) { accountApi.createAccount(any(), any(), any()) }
 		coVerify { accountApi.login(any(), any(), any()) }
 
-		coVerify { globalSettingsRepository.updateServerSettings(any()) }
+		coVerify { globalSettingsStore.updateServerSettings(any()) }
 		assertEquals(
 			token.auth,
 			settingsSlot.captured.bearerToken

--- a/common/src/desktopTest/kotlin/utils/TestProjectUtils.kt
+++ b/common/src/desktopTest/kotlin/utils/TestProjectUtils.kt
@@ -1,6 +1,6 @@
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.tree.NodeCoordinates
 import com.darkrockstudios.apps.hammer.common.data.tree.Tree
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
@@ -52,7 +52,7 @@ fun createRootDirectory(ffs: FakeFileSystem) {
 
 fun getProjectsDirectory(): Path {
 	val rootPath = getDefaultRootDocumentDirectory().toPath()
-	val proj = GlobalSettingsRepository.DEFAULT_PROJECTS_DIR.toPath()
+	val proj = GlobalSettingsStore.DEFAULT_PROJECTS_DIR.toPath()
 	val projectsDir = rootPath.div(proj)
 
 	return projectsDir

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryIos.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryIos.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data
 
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.zip.unzipBytesToDirectory
 import io.github.aakira.napier.Napier
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -23,11 +23,11 @@ actual val exampleProjectModule = module {
 }
 
 private class ExampleProjectRepositoryiOs(
-	globalSettingsRepository: GlobalSettingsRepository,
+	globalSettingsStore: GlobalSettingsStore,
 	fileSystem: FileSystem,
 	toml: Toml,
 	clock: Clock,
-) : ExampleProjectRepository(globalSettingsRepository, fileSystem, toml, clock) {
+) : ExampleProjectRepository(globalSettingsStore, fileSystem, toml, clock) {
 
 	override fun removeExampleProject() {
 		val projectPath = projectsDir() / PROJECT_NAME

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/IosRebasingGlobalSettingsDatasource.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/IosRebasingGlobalSettingsDatasource.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
 
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository.Companion.DEFAULT_PROJECTS_DIR
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore.Companion.DEFAULT_PROJECTS_DIR
 import com.darkrockstudios.apps.hammer.common.getDefaultRootDocumentDirectory
 
 /**

--- a/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/MainViewController.kt
+++ b/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/MainViewController.kt
@@ -9,7 +9,7 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.common.components.iosroot.IosRoot
 import com.darkrockstudios.apps.hammer.common.compose.rememberKoinInject
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.projectroot.ProjectRootScaffold
 import com.darkrockstudios.apps.hammer.common.projectselection.ProjectSelectScaffold
@@ -21,9 +21,9 @@ fun MainViewController(root: IosRoot): UIViewController = ComposeUIViewControlle
 
 @Composable
 private fun HammerApp(root: IosRoot) {
-	val globalSettingsRepository: GlobalSettingsRepository = rememberKoinInject()
-	val settingsState by globalSettingsRepository.globalSettingsUpdates
-		.collectAsState(initial = globalSettingsRepository.globalSettings)
+	val globalSettingsStore: GlobalSettingsStore = rememberKoinInject()
+	val settingsState by globalSettingsStore.globalSettingsUpdates
+		.collectAsState(initial = globalSettingsStore.globalSettings)
 
 	val systemDark = isSystemInDarkTheme()
 	val isDark = when (settingsState.uiTheme) {

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
@@ -18,7 +18,7 @@ import com.darkrockstudios.apps.hammer.common.compose.getDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.getMainDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
 import com.darkrockstudios.apps.hammer.common.data.migrator.DataMigrator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
@@ -119,10 +119,10 @@ fun main(args: Array<String>) {
 	val mainDispatcher = getMainDispatcher()
 
 	// Listen and react to Global Settings updates
-	val globalSettingsRepository = getKoin().get<GlobalSettingsRepository>()
-	val globalSettings = MutableValue(globalSettingsRepository.globalSettings)
+	val globalSettingsStore = getKoin().get<GlobalSettingsStore>()
+	val globalSettings = MutableValue(globalSettingsStore.globalSettings)
 	val settingsUpdateJob = scope.launch {
-		globalSettingsRepository.globalSettingsUpdates.collect { settings ->
+		globalSettingsStore.globalSettingsUpdates.collect { settings ->
 			withContext(mainDispatcher) {
 				globalSettings.getAndUpdate { settings }
 			}

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/sandbox/SandboxStartup.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/sandbox/SandboxStartup.kt
@@ -17,7 +17,7 @@ import kotlin.system.exitProcess
 /**
  * Resolves (or first-time-picks) the user's projects directory under macOS
  * sandboxing before any code touches the filesystem. Must run after Koin
- * starts but before [com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository]
+ * starts but before [com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore]
  * (or anything that depends on it) is instantiated — that repo's init reads
  * from the projects dir, which is inaccessible in the sandbox until we
  * activate a security-scoped bookmark for it.

--- a/docs/ARCHITECTURE_LAYERING.md
+++ b/docs/ARCHITECTURE_LAYERING.md
@@ -14,8 +14,8 @@ logic in the wrong layer.
 Layers are ordered from **lowest** (closest to data) to **highest** (closest to the UI):
 
 ```
-Data Sources  →  Repositories  →  Services  →  Use Cases  →  ViewModels
-  (lowest)                                                     (highest)
+Data Sources  →  Foundation  →  Repositories  →  Services  →  Use Cases  →  ViewModels
+  (lowest)                                                                    (highest)
 ```
 
 "Lower" means closer to data; "higher" means closer to the UI. Dependencies always point **downward** (higher depends on
@@ -28,19 +28,21 @@ Data Source  →  Repository  →  ViewModel
 ```
 
 **Services** and **Use Cases** are *optional* layers, inserted only when a specific need arises (see Decision rules). Do
-not create them speculatively.
+not create them speculatively. **Foundation** is a small, *fixed* set of cross-cutting stateful primitives that the
+whole data layer sits on (see Foundation primitives); you depend on it, you do not add to it casually.
 
 ---
 
 ## Layer reference
 
-| Layer       | State     | Lifetime / DI         | May reference                                                  | Required? |
-|-------------|-----------|-----------------------|----------------------------------------------------------------|-----------|
-| Data Source | Stateless | Factory (new per use) | Nothing in these layers                                        | Yes       |
-| Repository  | Stateful  | Scoped singleton      | Data Sources                                                   | Yes       |
-| Service     | Stateful  | Scoped singleton      | Repositories, Data Sources                                     | No        |
-| Use Case    | Stateless | Factory (new per use) | Services, Repositories, Data Sources, other Use Cases (lazily) | No        |
-| ViewModel   | —         | Per screen/owner      | Use Cases, Services, Repositories                              | Yes       |
+| Layer       | State     | Lifetime / DI         | May reference                                                  | Required?  |
+|-------------|-----------|-----------------------|----------------------------------------------------------------|------------|
+| Data Source | Stateless | Factory (new per use) | Nothing in these layers                                        | Yes        |
+| Foundation  | Stateful  | Scoped singleton      | Data Sources, other Foundation primitives (acyclic)           | Fixed set  |
+| Repository  | Stateful  | Scoped singleton      | Data Sources, Foundation                                       | Yes        |
+| Service     | Stateful  | Scoped singleton      | Repositories, Foundation, Data Sources                         | No         |
+| Use Case    | Stateless | Factory (new per use) | Services, Repositories, Foundation, Data Sources, other Use Cases (lazily) | No |
+| ViewModel   | —         | Per screen/owner      | Use Cases, Services, Repositories, Foundation                  | Yes        |
 
 ---
 
@@ -52,11 +54,42 @@ Raw I/O and nothing else: network calls, database/DAO access, file/disk access, 
 stores, etc.). A data source holds **no state** and contains **no business logic**. It does not combine or call other
 data sources. Factory-produced (a fresh instance per use).
 
+### Foundation primitives — stateful, cross-cutting
+
+A small, **fixed** set of stateful primitives the entire data layer is built on. Unlike a Repository, a foundation
+primitive is not a domain area you "get/observe/save" — it is shared infrastructure (ID allocation, sync bookkeeping,
+app settings) that nearly every repository needs. Scoped singleton, like a Repository.
+
+Current members:
+
+- **`IdAllocator`** — hands out the project-wide monotonic entity IDs.
+- **`SyncJournal`** — records dirty entities and created/deleted IDs awaiting server reconciliation.
+- **`GlobalSettingsStore`** — owns the app-global settings (and server settings).
+
+Rules:
+
+- **May reference:** Data Sources, and *other foundation primitives* — but the foundation set must stay **acyclic**. It
+  is a DAG: `GlobalSettingsStore ← SyncJournal ← IdAllocator`. This is the **only** place a stateful component may
+  reference its own tier, and it is allowed precisely because the set is kept acyclic by hand.
+- **May be referenced by:** any higher layer (Repository, Service, Use Case, ViewModel) and other foundation primitives.
+  Depending *down* into a foundation primitive is always allowed.
+- **Must never reference upward.** A foundation primitive may not depend on a Repository or anything above it; that is
+  what keeps it a leaf and the whole graph acyclic.
+- **Not a default home.** Adding a class here is a deliberate, reviewed decision — not a way to dodge the no-sibling
+  rule. If a class is really a domain area, it is a Repository; if it coordinates repositories, it is a Service.
+
+> **Why this tier exists.** The no-sibling rule (below) exists for exactly one reason: to keep the dependency graph
+> acyclic. A handful of primitives — ID allocation, sync bookkeeping, settings — are needed by almost every repository,
+> and they are *already* acyclic leaves (nothing points back up into domain code). Forcing every repository to receive
+> IDs and sync-marking from above would be pure churn that buys nothing the rule was meant to protect. So we name the
+> tier honestly instead of pretending these dependencies are violations.
+
 ### Repositories — stateful
 
 Combine one or more **data sources** for a single domain area, and own the state for that area (caching, in-memory
 flows, dedup, the source-of-truth for that domain). A repository is the default home for "get/observe/save this kind of
-data." Scoped singleton.
+data." May also depend *down* on **Foundation primitives** (e.g. `IdAllocator` for new entity IDs, `SyncJournal` to mark
+edits dirty) — but **never on another Repository**. Scoped singleton.
 
 ### Services — stateful, **optional**
 
@@ -94,6 +127,10 @@ logic out of ViewModels; if logic is accumulating here, extract a Use Case.
    factory, or a `() -> T` lambda — never the constructed instance directly. Statelessness alone does **not** prevent a
    construction cycle; lazy resolution is what breaks it.
 5. **ViewModels never touch Data Sources.** Always go through a Repository (or a Service/Use Case above it).
+6. **Foundation primitives are a shared lower tier, not siblings.** Depending on `IdAllocator`, `SyncJournal`, or
+   `GlobalSettingsStore` from any layer is *downward* and always allowed — they are not siblings of the Repositories
+   that use them. They are the only stateful components that may reference their own tier, and only acyclically (see
+   Foundation primitives). A foundation primitive must never reference a Repository or higher.
 
 ---
 
@@ -122,6 +159,13 @@ Start from the minimal spine and add layers only when a concrete need appears.
 - I need to coordinate **two or more repositories** with shared/stateful logic → **yes, add a Service** (repos can't
   talk to each other, so the coordination goes here).
 - A single repository can do the job → **no.**
+
+**Do I add a Foundation primitive?**
+
+- **Almost never.** The set is fixed (`IdAllocator`, `SyncJournal`, `GlobalSettingsStore`). Only add one if it is a
+  genuinely cross-cutting, stateful primitive needed by *most* repositories *and* it is an acyclic leaf (never depends
+  upward). A domain area is a Repository; cross-repo coordination is a Service. "Two repositories both need it" is **not**
+  a reason — that is what a Service is for.
 
 **Inserting a layer later (minimizing churn):**
 

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/HeadlessClient.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/HeadlessClient.kt
@@ -2,7 +2,7 @@ package com.darkrockstudios.apps.hammer.integration
 
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.openProjectScope
@@ -13,7 +13,6 @@ import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ClientProjec
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import okio.Path
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
 import org.koin.core.scope.Scope
 import org.koin.mp.KoinPlatform.getKoin
 
@@ -68,7 +67,7 @@ class HeadlessClient private constructor(
 		suspend fun create(projectName: String, serverSettings: ServerSettings): HeadlessClient {
 			val koin = getKoin()
 			val projectsRepository: ProjectsRepository = koin.get<ProjectsRepository>()
-			val globalSettings: GlobalSettingsRepository = koin.get<GlobalSettingsRepository>()
+			val globalSettings: GlobalSettingsStore = koin.get<GlobalSettingsStore>()
 
 			val createResult = projectsRepository.createProject(projectName)
 			check(isSuccess(createResult)) { "Failed to create local project: $createResult" }

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/IndependentEditsTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/IndependentEditsTest.kt
@@ -36,7 +36,7 @@ class IndependentEditsTest : RoundTripTestBase() {
 		seedServerEntity(numericProjectId, E2eTestData.createTestScene(id = 1))
 		database().execute("UPDATE project SET last_id = 1 WHERE id = $numericProjectId;")
 
-		// Client creates a different scene locally with id=2 — IdRepository would
+		// Client creates a different scene locally with id=2 — IdAllocator would
 		// claim id=1 (it doesn't know about the server's reservation), causing an
 		// ID conflict. Force id=2 instead.
 		val localScene = client.sceneEditor.createScene(parent = null, sceneName = "Local Scene", forceId = 2)


### PR DESCRIPTION
Part of the layered-architecture refactor stack. **Base: `globalsearch-refactor`.**

Introduces a "Foundation primitives" tier for cross-cutting acyclic-leaf primitives that any layer may depend down into, and renames the three offenders out of the `Repository` namespace:

- `IdRepository` → `IdAllocator`
- `SyncDataRepository` → `SyncJournal`
- `GlobalSettingsRepository` → `GlobalSettingsStore`

Documented in `docs/ARCHITECTURE_LAYERING.md` (tier definition, dependency rule, and a "do I add one? almost never" guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)