### PR TITLE
Decouple SceneRepository; compose SceneSummary in SceneEditorService

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectEditorScopeUtils.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectEditorScopeUtils.kt
@@ -1,6 +1,5 @@
 package com.darkrockstudios.apps.hammer.common.data
 
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
@@ -51,12 +50,10 @@ suspend fun openProjectScope(projectDef: ProjectDef): Scope {
 suspend fun initializeProjectScope(projectDef: ProjectDef) {
 	val defScope = ProjectDefScope(projectDef)
 	getKoin().getScopeOrNull(defScope.getScopeId())?.let { projScope ->
-		val projectEditor: SceneRepository = projScope.get { parametersOf(projectDef) }
-		projectEditor.initializeSceneEditor()
-
-		// Eagerly create the service so its autosave side-effect subscription is active from
-		// project open (it subscribes to SceneContentRepository's buffer-persisted signal).
-		projScope.get<SceneEditorService>()
+		// Creates the service (activating its autosave side-effect subscription from project open)
+		// and runs the scene-editor init sequence: tree, then content (autosave), then metadata.
+		val sceneEditorService: SceneEditorService = projScope.get()
+		sceneEditorService.initialize()
 
 		val timeLineRepository: TimeLineRepository = projScope.get { parametersOf(projectDef) }
 		timeLineRepository.initialize()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsService.kt
@@ -96,8 +96,7 @@ class StatisticsService(
 		Napier.d("Recalculating project statistics...")
 
 		try {
-			val sceneSummary = sceneEditorRepository.sceneListChannel.first()
-			val tree = sceneSummary.sceneTree.root
+			val tree = sceneEditorRepository.sceneTreeUpdates.first().root
 
 			var numScenes = 0
 			var totalWords = 0

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/ReferenceIndexService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/ReferenceIndexService.kt
@@ -21,6 +21,10 @@ import org.koin.core.scope.ScopeCallback
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Clock
 
+/**
+ * Service that builds and maintains the encyclopedia reference index — which scenes reference which
+ * entries — by scanning scene metadata and matching entry names across the scene/encyclopedia repositories.
+ */
 class ReferenceIndexService(
 	projectDef: ProjectDef,
 	private val repository: ReferenceIndexRepository,
@@ -80,8 +84,8 @@ class ReferenceIndexService(
 		try {
 			val map = mutableMapOf<Int, MutableSet<Int>>()
 
-			val sceneSummary = sceneEditorRepository.sceneListChannel.first()
-			sceneSummary.sceneTree.root.forEach { node ->
+			val sceneTree = sceneEditorRepository.sceneTreeUpdates.first()
+			sceneTree.root.forEach { node ->
 				if (node.value.type == SceneItem.Type.Scene) {
 					val metadata = sceneMetadataRepository.loadSceneMetadata(node.value.id)
 					accumulate(map, node.value.id, metadata.confirmedReferences)
@@ -187,8 +191,8 @@ class ReferenceIndexService(
 			if (hits.isNotEmpty()) results.add(sceneItem.id)
 		}
 
-		val sceneSummary = sceneEditorRepository.sceneListChannel.first()
-		sceneSummary.sceneTree.root.forEach { node ->
+		val sceneTree = sceneEditorRepository.sceneTreeUpdates.first()
+		sceneTree.root.forEach { node ->
 			if (node.value.type == SceneItem.Type.Scene) {
 				consider(node.value)
 				yield()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/SceneMetadataReferenceRemapper.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/SceneMetadataReferenceRemapper.kt
@@ -6,6 +6,10 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.sceneme
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import kotlinx.coroutines.flow.first
 
+/**
+ * Rewrites confirmed/dismissed references in scene metadata when an entry id is remapped
+ * (e.g. after a sync re-id). The scene-side implementation of [ReferenceRemapper].
+ */
 class SceneMetadataReferenceRemapper(
 	private val sceneEditorRepository: SceneRepository,
 	private val sceneMetadataDatasource: SceneMetadataDatasource,
@@ -28,8 +32,8 @@ class SceneMetadataReferenceRemapper(
 
 	private suspend fun collectAllSceneIds(): Set<Int> {
 		val ids = mutableSetOf<Int>()
-		val summary = sceneEditorRepository.sceneListChannel.first()
-		summary.sceneTree.root.forEach { node ->
+		val sceneTree = sceneEditorRepository.sceneTreeUpdates.first()
+		sceneTree.root.forEach { node ->
 			if (node.value.type == SceneItem.Type.Scene) ids.add(node.value.id)
 		}
 		sceneEditorRepository.getArchivedScenes().forEach { ids.add(it.id) }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/BufferPersistedEvent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/BufferPersistedEvent.kt
@@ -1,0 +1,14 @@
+package com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository
+
+import com.darkrockstudios.apps.hammer.common.data.UpdateSource
+
+/**
+ * Signal emitted when a scene buffer is persisted to its temp (autosave) file, so callers can
+ * hang side-effects (writing-activity timestamps, stats) off saves without this repository
+ * reaching up into those collaborators. Full-save side-effects are handled inline by the
+ * caller of [persistBuffer].
+ */
+data class BufferPersistedEvent(
+	val sceneId: Int,
+	val source: UpdateSource,
+)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneContentRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneContentRepository.kt
@@ -1,11 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository
 
-import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
-import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
-import com.darkrockstudios.apps.hammer.common.data.SceneContent
-import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.UpdateSource
+import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
@@ -14,33 +9,19 @@ import com.darkrockstudios.apps.hammer.common.util.debounceUntilQuiescentBy
 import io.github.aakira.napier.Napier
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.StateFlow
 import org.koin.core.component.KoinComponent
 import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeCallback
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * Signal emitted when a scene buffer is persisted to its temp (autosave) file, so callers can
- * hang side-effects (writing-activity timestamps, stats) off saves without this repository
- * reaching up into those collaborators. Full-save side-effects are handled inline by the
- * caller of [persistBuffer].
- */
-data class BufferPersistedEvent(
-	val sceneId: Int,
-	val source: UpdateSource,
-)
-
-/**
- * The buffer / editing engine (responsibilities C + D of the old SceneRepository).
+ * The buffer / editing engine for scenes.
  *
  * Owns the in-memory scene buffers, the content debounce pipeline, temp-buffer autosave jobs,
  * dirty tracking, the buffer-update flow, and its own [editorScope] + [ScopeCallback] for temp
@@ -86,6 +67,11 @@ class SceneContentRepository(
 		onBufferOverflow = BufferOverflow.DROP_OLDEST
 	)
 	val bufferPersistedFlow: SharedFlow<BufferPersistedEvent> = _bufferPersistedFlow
+
+	private val _dirtyBufferIds = MutableStateFlow<Set<Int>>(emptySet())
+
+	/** The set of scene ids with unsaved buffers; re-emits on every dirty/clean transition. */
+	val dirtyBufferIds: StateFlow<Set<Int>> = _dirtyBufferIds
 
 	private val sceneBuffersLock = reentrantLock()
 	private val sceneBuffers = mutableMapOf<Int, SceneBuffer>()
@@ -153,6 +139,8 @@ class SceneContentRepository(
 	private fun updateSceneBuffer(newBuffer: SceneBuffer) {
 		sceneBuffersLock.withLock {
 			sceneBuffers[newBuffer.content.scene.id] = newBuffer
+			// Snapshot + publish under the lock so the dirty set can't lose a concurrent update.
+			_dirtyBufferIds.value = getDirtyBufferIds()
 		}
 		_bufferUpdateFlow.tryEmit(newBuffer)
 	}
@@ -227,7 +215,9 @@ class SceneContentRepository(
 	 */
 	fun discardBuffer(sceneItem: SceneItem, scenePath: HPath): SceneBuffer? {
 		val wasPresent = sceneBuffersLock.withLock {
-			sceneBuffers.remove(sceneItem.id) != null
+			val removed = sceneBuffers.remove(sceneItem.id) != null
+			if (removed) _dirtyBufferIds.value = getDirtyBufferIds()
+			removed
 		}
 		return if (wasPresent) {
 			clearTempScene(sceneItem)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneEditorService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneEditorService.kt
@@ -1,15 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository
 
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
-import com.darkrockstudios.apps.hammer.common.data.CResult
-import com.darkrockstudios.apps.hammer.common.data.MoveRequest
-import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
-import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
-import com.darkrockstudios.apps.hammer.common.data.SceneContent
-import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.SceneSummary
-import com.darkrockstudios.apps.hammer.common.data.UpdateSource
+import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
@@ -18,14 +10,14 @@ import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessio
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispatcher
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import io.github.aakira.napier.Napier
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.shareIn
 import org.koin.core.component.KoinComponent
 import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeCallback
@@ -59,6 +51,7 @@ class SceneEditorService(
 
 	private val dispatcherDefault by injectDefaultDispatcher()
 	private val dispatcherIo by injectIoDispatcher()
+	private val dispatcherMain by injectMainDispatcher()
 	private val serviceScope = CoroutineScope(dispatcherDefault)
 
 	init {
@@ -76,6 +69,16 @@ class SceneEditorService(
 	}
 
 	// region Writes / orchestration
+
+	/**
+	 * Project-open entry point: loads the scene tree, then starts the content (autosave) and
+	 * metadata engines, in order.
+	 */
+	suspend fun initialize() {
+		sceneEditorRepository.initializeSceneEditor()
+		sceneContentRepository.initialize()
+		sceneMetadataRepository.initialize()
+	}
 
 	suspend fun createScene(
 		parent: SceneItem?,
@@ -214,17 +217,38 @@ class SceneEditorService(
 
 	// region Derived state
 
-	val sceneListChannel: SharedFlow<SceneSummary> get() = sceneEditorRepository.sceneListChannel
+	/**
+	 * The scene list: the structural tree (from [SceneRepository]) combined with the dirty-buffer
+	 * set (from [SceneContentRepository]). Re-emits when either changes, so dirty markers update live.
+	 */
+	val sceneListChannel: SharedFlow<SceneSummary> = combine(
+		sceneEditorRepository.sceneTreeUpdates,
+		sceneContentRepository.dirtyBufferIds,
+	) { tree, dirtyBufferIds -> SceneSummary(tree, dirtyBufferIds) }
+		.shareIn(serviceScope, SharingStarted.Eagerly, replay = 1)
 
 	val metadataUpdateFlow: SharedFlow<Pair<Int, SceneMetadata>>
 		get() = sceneMetadataRepository.metadataUpdateFlow
 
-	fun getSceneSummaries(): SceneSummary = sceneEditorRepository.getSceneSummaries()
+	fun getSceneSummaries(): SceneSummary = SceneSummary(
+		sceneEditorRepository.getSceneTree(),
+		sceneContentRepository.getDirtyBufferIds(),
+	)
 
 	fun subscribeToSceneUpdates(
 		scope: CoroutineScope,
 		onSceneListUpdate: (SceneSummary) -> Unit,
-	): Job = sceneEditorRepository.subscribeToSceneUpdates(scope, onSceneListUpdate)
+	): Job {
+		val job = scope.launch {
+			sceneListChannel.collect { summary ->
+				withContext(dispatcherMain) {
+					onSceneListUpdate(summary)
+				}
+			}
+		}
+		sceneEditorRepository.forceSceneListReload()
+		return job
+	}
 
 	fun subscribeToBufferUpdates(
 		sceneDef: SceneItem?,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneMetadataRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneMetadataRepository.kt
@@ -16,7 +16,7 @@ import kotlin.time.Clock
 
 /**
  * Owns scene metadata (per-scene outline/notes/draft/references/timestamps) and the project
- * metadata (responsibilities E + F of the old SceneRepository).
+ * metadata.
  *
  * This is a *data* building block: pure persistence plus the two metadata flows. Higher-level
  * orchestration — marking the scene for sync and applying the reference-index delta on a

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
@@ -12,30 +12,28 @@ import com.darkrockstudios.apps.hammer.common.data.tree.ImmutableTree
 import com.darkrockstudios.apps.hammer.common.data.tree.Tree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
-import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.util.numDigits
 import io.github.aakira.napier.Napier
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import okio.IOException
 import okio.Path
 import org.koin.core.component.KoinComponent
 import kotlin.time.Clock
 
+/**
+ * Repository owning the scene tree: structure, ordering, paths and on-disk layout
+ * (create/move/delete/rename/archive). Emits structural [sceneTreeUpdates]; the dirty-buffer-aware
+ * [SceneSummary] is composed up in [SceneEditorService].
+ */
 class SceneRepository(
 	val projectDef: ProjectDef,
 	private val idAllocator: IdAllocator,
 	private val syncJournal: SyncJournal,
-	private val sceneMetadataRepository: SceneMetadataRepository,
-	private val sceneContentRepository: SceneContentRepository,
 	private val sceneMetadataDatasource: SceneMetadataDatasource,
 	private val sceneDatasource: SceneDatasource,
 	private val clock: Clock,
@@ -51,14 +49,15 @@ class SceneRepository(
 		order = 0
 	)
 
-	private val dispatcherMain by injectMainDispatcher()
-
-	private val _sceneListChannel = MutableSharedFlow<SceneSummary>(
+	private val _sceneTreeUpdates = MutableSharedFlow<ImmutableTree<SceneItem>>(
 		extraBufferCapacity = 1,
 		replay = 1,
 		onBufferOverflow = BufferOverflow.DROP_OLDEST
 	)
-	val sceneListChannel: SharedFlow<SceneSummary> = _sceneListChannel
+
+	/** Emits the scene tree after every structural change. The cross-cutting
+	 *  [SceneSummary] (tree + dirty buffers) is composed in [SceneEditorService]. */
+	val sceneTreeUpdates: SharedFlow<ImmutableTree<SceneItem>> = _sceneTreeUpdates
 
 	private val sceneTree = Tree<SceneItem>()
 	val rawTree: Tree<SceneItem>
@@ -101,7 +100,7 @@ class SceneRepository(
 	/**
 	 * Public entry point for marking a scene's current persisted identity for sync.
 	 * Used by [SceneEditorService] (which orchestrates metadata writes) and the sync layer,
-	 * keeping the hashing logic (responsibility G) on the data layer.
+	 * keeping the hashing logic on the data layer.
 	 */
 	suspend fun markSceneForSynchronization(scene: SceneItem) = markForSynchronization(scene)
 
@@ -122,23 +121,9 @@ class SceneRepository(
 		}
 	}
 
-	fun subscribeToSceneUpdates(
-		scope: CoroutineScope,
-		onSceneListUpdate: (SceneSummary) -> Unit
-	): Job {
-		val job = scope.launch {
-			sceneListChannel.collect { scenes ->
-				withContext(dispatcherMain) {
-					onSceneListUpdate(scenes)
-				}
-			}
-		}
-		reloadScenes()
-		return job
-	}
-
 	/**
-	 * This needs to be called after instantiation
+	 * Loads the scene tree from disk and starts emitting structural updates.
+	 * Content/metadata initialization is orchestrated by [SceneEditorService].
 	 */
 	suspend fun initializeSceneEditor(): SceneRepository {
 		val root = sceneDatasource.loadSceneTree(rootScene)
@@ -148,12 +133,7 @@ class SceneRepository(
 
 		idAllocator.findNextId()
 
-		// Loads any existing temp buffers and starts the content debounce/autosave engine.
-		sceneContentRepository.initialize()
-
 		reloadScenes()
-
-		sceneMetadataRepository.initialize()
 
 		return this
 	}
@@ -165,16 +145,8 @@ class SceneRepository(
 		reloadScenes()
 	}
 
-	fun getSceneSummaries(): SceneSummary {
-		return SceneSummary(
-			getSceneTree(),
-			sceneContentRepository.getDirtyBufferIds()
-		)
-	}
-
-	fun reloadScenes(summary: SceneSummary? = null) {
-		val scenes = summary ?: getSceneSummaries()
-		_sceneListChannel.tryEmit(scenes)
+	fun reloadScenes() {
+		_sceneTreeUpdates.tryEmit(getSceneTree())
 	}
 
 	private fun willNextSceneIncreaseMagnitude(parentId: Int?): Boolean {
@@ -492,13 +464,7 @@ class SceneRepository(
 		}
 
 		// Notify listeners of the new state of the tree
-		val imTree = sceneTree.toImmutableTree()
-
-		val newSummary = SceneSummary(
-			imTree,
-			sceneContentRepository.getDirtyBufferIds()
-		)
-		reloadScenes(newSummary)
+		reloadScenes()
 	}
 
 	private suspend fun updateSceneTreeForMove(moveRequest: MoveRequest) {

--- a/common/src/desktopTest/kotlin/integration/BaseIntegrationTest.kt
+++ b/common/src/desktopTest/kotlin/integration/BaseIntegrationTest.kt
@@ -145,8 +145,6 @@ abstract class BaseIntegrationTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = sceneMetadataRepository,
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,

--- a/common/src/desktopTest/kotlin/repositories/references/ReferenceIndexServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/references/ReferenceIndexServiceTest.kt
@@ -1,7 +1,6 @@
 package repositories.references
 
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.SceneSummary
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContainer
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
@@ -106,14 +105,11 @@ class ReferenceIndexServiceTest : BaseTest() {
 			depth = 0,
 			totalChildren = children.size,
 		)
-		val summary = SceneSummary(
-			sceneTree = ImmutableTree(root, totalChildren = children.size + 1),
-			hasDirtyBuffer = emptySet(),
-		)
-		val flow = MutableSharedFlow<SceneSummary>(
+		val tree = ImmutableTree(root, totalChildren = children.size + 1)
+		val flow = MutableSharedFlow<ImmutableTree<SceneItem>>(
 			replay = 1, extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST
-		).apply { tryEmit(summary) }
-		every { sceneEditor.sceneListChannel } returns flow
+		).apply { tryEmit(tree) }
+		every { sceneEditor.sceneTreeUpdates } returns flow
 		coEvery { sceneEditor.getArchivedScenes() } returns emptyList()
 		for ((item, metadata) in scenes) {
 			coEvery { sceneMetadataRepository.loadSceneMetadata(item.id) } returns metadata

--- a/common/src/desktopTest/kotlin/repositories/references/SceneMetadataReferenceRemapperTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/references/SceneMetadataReferenceRemapperTest.kt
@@ -3,7 +3,6 @@ package repositories.references
 import PROJECT_1_NAME
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.SceneSummary
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndex
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexDatasource
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
@@ -76,11 +75,11 @@ class SceneMetadataReferenceRemapperTest : BaseTest() {
 			depth = 0,
 			totalChildren = children.size,
 		)
-		val summary = SceneSummary(ImmutableTree(root, totalChildren = children.size + 1), emptySet())
-		val flow = MutableSharedFlow<SceneSummary>(
+		val tree = ImmutableTree(root, totalChildren = children.size + 1)
+		val flow = MutableSharedFlow<ImmutableTree<SceneItem>>(
 			replay = 1, extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST,
-		).apply { tryEmit(summary) }
-		every { sceneEditor.sceneListChannel } returns flow
+		).apply { tryEmit(tree) }
+		every { sceneEditor.sceneTreeUpdates } returns flow
 		coEvery { sceneEditor.getArchivedScenes() } returns archivedIds.map {
 			SceneItem(projectDef, SceneItem.Type.Scene, it, "A$it", it, archived = true)
 		}

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneContentRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneContentRepositoryTest.kt
@@ -99,8 +99,6 @@ class SceneContentRepositoryTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = sceneMetadataRepository,
-			sceneContentRepository = contentRepo,
 			sceneMetadataDatasource = sceneMetadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,
@@ -121,7 +119,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		createStack(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val newContent = SceneContent(
 			scene = SceneItem(getProject1Def(), SceneItem.Type.Scene, 1, "Scene ID 1", 0),
@@ -152,7 +150,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		createStack(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val sceneItem2 = SceneItem(getProject1Def(), SceneItem.Type.Scene, 3, "Scene ID 3", 0)
 		val newContent = SceneContent(
@@ -176,12 +174,12 @@ class SceneContentRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		createStack(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val onSceneUpdate: ((SceneSummary) -> Unit) = mockk()
 		coEvery { onSceneUpdate(any()) } just Runs
 
-		val subJob = repo.subscribeToSceneUpdates(scope, onSceneUpdate)
+		val subJob = service.subscribeToSceneUpdates(scope, onSceneUpdate)
 		advanceUntilIdle()
 		subJob.cancelAndJoin()
 		coVerify(atLeast = 1) { onSceneUpdate(any()) }
@@ -193,7 +191,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		createStack(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val sceneItem = SceneItem(getProject1Def(), SceneItem.Type.Scene, 3, "Scene ID 3", 0)
 
@@ -207,7 +205,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		createStack(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val sceneItem = SceneItem(getProject1Def(), SceneItem.Type.Scene, 3, "Scene ID 3", 0)
 		val content = SceneContent(scene = sceneItem, markdown = "Updated scene content ID 3")
@@ -242,7 +240,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		createStack(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val sceneItem = SceneItem(getProject1Def(), SceneItem.Type.Scene, 3, "Scene ID 3", 0)
 
@@ -260,7 +258,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		createStack(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		assertFalse(contentRepo.hasDirtyBuffers())
 	}
@@ -288,7 +286,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createStack(projDef)
 		writeTempBuffer(1)
 
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		assertTrue(contentRepo.hasDirtyBuffers())
 		assertTrue(contentRepo.hasDirtyBuffer(1))
@@ -304,7 +302,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createStack(projDef)
 		writeTempBuffer(sceneId)
 
-		repo.initializeSceneEditor()
+		service.initialize()
 		assertTrue(contentRepo.hasDirtyBuffer(sceneId))
 
 		val sceneItem = SceneItem(getProject1Def(), SceneItem.Type.Scene, sceneId, "Scene ID $sceneId", 0)
@@ -325,7 +323,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		writeTempBuffer(1)
 		writeTempBuffer(3)
 
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		assertTrue(contentRepo.hasDirtyBuffers())
 		assertTrue(contentRepo.hasDirtyBuffer(1))
@@ -372,7 +370,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		createStack(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val scenes = repo.getScenes()
 		assertEquals(
@@ -409,7 +407,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		createStack(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val oldPath1 = repo.getSceneFilePath(1).toOkioPath()
 		val oldPath6 = repo.getSceneFilePath(6).toOkioPath()

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryArchiveTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryArchiveTest.kt
@@ -12,7 +12,6 @@ import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRe
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
@@ -122,14 +121,6 @@ class SceneEditorRepositoryArchiveTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = SceneMetadataRepository(
-				projectDef = projectDef,
-				sceneMetadataDatasource = metadataDatasource,
-				projectMetadataDatasource = metadataRepository,
-				strRes = mockk(relaxed = true),
-				clock = Clock.System,
-			),
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = metadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLastEditedSceneTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLastEditedSceneTest.kt
@@ -90,8 +90,6 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = sceneMetadataRepository,
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = clock,
@@ -116,7 +114,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		val repo = createRepository(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val sceneItem = SceneItem(
 			projectDef = projDef,
@@ -141,7 +139,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		val repo = createRepository(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val sceneItem = SceneItem(
 			projectDef = projDef,
@@ -166,7 +164,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		val repo = createRepository(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val first = SceneItem(projDef, SceneItem.Type.Scene, 1, "Scene 1", 0)
 		val second = SceneItem(projDef, SceneItem.Type.Scene, 3, "Scene 3", 0)
@@ -202,7 +200,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 			clock.advanceTime(30.minutes)
 
 			val repo = createRepository(projDef)
-			repo.initializeSceneEditor()
+			service.initialize()
 
 			val sceneItem = SceneItem(projDef, SceneItem.Type.Scene, 7, "Scene 7", 0)
 			service.onContentChanged(SceneContent(sceneItem, "first edit"), UpdateSource.Editor)
@@ -231,7 +229,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 
 			clock.advanceTime(2.minutes)
 
-			repo.initializeSceneEditor()
+			service.initialize()
 
 			val sceneItem = SceneItem(projDef, SceneItem.Type.Scene, 5, "Scene 5", 0)
 			service.onContentChanged(SceneContent(sceneItem, "edit"), UpdateSource.Editor)
@@ -251,7 +249,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 		createProject(ffs, PROJECT_1_NAME)
 
 		val repo = createRepository(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 
 		val sceneItem = SceneItem(projDef, SceneItem.Type.Scene, 3, "Scene 3", 0)
 		service.onContentChanged(SceneContent(sceneItem, "edited"), UpdateSource.Editor)

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLoadTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLoadTest.kt
@@ -11,7 +11,6 @@ import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRe
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
@@ -115,14 +114,6 @@ class SceneEditorRepositoryLoadTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = SceneMetadataRepository(
-				projectDef = projectDef,
-				sceneMetadataDatasource = metadataDatasource,
-				projectMetadataDatasource = metadataRepository,
-				strRes = mockk(relaxed = true),
-				clock = Clock.System,
-			),
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = metadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryMoveTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryMoveTest.kt
@@ -9,7 +9,10 @@ import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.*
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.filterScenePathsOkio
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.tree.NodeCoordinates
@@ -145,14 +148,6 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = SceneMetadataRepository(
-				projectDef = projectDef,
-				sceneMetadataDatasource = metadataDatasource,
-				projectMetadataDatasource = metadataRepository,
-				strRes = mockk(relaxed = true),
-				clock = Clock.System,
-			),
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = metadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,
@@ -356,14 +351,6 @@ class SceneEditorRepositoryMoveTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = SceneMetadataRepository(
-				projectDef = projectDef,
-				sceneMetadataDatasource = metadataDatasource,
-				projectMetadataDatasource = metadataRepository,
-				strRes = mockk(relaxed = true),
-				clock = Clock.System,
-			),
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = metadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryOtherTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryOtherTest.kt
@@ -17,7 +17,6 @@ import com.darkrockstudios.apps.hammer.common.data.projectsrepository.Validation
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
-import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
@@ -165,14 +164,6 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = SceneMetadataRepository(
-				projectDef = projectDef,
-				sceneMetadataDatasource = metadataDatasource,
-				projectMetadataDatasource = metadataRepository,
-				strRes = mockk(relaxed = true),
-				clock = Clock.System,
-			),
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = metadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,
@@ -259,14 +250,6 @@ class SceneEditorRepositoryOtherTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = SceneMetadataRepository(
-				projectDef = projectDef,
-				sceneMetadataDatasource = metadataDatasource,
-				projectMetadataDatasource = metadataRepository,
-				strRes = mockk(relaxed = true),
-				clock = Clock.System,
-			),
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = metadataDatasource,
 			sceneDatasource = spy,
 			clock = Clock.System,

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryTestSimple.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryTestSimple.kt
@@ -156,8 +156,6 @@ class SceneEditorRepositoryTestSimple : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = sceneMetadataRepository,
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,
@@ -189,6 +187,8 @@ class SceneEditorRepositoryTestSimple : BaseTest() {
 		val repo = createRepository()
 
 		repo.initializeSceneEditor()
+		sceneContentRepository.initialize()
+		sceneMetadataRepository.initialize()
 
 		val metadata = sceneMetadataRepository.getMetadata()
 

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
@@ -120,8 +120,6 @@ class SceneEditorServiceTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = sceneMetadataRepository,
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,
@@ -140,7 +138,7 @@ class SceneEditorServiceTest : BaseTest() {
 		val projDef = getProject1Def()
 		createProject(ffs, PROJECT_1_NAME)
 		val service = createService(projDef)
-		repo.initializeSceneEditor()
+		service.initialize()
 		return service
 	}
 

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneMetadataRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneMetadataRepositoryTest.kt
@@ -108,8 +108,6 @@ class SceneMetadataRepositoryTest : BaseTest() {
 			projectDef = projectDef,
 			syncJournal = syncJournal,
 			idAllocator = idAllocator,
-			sceneMetadataRepository = sceneMetadataRepository,
-			sceneContentRepository = sceneContentRepository,
 			sceneMetadataDatasource = sceneMetadataDatasource,
 			sceneDatasource = sceneDatasource,
 			clock = Clock.System,


### PR DESCRIPTION
Part of the layered-architecture refactor stack. **Base: `foundation-refactor`** — top of the stack.

`SceneRepository` drops its sibling-repo dependencies and now emits a structure-only `sceneTreeUpdates` flow. `SceneContentRepository` exposes a `dirtyBufferIds` StateFlow. `SceneEditorService` composes the two into `SceneSummary` (via `combine`) and owns the init orchestration. Dirty markers update reactively rather than via imperative reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)