### PR TITLE
Fix mobile hamburger menu not showing drawer

### DIFF
--- a/server/src/main/resources/assets/css/base.css
+++ b/server/src/main/resources/assets/css/base.css
@@ -141,7 +141,6 @@ a:focus-visible {
 	backdrop-filter: blur(8px);
 	background: rgba(255, 255, 255, 0.95);
 	box-shadow: var(--shadow-sm);
-	overflow: hidden;
 }
 
 .header-container {


### PR DESCRIPTION
The site header has backdrop-filter (which makes it a containing block
for fixed-position descendants) combined with overflow: hidden. This
caused the mobile nav drawer (.header-nav, position: fixed; height: 100vh)
to be positioned relative to the short header and clipped to its height,
so tapping the hamburger only dimmed the page without revealing a usable
menu.

Remove overflow: hidden from .site-header. It was only needed to contain
the dev banner, which already clips itself via its own overflow: hidden.

https://claude.ai/code/session_01P2Zoqpb2NV4xTTKWSj472f