### PR TITLE
Fix project sync session lockout (same-install session reclaim)

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -18,6 +18,8 @@ import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.github.aakira.napier.Napier
 import io.ktor.http.*
 import korlibs.io.lang.InvalidArgumentException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -99,12 +101,18 @@ class ClientAccountSynchronizer(
 			}
 		} catch (e: CancellationException) {
 			Napier.i("Projects sync canceled: ${e.message}")
+
+			// End the session even while cancelling, or it leaks server-side and blocks the
+			// next begin until it expires.
+			syncId?.let {
+				withContext(NonCancellable) { serverProjectsApi.endProjectsSync(it) }
+			}
 			throw e
 		} catch (e: Exception) {
 			Napier.e("Projects sync failed", e)
 
 			syncId?.let {
-				serverProjectsApi.endProjectsSync(syncId)
+				withContext(NonCancellable) { serverProjectsApi.endProjectsSync(it) }
 			}
 
 			if (e.isAuthenticationFailure()) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
@@ -16,9 +16,11 @@ import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.sync_log_entity_failed
 import io.github.aakira.napier.Napier
 import io.ktor.http.*
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okio.IOException
 import org.koin.core.component.get
 import kotlin.coroutines.cancellation.CancellationException
@@ -149,7 +151,10 @@ class ClientProjectSynchronizer(
 		}
 	}
 
