### PR TITLE
Extract EncyclopediaService; make it the single door for UI

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/BrowseEntriesComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/BrowseEntriesComponent.kt
@@ -7,7 +7,7 @@ import com.arkivanov.decompose.value.getAndUpdate
 import com.arkivanov.decompose.value.update
 import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryLoadError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContainer
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
@@ -34,7 +34,7 @@ class BrowseEntriesComponent(
 	private val _filterText = MutableValue(restoredFilter?.filterText ?: "")
 	override val filterText: Value<String> = _filterText
 
-	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
+	private val encyclopediaService: EncyclopediaService by projectInject()
 
 	init {
 		stateKeeper.register(FILTER_KEY, SavedFilter.serializer()) {
@@ -54,13 +54,13 @@ class BrowseEntriesComponent(
 
 	override fun onResume() {
 		super.onResume()
-		encyclopediaRepository.loadEntries()
+		encyclopediaService.loadEntries()
 	}
 
 	private fun reindexEntries(entryDefs: List<EntryDef>) {
 		indexByTag.clear()
 		entryDefs.forEach { entryDef ->
-			val entryContainer = encyclopediaRepository.loadEntry(entryDef)
+			val entryContainer = encyclopediaService.loadEntry(entryDef)
 			entryContainer.entry.tags.forEach { tag ->
 				val ids = indexByTag[tag]
 				if (ids == null) {
@@ -74,7 +74,7 @@ class BrowseEntriesComponent(
 
 	private fun watchEntries() {
 		scope.launch {
-			encyclopediaRepository.entryListFlow.collect { entryDefs ->
+			encyclopediaService.entryListFlow.collect { entryDefs ->
 				entryContentCache.invalidateAll()
 				reindexEntries(entryDefs)
 
@@ -155,7 +155,7 @@ class BrowseEntriesComponent(
 			cachedEntry.entry
 		} else {
 			try {
-				val container = encyclopediaRepository.loadEntry(entryDef)
+				val container = encyclopediaService.loadEntry(entryDef)
 				entryContentCache.put(entryDef.id, container)
 				container.entry
 			} catch (e: EntryLoadError) {
@@ -172,8 +172,8 @@ class BrowseEntriesComponent(
 	}
 
 	override fun getImagePath(entryDef: EntryDef): String? {
-		return if (encyclopediaRepository.hasEntryImage(entryDef, "jpg")) {
-			encyclopediaRepository.getEntryImagePath(entryDef, "jpg").path
+		return if (encyclopediaService.hasEntryImage(entryDef, "jpg")) {
+			encyclopediaService.getEntryImagePath(entryDef, "jpg").path
 		} else {
 			null
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntryComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntryComponent.kt
@@ -6,7 +6,6 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.getAndUpdate
 import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryResult
@@ -23,7 +22,6 @@ class CreateEntryComponent(
 	private val _state = MutableValue(CreateEntry.State(projectDef = projectDef))
 	override val state: Value<CreateEntry.State> = _state
 
-	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
 	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val backfillEntryReferences: BackfillEntryReferencesUseCase by projectInject()
 
@@ -51,7 +49,7 @@ class CreateEntryComponent(
 	): EntryResult = withContext(dispatcherDefault) {
 		val result = encyclopediaService.createEntry(name, type, text, tags, imagePath)
 		if (result.error == EntryError.NONE) {
-			encyclopediaRepository.loadEntries()
+			encyclopediaService.loadEntries()
 			result.instance?.entry?.let { newEntry ->
 				backfillEntryReferences(newEntry)
 			}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntryComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntryComponent.kt
@@ -7,6 +7,7 @@ import com.arkivanov.decompose.value.getAndUpdate
 import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryResult
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
@@ -23,6 +24,7 @@ class CreateEntryComponent(
 	override val state: Value<CreateEntry.State> = _state
 
 	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
+	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val backfillEntryReferences: BackfillEntryReferencesUseCase by projectInject()
 
 	// Note: Back handler is disabled to allow predictive back animation.
@@ -47,7 +49,7 @@ class CreateEntryComponent(
 		tags: Set<String>,
 		imagePath: String?
 	): EntryResult = withContext(dispatcherDefault) {
-		val result = encyclopediaRepository.createEntry(name, type, text, tags, imagePath)
+		val result = encyclopediaService.createEntry(name, type, text, tags, imagePath)
 		if (result.error == EntryError.NONE) {
 			encyclopediaRepository.loadEntries()
 			result.instance?.entry?.let { newEntry ->

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
@@ -11,7 +11,6 @@ import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
 import com.darkrockstudios.apps.hammer.common.data.MenuDescriptor
 import com.darkrockstudios.apps.hammer.common.data.MenuItemDescriptor
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
-import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryResult
@@ -43,7 +42,6 @@ class ViewEntryComponent(
 	)
 	override val state: Value<ViewEntry.State> = _state
 
-	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
 	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val referenceIndexService: ReferenceIndexService by projectInject()
 	private val sceneEditorRepository: SceneEditorService by projectInject()
@@ -93,7 +91,7 @@ class ViewEntryComponent(
 	private fun reload() {
 		scope.launch {
 			val entryImagePath = getImagePath(state.value.entryDef)
-			val imageHash = encyclopediaRepository.calculateEntryImageHash(state.value.entryDef, "jpg")
+			val imageHash = encyclopediaService.calculateEntryImageHash(state.value.entryDef, "jpg")
 
 			val content = loadEntryContent(state.value.entryDef)
 			withContext(dispatcherMain) {
@@ -109,15 +107,15 @@ class ViewEntryComponent(
 	}
 
 	override fun getImagePath(entryDef: EntryDef): String? {
-		return if (encyclopediaRepository.hasEntryImage(entryDef, "jpg")) {
-			encyclopediaRepository.getEntryImagePath(entryDef, "jpg").path
+		return if (encyclopediaService.hasEntryImage(entryDef, "jpg")) {
+			encyclopediaService.getEntryImagePath(entryDef, "jpg").path
 		} else {
 			null
 		}
 	}
 
 	override suspend fun loadEntryContent(entryDef: EntryDef): EntryContent {
-		val container = encyclopediaRepository.loadEntry(entryDef)
+		val container = encyclopediaService.loadEntry(entryDef)
 		return container.entry
 	}
 
@@ -128,14 +126,14 @@ class ViewEntryComponent(
 	}
 
 	override suspend fun removeEntryImage(): Boolean {
-		if (encyclopediaRepository.removeEntryImage(state.value.entryDef)) {
+		if (encyclopediaService.removeEntryImage(state.value.entryDef)) {
 			reload()
 		}
 		return true
 	}
 
 	override suspend fun setImage(path: String) {
-		encyclopediaRepository.setEntryImage(state.value.entryDef, path)
+		encyclopediaService.setEntryImage(state.value.entryDef, path)
 		reload()
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
@@ -12,6 +12,7 @@ import com.darkrockstudios.apps.hammer.common.data.MenuDescriptor
 import com.darkrockstudios.apps.hammer.common.data.MenuItemDescriptor
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryResult
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
@@ -43,6 +44,7 @@ class ViewEntryComponent(
 	override val state: Value<ViewEntry.State> = _state
 
 	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
+	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val referenceIndexService: ReferenceIndexService by projectInject()
 	private val sceneEditorRepository: SceneEditorService by projectInject()
 	private val backfillEntryReferences: BackfillEntryReferencesUseCase by projectInject()
@@ -121,7 +123,7 @@ class ViewEntryComponent(
 
 	override suspend fun deleteEntry(entryDef: EntryDef): Boolean {
 		cleanupReferencesOnDelete(entryDef.id)
-		encyclopediaRepository.deleteEntry(entryDef)
+		encyclopediaService.deleteEntry(entryDef)
 		return true
 	}
 
@@ -204,7 +206,7 @@ class ViewEntryComponent(
 	): EntryResult = withContext(dispatcherDefault) {
 		val currentAliases = state.value.content?.aliases.orEmpty()
 		val previousName = state.value.entryDef.name
-		val result = encyclopediaRepository.updateEntry(
+		val result = encyclopediaService.updateEntry(
 			oldEntryDef = state.value.entryDef,
 			name = name,
 			text = text,
@@ -250,7 +252,7 @@ class ViewEntryComponent(
 				val newTags = tags.toMutableSet()
 				newTags.remove(tag)
 
-				encyclopediaRepository.updateEntry(
+				encyclopediaService.updateEntry(
 					oldEntryDef = state.value.entryDef,
 					name = name,
 					text = text,
@@ -287,7 +289,7 @@ class ViewEntryComponent(
 		val newTags = parseTagInput(tagInput)
 
 		state.value.content?.apply {
-			encyclopediaRepository.updateEntry(
+			encyclopediaService.updateEntry(
 				oldEntryDef = state.value.entryDef,
 				name = name,
 				text = text,
@@ -316,7 +318,7 @@ class ViewEntryComponent(
 			endAliasAdd()
 			return@withContext EntryResult(EntryError.NONE)
 		}
-		val result = encyclopediaRepository.updateEntry(
+		val result = encyclopediaService.updateEntry(
 			oldEntryDef = state.value.entryDef,
 			name = current.name,
 			text = current.text,
@@ -334,7 +336,7 @@ class ViewEntryComponent(
 	override fun removeAlias(alias: String) {
 		scope.launch {
 			state.value.content?.apply {
-				encyclopediaRepository.updateEntry(
+				encyclopediaService.updateEntry(
 					oldEntryDef = state.value.entryDef,
 					name = name,
 					text = text,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
@@ -11,7 +11,7 @@ import com.darkrockstudios.apps.hammer.common.components.ComponentToasterImpl
 import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
 import com.darkrockstudios.apps.hammer.common.components.projectroot.CloseConfirm
 import com.darkrockstudios.apps.hammer.common.data.*
-import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
@@ -56,7 +56,7 @@ class ProjectHomeComponent(
 	private val projectBackupRepository: ProjectBackupRepository by inject()
 	private val sceneEditorRepository: SceneEditorService by projectInject()
 	private val exportStoryUseCase: ExportStoryUseCase by projectInject()
-	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
+	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val projectSynchronizer: ClientProjectSynchronizer by projectInject()
 	private val statisticsService: StatisticsService by projectInject()
 	private val tagIndexService: TagIndexService by projectInject()
@@ -233,7 +233,7 @@ class ProjectHomeComponent(
 	}
 
 	override fun showEntry(entry: EntryAppearance) {
-		val def = encyclopediaRepository.findEntryDef(entry.entryId) ?: return
+		val def = encyclopediaService.findEntryDef(entry.entryId) ?: return
 		onShowEntry(def)
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
@@ -15,7 +15,7 @@ import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSear
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSearchState
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.SearchResult
 import com.darkrockstudios.apps.hammer.common.data.*
-import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
@@ -43,7 +43,7 @@ class ProjectRootComponent(
 	private val syncJournal: SyncJournal by projectInject()
 	private val sceneEditor: SceneEditorService by projectInject()
 	private val projectDataRepository: ProjectDataRepository by projectInject()
-	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
+	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val settingsRepository: GlobalSettingsStore by inject()
 	private val searchProjectUseCase: SearchProjectUseCase by projectInject()
 
@@ -281,7 +281,7 @@ class ProjectRootComponent(
 			}
 
 			is ProjectDeepLink.EncyclopediaEntry -> {
-				val entryDef = encyclopediaRepository.findEntryDef(link.entryId)
+				val entryDef = encyclopediaService.findEntryDef(link.entryId)
 				if (entryDef == null) {
 					Napier.w("Deep link skipped: no encyclopedia entry for id ${link.entryId}")
 					return

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectsync/ProjectSynchronizationComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectsync/ProjectSynchronizationComponent.kt
@@ -11,7 +11,7 @@ import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
-import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NoteError
@@ -43,7 +43,7 @@ class ProjectSynchronizationComponent(
 
 	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val sceneEditorRepository: SceneEditorService by projectInject()
-	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
+	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val notesRepository: NotesRepository by projectInject()
 	private val timeLineRepository: TimeLineRepository by projectInject()
 	private val sceneDraftRepository: SceneDraftRepository by projectInject()
@@ -247,7 +247,7 @@ class ProjectSynchronizationComponent(
 		}
 	}
 
-	override fun resolveEntryRef(id: Int) = encyclopediaRepository.findEntryDef(id)
+	override fun resolveEntryRef(id: Int) = encyclopediaService.findEntryDef(id)
 
 	private suspend fun onSyncProgress(progress: Float, log: SyncLogMessage? = null) {
 		Napier.d("Sync progress: $progress")
@@ -316,10 +316,10 @@ class ProjectSynchronizationComponent(
 	}
 
 	private suspend fun onEncyclopediaEntryConflict(serverEntity: ApiProjectEntity.EncyclopediaEntryEntity) {
-		val local = encyclopediaRepository.loadEntry(serverEntity.id).entry
+		val local = encyclopediaService.loadEntry(serverEntity.id).entry
 		val def = local.toDef(projectDef)
-		val image = if (encyclopediaRepository.hasEntryImage(def, "jpg")) {
-			val imageBytes = encyclopediaRepository.loadEntryImage(def, "jpg")
+		val image = if (encyclopediaService.hasEntryImage(def, "jpg")) {
+			val imageBytes = encyclopediaService.loadEntryImage(def, "jpg")
 			val imageBase64 = Base64.encode(imageBytes, url = true)
 			ApiProjectEntity.EncyclopediaEntryEntity.Image(imageBase64, "jpg")
 		} else {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
@@ -9,7 +9,7 @@ import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.SceneSummary
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
-import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.projectInject
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.countWords
@@ -43,7 +43,7 @@ class SceneMetadataPanelComponent(
 
 	private val appScope: CoroutineScope by inject(named(APP_SCOPE))
 	private val sceneEditor: SceneEditorService by projectInject()
-	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
+	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val scrubInvalidReferences: ScrubInvalidReferencesUseCase by projectInject()
 
 	private val searchableEntries = MutableStateFlow<List<SearchableEntry>>(emptyList())
@@ -85,7 +85,7 @@ class SceneMetadataPanelComponent(
 		}
 
 		scope.launch {
-			encyclopediaRepository.entryListFlow.collect { defs ->
+			encyclopediaService.entryListFlow.collect { defs ->
 				rebuildSearchableEntries(defs)
 				refreshReferences()
 			}
@@ -94,7 +94,7 @@ class SceneMetadataPanelComponent(
 		// Force the encyclopedia to publish its entry list so the search cache and
 		// chip resolver have data even if no other part of the UI has triggered a
 		// load yet.
-		scope.launch { encyclopediaRepository.ensureEntriesLoaded() }
+		scope.launch { encyclopediaService.ensureEntriesLoaded() }
 	}
 
 	private fun subscribeToMetadataUpdates() {
@@ -127,7 +127,7 @@ class SceneMetadataPanelComponent(
 
 	private suspend fun rebuildSearchableEntries(defs: List<EntryDef>) {
 		searchableEntries.value = defs.map { def ->
-			val container = encyclopediaRepository.loadEntry(def)
+			val container = encyclopediaService.loadEntry(def)
 			val terms = (listOf(def.name) + container.entry.aliases)
 				.filter { it.isNotBlank() }
 				.map { it.lowercase() }
@@ -153,9 +153,9 @@ class SceneMetadataPanelComponent(
 
 	private suspend fun refreshReferences() {
 		val metadata = state.value.metadata
-		val confirmed = metadata.confirmedReferences.mapNotNull { encyclopediaRepository.findEntryDef(it) }
+		val confirmed = metadata.confirmedReferences.mapNotNull { encyclopediaService.findEntryDef(it) }
 			.sortedBy { it.name.lowercase() }
-		val dismissed = metadata.dismissedReferences.mapNotNull { encyclopediaRepository.findEntryDef(it) }
+		val dismissed = metadata.dismissedReferences.mapNotNull { encyclopediaService.findEntryDef(it) }
 			.sortedBy { it.name.lowercase() }
 
 		withContext(dispatcherMain) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
@@ -206,6 +206,14 @@ class EncyclopediaDatasource(
 		}
 	}
 
+	/** Writes raw image bytes (e.g. an image pulled from the server during sync) to the entry's image path. */
+	suspend fun writeEntryImage(entryDef: EntryDef, imageBytes: ByteArray, fileExtension: String) {
+		val targetPath = getEntryImagePath(entryDef, fileExtension).toOkioPath()
+		fileSystem.write(targetPath) {
+			write(imageBytes)
+		}
+	}
+
 	suspend fun deleteEntry(entryDef: EntryDef): Boolean {
 		val path = getEntryPath(entryDef).toOkioPath()
 		fileSystem.delete(path)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
@@ -10,8 +10,6 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
-import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
-import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
@@ -36,8 +34,6 @@ class EncyclopediaRepository(
 	private val idAllocator: IdAllocator,
 	private val datasource: EncyclopediaDatasource,
 	private val syncJournal: SyncJournal,
-	private val statisticsRepository: StatisticsRepository,
-	private val referenceIndexRepository: ReferenceIndexRepository,
 ) : ScopeCallback, ProjectScoped, KoinComponent {
 
 	override val projectScope = ProjectDefScope(projectDef)
@@ -102,7 +98,6 @@ class EncyclopediaRepository(
 			aliases = cleanedAliases,
 		)
 
-		statisticsRepository.markDirty()
 		_entryContentChangedFlow.emit(Unit)
 		return EntryResult(container, EntryError.NONE)
 	}
@@ -211,7 +206,6 @@ class EncyclopediaRepository(
 
 		if (forceId == null) markForSynchronization(newDef)
 
-		statisticsRepository.markDirty()
 		_entryContentChangedFlow.emit(Unit)
 		return EntryResult(container, EntryError.NONE)
 	}
@@ -219,8 +213,6 @@ class EncyclopediaRepository(
 	suspend fun deleteEntry(entryDef: EntryDef): Boolean {
 		datasource.deleteEntry(entryDef)
 		syncJournal.recordIdDeletion(entryDef.id)
-		statisticsRepository.markDirty()
-		referenceIndexRepository.markEntryDeleted(entryDef.id)
 		_entryContentChangedFlow.emit(Unit)
 		return true
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaService.kt
@@ -1,21 +1,27 @@
 package com.darkrockstudios.apps.hammer.common.data.encyclopediarepository
 
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContainer
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
+import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import kotlinx.coroutines.flow.SharedFlow
 
 /**
- * The Component-facing API for encyclopedia writes. Wraps [EncyclopediaRepository]
- * and applies the cross-cutting side-effects (statistics, reference index) that the
- * repository deliberately does not reach sideways to perform. Reads still go through
- * the repository directly.
+ * The Component-facing API for the encyclopedia domain. Components and UI talk only to this
+ * service; [EncyclopediaRepository] is a lower-level building block. The service owns write
+ * orchestration — applying the cross-cutting side-effects (statistics, reference index) that
+ * the repository deliberately does not reach sideways to perform — and delegates reads
+ * one-to-one. Lower-level data consumers (services, use-cases, sync) still use the repository.
  */
 class EncyclopediaService(
 	private val repository: EncyclopediaRepository,
 	private val statisticsRepository: StatisticsRepository,
 	private val referenceIndexRepository: ReferenceIndexRepository,
 ) {
+
+	// region Writes / orchestration
 
 	suspend fun createEntry(
 		name: String,
@@ -51,4 +57,40 @@ class EncyclopediaService(
 		}
 		return deleted
 	}
+
+	suspend fun setEntryImage(entryDef: EntryDef, imagePath: String?) =
+		repository.setEntryImage(entryDef, imagePath)
+
+	suspend fun removeEntryImage(entryDef: EntryDef): Boolean =
+		repository.removeEntryImage(entryDef)
+
+	// endregion
+
+	// region Delegated reads
+
+	val entryListFlow: SharedFlow<List<EntryDef>> get() = repository.entryListFlow
+
+	fun loadEntries() = repository.loadEntries()
+
+	suspend fun ensureEntriesLoaded(): List<EntryDef> = repository.ensureEntriesLoaded()
+
+	fun loadEntry(entryDef: EntryDef): EntryContainer = repository.loadEntry(entryDef)
+
+	fun loadEntry(id: Int): EntryContainer = repository.loadEntry(id)
+
+	fun findEntryDef(id: Int): EntryDef? = repository.findEntryDef(id)
+
+	fun hasEntryImage(entryDef: EntryDef, fileExtension: String): Boolean =
+		repository.hasEntryImage(entryDef, fileExtension)
+
+	suspend fun calculateEntryImageHash(entryDef: EntryDef, fileExtension: String): String? =
+		repository.calculateEntryImageHash(entryDef, fileExtension)
+
+	fun getEntryImagePath(entryDef: EntryDef, fileExtension: String): HPath =
+		repository.getEntryImagePath(entryDef, fileExtension)
+
+	fun loadEntryImage(entryDef: EntryDef, fileExtension: String): ByteArray =
+		repository.loadEntryImage(entryDef, fileExtension)
+
+	// endregion
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaService.kt
@@ -1,0 +1,54 @@
+package com.darkrockstudios.apps.hammer.common.data.encyclopediarepository
+
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
+import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
+
+/**
+ * The Component-facing API for encyclopedia writes. Wraps [EncyclopediaRepository]
+ * and applies the cross-cutting side-effects (statistics, reference index) that the
+ * repository deliberately does not reach sideways to perform. Reads still go through
+ * the repository directly.
+ */
+class EncyclopediaService(
+	private val repository: EncyclopediaRepository,
+	private val statisticsRepository: StatisticsRepository,
+	private val referenceIndexRepository: ReferenceIndexRepository,
+) {
+
+	suspend fun createEntry(
+		name: String,
+		type: EntryType,
+		text: String,
+		tags: Set<String>,
+		imagePath: String?,
+		forceId: Int? = null,
+		aliases: List<String> = emptyList(),
+	): EntryResult {
+		val result = repository.createEntry(name, type, text, tags, imagePath, forceId, aliases)
+		if (result.error == EntryError.NONE) statisticsRepository.markDirty()
+		return result
+	}
+
+	suspend fun updateEntry(
+		oldEntryDef: EntryDef,
+		name: String,
+		text: String,
+		tags: Set<String>,
+		aliases: List<String> = emptyList(),
+	): EntryResult {
+		val result = repository.updateEntry(oldEntryDef, name, text, tags, aliases)
+		if (result.error == EntryError.NONE) statisticsRepository.markDirty()
+		return result
+	}
+
+	suspend fun deleteEntry(entryDef: EntryDef): Boolean {
+		val deleted = repository.deleteEntry(entryDef)
+		if (deleted) {
+			statisticsRepository.markDirty()
+			referenceIndexRepository.markEntryDeleted(entryDef.id)
+		}
+		return deleted
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.projectInject
@@ -39,6 +40,7 @@ class ClientEncyclopediaSynchronizer(
 
 	override val projectScope = ProjectDefScope(projectDef)
 	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
+	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val referenceRemapper: ReferenceRemapper by projectInject()
 
 	private suspend fun getEntity(id: Int): EntryDef? {
@@ -109,7 +111,7 @@ class ClientEncyclopediaSynchronizer(
 
 	override suspend fun deleteEntityLocal(id: Int, onLog: OnSyncLog) {
 		val def = encyclopediaRepository.getEntryDef(id)
-		encyclopediaRepository.deleteEntry(def)
+		encyclopediaService.deleteEntry(def)
 
 		onLog(syncLogI(strRes.get(Res.string.sync_encyclopedia_deleted, id), def.projectDef.name))
 	}
@@ -140,7 +142,7 @@ class ClientEncyclopediaSynchronizer(
 		handleImage(oldDef, serverDef, serverEntity)
 
 		if (oldDef != null) {
-			encyclopediaRepository.updateEntry(
+			encyclopediaService.updateEntry(
 				oldEntryDef = oldDef,
 				name = serverEntity.name,
 				text = serverEntity.text,
@@ -148,7 +150,7 @@ class ClientEncyclopediaSynchronizer(
 				aliases = serverEntity.aliases,
 			)
 		} else {
-			encyclopediaRepository.createEntry(
+			encyclopediaService.createEntry(
 				name = serverEntity.name,
 				text = serverEntity.text,
 				tags = serverEntity.tags,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.EntityType
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
@@ -18,20 +19,17 @@ import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchr
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogI
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
-import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.sync_encyclopedia_deleted
 import korlibs.crypto.encoding.Base64
 import kotlinx.coroutines.flow.first
-import okio.FileSystem
 
 class ClientEncyclopediaSynchronizer(
 	projectDef: ProjectDef,
 	serverProjectApi: ServerProjectApi,
 	projectMetadataDatasource: ProjectMetadataDatasource,
 	private val strRes: StrRes,
-	private val fileSystem: FileSystem
 ) : EntitySynchronizer<ApiProjectEntity.EncyclopediaEntryEntity>(
 	projectDef,
 	serverProjectApi,
@@ -41,6 +39,7 @@ class ClientEncyclopediaSynchronizer(
 	override val projectScope = ProjectDefScope(projectDef)
 	private val encyclopediaRepository: EncyclopediaRepository by projectInject()
 	private val encyclopediaService: EncyclopediaService by projectInject()
+	private val encyclopediaDatasource: EncyclopediaDatasource by projectInject()
 	private val referenceRemapper: ReferenceRemapper by projectInject()
 
 	private suspend fun getEntity(id: Int): EntryDef? {
@@ -164,25 +163,19 @@ class ClientEncyclopediaSynchronizer(
 		return true
 	}
 
-	private fun handleImage(
+	private suspend fun handleImage(
 		oldDef: EntryDef?,
 		serverDef: EntryDef,
 		serverEntity: ApiProjectEntity.EncyclopediaEntryEntity
 	) {
-		// Write the new image
 		val image = serverEntity.image
 		if (image != null) {
 			val imageBytes = Base64.decode(image.base64, url = true)
-			val imagePath = encyclopediaRepository.getEntryImagePath(serverDef, image.fileExtension)
-			fileSystem.write(imagePath.toOkioPath()) {
-				write(imageBytes)
-			}
-		} else {
-			// Delete the old image, if there is a new one it'll get written regardless
-			if (oldDef != null) {
-				val oldImagePath = encyclopediaRepository.getEntryImagePath(oldDef, "jpg")
-				fileSystem.delete(oldImagePath.toOkioPath(), false)
-			}
+			encyclopediaDatasource.writeEntryImage(serverDef, imageBytes, image.fileExtension)
+		} else if (oldDef != null && encyclopediaDatasource.hasEntryImage(oldDef, "jpg")) {
+			// Server reports no image; drop the local one. Raw datasource delete (no
+			// sync-marking) since we're applying server state, not making a local edit.
+			encyclopediaDatasource.removeEntryImage(oldDef)
 		}
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
@@ -74,8 +74,8 @@ class ClientEncyclopediaSynchronizer(
 		val def = entry.toDef(projectDef)
 
 		val DEFAULT_EXTENSION = "jpg"
-		val image = if (encyclopediaRepository.hasEntryImage(def, DEFAULT_EXTENSION)) {
-			val imageBytes = encyclopediaRepository.loadEntryImage(def, DEFAULT_EXTENSION)
+		val image = if (encyclopediaDatasource.hasEntryImage(def, DEFAULT_EXTENSION)) {
+			val imageBytes = encyclopediaDatasource.loadEntryImage(def, DEFAULT_EXTENSION)
 			val imageBase64 = Base64.encode(imageBytes, url = true)
 
 			ApiProjectEntity.EncyclopediaEntryEntity.Image(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -10,6 +10,7 @@ import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.exampleProjectModule
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
@@ -164,6 +165,7 @@ val mainModule = module {
 
 		factoryOf(::EncyclopediaDatasource)
 		scopedOf(::EncyclopediaRepository)
+		scopedOf(::EncyclopediaService)
 
 		scopedOf(::TimeLineDatasource)
 		scopedOf(::TimeLineRepository)

--- a/common/src/desktopTest/kotlin/components/encyclopedia/BrowseEntriesComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/encyclopedia/BrowseEntriesComponentTest.kt
@@ -5,7 +5,7 @@ import com.arkivanov.essenty.backhandler.BackHandler
 import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.statekeeper.StateKeeperDispatcher
 import com.darkrockstudios.apps.hammer.common.components.encyclopedia.BrowseEntriesComponent
-import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContainer
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
@@ -39,7 +39,7 @@ class BrowseEntriesComponentTest : BaseTest() {
 	private lateinit var context: ComponentContext
 
 	@MockK
-	private lateinit var encyclopediaRepository: EncyclopediaRepository
+	private lateinit var encyclopediaService: EncyclopediaService
 
 	private lateinit var entryListFlow: SharedFlow<List<EntryDef>>
 
@@ -50,7 +50,7 @@ class BrowseEntriesComponentTest : BaseTest() {
 		MockKAnnotations.init(this, relaxUnitFun = true)
 
 		val testModule = module {
-			single { encyclopediaRepository } bind EncyclopediaRepository::class
+			single { encyclopediaService } bind EncyclopediaService::class
 		}
 		setupKoin(testModule)
 
@@ -233,10 +233,10 @@ class BrowseEntriesComponentTest : BaseTest() {
 			flow.emit(entries.map { it.toDef(projDef) })
 		}
 
-		every { encyclopediaRepository.entryListFlow } returns entryListFlow
+		every { encyclopediaService.entryListFlow } returns entryListFlow
 
 		val entryDefSlot = slot<EntryDef>()
-		every { encyclopediaRepository.loadEntry(entryDef = capture(entryDefSlot)) } answers {
+		every { encyclopediaService.loadEntry(entryDef = capture(entryDefSlot)) } answers {
 			entries.find { it.entry.id == entryDefSlot.captured.id }!!
 		}
 	}

--- a/common/src/desktopTest/kotlin/components/encyclopedia/ViewEntryComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/encyclopedia/ViewEntryComponentTest.kt
@@ -6,6 +6,7 @@ import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.statekeeper.StateKeeper
 import com.darkrockstudios.apps.hammer.common.components.encyclopedia.ViewEntryComponent
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryResult
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContainer
@@ -41,6 +42,9 @@ class ViewEntryComponentTest : BaseTest() {
 	@MockK
 	private lateinit var encyclopediaRepository: EncyclopediaRepository
 
+	@MockK
+	private lateinit var encyclopediaService: EncyclopediaService
+
 	@BeforeEach
 	override fun setup() {
 		super.setup()
@@ -49,6 +53,7 @@ class ViewEntryComponentTest : BaseTest() {
 
 		val testModule = module {
 			single { encyclopediaRepository } bind EncyclopediaRepository::class
+			single { encyclopediaService } bind EncyclopediaService::class
 			single<ReferenceIndexService> { mockk(relaxed = true) }
 			single<SceneRepository> { mockk(relaxed = true) }
 			single<BackfillEntryReferencesUseCase> { mockk(relaxed = true) }
@@ -77,7 +82,7 @@ class ViewEntryComponentTest : BaseTest() {
 		coEvery { encyclopediaRepository.calculateEntryImageHash(any(), any()) } returns null
 		coEvery { encyclopediaRepository.loadEntry(entryDef = any()) } returns newContainer
 		coEvery {
-			encyclopediaRepository.updateEntry(
+			encyclopediaService.updateEntry(
 				oldEntryDef = origDef,
 				name = newName,
 				text = oldEntry.text,
@@ -117,7 +122,7 @@ class ViewEntryComponentTest : BaseTest() {
 		every { encyclopediaRepository.hasEntryImage(any(), any()) } returns false
 		coEvery { encyclopediaRepository.loadEntry(entryDef = any()) } returns newContainer
 		coEvery {
-			encyclopediaRepository.updateEntry(
+			encyclopediaService.updateEntry(
 				oldEntryDef = origDef,
 				name = newName,
 				text = oldEntry.text,

--- a/common/src/desktopTest/kotlin/components/encyclopedia/ViewEntryComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/encyclopedia/ViewEntryComponentTest.kt
@@ -5,7 +5,6 @@ import com.arkivanov.essenty.backhandler.BackHandler
 import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.statekeeper.StateKeeper
 import com.darkrockstudios.apps.hammer.common.components.encyclopedia.ViewEntryComponent
-import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryResult
@@ -40,9 +39,6 @@ class ViewEntryComponentTest : BaseTest() {
 	private lateinit var context: ComponentContext
 
 	@MockK
-	private lateinit var encyclopediaRepository: EncyclopediaRepository
-
-	@MockK
 	private lateinit var encyclopediaService: EncyclopediaService
 
 	@BeforeEach
@@ -52,7 +48,6 @@ class ViewEntryComponentTest : BaseTest() {
 		MockKAnnotations.init(this, relaxUnitFun = true)
 
 		val testModule = module {
-			single { encyclopediaRepository } bind EncyclopediaRepository::class
 			single { encyclopediaService } bind EncyclopediaService::class
 			single<ReferenceIndexService> { mockk(relaxed = true) }
 			single<SceneRepository> { mockk(relaxed = true) }
@@ -78,9 +73,9 @@ class ViewEntryComponentTest : BaseTest() {
 		val newEntry = oldEntry.copy(name = newName)
 		val newContainer = EntryContainer(newEntry)
 
-		every { encyclopediaRepository.hasEntryImage(any(), any()) } returns false
-		coEvery { encyclopediaRepository.calculateEntryImageHash(any(), any()) } returns null
-		coEvery { encyclopediaRepository.loadEntry(entryDef = any()) } returns newContainer
+		every { encyclopediaService.hasEntryImage(any(), any()) } returns false
+		coEvery { encyclopediaService.calculateEntryImageHash(any(), any()) } returns null
+		coEvery { encyclopediaService.loadEntry(entryDef = any()) } returns newContainer
 		coEvery {
 			encyclopediaService.updateEntry(
 				oldEntryDef = origDef,
@@ -119,8 +114,8 @@ class ViewEntryComponentTest : BaseTest() {
 		val newEntry = oldEntry.copy(name = newName)
 		val newContainer = EntryContainer(newEntry)
 
-		every { encyclopediaRepository.hasEntryImage(any(), any()) } returns false
-		coEvery { encyclopediaRepository.loadEntry(entryDef = any()) } returns newContainer
+		every { encyclopediaService.hasEntryImage(any(), any()) } returns false
+		coEvery { encyclopediaService.loadEntry(entryDef = any()) } returns newContainer
 		coEvery {
 			encyclopediaService.updateEntry(
 				oldEntryDef = origDef,

--- a/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
@@ -12,7 +12,6 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
-import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
@@ -45,12 +44,6 @@ class EncyclopediaRepositoryTest : BaseTest() {
 	@MockK
 	lateinit var syncJournal: SyncJournal
 
-	@MockK
-	lateinit var statisticsRepository: StatisticsRepository
-
-	private lateinit var referenceIndexDatasource: com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexDatasource
-	private lateinit var referenceIndexRepository: com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
-
 	lateinit var datasource: EncyclopediaDatasource
 
 	private lateinit var fileSystem: FakeFileSystem
@@ -77,17 +70,11 @@ class EncyclopediaRepositoryTest : BaseTest() {
 			fileSystem = fileSystem,
 			externalFileIo = externalFileIo,
 		)
-		referenceIndexDatasource = com.darkrockstudios.apps.hammer.common.data.references
-			.ReferenceIndexDatasource(fileSystem, toml, projDef)
-		referenceIndexRepository = com.darkrockstudios.apps.hammer.common.data.references
-			.ReferenceIndexRepository(projDef, referenceIndexDatasource)
 		return EncyclopediaRepository(
 			projectDef = projDef,
 			idAllocator = idAllocator,
 			datasource = datasource,
 			syncJournal = syncJournal,
-			statisticsRepository = statisticsRepository,
-			referenceIndexRepository = referenceIndexRepository,
 		)
 	}
 
@@ -290,29 +277,6 @@ class EncyclopediaRepositoryTest : BaseTest() {
 		assertFalse(fileSystem.exists(path))
 		assertEquals(entry1().id, deletionIdSlot.captured)
 		coVerify { syncJournal.recordIdDeletion(any()) }
-	}
-
-	@Test
-	fun `Delete Entry purges that entry id from the reference index`() = runTest {
-		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
-
-		val repo = createRepository()
-		referenceIndexDatasource.saveIndex(
-			com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndex(
-				isDirty = false,
-				entryToScenes = mapOf(
-					entry1().id to setOf(100, 200),
-					99 to setOf(100),
-				),
-			)
-		)
-		referenceIndexRepository.loadIndex()
-
-		repo.deleteEntry(entry1().toDef(projDef))
-
-		val saved = referenceIndexDatasource.loadIndex()
-		assertEquals(null, saved?.entryToScenes?.get(entry1().id))
-		assertEquals(setOf(100), saved?.entryToScenes?.get(99))
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaServiceTest.kt
@@ -1,0 +1,179 @@
+package repositories.encyclopedia
+
+import ENCYCLOPEDIA_ONLY_PROJECT_NAME
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
+import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndex
+import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexDatasource
+import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
+import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
+import createProject
+import getProjectDef
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import net.peanuuutz.tomlkt.Toml
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the cross-cutting side-effects the service applies on top of the repository:
+ * statistics dirty-marking and reference-index purging. These were previously baked into
+ * the repository and silently untested.
+ */
+class EncyclopediaServiceTest : BaseTest() {
+
+	private val projDef = getProjectDef(ENCYCLOPEDIA_ONLY_PROJECT_NAME)
+
+	@MockK
+	lateinit var idAllocator: IdAllocator
+
+	@MockK
+	lateinit var externalFileIo: ExternalFileIo
+
+	@MockK
+	lateinit var syncJournal: SyncJournal
+
+	@MockK
+	lateinit var statisticsRepository: StatisticsRepository
+
+	private lateinit var datasource: EncyclopediaDatasource
+	private lateinit var referenceIndexDatasource: ReferenceIndexDatasource
+	private lateinit var referenceIndexRepository: ReferenceIndexRepository
+
+	private lateinit var fileSystem: FakeFileSystem
+	private lateinit var toml: Toml
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+
+		MockKAnnotations.init(this, relaxUnitFun = true)
+
+		setupKoin()
+
+		every { syncJournal.isServerSynchronized() } returns false
+		fileSystem = FakeFileSystem()
+		toml = createTomlSerializer()
+		createProject(fileSystem, ENCYCLOPEDIA_ONLY_PROJECT_NAME)
+	}
+
+	private fun createService(): EncyclopediaService {
+		datasource = EncyclopediaDatasource(
+			projectDef = projDef,
+			toml = toml,
+			fileSystem = fileSystem,
+			externalFileIo = externalFileIo,
+		)
+		referenceIndexDatasource = ReferenceIndexDatasource(fileSystem, toml, projDef)
+		referenceIndexRepository = ReferenceIndexRepository(projDef, referenceIndexDatasource)
+		val repository = EncyclopediaRepository(
+			projectDef = projDef,
+			idAllocator = idAllocator,
+			datasource = datasource,
+			syncJournal = syncJournal,
+		)
+		return EncyclopediaService(
+			repository = repository,
+			statisticsRepository = statisticsRepository,
+			referenceIndexRepository = referenceIndexRepository,
+		)
+	}
+
+	@Test
+	fun `createEntry marks statistics dirty`() = runTest {
+		coEvery { idAllocator.claimNextId() } returns 10
+
+		val service = createService()
+		val result = service.createEntry(
+			name = "New Entry",
+			type = EntryType.PERSON,
+			text = "Some text",
+			tags = emptySet(),
+			imagePath = null,
+		)
+
+		assertEquals(EntryError.NONE, result.error)
+		coVerify { statisticsRepository.markDirty() }
+	}
+
+	@Test
+	fun `createEntry with invalid name does not mark statistics dirty`() = runTest {
+		val service = createService()
+		val result = service.createEntry(
+			name = "",
+			type = EntryType.PERSON,
+			text = "Some text",
+			tags = emptySet(),
+			imagePath = null,
+		)
+
+		assertEquals(EntryError.NAME_TOO_SHORT, result.error)
+		coVerify(exactly = 0) { statisticsRepository.markDirty() }
+	}
+
+	@Test
+	fun `updateEntry marks statistics dirty`() = runTest {
+		val service = createService()
+		val result = service.updateEntry(
+			oldEntryDef = entry1().toDef(projDef),
+			name = "A new name",
+			text = entry1().text,
+			tags = entry1().tags,
+		)
+
+		assertEquals(EntryError.NONE, result.error)
+		coVerify { statisticsRepository.markDirty() }
+	}
+
+	@Test
+	fun `updateEntry with invalid name does not mark statistics dirty`() = runTest {
+		val service = createService()
+		val result = service.updateEntry(
+			oldEntryDef = entry1().toDef(projDef),
+			name = "",
+			text = entry1().text,
+			tags = entry1().tags,
+		)
+
+		assertEquals(EntryError.NAME_TOO_SHORT, result.error)
+		coVerify(exactly = 0) { statisticsRepository.markDirty() }
+	}
+
+	@Test
+	fun `deleteEntry marks statistics dirty and purges the reference index`() = runTest {
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
+
+		val service = createService()
+		referenceIndexDatasource.saveIndex(
+			ReferenceIndex(
+				isDirty = false,
+				entryToScenes = mapOf(
+					entry1().id to setOf(100, 200),
+					99 to setOf(100),
+				),
+			)
+		)
+		referenceIndexRepository.loadIndex()
+
+		val deleted = service.deleteEntry(entry1().toDef(projDef))
+		assertTrue(deleted)
+
+		coVerify { statisticsRepository.markDirty() }
+
+		val saved = referenceIndexDatasource.loadIndex()
+		assertEquals(null, saved?.entryToScenes?.get(entry1().id))
+		assertEquals(setOf(100), saved?.entryToScenes?.get(99))
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
@@ -180,6 +180,7 @@ class SceneEditorServiceTest : BaseTest() {
 		val path = service.getSceneFilePathOrNull(created.id)!!.toOkioPath()
 		assertTrue(ffs.exists(path))
 		assertTrue(ffs.metadata(path).isDirectory)
+		coVerify { statisticsRepository.markDirty() }
 	}
 
 	@Test
@@ -203,10 +204,13 @@ class SceneEditorServiceTest : BaseTest() {
 		// deleteGroup only succeeds on an empty group, so create a fresh one.
 		val group = service.createGroup(null, "Empty Group")!!
 		assertEquals(SceneItem.Type.Group, group.type)
+		// createGroup itself marks dirty; isolate the delete's own side-effect.
+		clearMocks(statisticsRepository, answers = false)
 
 		val deleted = service.deleteGroup(group)
 		assertTrue(deleted)
 		assertNull(service.getSceneItemFromId(group.id))
+		coVerify { statisticsRepository.markDirty() }
 	}
 
 	@Test
@@ -259,18 +263,22 @@ class SceneEditorServiceTest : BaseTest() {
 			assertNull(service.getSceneItemFromId(1))
 			assertNotNull(service.getSceneItemFromIdIncludingArchived(1))
 			assertTrue(service.getArchivedScenes().any { it.id == 1 })
+			coVerify { statisticsRepository.markDirty() }
 		}
 
 	@Test
 	fun `Unarchive scene restores it to the tree`() = runTest(mainTestDispatcher) {
 		val service = initializedService()
 		service.archiveScene(service.getSceneItemFromId(1)!!)
+		// archiveScene itself marks dirty; isolate the unarchive's own side-effect.
+		clearMocks(statisticsRepository, answers = false)
 
 		val archivedScene = service.getArchivedScenes().first { it.id == 1 }
 		val unarchived = service.unarchiveScene(archivedScene)
 		assertNotNull(unarchived)
 		assertFalse(unarchived.archived)
 		assertNotNull(service.getSceneItemFromId(1))
+		coVerify { statisticsRepository.markDirty() }
 	}
 
 	// endregion
@@ -358,6 +366,19 @@ class SceneEditorServiceTest : BaseTest() {
 		assertNotNull(buffer)
 		assertFalse(buffer.dirty)
 		assertEquals("Content of scene id 3", buffer.content.markdown)
+	}
+
+	@Test
+	fun `Autosaving an edited buffer marks stats dirty`() = runTest(mainTestDispatcher) {
+		val service = initializedService()
+		val scene = service.getSceneItemFromId(3)!!
+		service.loadSceneBuffer(scene)
+
+		service.onContentChanged(SceneContent(scene, "Autosaved body"), UpdateSource.Editor)
+		advanceTimeBy(SceneContentRepository.BUFFER_COOL_DOWN.inWholeMilliseconds + 100)
+		advanceUntilIdle()
+
+		coVerify { statisticsRepository.markDirty() }
 	}
 
 	// endregion

--- a/common/src/desktopTest/kotlin/repositories/statistics/StatisticsRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/statistics/StatisticsRepositoryTest.kt
@@ -1,0 +1,120 @@
+package repositories.statistics
+
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.ProjectStatistics
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
+import getProject1Def
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the dirty-flag mechanics of [StatisticsRepository.markDirty]: synchronous in-memory
+ * flip, async persistence of the flag, and idempotency once already dirty.
+ */
+class StatisticsRepositoryTest : BaseTest() {
+
+	@MockK
+	private lateinit var datasource: StatisticsDatasource
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		MockKAnnotations.init(this, relaxUnitFun = true)
+		setupKoin()
+
+		coEvery { datasource.loadStatistics() } returns stats(isDirty = false)
+		coEvery { datasource.saveStatistics(any()) } just Runs
+	}
+
+	private fun stats(isDirty: Boolean) = ProjectStatistics(
+		numberOfScenes = 0,
+		totalWords = 0,
+		wordsByChapter = emptyMap(),
+		encyclopediaEntriesByType = emptyMap(),
+		isDirty = isDirty,
+		lastCalculated = Instant.fromEpochSeconds(0),
+	)
+
+	private fun createRepository() = StatisticsRepository(getProject1Def(), datasource)
+
+	@Test
+	fun `markDirty flips isDirty synchronously`() = runTest(mainTestDispatcher) {
+		val repo = createRepository()
+		assertFalse(repo.isDirty.value)
+
+		repo.markDirty()
+
+		// The in-memory flag flips before the persistence coroutine runs.
+		assertTrue(repo.isDirty.value)
+	}
+
+	@Test
+	fun `markDirty persists the dirty flag to the cache`() = runTest(mainTestDispatcher) {
+		val repo = createRepository()
+
+		repo.markDirty()
+		advanceUntilIdle()
+
+		coVerify { datasource.saveStatistics(match { it.isDirty }) }
+	}
+
+	@Test
+	fun `markDirty is idempotent once already dirty`() = runTest(mainTestDispatcher) {
+		val repo = createRepository()
+
+		repo.markDirty()
+		advanceUntilIdle()
+		clearMocks(datasource, answers = false)
+
+		repo.markDirty()
+		advanceUntilIdle()
+
+		// Already dirty in-memory, so the second call short-circuits without touching the cache.
+		coVerify(exactly = 0) { datasource.loadStatistics() }
+		coVerify(exactly = 0) { datasource.saveStatistics(any()) }
+	}
+
+	@Test
+	fun `markDirty does not rewrite an already-dirty cache`() = runTest(mainTestDispatcher) {
+		coEvery { datasource.loadStatistics() } returns stats(isDirty = true)
+		val repo = createRepository()
+
+		repo.markDirty()
+		advanceUntilIdle()
+
+		// Cache is already dirty on disk; nothing to persist.
+		coVerify(exactly = 0) { datasource.saveStatistics(any()) }
+	}
+
+	@Test
+	fun `loadStatistics reflects the persisted dirty flag`() = runTest(mainTestDispatcher) {
+		coEvery { datasource.loadStatistics() } returns stats(isDirty = true)
+		val repo = createRepository()
+
+		val loaded = repo.loadStatistics()
+
+		assertEquals(true, loaded?.isDirty)
+		assertTrue(repo.isDirty.value)
+	}
+
+	@Test
+	fun `clearDirty resets the flag`() = runTest(mainTestDispatcher) {
+		val repo = createRepository()
+		repo.markDirty()
+		advanceUntilIdle()
+		assertTrue(repo.isDirty.value)
+
+		repo.clearDirty()
+
+		assertFalse(repo.isDirty.value)
+	}
+}

--- a/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
@@ -16,7 +16,6 @@ import io.mockk.coVerifyOrder
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import okio.fakefilesystem.FakeFileSystem
 import org.jetbrains.compose.resources.StringResource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -66,7 +65,6 @@ class ClientEncyclopediaSynchronizerTest : BaseTest() {
 		serverProjectApi = serverProjectApi,
 		projectMetadataDatasource = projectMetadataDatasource,
 		strRes = strRes,
-		fileSystem = FakeFileSystem(),
 	)
 
 	@Test


### PR DESCRIPTION
Top of the layered-architecture refactor stack. **Base: `foundation-scenerepository-refactor2`** (#559).

`EncyclopediaRepository` was the last repository reaching sideways into siblings — it called `statisticsRepository.markDirty()` and `referenceIndexRepository.markEntryDeleted()` on entry writes. This decouples it, mirroring `SceneEditorService`:

- **EncyclopediaService** owns write orchestration (the cross-cutting stats / reference-index side-effects) and delegates reads. The repository is now pure data with zero sibling-repo deps.
- All seven encyclopedia UI components route through the service; lower-level data consumers (sync, the reference/statistics/tag services, use-cases) keep the repository directly — the same service-vs-repository split the scene side uses.

Also backfills dirty-marking test coverage that was silently absent (the mocks swallowed `markDirty`): encyclopedia create/update/delete side-effects, the previously-unasserted `SceneEditorService` write paths, and `StatisticsRepository.markDirty` mechanics.

Verified: full `:common:desktopTest` green, 10/10 Android instrumented on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)