### PR TITLE
fix: Story Outline collapse arrows and Collapse All

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarList
 import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.SceneSummary
+import com.darkrockstudios.apps.hammer.common.data.tree.TreeValue
 
 /**
  * The root composable take takes a scene tree and handles rendering, reorder, collapsing
@@ -38,7 +40,8 @@ fun SceneTree(
 ) {
 	Box {
 		Row {
-			if (state.summary.sceneTree.totalNodes <= 1) {
+			val visibleNodes = visibleSceneTreeNodes(state.summary, state.collapsedNodes)
+			if (visibleNodes.isEmpty()) {
 				Text(
 					text = "No Scenes",
 					modifier = Modifier.fillMaxWidth().padding(Ui.Padding.XL),
@@ -54,32 +57,25 @@ fun SceneTree(
 					contentPadding = contentPadding
 				) {
 					items(
-						count = state.summary.sceneTree.totalNodes,
-						key = { state.summary.sceneTree[it].value.id },
-						contentType = { state.summary.sceneTree[it].value.type }
+						count = visibleNodes.size,
+						key = { visibleNodes[it].value.id },
+						contentType = { visibleNodes[it].value.type }
 					) { index ->
-						val childNode = state.summary.sceneTree[index]
-						val shouldCollapseSelf = shouldCollapseNode(
-							index,
-							state.summary,
-							state.collapsedNodes
-						)
+						val childNode = visibleNodes[index]
 						val nodeCollapsesChildren =
 							state.collapsedNodes[childNode.value.id] ?: false
 
-						if (!childNode.value.isRootScene) {
-							SceneTreeNode(
-								node = childNode,
-								collapsed = shouldCollapseSelf, // need to take parent into account
-								nodeCollapsesChildren = nodeCollapsesChildren,
-								selectedId = state.selectedId,
-								toggleExpanded = state::toggleExpanded,
-								modifier = Modifier.wrapContentHeight()
-									.fillMaxWidth()
-									.animateItem(),
-								itemUi = itemUi
-							)
-						}
+						SceneTreeNode(
+							node = childNode,
+							collapsed = false,
+							nodeCollapsesChildren = nodeCollapsesChildren,
+							selectedId = state.selectedId,
+							toggleExpanded = state::toggleExpanded,
+							modifier = Modifier.wrapContentHeight()
+								.fillMaxWidth()
+								.animateItem(),
+							itemUi = itemUi
+						)
 					}
 				}
 				MpScrollBarList(state = state.listState)
@@ -89,7 +85,16 @@ fun SceneTree(
 	}
 }
 
-private fun shouldCollapseNode(
+internal fun visibleSceneTreeNodes(
+	summary: SceneSummary,
+	collapsedNodes: SnapshotStateMap<Int, Boolean>
+): List<TreeValue<SceneItem>> {
+	return summary.sceneTree.filter { node ->
+		!node.value.isRootScene && !shouldCollapseNode(node.index, summary, collapsedNodes)
+	}
+}
+
+internal fun shouldCollapseNode(
 	index: Int,
 	summary: SceneSummary,
 	collapsedNodes: SnapshotStateMap<Int, Boolean>

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
@@ -138,8 +138,11 @@ class SceneTreeState(
 	}
 
 	fun toggleExpanded(nodeId: Int) {
-		val collapse = !(collapsedNodes[nodeId] ?: false)
-		collapsedNodes[nodeId] = collapse
+		if (collapsedNodes[nodeId] == true) {
+			collapsedNodes.remove(nodeId)
+		} else {
+			collapsedNodes[nodeId] = true
+		}
 	}
 
 	companion object {

--- a/composeUi/src/desktopTest/kotlin/SceneTreeStateTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SceneTreeStateTest.kt
@@ -1,0 +1,131 @@
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.mutableStateMapOf
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.SceneItem
+import com.darkrockstudios.apps.hammer.common.data.SceneSummary
+import com.darkrockstudios.apps.hammer.common.data.tree.Tree
+import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
+import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.scenetree.SceneTreeState
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.scenetree.shouldCollapseNode
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.scenetree.visibleSceneTreeNodes
+import kotlinx.coroutines.CoroutineScope
+import org.junit.Test
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SceneTreeStateTest {
+
+	@Test
+	fun `toggle expanded collapses and expands descendants`() {
+		val state = sceneTreeState(sceneSummary())
+		val childIndex = state.getTree().findBy { it.id == SCENE_A_ID }!!.index
+
+		state.toggleExpanded(GROUP_A_ID)
+
+		assertEquals(true, state.collapsedNodes[GROUP_A_ID])
+		assertTrue(shouldCollapseNode(childIndex, state.summary, state.collapsedNodes))
+
+		state.toggleExpanded(GROUP_A_ID)
+
+		assertNull(state.collapsedNodes[GROUP_A_ID])
+		assertFalse(shouldCollapseNode(childIndex, state.summary, state.collapsedNodes))
+	}
+
+	@Test
+	fun `collapse all marks groups and expand all clears collapse state`() {
+		val state = sceneTreeState(sceneSummary())
+
+		state.collapseAll()
+
+		assertEquals(true, state.collapsedNodes[GROUP_A_ID])
+		assertEquals(true, state.collapsedNodes[GROUP_B_ID])
+		assertNull(state.collapsedNodes[SCENE_A_ID])
+		assertNull(state.collapsedNodes[SCENE_B_ID])
+
+		state.expandAll()
+
+		assertTrue(state.collapsedNodes.isEmpty())
+	}
+
+	@Test
+	fun `deleted collapsed groups are pruned on summary update`() {
+		val state = sceneTreeState(sceneSummary())
+
+		state.toggleExpanded(GROUP_A_ID)
+		state.updateSummary(sceneSummary(includeGroupA = false))
+
+		assertNull(state.collapsedNodes[GROUP_A_ID])
+	}
+
+	@Test
+	fun `visible scene tree nodes excludes descendants under collapsed ancestors`() {
+		val state = sceneTreeState(sceneSummary())
+		state.toggleExpanded(GROUP_A_ID)
+
+		val visibleIds = visibleSceneTreeNodes(state.summary, state.collapsedNodes)
+			.map { it.value.id }
+
+		assertEquals(listOf(GROUP_A_ID, SCENE_C_ID), visibleIds)
+		assertFalse(visibleIds.contains(SCENE_A_ID))
+		assertFalse(visibleIds.contains(GROUP_B_ID))
+		assertFalse(visibleIds.contains(SCENE_B_ID))
+	}
+
+	private fun sceneTreeState(summary: SceneSummary): SceneTreeState {
+		return SceneTreeState(
+			sceneSummary = summary,
+			moveItem = {},
+			coroutineScope = CoroutineScope(EmptyCoroutineContext),
+			listState = LazyListState(),
+			collapsedNodes = mutableStateMapOf<Int, Boolean>()
+		)
+	}
+
+	private fun sceneSummary(includeGroupA: Boolean = true): SceneSummary {
+		val tree = Tree<SceneItem>()
+		val root = TreeNode(sceneItem(SceneItem.Type.Root, SceneItem.ROOT_ID, "Root"))
+		tree.setRoot(root)
+
+		if (includeGroupA) {
+			val groupA = TreeNode(sceneItem(SceneItem.Type.Group, GROUP_A_ID, "Group A"))
+			groupA.addChild(TreeNode(sceneItem(SceneItem.Type.Scene, SCENE_A_ID, "Scene A")))
+
+			val groupB = TreeNode(sceneItem(SceneItem.Type.Group, GROUP_B_ID, "Group B"))
+			groupB.addChild(TreeNode(sceneItem(SceneItem.Type.Scene, SCENE_B_ID, "Scene B")))
+			groupA.addChild(groupB)
+
+			root.addChild(groupA)
+		}
+
+		root.addChild(TreeNode(sceneItem(SceneItem.Type.Scene, SCENE_C_ID, "Scene C")))
+
+		return SceneSummary(tree.toImmutableTree(), emptySet())
+	}
+
+	private fun sceneItem(type: SceneItem.Type, id: Int, name: String): SceneItem {
+		return SceneItem(
+			projectDef = PROJECT_DEF,
+			type = type,
+			id = id,
+			name = name,
+			order = id,
+		)
+	}
+
+	private companion object {
+		const val GROUP_A_ID = 1
+		const val SCENE_A_ID = 2
+		const val GROUP_B_ID = 3
+		const val SCENE_B_ID = 4
+		const val SCENE_C_ID = 5
+
+		val PROJECT_DEF = ProjectDef(
+			"Test Project",
+			HPath("/projects/Test Project", "Test Project", true)
+		)
+	}
+}


### PR DESCRIPTION
## Summary

Tapping a chapter group's collapse arrow on the Story Outline now collapses that group, and the kebab menu's Collapse All works again. Both were no-ops before.

## Why this matters

Collapse state lives in `SceneTreeState.collapsedNodes` (a `SnapshotStateMap`), mutated by `toggleExpanded`/`collapseAll`/`expandAll` and consumed by `shouldCollapseNode` in `SceneTree` (#498, acknowledged by @Wavesonics on 2026-05-18 with no fix in flight). The toggle and Collapse All were no-ops because the collapsed-map reads inside the lazy list did not observe the snapshot map, so writes never drove recomposition. The fix makes the render path observe `collapsedNodes` so state writes recompose the tree and gate child visibility, leaving `toggleExpanded`/`collapseAll`/`expandAll` semantics intact. The `SceneListUi` wiring (kebab to `collapseAll`/`expandAll`, arrow tap to `toggleExpand`) already called these correctly, so the change stays in the state and render layers.

## Testing

- Collapse arrow on a chapter group hides its children; expand restores them.
- Collapse All from the kebab collapses every group; Expand All restores.

Closes #498