-	private suspend fun endSync() {
+	// Runs as cleanup, often from a cancelled sync coroutine. Without NonCancellable the
+	// endProjectSync network call would be skipped at its first suspension point, leaking the
+	// server session and blocking the next begin_sync until it expires.
+	private suspend fun endSync() = withContext(NonCancellable) {
 		try {
 			val syncId = syncJournal.loadSyncData().currentSyncId
 				?: throw IllegalStateException("No sync ID")

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
@@ -8,14 +8,25 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.*
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.BackupOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.CollateIdsOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.EnsureProjectIdOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.EntityDeleteOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.EntityTransferOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.FetchLocalDataOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.FetchServerDataOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.FinalizeSyncOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.IdConflictResolutionOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.PrepareForSyncOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.ProjectDataSyncOperation
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.WritingActivitySyncOperation
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.sync_log_entity_failed
 import io.github.aakira.napier.Napier
-import io.ktor.http.*
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -151,9 +162,7 @@ class ClientProjectSynchronizer(
 		}
 	}
 
-	// Runs as cleanup, often from a cancelled sync coroutine. Without NonCancellable the
-	// endProjectSync network call would be skipped at its first suspension point, leaking the
-	// server session and blocking the next begin_sync until it expires.
+	// Runs as cleanup, often from a cancelled sync coroutine
 	private suspend fun endSync() = withContext(NonCancellable) {
 		try {
 			val syncId = syncJournal.loadSyncData().currentSyncId

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -122,6 +122,18 @@ The client calls `begin_sync` to get a valid `syncID`. This `syncID` is provided
 
 There can be only one valid `syncID` per project at any given time. This prevents race conditions with two clients syncing the same project at the same time.
 
+#### Reclaiming a session (same install only)
+
+A stale session would otherwise lock a user out of their own project until it expires — for example when a prior sync's `end_sync` never reached the server (the client was cancelled mid-sync, lost auth, or dropped its connection). To avoid this, `begin_sync` may **reclaim** an existing project session, but only when the request comes from the **same install** that owns it.
+
+The install is identified server-side from the authenticated bearer token (never a client-supplied value), so it cannot be spoofed. The rules are:
+
+- **Same install** as the active session → the old session is terminated and a fresh `syncID` is issued. The previous `syncID` immediately becomes invalid.
+- **Different install**, session still active → `400 Bad Request`; the original session keeps its claim, preserving the cross-device race protection above.
+- **Expired session** (any install) → treated as gone and reclaimable by anyone.
+
+The client also fires `end_sync` even when its sync is cancelled, so sessions are normally released cleanly; reclaim is the safety net for the cases where that request can't be delivered.
+
 You may however have `syncID`s for multiple different projects simultaneously.
 
 These are Project level `syncID`s. Account syncing use separate Account level `syncID`s. There may only be one valid Account level `syncID` at a time, and if there is a valid Account `syncID`, then no Project level `syncID`s are allowed to be created. The Account level sync must finish before any Project level syncs may begin.

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -411,11 +411,21 @@ references to that ID in the process.
 **Conflicts**
 The same file that has been edited in different ways on different devices, must allow the user to resolve the conflict in order to bring them back into sync with each other.
 
-**Dirty Entity** When a client edits a local Entity, the client first hashes the existing,
-pre-edited content, and saves off the **Entity ID** and this pre-edit hash of the data to a "dirty
-list". If the client and server are in sync at the time of this edit, then the saved hash in the
-dirty list will match the hash of the server's copy of the Entity.
-At syncing time this allows us to detect conflicts. If another client edits the same entity, and
-syncs with the server first.
-Thus our local "dirty list" hash will not match the hash of the server side copy, and we'll know we
-have a conflict that needs resolving.
+**Dirty Entity** When a client edits a local Entity, it adds the **Entity ID** to a "dirty list"
+together with that Entity's **conflict baseline** — the hash the server last confirmed for it. At
+sync time the client sends this baseline as the upload's `original hash`; if another client edited
+the same Entity and synced first, the server's hash no longer matches the baseline and the conflict
+is detected.
+
+The baseline is the hash recorded the last time the client and server agreed on the Entity (on a
+successful upload or download), **not** a hash re-derived from the current local content at edit
+time. Re-deriving it is unsafe: an Entity's hash includes fields such as `lastEdited` that the
+autosave can stamp independently of a real content change, so a freshly computed baseline can
+disagree with the server even when nothing meaningful changed — forging a phantom conflict. This is
+the same locked-baseline scheme `project_data` uses with its `lastSyncedHash`.
+
+A baseline exists for every Entity the client and server have agreed on, set on each successful
+transfer. If a baseline is absent the server cannot conflict-check and accepts the upload, so a
+project whose sync data predates this scheme backfills a baseline for every in-sync Entity on its
+first sync (the local hash, which equals the server's for an agreed Entity) before any upload relies
+on it.

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsRepository.kt
@@ -165,6 +165,12 @@ class AccountsRepository(
 		}
 	}
 
+	/** The install id bound to [token], or null if the token is unknown. */
+	suspend fun getInstallId(token: String): String? {
+		val hashedToken = tokenHasher.hashToken(token)
+		return authTokenDao.getTokenByAuthToken(hashedToken)?.install_id
+	}
+
 	suspend fun refreshToken(userId: Long, installId: String, refreshToken: String): SResult<Token> {
 		val hashedRefreshToken = tokenHasher.hashToken(refreshToken)
 		val authToken = authTokenDao.getTokenByInstallId(userId, installId)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityRepository.kt
@@ -5,7 +5,11 @@ import com.darkrockstudios.apps.hammer.base.http.ClientEntityState
 import com.darkrockstudios.apps.hammer.base.http.ProjectSynchronizationBegan
 import com.darkrockstudios.apps.hammer.dependencyinjection.PROJECTS_SYNC_MANAGER
 import com.darkrockstudios.apps.hammer.dependencyinjection.PROJECT_SYNC_MANAGER
-import com.darkrockstudios.apps.hammer.project.synchronizers.*
+import com.darkrockstudios.apps.hammer.project.synchronizers.ServerEncyclopediaSynchronizer
+import com.darkrockstudios.apps.hammer.project.synchronizers.ServerNoteSynchronizer
+import com.darkrockstudios.apps.hammer.project.synchronizers.ServerSceneDraftSynchronizer
+import com.darkrockstudios.apps.hammer.project.synchronizers.ServerSceneSynchronizer
+import com.darkrockstudios.apps.hammer.project.synchronizers.ServerTimelineSynchronizer
 import com.darkrockstudios.apps.hammer.projects.ProjectsSynchronizationSession
 import com.darkrockstudios.apps.hammer.syncsessionmanager.SyncSessionManager
 import com.darkrockstudios.apps.hammer.utilities.Msg
@@ -61,10 +65,7 @@ class ProjectEntityRepository(
 			return SResult.failure(ProjectNotFound(projectDef))
 		}
 
-		// Reclaim a stale session, but only the originating install may do so. A prior sync from
-		// this install whose end_sync never reached the server (cancelled mid-flight, expired
-		// auth, dropped network) must not lock the owner out. A still-active session from a
-		// *different* install is a genuine concurrent sync and keeps its claim until it expires.
+		// Reclaim a stale session for a given installId
 		val activeSession = sessionManager.getActiveSyncSession(syncKey)
 		if (activeSession != null && activeSession.installId != installId) {
 			return SResult.failure(

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityRepository.kt
@@ -42,51 +42,65 @@ class ProjectEntityRepository(
 		userId: Long,
 		projectDef: ProjectDefinition,
 		clientState: ClientEntityState?,
-		lite: Boolean
+		lite: Boolean,
+		installId: String? = null,
 	): SResult<ProjectSynchronizationBegan> {
 
 		val syncKey = ProjectSyncKey(userId, projectDef)
 
-		return if (
-			projectsSessions.hasActiveSyncSession(userId) ||
-			sessionManager.hasActiveSyncSession(syncKey)
-		) {
-			SResult.failure(
-				"begin sync failure: existing session",
+		// An in-progress account-level sync (creating/renaming/deleting projects) must not be
+		// raced by a project sync, so it still blocks beginning one.
+		if (projectsSessions.hasActiveSyncSession(userId)) {
+			return SResult.failure(
+				"begin sync failure: existing account session",
 				Msg.r("api_project_sync_begin_error_session", userId)
 			)
-		} else {
-			if (projectEntityDatasource.checkProjectExists(userId, projectDef).not()) {
-				return SResult.failure(ProjectNotFound(projectDef))
-			}
-
-			var projectSyncData = projectEntityDatasource.loadProjectSyncData(userId, projectDef)
-
-			if (projectSyncData.lastId < 0) {
-				val lastId = projectEntityDatasource.findLastId(userId, projectDef)
-				projectSyncData = projectSyncData.copy(lastId = lastId ?: -1)
-			}
-
-			val newSyncId =
-				sessionManager.createNewSession(syncKey) { key: ProjectSyncKey, sync: String ->
-					ProjectSynchronizationSession(
-						userId = key.userId,
-						projectDef = key.projectDef,
-						started = clock.now(),
-						syncId = sync
-					)
-				}
-
-			val updateSequence = getUpdateSequence(userId, projectDef, clientState, lite)
-			val syncBegan = ProjectSynchronizationBegan(
-				syncId = newSyncId,
-				lastId = projectSyncData.lastId,
-				lastSync = projectSyncData.lastSync,
-				idSequence = updateSequence,
-				deletedIds = projectSyncData.deletedIds,
-			)
-			SResult.success(syncBegan)
 		}
+
+		if (projectEntityDatasource.checkProjectExists(userId, projectDef).not()) {
+			return SResult.failure(ProjectNotFound(projectDef))
+		}
+
+		// Reclaim a stale session, but only the originating install may do so. A prior sync from
+		// this install whose end_sync never reached the server (cancelled mid-flight, expired
+		// auth, dropped network) must not lock the owner out. A still-active session from a
+		// *different* install is a genuine concurrent sync and keeps its claim until it expires.
+		val activeSession = sessionManager.getActiveSyncSession(syncKey)
+		if (activeSession != null && activeSession.installId != installId) {
+			return SResult.failure(
+				"begin sync failure: active session on another install",
+				Msg.r("api_project_sync_begin_error_session", userId)
+			)
+		}
+		sessionManager.terminateSession(syncKey)
+
+		var projectSyncData = projectEntityDatasource.loadProjectSyncData(userId, projectDef)
+
+		if (projectSyncData.lastId < 0) {
+			val lastId = projectEntityDatasource.findLastId(userId, projectDef)
+			projectSyncData = projectSyncData.copy(lastId = lastId ?: -1)
+		}
+
+		val newSyncId =
+			sessionManager.createNewSession(syncKey) { key: ProjectSyncKey, sync: String ->
+				ProjectSynchronizationSession(
+					userId = key.userId,
+					projectDef = key.projectDef,
+					started = clock.now(),
+					syncId = sync,
+					installId = installId,
+				)
+			}
+
+		val updateSequence = getUpdateSequence(userId, projectDef, clientState, lite)
+		val syncBegan = ProjectSynchronizationBegan(
+			syncId = newSyncId,
+			lastId = projectSyncData.lastId,
+			lastSync = projectSyncData.lastSync,
+			idSequence = updateSequence,
+			deletedIds = projectSyncData.deletedIds,
+		)
+		return SResult.success(syncBegan)
 	}
 
 	suspend fun endProjectSync(

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectRoutes.kt
@@ -1,23 +1,46 @@
 package com.darkrockstudios.apps.hammer.project
 
 import com.darkrockstudios.apps.hammer.account.AccountsRepository
-import com.darkrockstudios.apps.hammer.base.http.*
+import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.ClientEntityState
+import com.darkrockstudios.apps.hammer.base.http.DeleteIdsResponse
+import com.darkrockstudios.apps.hammer.base.http.HEADER_ENTITY_HASH
+import com.darkrockstudios.apps.hammer.base.http.HEADER_ENTITY_TYPE
+import com.darkrockstudios.apps.hammer.base.http.HEADER_ORIGINAL_HASH
+import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
+import com.darkrockstudios.apps.hammer.base.http.SaveEntityResponse
+import com.darkrockstudios.apps.hammer.base.http.StaleHashResponse
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataUploadRequest
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityConflictException
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.dependencyinjection.DISPATCHER_IO
 import com.darkrockstudios.apps.hammer.plugins.ServerUserIdPrincipal
 import com.darkrockstudios.apps.hammer.plugins.USER_AUTH
-import com.darkrockstudios.apps.hammer.utilities.*
+import com.darkrockstudios.apps.hammer.utilities.ERROR_MISSING_ENTITY_ID
+import com.darkrockstudios.apps.hammer.utilities.ERR_KEY_UNKNOWN
+import com.darkrockstudios.apps.hammer.utilities.ServerResult
+import com.darkrockstudios.apps.hammer.utilities.isSuccess
+import com.darkrockstudios.apps.hammer.utilities.requireEntityId
+import com.darkrockstudios.apps.hammer.utilities.requireProjectDef
+import com.darkrockstudios.apps.hammer.utilities.requireSyncId
+import com.darkrockstudios.apps.hammer.utilities.respondMissingParameter
 import com.github.aymanizz.ktori18n.R
 import com.github.aymanizz.ktori18n.t
-import io.ktor.http.*
-import io.ktor.server.application.*
-import io.ktor.server.auth.*
-import io.ktor.server.request.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import io.ktor.util.logging.*
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.log
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.principal
+import io.ktor.server.request.receive
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.request.receiveStream
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.util.logging.Logger
 import korlibs.io.compression.deflate.GZIP
 import korlibs.io.compression.uncompress
 import kotlinx.coroutines.withContext
@@ -54,8 +77,7 @@ private fun Route.beginProjectSync() {
 		val projectDef = call.requireProjectDef() ?: return@post
 		val lite = call.parameters["lite"]?.toBoolean() ?: false
 
-		// Derived from the authenticated token (not client-asserted) so only the originating
-		// install can reclaim its own stale sync session.
+		// Derived from the authenticated token (not client-asserted)
 		val installId = call.request.headers[HttpHeaders.Authorization]
 			?.substringAfter("Bearer ", "")
 			?.takeIf { it.isNotBlank() }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectRoutes.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.project
 
+import com.darkrockstudios.apps.hammer.account.AccountsRepository
 import com.darkrockstudios.apps.hammer.base.http.*
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataUploadRequest
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityConflictException
@@ -44,6 +45,7 @@ fun Route.projectRoutes(logger: Logger) {
 
 private fun Route.beginProjectSync() {
 	val projectEntityRepository: ProjectEntityRepository = get()
+	val accountsRepository: AccountsRepository = get()
 	val json: Json = get()
 	val ioDispatcher: CoroutineContext = get(named(DISPATCHER_IO))
 
@@ -51,6 +53,13 @@ private fun Route.beginProjectSync() {
 		val principal = call.principal<ServerUserIdPrincipal>()!!
 		val projectDef = call.requireProjectDef() ?: return@post
 		val lite = call.parameters["lite"]?.toBoolean() ?: false
+
+		// Derived from the authenticated token (not client-asserted) so only the originating
+		// install can reclaim its own stale sync session.
+		val installId = call.request.headers[HttpHeaders.Authorization]
+			?.substringAfter("Bearer ", "")
+			?.takeIf { it.isNotBlank() }
+			?.let { accountsRepository.getInstallId(it) }
 
 		val clientState: ClientEntityState? = withContext(ioDispatcher) {
 			val compressed = call.receiveStream().readAllBytes()
@@ -67,6 +76,7 @@ private fun Route.beginProjectSync() {
 			projectDef,
 			clientState,
 			lite,
+			installId,
 		)
 		if (isSuccess(result)) {
 			call.respond(result.data)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectSynchronizationSession.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectSynchronizationSession.kt
@@ -7,5 +7,7 @@ data class ProjectSynchronizationSession(
 	override val userId: Long,
 	val projectDef: ProjectDefinition,
 	override val started: Instant,
-	override val syncId: String
+	override val syncId: String,
+	// The install that began the session. Only this install may reclaim it before it expires.
+	val installId: String? = null,
 ) : SynchronizationSession(userId, started, syncId)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProjectSyncTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProjectSyncTest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class ProjectSyncTest : ProjectSyncTestBase() {
@@ -315,7 +316,7 @@ class ProjectSyncTest : ProjectSyncTestBase() {
 	}
 
 	@Test
-	fun `Client tries to begin sync while another sync is in progress`(): Unit = runBlocking {
+	fun `Beginning sync again reclaims the same user's existing session`(): Unit = runBlocking {
 		val database = database()
 		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database)
 		TestDataSet1.createFullDataset(database, encryptor())
@@ -331,21 +332,68 @@ class ProjectSyncTest : ProjectSyncTestBase() {
 		client().apply {
 			val synchronizationBegan1 = projectSynchronizationBegan(userId, authToken, state)
 
-			val synchronizationBegan2Response =
-				projectSynchronizationBeganRequest(userId, authToken, state)
-			assertEquals(HttpStatusCode.BadRequest, synchronizationBegan2Response.status)
+			// A leaked/stale session must not lock the owner out: beginning again succeeds and
+			// reclaims the session with a fresh sync ID.
+			val synchronizationBegan2 = projectSynchronizationBegan(userId, authToken, state)
+			assertNotEquals(synchronizationBegan1.syncId, synchronizationBegan2.syncId)
 
-			// Check that the original sync ID is still valid
-			val downloadResponse: ApiProjectEntity.SceneEntity = downloadEntity(
+			// The reclaimed (old) sync ID is no longer valid.
+			val staleDownloadResponse = downloadEntityRequest(
 				userId,
 				authToken,
 				synchronizationBegan1.syncId,
 				checkEntityId,
 				null,
 			)
+			assertNotEquals(HttpStatusCode.OK, staleDownloadResponse.status)
+
+			// The new session works.
+			val downloadResponse: ApiProjectEntity.SceneEntity = downloadEntity(
+				userId,
+				authToken,
+				synchronizationBegan2.syncId,
+				checkEntityId,
+				null,
+			)
 			assertEquals(checkEntityId, downloadResponse.id)
 
-			endSyncRequest(userId, authToken, synchronizationBegan1)
+			endSyncRequest(userId, authToken, synchronizationBegan2)
+		}
+	}
+
+	@Test
+	fun `Begin sync from a different install is rejected while a session is active`(): Unit = runBlocking {
+		val database = database()
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database)
+		TestDataSet1.createFullDataset(database, encryptor())
+		val userId = 1L
+		val checkEntityId = 1
+		val authTokenA = createAuthToken(userId, "install-a", database = database, tokenHasher = tokenHasher())
+		val authTokenB = createAuthToken(userId, "install-b", database = database, tokenHasher = tokenHasher())
+		doStartServer()
+
+		val state = ClientEntityState(
+			entities = emptySet()
+		)
+
+		client().apply {
+			val began = projectSynchronizationBegan(userId, authTokenA, state)
+
+			// A different install must not steal an active session.
+			val otherInstallResponse = projectSynchronizationBeganRequest(userId, authTokenB, state)
+			assertEquals(HttpStatusCode.BadRequest, otherInstallResponse.status)
+
+			// The original install's session is untouched and still usable.
+			val download: ApiProjectEntity.SceneEntity = downloadEntity(
+				userId,
+				authTokenA,
+				began.syncId,
+				checkEntityId,
+				null,
+			)
+			assertEquals(checkEntityId, download.id)
+
+			endSyncRequest(userId, authTokenA, began)
 		}
 	}
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/repository/ProjectEntityRepositoryBaseTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/repository/ProjectEntityRepositoryBaseTest.kt
@@ -11,6 +11,7 @@ import com.darkrockstudios.apps.hammer.syncsessionmanager.SyncSessionManager
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import com.darkrockstudios.apps.hammer.utils.TestClock
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.serialization.json.Json
@@ -59,6 +60,10 @@ abstract class ProjectEntityRepositoryBaseTest : BaseTest() {
 		projectEntityDatasource = mockk()
 
 		clientState = mockk()
+
+		// beginProjectSync inspects any existing session for the key, then reclaims it.
+		every { projectSessionManager.getActiveSyncSession(any()) } returns null
+		every { projectSessionManager.terminateSession(any()) } returns false
 
 		coEvery {
 			sceneSynchronizer.getUpdateSequence(

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/repository/ProjectEntityRepositorySyncTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/repository/ProjectEntityRepositorySyncTest.kt
@@ -2,11 +2,14 @@ package com.darkrockstudios.apps.hammer.project.repository
 
 import com.darkrockstudios.apps.hammer.project.ProjectEntityRepository
 import com.darkrockstudios.apps.hammer.project.ProjectSyncData
+import com.darkrockstudios.apps.hammer.project.ProjectSyncKey
 import com.darkrockstudios.apps.hammer.project.ProjectSynchronizationSession
 import com.darkrockstudios.apps.hammer.utilities.isSuccess
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.just
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -36,7 +39,6 @@ class ProjectEntityRepositorySyncTest : ProjectEntityRepositoryBaseTest() {
 		)
 
 		coEvery { projectsSessionManager.hasActiveSyncSession(any()) } returns false
-		coEvery { projectSessionManager.hasActiveSyncSession(any()) } returns false
 
 		coEvery {
 			projectEntityDatasource.checkProjectExists(
@@ -64,6 +66,65 @@ class ProjectEntityRepositorySyncTest : ProjectEntityRepositoryBaseTest() {
 	}
 
 	@Test
+	fun `Begin Project Sync reclaims the same install's existing session`() = runTest {
+		val syncId = "sync-id"
+		val installId = "install-1"
+		val syncData = ProjectSyncData(
+			lastSync = clock.now(),
+			lastId = 1,
+			deletedIds = emptySet()
+		)
+
+		// This install already has a leaked/stale session (e.g. a prior sync whose end_sync
+		// never reached the server). The owner must be able to begin again rather than being
+		// locked out until it expires.
+		coEvery { projectsSessionManager.hasActiveSyncSession(any()) } returns false
+		every { projectSessionManager.getActiveSyncSession(any()) } returns ProjectSynchronizationSession(
+			userId, projectDefinition, clock.now(), "stale-sync-id", installId
+		)
+		every { projectSessionManager.terminateSession(any()) } returns true
+
+		coEvery {
+			projectEntityDatasource.checkProjectExists(userId, projectDefinition)
+		} returns true
+		coEvery {
+			projectEntityDatasource.loadProjectSyncData(userId, projectDefinition)
+		} returns syncData
+
+		mockCreateSession(syncId)
+
+		createProjectRepository().apply {
+			val result = beginProjectSync(userId, projectDefinition, clientState, false, installId)
+
+			assertTrue(isSuccess(result))
+			assertTrue(result.data.syncId.isNotBlank())
+		}
+
+		verify { projectSessionManager.terminateSession(ProjectSyncKey(userId, projectDefinition)) }
+	}
+
+	@Test
+	fun `Begin Project Sync is rejected when another install holds an active session`() = runTest {
+		coEvery { projectsSessionManager.hasActiveSyncSession(any()) } returns false
+		every { projectSessionManager.getActiveSyncSession(any()) } returns ProjectSynchronizationSession(
+			userId, projectDefinition, clock.now(), "other-sync-id", "other-install"
+		)
+
+		coEvery {
+			projectEntityDatasource.checkProjectExists(userId, projectDefinition)
+		} returns true
+
+		createProjectRepository().apply {
+			val result = beginProjectSync(userId, projectDefinition, clientState, false, "install-1")
+
+			assertFalse(isSuccess(result))
+		}
+
+		// The other install's session must be left intact.
+		verify(exactly = 0) { projectSessionManager.terminateSession(any()) }
+	}
+
+	@Test
 	fun `Begin Project Sync - Update Sequence - Remove Dupes`() = runTest {
 		val syncId = "sync-id"
 		val syncData = ProjectSyncData(
@@ -73,7 +134,6 @@ class ProjectEntityRepositorySyncTest : ProjectEntityRepositoryBaseTest() {
 		)
 
 		coEvery { projectsSessionManager.hasActiveSyncSession(any()) } returns false
-		coEvery { projectSessionManager.hasActiveSyncSession(any()) } returns false
 
 		coEvery {
 			projectEntityDatasource.checkProjectExists(


### PR DESCRIPTION
## Problem

Resolving a **project-data** conflict (author name / theme / word-count goal) and letting the sync continue could fail with:

```
HTTP 400 Bad Request — Failed to begin sync: User [1] already has a synchronization session
```

A project sync session that wasn't cleanly ended — a prior sync cancelled mid-flight, an expired token, or a dropped connection — leaks server-side and blocks **every** subsequent sync of that project until it expires (2 min), locking the user out of their own project.

## Fix

**Server — reclaim a stale session, scoped to the originating install** (`begin_sync`):
- The install is derived from the authenticated bearer token (never a client-supplied value, so it can't be spoofed).
- **Same install** as the active session → terminate it, issue a fresh `syncId` (the old one is invalidated).
- **Different install**, still-active session → still `400` (cross-device race protection preserved).
- **Expired** session (any install) → reclaimable.
- An active **account-level** session still blocks project `begin_sync`.

**Client — don't leak sessions on cancellation:** the `end_sync` cleanup now runs under `NonCancellable` in both the project and account synchronizers, so the request reaches the server even when the sync coroutine is cancelled.

## Docs

`docs/SYNCING-PROTOCOL.md` gains a "Reclaiming a session (same install only)" subsection under project-level SyncIDs (alongside the locked-baseline doc update).

## Tests

- Unit (`ProjectEntityRepositorySyncTest`): reclaim same install / reject other install.
- E2E (`ProjectSyncTest`): reclaim issues a new `syncId` and invalidates the old one; a second install is rejected while the first session stays usable.
- Full `server:test`, `common` synchronizer tests, and `integrationTests:jvmTest` (the #582 end-to-end sync scenarios) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)