### PR TITLE
Halve PDF export time by avoiding TOC dry-run pass

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfStoryRenderer.kt
@@ -12,10 +12,16 @@ import okio.BufferedSink
 
 private const val TOC_TITLE = "Contents"
 
+private fun chapterAnchorId(index: Int): String = "chapter-$index"
+
 /**
  * Renders the story as a PDF mirroring the EPUB layout: a title page, a clickable table of contents,
  * then one auto-paginating section per chapter. Chapter bodies are rendered from markdown so headings,
  * emphasis, and lists are laid out as formatted text rather than literal syntax.
+ *
+ * The contents page is hand-built from anchor/linkToAnchor rather than the library's `tableOfContents`,
+ * which prints page numbers and so forces a full dry-run layout of the whole book to resolve them —
+ * doubling export time. Matching EPUB, entries carry no page numbers, so a single layout pass suffices.
  */
 fun writeStoryAsPdf(
 	sink: BufferedSink,
@@ -43,17 +49,25 @@ fun writeStoryAsPdf(
 			authorName?.let { text("by $it") { fontSize = 16.sp } }
 		}
 
-		// Contents page — tableOfContents expands the chapter bookmarks below into clickable rows.
+		// Contents page — each row links to the matching chapter's anchor below.
 		page {
 			text(TOC_TITLE) { fontSize = 26.sp; bold = true }
-			tableOfContents(maxLevel = 0)
+			column(spacing = 6.dp) {
+				effective.forEachIndexed { index, chapter ->
+					linkToAnchor(chapterAnchorId(index)) {
+						text("${index + 1}. ${chapter.name}")
+					}
+				}
+			}
 		}
 
 		// One section per chapter. The title is a literal text heading (not markdown) so metacharacters
 		// in a chapter name render verbatim; Slice keeps it on the same page as the body that follows.
+		// bookmark drives the reader's outline panel; anchor is the jump target for the contents page.
 		effective.forEachIndexed { index, chapter ->
 			page {
 				bookmark(chapter.name)
+				anchor(chapterAnchorId(index))
 				text("${index + 1}. ${chapter.name}") { fontSize = 22.sp; bold = true }
 				if (chapter.markdown.isNotBlank()) {
 					markdown(chapter.markdown.stripBackslashEscapes(), theme = MarkdownTheme())

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfStoryRenderer.kt
@@ -18,10 +18,6 @@ private fun chapterAnchorId(index: Int): String = "chapter-$index"
  * Renders the story as a PDF mirroring the EPUB layout: a title page, a clickable table of contents,
  * then one auto-paginating section per chapter. Chapter bodies are rendered from markdown so headings,
  * emphasis, and lists are laid out as formatted text rather than literal syntax.
- *
- * The contents page is hand-built from anchor/linkToAnchor rather than the library's `tableOfContents`,
- * which prints page numbers and so forces a full dry-run layout of the whole book to resolve them —
- * doubling export time. Matching EPUB, entries carry no page numbers, so a single layout pass suffices.
  */
 fun writeStoryAsPdf(
 	sink: BufferedSink,


### PR DESCRIPTION
## Problem

PDF export takes multiple seconds even for small projects, while Markdown and EPUB are near-instant. Markdown/EPUB emit markup and let the reader typeset; PDF must lay out the text itself — but the bulk of the time was an avoidable second pass.

The contents page used the library's `tableOfContents()`, which prints page numbers. Resolving those numbers requires a full dry-run layout of the entire book (`DocumentRenderer` runs a `CountingPdfDriver` pass with real font metrics) before the real render. Net effect: the whole manuscript is typeset twice.

## Fix

Build the contents page by hand with `anchor()` / `linkToAnchor()` — a clickable list of chapter titles with no page numbers (matching the EPUB contents page, which has none either). With no `TocNode` in the document and no headers/footers, the dry-run pass is skipped and the book lays out once.

- Clickable contents entries and the PDF outline (`bookmark()`) are preserved.
- Only change in output: no "…… 42" page numbers next to entries.

Roughly halves export time.

## Testing

Existing `ExportStoryUseCaseTest` PDF cases pass.
