### PR TITLE
Fix phantom sync conflicts: lock the baseline + migration backfill + e2e sync tests

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftRepository.kt
@@ -4,7 +4,6 @@ import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import io.github.aakira.napier.Napier
 import kotlin.time.Clock
@@ -18,7 +17,6 @@ class SceneDraftRepository(
 	override val projectScope = ProjectDefScope(projectDef)
 
 	private val idAllocator: IdAllocator by projectInject()
-	private val syncJournal: SyncJournal by projectInject()
 
 	suspend fun getAllDrafts(): Set<DraftDef> = datasource.getAllDrafts()
 	fun getSceneIdsThatHaveDrafts(): List<Int> = datasource.getSceneIdsThatHaveDrafts()
@@ -55,16 +53,5 @@ class SceneDraftRepository(
 		datasource.storeDraft(newDef, content)
 
 		return newDef
-	}
-
-	/**
-	 * Drafts are never edited after creation. Creation marks them to be synced implicitly, then
-	 * after the fact, we should never need to mark them for sync again, so this is unused.
-	 * But I'm leaving it here just in case we need it at some point.
-	 */
-	protected suspend fun markForSynchronization(originalDef: DraftDef) {
-		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(originalDef.id)) {
-			syncJournal.markEntityAsDirty(originalDef.id)
-		}
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftRepository.kt
@@ -1,7 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data.drafts
 
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
-import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
@@ -63,19 +62,9 @@ class SceneDraftRepository(
 	 * after the fact, we should never need to mark them for sync again, so this is unused.
 	 * But I'm leaving it here just in case we need it at some point.
 	 */
-	protected suspend fun markForSynchronization(originalDef: DraftDef, originalContent: String) {
-		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(
-				originalDef.id
-			)
-		) {
-			val hash = EntityHasher.hashSceneDraft(
-				id = originalDef.id,
-				sceneId = originalDef.sceneId,
-				created = originalDef.draftTimestamp,
-				name = originalDef.draftName,
-				content = originalContent,
-			)
-			syncJournal.markEntityAsDirty(originalDef.id, hash)
+	protected suspend fun markForSynchronization(originalDef: DraftDef) {
+		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(originalDef.id)) {
+			syncJournal.markEntityAsDirty(originalDef.id)
 		}
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
@@ -1,7 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data.encyclopediarepository
 
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
-import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource.Companion.ENTRY_NAME_PATTERN
@@ -15,7 +14,6 @@ import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
-import korlibs.crypto.encoding.Base64
 import korlibs.io.async.launch
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
@@ -142,33 +140,8 @@ class EncyclopediaRepository(
 	}
 
 	private suspend fun markForSynchronization(entryDef: EntryDef) {
-		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(
-				entryDef.id
-			)
-		) {
-			val DEFAULT_EXTENSION = "jpg"
-			val entry = datasource.loadEntry(entryDef).entry
-			val image = if (datasource.hasEntryImage(entryDef, DEFAULT_EXTENSION)) {
-				val imageBytes = datasource.loadEntryImage(entryDef, DEFAULT_EXTENSION)
-				val imageBase64 = Base64.encode(imageBytes, url = true)
-
-				ApiProjectEntity.EncyclopediaEntryEntity.Image(
-					base64 = imageBase64,
-					fileExtension = DEFAULT_EXTENSION,
-				)
-			} else {
-				null
-			}
-			val hash = EntityHasher.hashEncyclopediaEntry(
-				id = entryDef.id,
-				name = entryDef.name,
-				entryType = entryDef.type.text,
-				text = entry.text,
-				tags = entry.tags,
-				image = image,
-				aliases = entry.aliases,
-			)
-			syncJournal.markEntityAsDirty(entryDef.id, hash)
+		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(entryDef.id)) {
+			syncJournal.markEntityAsDirty(entryDef.id)
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesRepository.kt
@@ -1,6 +1,5 @@
 package com.darkrockstudios.apps.hammer.common.data.notesrepository
 
-import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
@@ -79,20 +78,9 @@ class NotesRepository(
 		_notesListFlow.emit(notes)
 	}
 
-	private suspend fun markForSync(id: Int, originalHash: String? = null) {
+	private suspend fun markForSync(id: Int) {
 		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(id)) {
-			val hash = if (originalHash != null) {
-				originalHash
-			} else {
-				val noteContainer = _notes.first { it.note.id == id }
-				EntityHasher.hashNote(
-					id = noteContainer.note.id,
-					created = noteContainer.note.created,
-					content = noteContainer.note.content,
-					tags = noteContainer.note.tags,
-				)
-			}
-			syncJournal.markEntityAsDirty(id, hash)
+			syncJournal.markEntityAsDirty(id)
 		}
 	}
 
@@ -116,10 +104,7 @@ class NotesRepository(
 
 			notesDatasource.storeNote(newNote)
 
-			markForSync(
-				id = newId,
-				originalHash = ""
-			)
+			markForSync(id = newId)
 
 			_noteContentChangedFlow.emit(Unit)
 			CResult.success(newNote.note)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
@@ -1,13 +1,11 @@
 package com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository
 
-import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.toApiType
 import com.darkrockstudios.apps.hammer.common.data.tree.ImmutableTree
 import com.darkrockstudios.apps.hammer.common.data.tree.Tree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
@@ -65,35 +63,7 @@ class SceneRepository(
 
 	private suspend fun markForSynchronization(scene: SceneItem) {
 		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(scene.id)) {
-			val metadata = sceneMetadataDatasource.loadMetadata(scene.id)
-			val pathSegments = getPathSegments(scene)
-
-			// For archived scenes, resolve path from filesystem since they're not in tree
-			val content = if (scene.archived) {
-				val scenePath = resolveScenePathFromFilesystemIncludingArchived(scene.id)
-					?: error("Archived scene file not found for ID ${scene.id}")
-				loadSceneMarkdownRaw(scene, scenePath)
-			} else {
-				loadSceneMarkdownRaw(scene)
-			}
-
-			val hash = EntityHasher.hashScene(
-				id = scene.id,
-				order = scene.order,
-				path = pathSegments,
-				name = scene.name,
-				type = scene.type.toApiType(),
-				content = content,
-				outline = metadata?.outline ?: "",
-				notes = metadata?.notes ?: "",
-				archived = scene.archived,
-				confirmedReferences = metadata?.confirmedReferences ?: emptySet(),
-				dismissedReferences = metadata?.dismissedReferences ?: emptySet(),
-				tags = metadata?.tags ?: emptySet(),
-				created = metadata?.created,
-				lastEdited = metadata?.lastEdited,
-			)
-			syncJournal.markEntityAsDirty(scene.id, hash)
+			syncJournal.markEntityAsDirty(scene.id)
 		}
 	}
 
@@ -394,30 +364,6 @@ class SceneRepository(
 		}
 	}
 
-	private suspend fun markForSynchronization(scene: SceneItem, content: String) {
-		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(scene.id)) {
-			val metadata = sceneMetadataDatasource.loadMetadata(scene.id)
-			val pathSegments = getPathSegments(scene)
-			val hash = EntityHasher.hashScene(
-				id = scene.id,
-				order = scene.order,
-				path = pathSegments,
-				name = scene.name,
-				type = scene.type.toApiType(),
-				content = content,
-				outline = metadata?.outline ?: "",
-				notes = metadata?.notes ?: "",
-				archived = scene.archived,
-				confirmedReferences = metadata?.confirmedReferences ?: emptySet(),
-				dismissedReferences = metadata?.dismissedReferences ?: emptySet(),
-				tags = metadata?.tags ?: emptySet(),
-				created = metadata?.created,
-				lastEdited = metadata?.lastEdited,
-			)
-			syncJournal.markEntityAsDirty(scene.id, hash)
-		}
-	}
-
 	suspend fun moveScene(moveRequest: MoveRequest) {
 		val fromNode = sceneTree.find { it.id == moveRequest.id }
 		val fromParentNode = fromNode.parent
@@ -553,11 +499,7 @@ class SceneRepository(
 			if (existingPath != newPath) {
 				try {
 					originalChildren?.find { it.id == childNode.value.id }?.let { originalChild ->
-						val realPath = sceneDatasource.getPathFromFilesystem(childNode.value)
-							?: error("Could not find Scene on filesystem: ${childNode.value.id}")
-
-						val content = loadSceneMarkdownRaw(childNode.value, realPath)
-						markForSynchronization(originalChild, content)
+						markForSynchronization(originalChild)
 					}
 					sceneDatasource.moveScene(sourcePath = existingPath, targetPath = newPath)
 				} catch (e: IOException) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/EntitySynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/EntitySynchronizer.kt
@@ -30,7 +30,11 @@ abstract class EntitySynchronizer<T : ApiProjectEntity>(
 		originalHash: String?,
 		onConflict: EntityConflictHandler<T>,
 		onLog: OnSyncLog,
-		force: Boolean = false
+		force: Boolean = false,
+		// Invoked with the hash the server now holds when an upload is accepted, so the caller can
+		// lock it in as the conflict baseline. The hash of the exact entity we sent, captured here
+		// rather than re-derived later (local state may have already drifted).
+		onSynced: suspend (id: Int, hash: String) -> Unit = { _, _ -> },
 	): Boolean {
 		Napier.d("Uploading Scene $id")
 
@@ -47,6 +51,7 @@ abstract class EntitySynchronizer<T : ApiProjectEntity>(
 		)
 		return if (result.isSuccess) {
 			onLog(syncLogI("Uploaded Scene $id", projectDef))
+			onSynced(id, entity.hash())
 			true
 		} else {
 			val exception = result.exceptionOrNull()
@@ -68,6 +73,7 @@ abstract class EntitySynchronizer<T : ApiProjectEntity>(
 				if (resolveResult.isSuccess) {
 					onLog(syncLogI("Resolved conflict for scene $id", projectDef))
 					storeEntity(resolvedEntity, syncId, onLog)
+					onSynced(id, resolvedEntity.hash())
 					true
 				} else {
 					onLog(syncLogE("Scene conflict resolution failed for $id", projectDef))

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ProjectSynchronizationData.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ProjectSynchronizationData.kt
@@ -26,10 +26,17 @@ data class ProjectSynchronizationData(
 	val lastSync: Instant,
 	val dirty: List<EntityOriginalState>,
 	val deletedIds: Set<Int>,
+	// The hash the server last confirmed it holds, per entity: the locked conflict baseline. Set
+	// only on a successful transfer (to the hash of exactly what was sent), never re-derived from
+	// local state — so a field that mutates after a sync (e.g. `lastEdited`) can't taint it.
+	val syncedHashes: Map<Int, String> = emptyMap(),
 )
 
 @Serializable
 data class EntityOriginalState(
 	val id: Int,
-	val originalHash: String
+	// Null when the server has never confirmed a hash for this entity (brand-new, or first edit
+	// after upgrading to synced-hash tracking). A null baseline tells the server to skip the
+	// conflict check and accept the upload (the entity self-heals its baseline on that sync).
+	val originalHash: String? = null,
 )

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
@@ -28,12 +28,35 @@ class SyncJournal(
 		return syncData.dirty.any { it.id == id }
 	}
 
-	suspend fun markEntityAsDirty(id: Int, oldHash: String) {
+	/**
+	 * Flags an entity as changed since the last sync. The conflict baseline is the hash the server
+	 * last confirmed ([ProjectSynchronizationData.syncedHashes]), not a hash re-derived from the
+	 * current (already-edited) local state — re-deriving it would let `lastEdited` taint the baseline.
+	 */
+	suspend fun markEntityAsDirty(id: Int) {
+		if (globalSettingsStore.isServerSynchronized().not()) return
+
+		val syncData = datasource.loadSyncData()
+		if (syncData.dirty.any { it.id == id }) return
+
+		val baseline = syncData.syncedHashes[id]
+		val newSyncData = syncData.copy(
+			dirty = syncData.dirty + EntityOriginalState(id, baseline)
+		)
+		datasource.saveSyncData(newSyncData)
+	}
+
+	/**
+	 * Records the hash the server now holds for an entity, captured at the moment of a successful
+	 * transfer (the exact bytes uploaded or downloaded). This is the only place the conflict
+	 * baseline is ever set.
+	 */
+	suspend fun recordSyncedHash(id: Int, hash: String) {
 		if (globalSettingsStore.isServerSynchronized().not()) return
 
 		val syncData = datasource.loadSyncData()
 		val newSyncData = syncData.copy(
-			dirty = syncData.dirty + EntityOriginalState(id, oldHash)
+			syncedHashes = syncData.syncedHashes + (id to hash)
 		)
 		datasource.saveSyncData(newSyncData)
 	}
@@ -50,12 +73,13 @@ class SyncJournal(
 		if (globalSettingsStore.isServerSynchronized().not()) return
 
 		val syncData = datasource.loadSyncData()
-		val newSyncData = if (syncData.newIds.contains(deletedId)) {
+		val withoutSyncedHash = syncData.copy(syncedHashes = syncData.syncedHashes - deletedId)
+		val newSyncData = if (withoutSyncedHash.newIds.contains(deletedId)) {
 			// Brand-new entity the server never saw: drop the claim so it can't
 			// become a phantom newId. Nothing to tell the server to delete.
-			syncData.copy(newIds = syncData.newIds - deletedId)
+			withoutSyncedHash.copy(newIds = withoutSyncedHash.newIds - deletedId)
 		} else {
-			syncData.copy(deletedIds = syncData.deletedIds + deletedId)
+			withoutSyncedHash.copy(deletedIds = withoutSyncedHash.deletedIds + deletedId)
 		}
 		datasource.saveSyncData(newSyncData)
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
@@ -25,7 +25,8 @@ class EntityTransferOperation(
 	private val strRes: StrRes,
 	private val entitySynchronizers: EntitySynchronizers,
 	private val projectMetadataDatasource: ProjectMetadataDatasource,
-	private val serverProjectApi: ServerProjectApi
+	private val serverProjectApi: ServerProjectApi,
+	private val syncJournal: SyncJournal,
 ) : SyncOperation(projectDef) {
 	override suspend fun execute(
 		state: SyncOperationState,
@@ -147,7 +148,11 @@ class EntityTransferOperation(
 			allSuccess =
 				if (clientHasEntity && (isNewlyCreated || (localIsDirty != null || thisId > state.serverSyncData.lastId))) {
 					Napier.d("Upload ID $thisId (clientHasEntity: $clientHasEntity isNewlyCreated: $isNewlyCreated localIsDirty: $localIsDirty thisId: $thisId Server Last ID: ${state.serverSyncData.lastId})")
-					val originalHash = localIsDirty?.originalHash
+					// Source the conflict baseline from the server-confirmed hash, not the dirty
+					// entry's frozen copy: a partial sync (this entity uploaded, a later one failed,
+					// so finalize never ran to clear the dirty list) advances syncedHashes but leaves
+					// the dirty entry stale. On retry the stale baseline would forge a phantom conflict.
+					val originalHash = state.resolvedClientSyncData.syncedHashes[thisId]
 					val success =
 						uploadEntity(
 							thisId,
@@ -223,7 +228,8 @@ class EntityTransferOperation(
 		)
 
 		return if (entityResponse.isSuccess) {
-			val success = when (val serverEntity = entityResponse.getOrThrow().entity) {
+			val serverEntity = entityResponse.getOrThrow().entity
+			val success = when (serverEntity) {
 				is ApiProjectEntity.SceneEntity ->
 					entitySynchronizers.sceneSynchronizer.storeEntity(
 						serverEntity,
@@ -261,6 +267,9 @@ class EntityTransferOperation(
 			}
 
 			if (success) {
+				// Lock the downloaded entity's hash in as the conflict baseline: it's exactly
+				// what the server holds, so a later local edit won't forge a phantom conflict.
+				syncJournal.recordSyncedHash(serverEntity.id, serverEntity.hash())
 				onLog(
 					syncLogI(
 						strRes.get(Res.string.sync_log_entity_download_success, id),
@@ -359,7 +368,10 @@ class EntityTransferOperation(
 	): Boolean {
 		val type: EntityType? = entitySynchronizers.findEntityType(id)
 		return if (type != null) {
-			entitySynchronizers[type].uploadEntity(id, syncId, originalHash, onConflict, onLog, force)
+			entitySynchronizers[type].uploadEntity(
+				id, syncId, originalHash, onConflict, onLog, force,
+				onSynced = { syncedId, hash -> syncJournal.recordSyncedHash(syncedId, hash) },
+			)
 		} else {
 			onLog(
 				syncLogW(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchLocalDataOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchLocalDataOperation.kt
@@ -36,11 +36,22 @@ class FetchLocalDataOperation(
 				return CResult.failure(MissingProjectIdException(projectDef.name))
 			}
 
-			val clientSyncData = syncJournal.loadSyncData()
+			val loadedSyncData = syncJournal.loadSyncData()
 			val entityState = if (state.onlyNew) {
 				null
 			} else {
-				getEntityState(clientSyncData)
+				getEntityState(loadedSyncData)
+			}
+
+			// Give every entity a conflict baseline before an upload reads one: a missing baseline
+			// uploads as null, which the server lets overwrite a concurrent edit unchecked. An
+			// empty syncedHashes map (an upgraded client) leaves entities exposed until backfilled.
+			val clientSyncData = if (entityState != null) {
+				val backfilled = backfillSyncedHashes(loadedSyncData, entityState)
+				if (backfilled !== loadedSyncData) syncJournal.saveSyncData(backfilled)
+				backfilled
+			} else {
+				loadedSyncData
 			}
 
 			val fetchLocalDataState = FetchLocalDataState.fromSyncOperationState(
@@ -68,6 +79,31 @@ class FetchLocalDataOperation(
 		}.toSet()
 
 		return ClientEntityState(entities)
+	}
+
+	private fun backfillSyncedHashes(
+		syncData: ProjectSynchronizationData,
+		entityState: ClientEntityState,
+	): ProjectSynchronizationData {
+		val dirtyById = syncData.dirty.associateBy { it.id }
+		val additions = HashMap<Int, String>()
+		for (entity in entityState.entities) {
+			if (syncData.syncedHashes.containsKey(entity.id)) continue
+			val baseline = if (entity.id in dirtyById) {
+				// A dirty entity's local hash is the edited content; its baseline is the frozen
+				// pre-edit hash from the dirty entry (null when unrecoverable).
+				dirtyById.getValue(entity.id).originalHash
+			} else {
+				// An in-sync entity's local hash equals the server's, so it is a valid baseline.
+				entity.hash
+			}
+			if (baseline != null) additions[entity.id] = baseline
+		}
+		return if (additions.isEmpty()) {
+			syncData
+		} else {
+			syncData.copy(syncedHashes = syncData.syncedHashes + additions)
+		}
 	}
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
@@ -77,13 +77,21 @@ class FinalizeSyncOperation(
 				state.collatedIds.dirtyEntities.clear()
 
 				if (newLastId != null && syncFinishedAt != null) {
+					// syncedHashes are written to disk per-entity during transfer; reload them here
+					// so this final write (built from the sync-start snapshot) doesn't clobber them.
+					// dirty/newIds come from the in-memory state, which holds the id-conflict
+					// remapping. Prune deleted ids (incl. server-driven deletions that bypass
+					// recordIdDeletion) so stale baselines can't mis-fire if an id is reused.
+					val persistedSyncedHashes = syncDataDatasource.loadSyncData().syncedHashes -
+						state.collatedIds.combinedDeletions
 					val finalSyncData = state.clientSyncData.copy(
 						currentSyncId = null,
 						lastId = newLastId,
 						lastSync = syncFinishedAt,
 						dirty = state.collatedIds.dirtyEntities,
 						newIds = emptyList(),
-						deletedIds = state.collatedIds.combinedDeletions
+						deletedIds = state.collatedIds.combinedDeletions,
+						syncedHashes = persistedSyncedHashes,
 					)
 					syncDataDatasource.saveSyncData(finalSyncData)
 				} else {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineRepository.kt
@@ -1,6 +1,5 @@
 package com.darkrockstudios.apps.hammer.common.data.timelinerepository
 
-import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
@@ -89,7 +88,7 @@ class TimeLineRepository(
 
 		if (id != null) {
 			val index = newTimeline.events.indexOf(event)
-			markForSynchronization(event, index)
+			markForSynchronization(event)
 		}
 
 		return event
@@ -125,7 +124,7 @@ class TimeLineRepository(
 		storeAndEmitTimeline(updatedTimeline)
 
 		if (markForSync) {
-			markForSynchronization(oldEvent ?: cleaned, originalIndex)
+			markForSynchronization(oldEvent ?: cleaned)
 		}
 
 		return true
@@ -233,7 +232,7 @@ class TimeLineRepository(
 
 						// Mark for synchronization
 						val originalEvent = originalTimeline.events.first { it.id == curEvent.id }
-						markForSynchronization(originalEvent, originalEvent.order)
+						markForSynchronization(originalEvent)
 					}
 				}
 
@@ -248,19 +247,9 @@ class TimeLineRepository(
 		}
 	}
 
-	private suspend fun markForSynchronization(originalEvent: TimeLineEvent, originalOrder: Int) {
-		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(
-				originalEvent.id
-			)
-		) {
-			val hash = EntityHasher.hashTimelineEvent(
-				id = originalEvent.id,
-				order = originalOrder,
-				content = originalEvent.content,
-				date = originalEvent.date,
-				tags = originalEvent.tags,
-			)
-			syncJournal.markEntityAsDirty(originalEvent.id, hash)
+	private suspend fun markForSynchronization(originalEvent: TimeLineEvent) {
+		if (syncJournal.isServerSynchronized() && !syncJournal.isEntityDirty(originalEvent.id)) {
+			syncJournal.markEntityAsDirty(originalEvent.id)
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineRepository.kt
@@ -163,7 +163,8 @@ class TimeLineRepository(
 	}
 
 	suspend fun storeTimeline() {
-		datasource.storeTimeline(timelineFlow.replayCache.first(), projectDef)
+		// Nothing to persist if the timeline was never loaded this session.
+		timelineFlow.replayCache.firstOrNull()?.let { datasource.storeTimeline(it, projectDef) }
 	}
 
 	suspend fun getTimelineEvent(id: Int): TimeLineEvent? {

--- a/common/src/desktopTest/kotlin/integration/BaseIntegrationTest.kt
+++ b/common/src/desktopTest/kotlin/integration/BaseIntegrationTest.kt
@@ -167,7 +167,7 @@ abstract class BaseIntegrationTest : BaseTest() {
 	protected fun enableServerSync() {
 		every { syncJournal.isServerSynchronized() } returns true
 		coEvery { syncJournal.isEntityDirty(any()) } returns false
-		coEvery { syncJournal.markEntityAsDirty(any(), any()) } returns Unit
+		coEvery { syncJournal.markEntityAsDirty(any()) } returns Unit
 	}
 
 	/**

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneContentRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneContentRepositoryTest.kt
@@ -79,7 +79,7 @@ class SceneContentRepositoryTest : BaseTest() {
 		)
 		coEvery { syncJournal.isServerSynchronized() } returns false
 		coEvery { syncJournal.isEntityDirty(any()) } returns false
-		coEvery { syncJournal.markEntityAsDirty(any(), any()) } just Runs
+		coEvery { syncJournal.markEntityAsDirty(any()) } just Runs
 	}
 
 	private fun createStack(projectDef: ProjectDef) {

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLastEditedSceneTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorRepositoryLastEditedSceneTest.kt
@@ -67,7 +67,7 @@ class SceneEditorRepositoryLastEditedSceneTest : BaseTest() {
 
 		coEvery { syncJournal.isServerSynchronized() } returns false
 		coEvery { syncJournal.isEntityDirty(any()) } returns false
-		coEvery { syncJournal.markEntityAsDirty(any(), any()) } just Runs
+		coEvery { syncJournal.markEntityAsDirty(any()) } just Runs
 	}
 
 	private fun createRepository(projectDef: ProjectDef): SceneRepository {

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
@@ -96,7 +96,7 @@ class SceneEditorServiceTest : BaseTest() {
 
 		coEvery { syncJournal.isServerSynchronized() } returns false
 		coEvery { syncJournal.isEntityDirty(any()) } returns false
-		coEvery { syncJournal.markEntityAsDirty(any(), any()) } just Runs
+		coEvery { syncJournal.markEntityAsDirty(any()) } just Runs
 		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
 	}
 
@@ -536,44 +536,24 @@ class SceneEditorServiceTest : BaseTest() {
 			)
 		}
 
-	// Risk Register #4: markForSynchronization must hash the exact persisted identity. Pin the
-	// EntityHasher inputs so a future carve can't silently change what gets hashed.
+	// Risk Register #4: a mutation must flag the scene for sync. The conflict baseline is the
+	// server-confirmed hash recorded at sync time (SyncJournal.syncedHashes), NOT a hash
+	// re-derived from the already-mutated local state — re-deriving here is what let `lastEdited`
+	// taint the baseline and forge a phantom conflict on every edit.
 	@Test
-	fun `Marking for synchronization hashes the exact persisted scene identity`() =
+	fun `Marking for synchronization flags the scene dirty`() =
 		runTest(mainTestDispatcher) {
 			coEvery { syncJournal.isServerSynchronized() } returns true
 			coEvery { syncJournal.isEntityDirty(1) } returns false
+			coEvery { syncJournal.markEntityAsDirty(1) } just Runs
 
 			val service = initializedService()
 			val scene = service.getSceneItemFromId(1)!!
-			val metadata = sceneMetadataDatasource.loadMetadata(1)
-
-			// Recompute the expected hash from the pre-mutation persisted state.
-			val expectedHash = EntityHasher.hashScene(
-				id = scene.id,
-				order = scene.order,
-				path = service.getPathSegments(scene),
-				name = scene.name,
-				type = scene.type.toApiType(),
-				content = service.loadSceneMarkdownRaw(scene),
-				outline = metadata?.outline ?: "",
-				notes = metadata?.notes ?: "",
-				archived = scene.archived,
-				confirmedReferences = metadata?.confirmedReferences ?: emptySet(),
-				dismissedReferences = metadata?.dismissedReferences ?: emptySet(),
-				tags = metadata?.tags ?: emptySet(),
-				created = metadata?.created,
-				lastEdited = metadata?.lastEdited,
-			)
-
-			val hashSlot = slot<String>()
-			coEvery { syncJournal.markEntityAsDirty(1, capture(hashSlot)) } just Runs
 
 			// Any mutation marks the scene for sync before changing it.
 			service.renameScene(scene, "Renamed")
 
-			coVerify { syncJournal.markEntityAsDirty(1, any()) }
-			assertEquals(expectedHash, hashSlot.captured)
+			coVerify { syncJournal.markEntityAsDirty(1) }
 		}
 
 	// Risk Register #3: editor edits are debounced by BUFFER_COOL_DOWN then autosaved to a

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneMetadataRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneMetadataRepositoryTest.kt
@@ -80,7 +80,7 @@ class SceneMetadataRepositoryTest : BaseTest() {
 		)
 		coEvery { syncJournal.isServerSynchronized() } returns false
 		coEvery { syncJournal.isEntityDirty(any()) } returns false
-		coEvery { syncJournal.markEntityAsDirty(any(), any()) } just Runs
+		coEvery { syncJournal.markEntityAsDirty(any()) } just Runs
 
 		setupKoin()
 	}
@@ -168,7 +168,7 @@ class SceneMetadataRepositoryTest : BaseTest() {
 		service.storeMetadata(newMetadata, sceneId)
 
 		assertEquals(newMetadata, sceneMetadataRepository.loadSceneMetadata(sceneId))
-		coVerify { syncJournal.markEntityAsDirty(sceneId, any()) }
+		coVerify { syncJournal.markEntityAsDirty(sceneId) }
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/repositories/syncdata/SyncJournalTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/syncdata/SyncJournalTest.kt
@@ -287,17 +287,37 @@ class SyncJournalTest : BaseTest() {
 	}
 
 	@Test
-	fun `Mark Entity Dirty`() = runTest {
+	fun `Mark Entity Dirty uses the server-confirmed hash as the baseline`() = runTest {
 		createProject(ffs, PROJECT_2_NAME)
 		val projectDef = getProjectDef(PROJECT_2_NAME)
 		every { globalSettingsStore.isServerSynchronized() } returns true
 		val repo = createRepository(projectDef)
 
-		repo.markEntityAsDirty(1, "old-hash")
+		// The baseline is the hash the server last confirmed, not a value re-derived now.
+		repo.recordSyncedHash(1, "confirmed-hash")
+		repo.markEntityAsDirty(1)
 
 		val loadedData = ffs.readJson<ProjectSynchronizationData>(syncPath(projectDef), json)
 		assertEquals(
-			listOf(EntityOriginalState(1, "old-hash")),
+			listOf(EntityOriginalState(1, "confirmed-hash")),
+			loadedData?.dirty
+		)
+	}
+
+	@Test
+	fun `Mark Entity Dirty with no synced hash records a null baseline`() = runTest {
+		createProject(ffs, PROJECT_2_NAME)
+		val projectDef = getProjectDef(PROJECT_2_NAME)
+		every { globalSettingsStore.isServerSynchronized() } returns true
+		val repo = createRepository(projectDef)
+
+		// No prior sync for this entity: the server never confirmed a hash, so the baseline is
+		// null and the server will accept the upload without a conflict check.
+		repo.markEntityAsDirty(1)
+
+		val loadedData = ffs.readJson<ProjectSynchronizationData>(syncPath(projectDef), json)
+		assertEquals(
+			listOf(EntityOriginalState(1, null)),
 			loadedData?.dirty
 		)
 	}

--- a/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
@@ -36,6 +36,9 @@ class EntityTransferOperationTest : BaseTest() {
 	@MockK(relaxed = true)
 	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
 
+	@MockK(relaxed = true)
+	private lateinit var syncJournal: SyncJournal
+
 	private lateinit var strRes: TestStrRes
 
 	private lateinit var clock: TestClock
@@ -68,6 +71,7 @@ class EntityTransferOperationTest : BaseTest() {
 			strRes = strRes,
 			entitySynchronizers = EntitySynchronizers(projectDef),
 			projectMetadataDatasource = projectMetadataDatasource,
+			syncJournal = syncJournal,
 		)
 	}
 
@@ -101,7 +105,10 @@ class EntityTransferOperationTest : BaseTest() {
 				any()
 			)
 		} returns Result.success(
-			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity>())
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 4
+				every { hash() } returns "downloaded-hash-4"
+			})
 		)
 		coEvery {
 			serverProjectApi.downloadEntity(
@@ -112,7 +119,10 @@ class EntityTransferOperationTest : BaseTest() {
 				any()
 			)
 		} returns Result.success(
-			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity>())
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 11
+				every { hash() } returns "downloaded-hash-11"
+			})
 		)
 
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
@@ -152,11 +162,13 @@ class EntityTransferOperationTest : BaseTest() {
 		val data = result.data
 		assertIs<EntityTransferState>(data)
 
-		coVerify { mockSynchronizers.sceneSynchronizer.uploadEntity(1, any(), any(), any(), any()) }
-		coVerify { mockSynchronizers.sceneSynchronizer.uploadEntity(3, any(), any(), any(), any()) }
+		coVerify { mockSynchronizers.sceneSynchronizer.uploadEntity(1, any(), any(), any(), any(), any(), any()) }
+		coVerify { mockSynchronizers.sceneSynchronizer.uploadEntity(3, any(), any(), any(), any(), any(), any()) }
 		coVerify {
 			mockSynchronizers.sceneSynchronizer.uploadEntity(
 				12,
+				any(),
+				any(),
 				any(),
 				any(),
 				any(),

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FetchLocalDataOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FetchLocalDataOperationTest.kt
@@ -123,10 +123,71 @@ class FetchLocalDataOperationTest : BaseTest() {
 		val data = result.data
 		assertIs<FetchLocalDataState>(data)
 
-		assertEquals(projectData, data.clientSyncData)
+		// Backfill gives every entity a baseline: dirty entities (1, 3) recover the frozen hash from
+		// the dirty list, in-sync entities (2, 4, 5, 6, 7, 10) take their local hash. The new id
+		// (11) is absent from the entity state, so it stays unbackfilled.
+		val expectedSyncData = projectData.copy(
+			syncedHashes = mapOf(
+				1 to "old-hash-1",
+				3 to "old-hash-3",
+				2 to "hash-2",
+				4 to "hash-4",
+				5 to "hash-5",
+				6 to "hash-6",
+				7 to "hash-7",
+				10 to "hash-10",
+			)
+		)
+		assertEquals(expectedSyncData, data.clientSyncData)
 		assertEquals(
 			data.entityState,
 			ClientEntityState(produceEntityHashSet(1, 2, 3, 4, 5, 6, 7, 10))
+		)
+	}
+
+	@Test
+	fun `Backfill leaves already-recorded baselines untouched`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+
+		val existing = ProjectSynchronizationData(
+			lastId = 3,
+			newIds = emptyList(),
+			lastSync = Instant.fromEpochSeconds(123456),
+			dirty = produceEntityStateList(1),
+			deletedIds = emptySet(),
+			syncedHashes = mapOf(2 to "already-recorded-2"),
+		)
+
+		coEvery { projectMetadataDatasource.loadMetadata(any()) } returns metadata
+		coEvery { syncJournal.loadSyncData() } returns existing
+
+		mockSynchronizers.synchronizers.forEach { synchronizer ->
+			when (synchronizer) {
+				is ClientSceneSynchronizer ->
+					coEvery { synchronizer.hashEntities(any()) } returns produceEntityHashSet(1, 2, 3)
+
+				else -> coEvery { synchronizer.hashEntities(any()) } returns emptySet()
+			}
+		}
+
+		val result = op.execute(
+			state = InitialSyncOperationState(false),
+			onProgress = mockk(relaxed = true),
+			onLog = mockk(relaxed = true),
+			onConflict = mockk(relaxed = true),
+			onComplete = mockk(relaxed = true),
+		)
+
+		assertTrue(isSuccess(result))
+		val data = result.data
+		assertIs<FetchLocalDataState>(data)
+		assertEquals(
+			mapOf(
+				2 to "already-recorded-2", // untouched — never overwritten
+				1 to "old-hash-1",         // dirty: recovered from the frozen baseline
+				3 to "hash-3",             // in-sync: local hash
+			),
+			data.clientSyncData.syncedHashes,
 		)
 	}
 

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
@@ -39,6 +39,7 @@ import org.koin.test.KoinTest
 import org.koin.test.get
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
+import kotlin.test.assertFalse
 import kotlin.uuid.Uuid
 
 /**
@@ -65,6 +66,7 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 
 	private var mainExecutor: java.util.concurrent.ExecutorService? = null
 	private val loadedClientModules = mutableListOf<Module>()
+	private val openClients = mutableListOf<HeadlessClient>()
 
 	@BeforeEach
 	override fun setup() {
@@ -109,6 +111,10 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 
 	@AfterEach
 	fun tearDownClient() {
+		// Close tracked clients before the modules unload, so a test that throws before its own
+		// cleanup can't leak its project scope into the next test.
+		openClients.forEach { runCatching { it.close() } }
+		openClients.clear()
 		try {
 			GlobalContext.getOrNull()?.let {
 				it.get<HttpClient>().close()
@@ -216,9 +222,12 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 			// and rejects the pre-seeded auth token).
 			single<FileSystem> { sharedFileSystem }
 
+			// FakeFileSystem is not thread-safe, so bind IO and Default to the same single-threaded
+			// dispatcher as Main: this serializes all client-side filesystem work and keeps
+			// concurrent opens from corrupting its open-file list.
 			single<CoroutineContext>(named(DISPATCHER_MAIN)) { mainDispatcher }
-			single<CoroutineContext>(named(DISPATCHER_IO)) { Dispatchers.IO }
-			single<CoroutineContext>(named(DISPATCHER_DEFAULT)) { Dispatchers.Default }
+			single<CoroutineContext>(named(DISPATCHER_IO)) { mainDispatcher }
+			single<CoroutineContext>(named(DISPATCHER_DEFAULT)) { mainDispatcher }
 		}
 
 		val clientModules = listOf(mainModule, testOverrides)
@@ -238,4 +247,24 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 		bearerToken = authToken.auth,
 		refreshToken = authToken.refresh,
 	)
+
+	/** Creates a client and registers it for teardown-close so it can't leak the project scope. */
+	protected suspend fun newClient(projectName: String): HeadlessClient =
+		HeadlessClient.create(projectName, makeServerSettings()).also { openClients += it }
+
+	/** The hash the server currently stores for an entity, or null if it holds none. */
+	protected fun serverEntityHash(projectName: String, entityId: Int): String? {
+		val projectId = serverNumericProjectIdFor(projectName) ?: return null
+		return database().serverDatabase.storyEntityQueries
+			.getEntityHash(userId = userId, projectId = projectId, id = entityId.toLong())
+			.executeAsOneOrNull()
+	}
+
+	/** Runs a sync that must not hit the conflict resolver; returns the sync's success flag. */
+	protected suspend fun HeadlessClient.syncNoConflict(): Boolean {
+		var conflicted = false
+		val ok = sync(resolveConflict = { entity -> conflicted = true; entity })
+		assertFalse(conflicted, "single-client resync raised a phantom conflict")
+		return ok
+	}
 }

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/EditResyncNoConflictTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/EditResyncNoConflictTest.kt
@@ -1,0 +1,57 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.UpdateSource
+import com.darkrockstudios.apps.hammer.integration.HeadlessClient
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A single client, with no other device involved, edits a scene through the editor and syncs again.
+ * That must not raise a conflict.
+ *
+ * The edit goes through the real editor path (`onContentChanged` + the debounce autosave), which
+ * stamps `lastEdited`. Were the sync baseline re-derived from local state instead of locked to what
+ * the server confirmed, that stamp would taint the baseline and the resync would conflict.
+ */
+class EditResyncNoConflictTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 60)
+	fun `editing a scene through the editor and resyncing does not conflict`() = runBlocking {
+		val client = HeadlessClient.create("edit resync", makeServerSettings())
+
+		// Sync #1: establish the scene on the server.
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Scene")
+		requireNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "first version"))
+		assertTrue(client.sync(), "first sync should succeed")
+
+		// Edit through the editor and let the debounce autosave fire (this stamps lastEdited).
+		client.sceneEditorService.onContentChanged(
+			SceneContent(scene, "second version, edited in the editor"),
+			UpdateSource.Editor,
+		)
+		delay(1500)
+
+		// Sync #2: single client, nothing else touched this scene — must not conflict.
+		var conflicted = false
+		val ok = client.sync(resolveConflict = { entity ->
+			conflicted = true
+			entity
+		})
+		assertTrue(ok, "second sync should succeed")
+		assertFalse(
+			conflicted,
+			"A single client editing its own scene and resyncing raised a phantom conflict — " +
+				"the sync baseline disagrees with what the server confirmed.",
+		)
+
+		client.close()
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/EntityTypeResyncMatrixTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/EntityTypeResyncMatrixTest.kt
@@ -1,0 +1,129 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
+import com.darkrockstudios.apps.hammer.common.data.isSuccess
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
+import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The conflict-baseline logic lives in the shared sync layer, so it must hold for every entity type.
+ * Each test creates an entity, syncs, edits it, and resyncs: a single client must never raise a
+ * phantom conflict, and the server's stored hash must actually change across the edit (so a resync
+ * that uploaded nothing can't pass vacuously).
+ */
+class EntityTypeResyncMatrixTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 60)
+	fun `note edit and resync does not conflict`() = runBlocking {
+		val project = "note matrix"
+		val client = newClient(project)
+		val notes: NotesRepository = client.scope.get()
+
+		val created = notes.createNote("first body", tags = setOf("a"))
+		check(isSuccess(created)) { "createNote failed: $created" }
+		assertTrue(client.sync(), "first sync should succeed")
+		val before = serverEntityHash(project, created.data.id)
+		assertNotNull(before, "note should be on the server after the first sync")
+
+		notes.updateNote(created.data.copy(content = "edited body", tags = setOf("b")))
+		assertTrue(client.syncNoConflict(), "resync should succeed")
+		assertNotEquals(before, serverEntityHash(project, created.data.id), "edit must reach the server")
+	}
+
+	@Test
+	@Timeout(value = 60)
+	fun `timeline event edit and resync does not conflict`() = runBlocking {
+		val project = "timeline matrix"
+		val client = newClient(project)
+		val timeline: TimeLineRepository = client.scope.get()
+		timeline.initialize()
+
+		val event = timeline.createEvent(content = "battle", date = "1920", tags = setOf("a"))
+		assertTrue(client.sync(), "first sync should succeed")
+		val before = serverEntityHash(project, event.id)
+		assertNotNull(before, "event should be on the server after the first sync")
+
+		timeline.updateEvent(event.copy(content = "the great battle", date = "1921"))
+		assertTrue(client.syncNoConflict(), "resync should succeed")
+		assertNotEquals(before, serverEntityHash(project, event.id), "edit must reach the server")
+	}
+
+	@Test
+	@Timeout(value = 60)
+	fun `encyclopedia entry edit and resync does not conflict`() = runBlocking {
+		val project = "encyclopedia matrix"
+		val client = newClient(project)
+		val encyclopedia: EncyclopediaRepository = client.scope.get()
+		encyclopedia.ensureEntriesLoaded()
+
+		val created = encyclopedia.createEntry(
+			name = "Hero",
+			type = EntryType.PERSON,
+			text = "a brave hero",
+			tags = setOf("hero"),
+			imagePath = null,
+		)
+		val container = assertNotNull(created.instance, "entry should be created")
+		assertTrue(client.sync(), "first sync should succeed")
+		val before = serverEntityHash(project, container.entry.id)
+		assertNotNull(before, "entry should be on the server after the first sync")
+
+		val entryDef = encyclopedia.getEntryDef(container.entry.id)
+		encyclopedia.updateEntry(
+			oldEntryDef = entryDef,
+			name = "Hero",
+			text = "a very brave hero",
+			tags = setOf("hero", "legend"),
+		)
+		assertTrue(client.syncNoConflict(), "resync should succeed")
+		assertNotEquals(before, serverEntityHash(project, container.entry.id), "edit must reach the server")
+	}
+
+	@Test
+	@Timeout(value = 60)
+	fun `scene draft create and resync does not conflict`() = runBlocking {
+		// Drafts are immutable (create-only); confirm one syncs and a later resync doesn't
+		// re-flag it into a phantom conflict.
+		val project = "draft matrix"
+		val client = newClient(project)
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Scene")
+		requireNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "body"))
+		assertTrue(client.sync(), "scene sync should succeed")
+
+		val drafts: SceneDraftRepository = client.scope.get()
+		val draft = drafts.saveDraft(scene, "first pass")
+		assertNotNull(draft, "draft should be created")
+		assertTrue(client.sync(), "draft sync should succeed")
+		assertNotNull(serverEntityHash(project, draft.id), "draft should be on the server")
+		assertTrue(client.syncNoConflict(), "a later resync should not conflict")
+	}
+
+	@Test
+	@Timeout(value = 60)
+	fun `deleting a scene and resyncing removes it from the server without conflict`() = runBlocking {
+		val project = "delete matrix"
+		val client = newClient(project)
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Doomed")
+		requireNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "body"))
+		assertTrue(client.sync(), "first sync should succeed")
+		assertNotNull(serverEntityHash(project, scene.id), "scene should exist on the server before deletion")
+
+		assertTrue(client.sceneEditorService.deleteScene(scene), "local delete should succeed")
+		assertTrue(client.syncNoConflict(), "delete resync should succeed")
+		assertNull(serverEntityHash(project, scene.id), "server should have deleted the entity")
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/ResyncBaselineScenariosTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/ResyncBaselineScenariosTest.kt
@@ -1,0 +1,103 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.e2e.util.E2eTestData
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Single-client resync must never raise a conflict, whichever field changed or however the baseline
+ * was established: metadata-only edits, renames, and an edit after a download sets the baseline.
+ * Each asserts the server's stored hash actually changed, so a resync that uploaded nothing can't
+ * pass vacuously.
+ */
+class ResyncBaselineScenariosTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 60)
+	fun `editing only scene metadata and resyncing does not conflict`() = runBlocking {
+		val project = "metadata resync"
+		val client = newClient(project)
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Scene")
+		requireNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "body"))
+		assertTrue(client.sync(), "first sync should succeed")
+		val before = serverEntityHash(project, scene.id)
+		assertNotNull(before, "scene should be on the server after the first sync")
+
+		// Change metadata only (no content edit, so lastEdited is not bumped).
+		val metadata = client.sceneEditorService.loadSceneMetadata(scene.id)
+		client.sceneEditorService.storeMetadata(
+			metadata.copy(notes = "a note added later", outline = "an outline"),
+			scene.id,
+		)
+
+		assertTrue(client.syncNoConflict(), "second sync should succeed")
+		assertNotEquals(
+			before, serverEntityHash(project, scene.id),
+			"the metadata edit must have reached the server (else the resync proved nothing)",
+		)
+	}
+
+	@Test
+	@Timeout(value = 60)
+	fun `renaming a scene and resyncing does not conflict`() = runBlocking {
+		val project = "rename resync"
+		val client = newClient(project)
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Original Name")
+		requireNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "body"))
+		assertTrue(client.sync(), "first sync should succeed")
+		val before = serverEntityHash(project, scene.id)
+		assertNotNull(before, "scene should be on the server after the first sync")
+
+		client.sceneEditorService.renameScene(scene, "Renamed")
+
+		assertTrue(client.syncNoConflict(), "second sync should succeed")
+		assertNotEquals(
+			before, serverEntityHash(project, scene.id),
+			"the rename must have reached the server",
+		)
+	}
+
+	@Test
+	@Timeout(value = 60)
+	fun `editing after downloading a server change and resyncing does not conflict`() = runBlocking {
+		val project = "download then edit"
+		val client = newClient(project)
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Shared")
+		requireNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "v1"))
+		assertTrue(client.sync(), "first sync should succeed")
+
+		// Another device edits the same scene; the client has no local change, so the next sync
+		// downloads the server's version and the baseline is established from that download.
+		mutateServerEntity(
+			requireNotNull(serverNumericProjectIdFor(project)),
+			E2eTestData.createTestScene(id = scene.id).copy(content = "server version"),
+		)
+		assertTrue(client.sync(), "download sync should succeed")
+		assertEquals(
+			"server version",
+			client.sceneEditor.loadSceneMarkdownRaw(requireNotNull(client.sceneEditor.getSceneItemFromId(scene.id))),
+			"client should have the server's content after download",
+		)
+		val afterDownload = serverEntityHash(project, scene.id)
+
+		// Edit the downloaded scene and resync — must not conflict, and must land.
+		client.sceneEditor.storeSceneMarkdownRaw(
+			SceneContent(requireNotNull(client.sceneEditor.getSceneItemFromId(scene.id)), "local follow-up edit"),
+		)
+		assertTrue(client.syncNoConflict(), "resync after local edit should succeed")
+		assertNotEquals(
+			afterDownload, serverEntityHash(project, scene.id),
+			"the follow-up edit must have reached the server",
+		)
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/SceneTimestampsTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/SceneTimestampsTest.kt
@@ -28,11 +28,12 @@ class SceneTimestampsTest : RoundTripTestBase() {
 		val beforeEdit = kotlin.time.Clock.System.now()
 		val scene = client.sceneEditorService.createScene(parent = null, sceneName = "Timed Scene")
 		assertNotNull(scene)
-		client.sceneEditorService.onContentChanged(
-			SceneContent(scene, "first content"),
-			com.darkrockstudios.apps.hammer.common.data.UpdateSource.Editor,
+		// Persist synchronously: onContentChanged registers the editor buffer asynchronously, so an
+		// immediate storeSceneBuffer would find none and silently no-op.
+		assertTrue(
+			client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "first content")),
+			"raw store should persist the scene content to disk",
 		)
-		client.sceneEditorService.storeSceneBuffer(scene)
 
 		assertTrue(client.sync(), "Sync should succeed")
 		val afterSync = kotlin.time.Clock.System.now()
@@ -47,14 +48,14 @@ class SceneTimestampsTest : RoundTripTestBase() {
 		assertNotNull(numericProjectId)
 		val storedEntity = loadServerSceneEntity(numericProjectId, scene.id)
 
-		// SceneRepository's storeAllBuffers runs inside prepareForSync and
-		// bumps lastEdited via recordSceneActivity right before upload, and the
-		// debounced contentFlow can fire again post-sync. That means there's no
-		// race-free local snapshot we can pin against the server's value, and
-		// "client bumped to NOW just before upload" is observationally identical
-		// to "server stamped NOW on receipt" — we can't distinguish them here.
-		// What we can prove: timestamps are non-null and land inside the test's
-		// window, ruling out drops, epoch-0 resets, and clearly-wrong stamps.
+		assertEquals(
+			"first content", storedEntity.content,
+			"the uploaded scene content must reach the server",
+		)
+
+		// A client stamp of NOW is observationally identical to a server stamp of NOW on receipt,
+		// so assert the timestamps land inside the test window rather than pinning an exact value —
+		// ruling out drops, epoch-0 resets, and clearly-wrong stamps.
 		val serverCreated = storedEntity.created
 		val serverLastEdited = storedEntity.lastEdited
 		assertNotNull(serverCreated, "server stored a created timestamp")

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/SyncFuzzTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/SyncFuzzTest.kt
@@ -1,0 +1,82 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.UpdateSource
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.random.Random
+import kotlin.test.assertTrue
+
+/**
+ * Property test: a single client driving a random interleaving of editor content edits, metadata
+ * edits, renames, and syncs must NEVER raise a conflict — there is no other device, so any conflict
+ * is a phantom. Content edits go through the real editor autosave path (which stamps lastEdited),
+ * exercising orderings the hand-written scenarios don't cover (a rename between two content edits, a
+ * metadata change between an edit and a sync).
+ *
+ * Seeded for reproducibility: a failure prints the seed and iteration so the exact sequence can be
+ * replayed. Add seeds to [SEEDS] for more coverage.
+ */
+class SyncFuzzTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 180)
+	fun `random single-client edit and sync sequences never conflict`() = runBlocking {
+		for (seed in SEEDS) {
+			runSequence(seed)
+		}
+	}
+
+	private suspend fun runSequence(seed: Long) {
+		val rng = Random(seed)
+		val client = newClient("fuzz $seed")
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Fuzz Scene")
+		requireNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "seed content"))
+		assertTrue(client.sync(), "[seed $seed] initial sync should succeed")
+
+		var contentVersion = 0
+		repeat(ITERATIONS) { i ->
+			// Re-resolve by id each step: a rename changes the on-disk filename, so a cached
+			// SceneItem goes stale, but the id is stable.
+			val current = client.sceneEditor.getSceneItemFromId(scene.id)
+				?: error("[seed $seed] scene vanished at iteration $i")
+
+			when (rng.nextInt(5)) {
+				// Content edits are weighted 2/5 — they drive the lastEdited/autosave path.
+				0, 1 -> {
+					contentVersion++
+					client.sceneEditorService.onContentChanged(
+						SceneContent(current, "fuzz edit $contentVersion"),
+						UpdateSource.Editor,
+					)
+					// Let the 500ms debounce autosave + the async lastEdited stamp fully land.
+					delay(1500)
+				}
+
+				2 -> {
+					val metadata = client.sceneEditorService.loadSceneMetadata(current.id)
+					client.sceneEditorService.storeMetadata(
+						metadata.copy(notes = "note at $i", outline = "outline at $i"),
+						current.id,
+					)
+				}
+
+				3 -> client.sceneEditorService.renameScene(current, "Fuzz Scene $i")
+
+				4 -> assertTrue(client.syncNoConflict(), "[seed $seed] sync failed at iteration $i")
+			}
+		}
+
+		// Flush whatever is still dirty; a single client must still not conflict.
+		assertTrue(client.syncNoConflict(), "[seed $seed] final sync should succeed")
+	}
+
+	companion object {
+		private const val ITERATIONS = 20
+		private val SEEDS = listOf(1L, 8675309L, 424242L)
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/SyncHashStabilityTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/SyncHashStabilityTest.kt
@@ -1,0 +1,47 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.synchronizers.ClientSceneSynchronizer
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * After a clean sync, the hash the client computes for a scene (its conflict baseline) must equal
+ * the hash the server stored on upload. Any divergence means the next sync conflicts even though
+ * nothing changed — so this pins the client and server hashers to the same answer for the same
+ * entity, end to end. Design-agnostic: holds whatever fields participate in the hash.
+ */
+class SyncHashStabilityTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 60)
+	fun `client sync hash matches the hash the server stored`() = runBlocking {
+		val project = "hash stability agreement"
+		val client = newClient(project)
+
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Agreed Scene")
+		assertNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(
+			sceneItem = SceneContent(scene = scene, markdown = "content that rides the wire"),
+		)
+		assertTrue(client.sync(), "Sync should succeed")
+
+		val serverHash = serverEntityHash(project, scene.id)
+		assertNotNull(serverHash, "Server should have stored a hash for the synced scene")
+
+		val synchronizer: ClientSceneSynchronizer = client.scope.get()
+		val clientHash = synchronizer.getEntityHash(scene.id)
+		assertNotNull(clientHash, "Client should compute a hash for the synced scene")
+
+		assertEquals(
+			serverHash, clientHash,
+			"Client's sync hash differs from the hash the server stored for the same scene — " +
+				"every resync of this untouched scene would raise a phantom conflict.",
+		)
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/SyncedHashBackfillTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/SyncedHashBackfillTest.kt
@@ -1,0 +1,81 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Migration guard. After an upgrade the syncedHashes map is empty (the field is new), so a dirty
+ * entity would upload with a null baseline and the server would skip the conflict check, silently
+ * overwriting a concurrent edit. The first sync must backfill baselines for in-sync entities so a
+ * later edit still catches a genuine conflict.
+ */
+class SyncedHashBackfillTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 60)
+	fun `post-upgrade sync backfills syncedHashes for an in-sync entity`() = runBlocking {
+		val project = "backfill in-sync"
+		val client = newClient(project)
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Scene")
+		requireNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "body"))
+		assertTrue(client.sync(), "initial sync should succeed")
+
+		val journal: SyncJournal = client.scope.get()
+		// Simulate an upgrade: empty the syncedHashes map.
+		journal.saveSyncData(journal.loadSyncData().copy(syncedHashes = emptyMap()))
+		assertNull(journal.loadSyncData().syncedHashes[scene.id], "precondition: syncedHashes wiped")
+
+		// A plain sync with no local edits must restore the baseline.
+		assertTrue(client.sync(), "post-upgrade sync should succeed")
+
+		assertEquals(
+			serverEntityHash(project, scene.id),
+			journal.loadSyncData().syncedHashes[scene.id],
+			"the in-sync entity's baseline must be backfilled to the server's hash",
+		)
+	}
+
+	@Test
+	@Timeout(value = 60)
+	fun `after backfill a concurrent server edit is caught as a conflict`() = runBlocking {
+		val project = "backfill conflict"
+		val client = newClient(project)
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = "Scene")
+		requireNotNull(scene)
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "v1"))
+		assertTrue(client.sync(), "initial sync should succeed")
+
+		val journal: SyncJournal = client.scope.get()
+		journal.saveSyncData(journal.loadSyncData().copy(syncedHashes = emptyMap()))
+
+		// Post-upgrade sync restores the baseline for the untouched entity.
+		assertTrue(client.sync(), "post-upgrade sync should succeed")
+
+		// Another device changes the same scene on the server.
+		mutateServerEntity(
+			requireNotNull(serverNumericProjectIdFor(project)),
+			com.darkrockstudios.apps.hammer.e2e.util.E2eTestData.createTestScene(id = scene.id)
+				.copy(content = "server version"),
+		)
+
+		// The client edits it too and syncs; the divergence from the server must surface as a conflict.
+		client.sceneEditor.storeSceneMarkdownRaw(
+			SceneContent(requireNotNull(client.sceneEditor.getSceneItemFromId(scene.id)), "local version"),
+		)
+		var conflicted = false
+		assertTrue(
+			client.sync(resolveConflict = { entity -> conflicted = true; entity }),
+			"sync should complete",
+		)
+		assertTrue(conflicted, "the concurrent server edit must surface as a conflict, not a silent overwrite")
+	}
+}

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
@@ -68,6 +68,9 @@ abstract class EndToEndTest {
 
 	@AfterEach
 	fun tearDown() {
+		// Close the per-test HttpClient before stopping the server so its engine threads and
+		// connection pool don't accumulate across the suite (a leak that grows test-to-test).
+		runCatching { client.close() }
 		server.stop(1000, 3000)
 	}
 


### PR DESCRIPTION
## Summary

Fixes the bug where a single client editing a scene and re-syncing raised a **conflict on every sync** — with no other device involved. Roots out the cause, adds a second fix for the post-upgrade window it exposed, and builds out end-to-end sync test coverage (which itself flushed out two more latent bugs).

## The bug

A single client would: sync (all green) → edit scene content → sync → **phantom conflict**. Every time.

**Root cause:** the conflict baseline (`originalHash`) was re-derived from local state at mark-dirty time, but `lastEdited` — which is part of the hash and is stamped by the autosave *during* the flush — had already moved. So the baseline the client computed disagreed with what the server had stored, and the server flagged a conflict.

**The fix (lock the baseline):** record the hash the server confirms on each successful transfer (`ProjectSynchronizationData.syncedHashes`) and use *that* as the conflict baseline — never a value re-derived from drifting local state. `lastEdited` stays in the hash.

## Second fix — post-upgrade backfill

`syncedHashes` is a new field, so an upgraded client starts with it empty → entities upload with a `null` baseline, which the server treats as "no conflict possible" and lets overwrite a concurrent edit. The first sync now backfills a baseline for every in-sync entity (from its local hash, which equals the server's for an agreed entity) so a genuine conflict is still caught.

## Test build-out + two bugs it found

Added a real end-to-end sync suite (round-trip against an in-process server): a content-edit regression test, a per-entity-type resync matrix, baseline scenarios (metadata-only / rename / download-then-edit), a client↔server hash-stability invariant, and a seeded property/fuzz test. Building it surfaced two latent bugs:

- **Timeline store race** — `TimeLineRepository.storeTimeline()` used `replayCache.first()`, which threw when the timeline was never loaded (it runs on every sync's finalize).
- **FakeFileSystem thread-safety** — the integration harness bound the client IO/Default dispatchers to the real multi-threaded dispatchers, so concurrent filesystem opens corrupted the non-thread-safe `FakeFileSystem` and failed roughly 1 in 3 full runs. Fixed by serializing client-side filesystem work onto a single thread.

## Cleanups

- Removed dead `SceneDraftRepository.markForSynchronization` (drafts are immutable after creation).
- Fixed a blind spot in `SceneTimestampsTest`: content was set via `onContentChanged` + an immediate `storeSceneBuffer`, which (because buffer registration is async) no-op'd and left the scene empty on the server — the test only checked timestamps. Now persists synchronously and asserts the content reaches the server.

## Testing

- New + existing integration suite green across many runs; the FakeFileSystem fix verified with 5 consecutive green full runs.
- `common` / `base` / `composeUi` desktop test suites green.
- TDD throughout — each fix has a regression test confirmed **red** before the fix and **green** after.

## Commit breakdown

| Commit | What |
|---|---|
| Lock the sync baseline to the server-confirmed hash | the core fix + regression test |
| Add e2e sync resync scenarios and stabilize the integration harness | scenarios + the FakeFileSystem thread-safety fix |
| Add per-entity-type sync resync matrix | note / timeline / encyclopedia / draft / delete coverage |
| Fix timeline store race on sync finalize | `storeTimeline` guard |
| Add sync fuzz/property test | seeded random edit/metadata/rename/sync sequences |
| Backfill sync baselines on the first post-upgrade sync | the migration fix |
| Remove dead SceneDraftRepository.markForSynchronization | dead code |
| Persist + assert scene content in SceneTimestampsTest | test blind-spot fix |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
