### PR TITLE
Pre-sync change probe: skip syncing unchanged projects

### DIFF
--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/ProjectsApi.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/ProjectsApi.kt
@@ -21,3 +21,22 @@ data class CreateProjectResponse(
 	val projectId: ProjectId,
 	val alreadyExisted: Boolean,
 )
+
+/** One project's locally-computed project-wide content hash, sent to the change probe. */
+@Serializable
+data class ProjectHashItem(
+	val projectId: ProjectId,
+	val hash: String,
+)
+
+/** Batched pre-sync probe: the client's current project-wide hash for each eligible project. */
+@Serializable
+data class ProjectsSyncProbeRequest(
+	val projects: List<ProjectHashItem>,
+)
+
+/** Projects whose server-side hash matches the client's — safe to skip syncing this session. */
+@Serializable
+data class ProjectsSyncProbeResponse(
+	val unchangedProjects: Set<ProjectId>,
+)

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectContentHasher.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectContentHasher.kt
@@ -1,0 +1,35 @@
+package com.darkrockstudios.apps.hammer.base.http.synchronizer
+
+import com.appmattus.crypto.Algorithm
+import com.darkrockstudios.apps.hammer.base.http.EntityHash
+import korlibs.crypto.encoding.base64Url
+
+/**
+ * Aggregates a project's per-entity hashes plus its project-data hash into a single
+ * project-wide content hash. Computed with identical logic on the client and the server
+ * so the two can be compared directly by the pre-sync change probe (see SYNCING-PROTOCOL.md).
+ *
+ * Entities are folded in ascending-id order so the result is independent of enumeration
+ * order. Writing activity is intentionally excluded: it is per-device and conflict-free, so
+ * no single device ever holds the full union and a symmetric hash including it would never
+ * match across devices.
+ */
+object ProjectContentHasher {
+	/**
+	 * Bump whenever the hashing scheme changes (here, in [EntityHasher], or in [ProjectDataHasher]).
+	 * A cached client hash carrying an older version is treated as absent, forcing a normal sync
+	 * that recomputes and re-caches it at the current version.
+	 */
+	const val ALGO_VERSION: Int = 1
+
+	fun hash(entityHashes: Collection<EntityHash>, projectDataHash: String): String {
+		val buf = ByteArray(4)
+		val d = Algorithm.MurmurHash3_X64_128().createDigest()
+		entityHashes.sortedBy { it.id }.forEach { entity ->
+			d.update(entity.id, buf)
+			d.update(entity.hash, buf)
+		}
+		d.update(projectDataHash, buf)
+		return d.digest().base64Url
+	}
+}

--- a/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectContentHasherTest.kt
+++ b/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectContentHasherTest.kt
@@ -1,0 +1,70 @@
+package com.darkrockstudios.apps.hammer.base.http.synchronizer
+
+import com.darkrockstudios.apps.hammer.base.http.EntityHash
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class ProjectContentHasherTest {
+
+	private val pd = "project-data-hash"
+
+	@Test
+	fun `same input produces same hash`() {
+		val entities = setOf(EntityHash(1, "a"), EntityHash(2, "b"))
+		assertEquals(
+			ProjectContentHasher.hash(entities, pd),
+			ProjectContentHasher.hash(entities, pd),
+		)
+	}
+
+	@Test
+	fun `entity order does not affect hash`() {
+		val forward = listOf(EntityHash(1, "a"), EntityHash(2, "b"), EntityHash(3, "c"))
+		val shuffled = listOf(EntityHash(3, "c"), EntityHash(1, "a"), EntityHash(2, "b"))
+		assertEquals(
+			ProjectContentHasher.hash(forward, pd),
+			ProjectContentHasher.hash(shuffled, pd),
+			"hash must be independent of entity enumeration order",
+		)
+	}
+
+	@Test
+	fun `changing an entity hash changes the result`() {
+		val a = setOf(EntityHash(1, "a"), EntityHash(2, "b"))
+		val b = setOf(EntityHash(1, "a"), EntityHash(2, "b2"))
+		assertNotEquals(ProjectContentHasher.hash(a, pd), ProjectContentHasher.hash(b, pd))
+	}
+
+	@Test
+	fun `adding an entity changes the result`() {
+		val a = setOf(EntityHash(1, "a"))
+		val b = setOf(EntityHash(1, "a"), EntityHash(2, "b"))
+		assertNotEquals(ProjectContentHasher.hash(a, pd), ProjectContentHasher.hash(b, pd))
+	}
+
+	@Test
+	fun `changing the project data hash changes the result`() {
+		val entities = setOf(EntityHash(1, "a"))
+		assertNotEquals(
+			ProjectContentHasher.hash(entities, "data-1"),
+			ProjectContentHasher.hash(entities, "data-2"),
+		)
+	}
+
+	@Test
+	fun `an id moving between entities is detected`() {
+		// {id=1: "x", id=2: "y"} must not collide with {id=1: "y", id=2: "x"}
+		val a = setOf(EntityHash(1, "x"), EntityHash(2, "y"))
+		val b = setOf(EntityHash(1, "y"), EntityHash(2, "x"))
+		assertNotEquals(ProjectContentHasher.hash(a, pd), ProjectContentHasher.hash(b, pd))
+	}
+
+	@Test
+	fun `empty project has a stable hash`() {
+		assertEquals(
+			ProjectContentHasher.hash(emptySet(), pd),
+			ProjectContentHasher.hash(emptySet(), pd),
+		)
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
@@ -457,20 +457,32 @@ class ProjectsListComponent(
 					projects = projectsRepository.getProjects()
 					syncNewProjectStatus(projects)
 
-					// Filter to only sync projects that have a serverProjectId assigned
-					val projectsToSync = projects.filter { projectDef ->
+					// Only sync projects that have a serverProjectId assigned
+					val projectsToSync = projects.mapNotNull { projectDef ->
 						val metadata = projectMetadataDatasource.loadMetadata(projectDef)
-						val hasServerId = metadata.info.serverProjectId != null
-						if (!hasServerId) {
+						val serverProjectId = metadata.info.serverProjectId
+						if (serverProjectId == null) {
 							Napier.w { "Skipping project sync for '${projectDef.name}' - no server project ID yet" }
 							syncProgressStatus(projectDef.name, ProjectsList.Status.Pending)
+							null
+						} else {
+							SyncedProjectDefinition(projectDef, serverProjectId)
 						}
-						hasServerId
 					}
 
-					projectsToSync.parallelMap { projectDef ->
+					// Pre-sync change probe: skip projects the server confirms are unchanged.
+					val unchangedProjectIds = projectsSynchronizer.probeUnchangedProjects(projectsToSync)
+
+					projectsToSync.parallelMap { synced ->
+						val projectDef = synced.projectDef
 						newScope.launch {
 							try {
+								if (synced.projectId in unchangedProjectIds) {
+									onSyncLog(syncLogI("No changes — skipped", projectDef))
+									syncProgressStatus(projectDef.name, ProjectsList.Status.Complete)
+									return@launch
+								}
+
 								syncProgressStatus(projectDef.name, ProjectsList.Status.Syncing)
 
 								suspend fun onProgress(progress: Float, message: SyncLogMessage?) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataRepository.kt
@@ -3,6 +3,8 @@ package com.darkrockstudios.apps.hammer.common.data.projectdata
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
+import com.darkrockstudios.apps.hammer.common.data.projectInject
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataDatasource
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +18,9 @@ class ProjectDataRepository(
 ) : ProjectScoped {
 
 	override val projectScope = ProjectDefScope(projectDef)
+
+	// Lazy to avoid eager construction of the sync journal for projects that never sync.
+	private val syncDataDatasource: SyncDataDatasource by projectInject()
 
 	private val mutex = Mutex()
 	private val _state = MutableStateFlow<StoredProjectData?>(null)
@@ -37,6 +42,8 @@ class ProjectDataRepository(
 		val next = current.copy(data = nextData)
 		datasource.save(next)
 		_state.value = next
+		// Project data is part of the project-wide hash; invalidate so the probe re-syncs it.
+		syncDataDatasource.invalidateProjectHash()
 	}
 
 	/**

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -4,6 +4,8 @@ import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectDefinition
 import com.darkrockstudios.apps.hammer.base.http.BeginProjectsSyncResponse
+import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SyncedProjectDefinition
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
@@ -120,6 +122,59 @@ class ClientAccountSynchronizer(
 			}
 
 			false
+		}
+	}
+
+	/**
+	 * Pre-sync change probe. Reads each project's cached project-wide hash from its journal and asks
+	 * the server, in a single request, which of them still match. Returns the [ProjectId]s the caller
+	 * can skip syncing this session.
+	 *
+	 * A project is only probed when it is provably clean: it has a cached hash at the current algorithm
+	 * version and no pending journal work. A cached hash coexisting with pending work is an invariant
+	 * violation (a mutation that failed to clear the cache) — we log it and fall back to a full sync.
+	 * Any probe failure returns an empty set, so everything syncs the normal way.
+	 */
+	suspend fun probeUnchangedProjects(projects: List<SyncedProjectDefinition>): Set<ProjectId> {
+		val items = mutableListOf<ProjectHashItem>()
+		for (synced in projects) {
+			val syncData = loadProjectSyncData(synced.projectDef) ?: continue
+			if (syncData.hashAlgoVersion != ProjectContentHasher.ALGO_VERSION) continue
+			val cachedHash = syncData.cachedProjectHash ?: continue
+
+			val hasPendingWork = syncData.dirty.isNotEmpty() || syncData.newIds.isNotEmpty()
+			if (hasPendingWork) {
+				Napier.e(
+					"Cache/journal inconsistency for project '${synced.projectDef.name}': cached hash " +
+						"present despite pending journal work. A write path likely bypassed the " +
+						"dirty-tracking hook. Forcing full sync."
+				)
+				continue
+			}
+
+			items += ProjectHashItem(synced.projectId, cachedHash)
+		}
+
+		if (items.isEmpty()) return emptySet()
+
+		val result = serverProjectsApi.probeProjectChanges(items)
+		return if (result.isSuccess) {
+			result.getOrThrow().unchangedProjects
+		} else {
+			Napier.w("Sync probe failed; syncing all projects", result.exceptionOrNull())
+			emptySet()
+		}
+	}
+
+	// Corrupt or unreadable journal just makes the project ineligible for the probe (full sync).
+	@Suppress("SwallowedException")
+	private fun loadProjectSyncData(projectDef: ProjectDef): ProjectSynchronizationData? {
+		val path = projectDef.path.toOkioPath() / SyncDataDatasource.SYNC_FILE_NAME
+		if (!fileSystem.exists(path)) return null
+		return try {
+			fileSystem.read(path) { json.decodeFromString<ProjectSynchronizationData>(readUtf8()) }
+		} catch (e: SerializationException) {
+			null
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -5,11 +5,14 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectDefinition
 import com.darkrockstudios.apps.hammer.base.http.BeginProjectsSyncResponse
 import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SyncedProjectDefinition
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
+import com.darkrockstudios.apps.hammer.common.data.projectdata.loadStoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
@@ -20,11 +23,14 @@ import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.github.aakira.napier.Napier
 import io.ktor.http.*
 import korlibs.io.lang.InvalidArgumentException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
 import okio.Path
 import kotlin.coroutines.cancellation.CancellationException
@@ -37,6 +43,7 @@ class ClientAccountSynchronizer(
 	private val serverProjectsApi: ServerProjectsApi,
 	private val networkConnectivity: NetworkConnectivity,
 	private val json: Json,
+	private val toml: Toml,
 	private val strRes: StrRes,
 ) {
 	var initialSync = false
@@ -131,52 +138,85 @@ class ClientAccountSynchronizer(
 	 * can skip syncing this session.
 	 *
 	 * A project is only probed when it is provably clean: it has a cached hash at the current algorithm
-	 * version and no pending journal work. A cached hash coexisting with pending work is an invariant
+	 * version and no pending local work — neither pending entity work (`dirty`/`newIds`) nor an
+	 * unsynced project-data edit. (`deletedIds` is deliberately excluded: it is a persistent tombstone
+	 * set, not pending work — matching [SyncJournal.needsSync] — and deletions are already caught by
+	 * the project-wide hash itself.) A cached hash coexisting with pending work is an invariant
 	 * violation (a mutation that failed to clear the cache) — we log it and fall back to a full sync.
-	 * Any probe failure returns an empty set, so everything syncs the normal way.
+	 *
+	 * The whole probe is best-effort: any failure (an unreadable journal, an I/O error, a probe call
+	 * that fails) degrades to an empty set so everything syncs the normal way. It must never turn a
+	 * recoverable per-project issue into a failure of the surrounding account sync.
 	 */
+	@Suppress("TooGenericExceptionCaught")
 	suspend fun probeUnchangedProjects(projects: List<SyncedProjectDefinition>): Set<ProjectId> {
-		val items = mutableListOf<ProjectHashItem>()
-		for (synced in projects) {
-			val syncData = loadProjectSyncData(synced.projectDef) ?: continue
-			if (syncData.hashAlgoVersion != ProjectContentHasher.ALGO_VERSION) continue
-			val cachedHash = syncData.cachedProjectHash ?: continue
+		return try {
+			val items = mutableListOf<ProjectHashItem>()
+			for (synced in projects) {
+				val syncData = loadProjectSyncData(synced.projectDef) ?: continue
+				if (syncData.hashAlgoVersion != ProjectContentHasher.ALGO_VERSION) continue
+				val cachedHash = syncData.cachedProjectHash ?: continue
 
-			val hasPendingWork = syncData.dirty.isNotEmpty() || syncData.newIds.isNotEmpty()
-			if (hasPendingWork) {
-				Napier.e(
-					"Cache/journal inconsistency for project '${synced.projectDef.name}': cached hash " +
-						"present despite pending journal work. A write path likely bypassed the " +
-						"dirty-tracking hook. Forcing full sync."
-				)
-				continue
+				val entityWorkPending = syncData.dirty.isNotEmpty() || syncData.newIds.isNotEmpty()
+				val projectDataDirty = isProjectDataDirty(synced.projectDef)
+				if (entityWorkPending || projectDataDirty) {
+					val kind = if (projectDataDirty) "project-data" else "journal"
+					Napier.e(
+						"Cache/journal inconsistency for project '${synced.projectDef.name}': cached hash " +
+							"present despite pending $kind work. A write path likely bypassed the " +
+							"invalidation hook. Forcing full sync."
+					)
+					continue
+				}
+
+				items += ProjectHashItem(synced.projectId, cachedHash)
 			}
 
-			items += ProjectHashItem(synced.projectId, cachedHash)
-		}
+			if (items.isEmpty()) return emptySet()
 
-		if (items.isEmpty()) return emptySet()
-
-		val result = serverProjectsApi.probeProjectChanges(items)
-		return if (result.isSuccess) {
-			result.getOrThrow().unchangedProjects
-		} else {
-			Napier.w("Sync probe failed; syncing all projects", result.exceptionOrNull())
+			val result = serverProjectsApi.probeProjectChanges(items)
+			if (result.isSuccess) {
+				result.getOrThrow().unchangedProjects
+			} else {
+				Napier.w("Sync probe failed; syncing all projects", result.exceptionOrNull())
+				emptySet()
+			}
+		} catch (e: CancellationException) {
+			throw e
+		} catch (e: Exception) {
+			Napier.w("Sync probe failed; syncing all projects", e)
 			emptySet()
 		}
 	}
 
-	// Corrupt or unreadable journal just makes the project ineligible for the probe (full sync).
-	@Suppress("SwallowedException")
-	private fun loadProjectSyncData(projectDef: ProjectDef): ProjectSynchronizationData? {
-		val path = projectDef.path.toOkioPath() / SyncDataDatasource.SYNC_FILE_NAME
-		if (!fileSystem.exists(path)) return null
-		return try {
-			fileSystem.read(path) { json.decodeFromString<ProjectSynchronizationData>(readUtf8()) }
-		} catch (e: SerializationException) {
-			null
-		}
+	/**
+	 * True when the project's local project-data blob differs from the hash the server last confirmed.
+	 * Project-data edits don't touch the entity journal, so this is their backstop: it catches a stale
+	 * cached hash even if [ProjectDataRepository.updateData]'s invalidation was missed. A never-synced
+	 * project (null `lastSyncedHash`) baselines against the default-data hash, which is what the server
+	 * holds for it too.
+	 */
+	private suspend fun isProjectDataDirty(projectDef: ProjectDef): Boolean {
+		val stored = loadStoredProjectData(projectDef, fileSystem, toml)
+		val currentHash = ProjectDataHasher.hash(stored.data)
+		val baseline = stored.lastSyncedHash ?: ProjectDataHasher.hash(ProjectData())
+		return currentHash != baseline
 	}
+
+	// Reads a project's sync journal off the IO dispatcher without opening a project scope. Any read
+	// or parse failure just makes the project ineligible for the probe (it full-syncs) — never throws.
+	@Suppress("TooGenericExceptionCaught", "SwallowedException")
+	private suspend fun loadProjectSyncData(projectDef: ProjectDef): ProjectSynchronizationData? =
+		withContext(Dispatchers.IO) {
+			val path = projectDef.path.toOkioPath() / SyncDataDatasource.SYNC_FILE_NAME
+			if (!fileSystem.exists(path)) return@withContext null
+			try {
+				fileSystem.read(path) { json.decodeFromString<ProjectSynchronizationData>(readUtf8()) }
+			} catch (e: Exception) {
+				Napier.d("Unreadable sync journal for '${projectDef.name}', will full-sync: ${e.message}")
+				null
+			}
+		}
 
 	private fun processProjectSyncData(
 		serverSyncData: BeginProjectsSyncResponse,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ProjectSynchronizationData.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ProjectSynchronizationData.kt
@@ -30,6 +30,14 @@ data class ProjectSynchronizationData(
 	// only on a successful transfer (to the hash of exactly what was sent), never re-derived from
 	// local state — so a field that mutates after a sync (e.g. `lastEdited`) can't taint it.
 	val syncedHashes: Map<Int, String> = emptyMap(),
+	/**
+	 * The project-wide content hash as of the last successful sync, read by the pre-sync change
+	 * probe to skip unchanged projects. Written only by FinalizeSyncOperation; cleared by any
+	 * content mutation (see SyncJournal). Null/absent means "recompute via a normal sync".
+	 */
+	val cachedProjectHash: String? = null,
+	/** [ProjectContentHasher.ALGO_VERSION] under which [cachedProjectHash] was computed. */
+	val hashAlgoVersion: Int = 0,
 )
 
 @Serializable

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataDatasource.kt
@@ -59,6 +59,17 @@ class SyncDataDatasource(
 		}
 	}
 
+	/**
+	 * Clears the cached project-wide hash so the next pre-sync probe can't skip a project whose
+	 * content just changed. No-op when sync data doesn't exist yet or the hash is already cleared,
+	 * so it never creates a journal for a not-yet-synchronized project.
+	 */
+	suspend fun invalidateProjectHash() {
+		val current = loadSyncDataOrNull() ?: return
+		if (current.cachedProjectHash == null) return
+		saveSyncData(current.copy(cachedProjectHash = null))
+	}
+
 	suspend fun createSyncData(): ProjectSynchronizationData {
 		val lastId = idAllocator.peekLastId()
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
@@ -40,13 +40,9 @@ class SyncJournal(
 		if (syncData.dirty.any { it.id == id }) return
 
 		val baseline = syncData.syncedHashes[id]
-		// Clearing the cached project hash in the same write keeps the invariant
-		// "cached hash present ⟹ no pending journal work" airtight (see SYNCING-PROTOCOL.md).
-		val newSyncData = syncData.copy(
-			dirty = syncData.dirty + EntityOriginalState(id, baseline),
-			cachedProjectHash = null,
+		saveInvalidatingProjectHash(
+			syncData.copy(dirty = syncData.dirty + EntityOriginalState(id, baseline))
 		)
-		datasource.saveSyncData(newSyncData)
 	}
 
 	/**
@@ -68,11 +64,7 @@ class SyncJournal(
 		if (globalSettingsStore.isServerSynchronized().not()) return
 
 		val syncData = datasource.loadSyncData()
-		val newSyncData = syncData.copy(
-			newIds = syncData.newIds + claimedId,
-			cachedProjectHash = null,
-		)
-		datasource.saveSyncData(newSyncData)
+		saveInvalidatingProjectHash(syncData.copy(newIds = syncData.newIds + claimedId))
 	}
 
 	suspend fun recordIdDeletion(deletedId: Int) {
@@ -83,17 +75,22 @@ class SyncJournal(
 		val newSyncData = if (withoutSyncedHash.newIds.contains(deletedId)) {
 			// Brand-new entity the server never saw: drop the claim so it can't
 			// become a phantom newId. Nothing to tell the server to delete.
-			withoutSyncedHash.copy(
-				newIds = withoutSyncedHash.newIds - deletedId,
-				cachedProjectHash = null,
-			)
+			withoutSyncedHash.copy(newIds = withoutSyncedHash.newIds - deletedId)
 		} else {
-			withoutSyncedHash.copy(
-				deletedIds = withoutSyncedHash.deletedIds + deletedId,
-				cachedProjectHash = null,
-			)
+			withoutSyncedHash.copy(deletedIds = withoutSyncedHash.deletedIds + deletedId)
 		}
-		datasource.saveSyncData(newSyncData)
+		saveInvalidatingProjectHash(newSyncData)
+	}
+
+	/**
+	 * Single chokepoint for content mutations: persists [data] with the cached project-wide hash
+	 * cleared in the same write. This keeps the invariant "cached hash present ⟹ no pending local
+	 * work" airtight (see SYNCING-PROTOCOL.md) so a new mutation path can't silently leave the probe
+	 * able to skip a project that actually changed. Sync-internal writes that must preserve the cache
+	 * (e.g. [recordSyncedHash], FinalizeSync) go through [datasource] directly instead.
+	 */
+	private fun saveInvalidatingProjectHash(data: ProjectSynchronizationData) {
+		datasource.saveSyncData(data.copy(cachedProjectHash = null))
 	}
 
 	fun isServerSynchronized(): Boolean {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncJournal.kt
@@ -40,8 +40,11 @@ class SyncJournal(
 		if (syncData.dirty.any { it.id == id }) return
 
 		val baseline = syncData.syncedHashes[id]
+		// Clearing the cached project hash in the same write keeps the invariant
+		// "cached hash present ⟹ no pending journal work" airtight (see SYNCING-PROTOCOL.md).
 		val newSyncData = syncData.copy(
-			dirty = syncData.dirty + EntityOriginalState(id, baseline)
+			dirty = syncData.dirty + EntityOriginalState(id, baseline),
+			cachedProjectHash = null,
 		)
 		datasource.saveSyncData(newSyncData)
 	}
@@ -65,7 +68,10 @@ class SyncJournal(
 		if (globalSettingsStore.isServerSynchronized().not()) return
 
 		val syncData = datasource.loadSyncData()
-		val newSyncData = syncData.copy(newIds = syncData.newIds + claimedId)
+		val newSyncData = syncData.copy(
+			newIds = syncData.newIds + claimedId,
+			cachedProjectHash = null,
+		)
 		datasource.saveSyncData(newSyncData)
 	}
 
@@ -77,9 +83,15 @@ class SyncJournal(
 		val newSyncData = if (withoutSyncedHash.newIds.contains(deletedId)) {
 			// Brand-new entity the server never saw: drop the claim so it can't
 			// become a phantom newId. Nothing to tell the server to delete.
-			withoutSyncedHash.copy(newIds = withoutSyncedHash.newIds - deletedId)
+			withoutSyncedHash.copy(
+				newIds = withoutSyncedHash.newIds - deletedId,
+				cachedProjectHash = null,
+			)
 		} else {
-			withoutSyncedHash.copy(deletedIds = withoutSyncedHash.deletedIds + deletedId)
+			withoutSyncedHash.copy(
+				deletedIds = withoutSyncedHash.deletedIds + deletedId,
+				cachedProjectHash = null,
+			)
 		}
 		datasource.saveSyncData(newSyncData)
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
@@ -2,9 +2,12 @@ package com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations
 
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
@@ -22,6 +25,7 @@ class FinalizeSyncOperation(
 	private val serverProjectApi: ServerProjectApi,
 	private val globalSettingsStore: GlobalSettingsStore,
 	private val syncDataDatasource: SyncDataDatasource,
+	private val projectDataDatasource: ProjectDataDatasource,
 ) : SyncOperation(projectDef) {
 
 	override suspend fun execute(
@@ -84,6 +88,10 @@ class FinalizeSyncOperation(
 					// recordIdDeletion) so stale baselines can't mis-fire if an id is reused.
 					val persistedSyncedHashes = syncDataDatasource.loadSyncData().syncedHashes -
 						state.collatedIds.combinedDeletions
+					// Cache the project-wide hash of the now-reconciled local state so the next
+					// app open can probe-skip this project if nothing changed. Computed from the
+					// final state, not the pre-sync snapshot, since entity transfer may have changed it.
+					val projectHash = computeProjectHash()
 					val finalSyncData = state.clientSyncData.copy(
 						currentSyncId = null,
 						lastId = newLastId,
@@ -92,6 +100,8 @@ class FinalizeSyncOperation(
 						newIds = emptyList(),
 						deletedIds = state.collatedIds.combinedDeletions,
 						syncedHashes = persistedSyncedHashes,
+						cachedProjectHash = projectHash,
+						hashAlgoVersion = ProjectContentHasher.ALGO_VERSION,
 					)
 					syncDataDatasource.saveSyncData(finalSyncData)
 				} else {
@@ -122,6 +132,14 @@ class FinalizeSyncOperation(
 
 	private suspend fun finalizeSync() {
 		entitySynchronizers.synchronizers.values.forEach { it.finalizeSync() }
+	}
+
+	private suspend fun computeProjectHash(): String {
+		val entityHashes = entitySynchronizers.synchronizers.values
+			.flatMap { it.hashEntities(emptyList()) }
+			.toSet()
+		val projectDataHash = ProjectDataHasher.hash(projectDataDatasource.load().data)
+		return ProjectContentHasher.hash(entityHashes, projectDataHash)
 	}
 
 	private suspend fun userId(): Long {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
@@ -4,11 +4,15 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.BeginProjectsSyncResponse
 import com.darkrockstudios.apps.hammer.base.http.CreateProjectResponse
 import com.darkrockstudios.apps.hammer.base.http.HEADER_SYNC_ID
+import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
+import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeRequest
+import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeResponse
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 
 class ServerProjectsApi(
 	httpClient: HttpClient,
@@ -20,6 +24,19 @@ class ServerProjectsApi(
 		return get(
 			path = "/api/projects/$userId/begin_sync",
 			parse = { it.body() },
+		)
+	}
+
+	suspend fun probeProjectChanges(
+		items: List<ProjectHashItem>,
+	): Result<ProjectsSyncProbeResponse> {
+		return post(
+			path = "/api/projects/$userId/sync_probe",
+			parse = { it.body() },
+			builder = {
+				contentType(ContentType.Application.Json)
+				setBody(ProjectsSyncProbeRequest(items))
+			},
 		)
 	}
 

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -9,7 +9,10 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
+import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.sync.accountsync.ClientAccountSynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityOriginalState
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ProjectSynchronizationData
@@ -24,6 +27,7 @@ import io.ktor.http.*
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import net.peanuuutz.tomlkt.Toml
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import org.junit.jupiter.api.BeforeEach
@@ -91,6 +95,7 @@ class ClientAccountSynchronizerTest {
 		serverProjectsApi = serverProjectsApi,
 		networkConnectivity = networkConnectivity,
 		json = json,
+		toml = Toml,
 		strRes = TestStrRes(),
 	)
 
@@ -129,6 +134,12 @@ class ClientAccountSynchronizerTest {
 		val path = projectDef.path.toOkioPath() / "sync.json"
 		path.parent?.let { ffs.createDirectories(it) }
 		ffs.write(path) { writeUtf8(json.encodeToString(data)) }
+	}
+
+	private fun writeProjectData(projectDef: ProjectDef, data: StoredProjectData) {
+		val path = projectDef.path.toOkioPath() / "project_data.toml"
+		path.parent?.let { ffs.createDirectories(it) }
+		ffs.write(path) { writeUtf8(Toml.encodeToString(data)) }
 	}
 
 	@Test
@@ -206,6 +217,42 @@ class ClientAccountSynchronizerTest {
 			.probeUnchangedProjects(listOf(SyncedProjectDefinition(def, projectId)))
 
 		assertTrue(result.isEmpty())
+	}
+
+	@Test
+	fun `probe skips a project whose project-data changed but entity journal is clean`() = runTest {
+		val def = projectDef("Zeta")
+		val projectId = ProjectId("uuid-zeta")
+		// Clean entity journal + a cached hash, but project-data diverges from its last-synced hash.
+		writeProjectSyncData(def, cleanProjectSyncData(hash = "zeta-hash"))
+		writeProjectData(
+			def,
+			StoredProjectData(
+				data = ProjectData(authorName = "Edited"),
+				lastSyncedHash = ProjectDataHasher.hash(ProjectData()),
+			),
+		)
+
+		val result = createSynchronizer()
+			.probeUnchangedProjects(listOf(SyncedProjectDefinition(def, projectId)))
+
+		assertTrue(result.isEmpty(), "a project-data-only edit must not be probe-skipped")
+		coVerify(exactly = 0) { serverProjectsApi.probeProjectChanges(any()) }
+	}
+
+	@Test
+	fun `probe treats an unreadable journal as ineligible without throwing`() = runTest {
+		val def = projectDef("Eta")
+		val projectId = ProjectId("uuid-eta")
+		val path = def.path.toOkioPath() / "sync.json"
+		path.parent?.let { ffs.createDirectories(it) }
+		ffs.write(path) { writeUtf8("}{ not valid json") }
+
+		val result = createSynchronizer()
+			.probeUnchangedProjects(listOf(SyncedProjectDefinition(def, projectId)))
+
+		assertTrue(result.isEmpty())
+		coVerify(exactly = 0) { serverProjectsApi.probeProjectChanges(any()) }
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -11,6 +11,7 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
+import com.darkrockstudios.apps.hammer.base.http.writeToml
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.sync.accountsync.ClientAccountSynchronizer
@@ -139,7 +140,7 @@ class ClientAccountSynchronizerTest {
 	private fun writeProjectData(projectDef: ProjectDef, data: StoredProjectData) {
 		val path = projectDef.path.toOkioPath() / "project_data.toml"
 		path.parent?.let { ffs.createDirectories(it) }
-		ffs.write(path) { writeUtf8(Toml.encodeToString(data)) }
+		ffs.writeToml(path, Toml, data)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -9,10 +9,14 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
 import com.darkrockstudios.apps.hammer.common.data.sync.accountsync.ClientAccountSynchronizer
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityOriginalState
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ProjectSynchronizationData
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ProjectsSynchronizationData
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.RenamedProject
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectsApi
 import com.darkrockstudios.apps.hammer.common.util.NetworkConnectivity
@@ -29,6 +33,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 class ClientAccountSynchronizerTest {
 
@@ -107,6 +112,100 @@ class ClientAccountSynchronizerTest {
 		coEvery { serverProjectsApi.beginProjectsSync() } returns Result.success(emptyServerResponse())
 		coEvery { serverProjectsApi.endProjectsSync(any()) } returns Result.success("ok")
 		coEvery { networkConnectivity.hasActiveConnection() } returns true
+	}
+
+	private fun cleanProjectSyncData(hash: String?, algoVersion: Int = ProjectContentHasher.ALGO_VERSION) =
+		ProjectSynchronizationData(
+			lastId = 0,
+			newIds = emptyList(),
+			lastSync = Instant.DISTANT_PAST,
+			dirty = emptyList(),
+			deletedIds = emptySet(),
+			cachedProjectHash = hash,
+			hashAlgoVersion = algoVersion,
+		)
+
+	private fun writeProjectSyncData(projectDef: ProjectDef, data: ProjectSynchronizationData) {
+		val path = projectDef.path.toOkioPath() / "sync.json"
+		path.parent?.let { ffs.createDirectories(it) }
+		ffs.write(path) { writeUtf8(json.encodeToString(data)) }
+	}
+
+	@Test
+	fun `probe sends a clean project's cached hash and returns the server's unchanged set`() = runTest {
+		val def = projectDef("Alpha")
+		val projectId = ProjectId("uuid-alpha")
+		writeProjectSyncData(def, cleanProjectSyncData(hash = "alpha-hash"))
+
+		val captured = slot<List<ProjectHashItem>>()
+		coEvery { serverProjectsApi.probeProjectChanges(capture(captured)) } returns
+			Result.success(ProjectsSyncProbeResponse(unchangedProjects = setOf(projectId)))
+
+		val result = createSynchronizer()
+			.probeUnchangedProjects(listOf(SyncedProjectDefinition(def, projectId)))
+
+		assertEquals(setOf(projectId), result)
+		assertEquals(listOf(ProjectHashItem(projectId, "alpha-hash")), captured.captured)
+	}
+
+	@Test
+	fun `probe skips a project with pending journal work and never calls the server`() = runTest {
+		val def = projectDef("Beta")
+		val projectId = ProjectId("uuid-beta")
+		writeProjectSyncData(
+			def,
+			cleanProjectSyncData(hash = "beta-hash").copy(dirty = listOf(EntityOriginalState(1, "old"))),
+		)
+
+		val result = createSynchronizer()
+			.probeUnchangedProjects(listOf(SyncedProjectDefinition(def, projectId)))
+
+		assertTrue(result.isEmpty())
+		coVerify(exactly = 0) { serverProjectsApi.probeProjectChanges(any()) }
+	}
+
+	@Test
+	fun `probe ignores a cache written under an older algorithm version`() = runTest {
+		val def = projectDef("Gamma")
+		val projectId = ProjectId("uuid-gamma")
+		writeProjectSyncData(
+			def,
+			cleanProjectSyncData(hash = "gamma-hash", algoVersion = ProjectContentHasher.ALGO_VERSION - 1),
+		)
+
+		val result = createSynchronizer()
+			.probeUnchangedProjects(listOf(SyncedProjectDefinition(def, projectId)))
+
+		assertTrue(result.isEmpty())
+		coVerify(exactly = 0) { serverProjectsApi.probeProjectChanges(any()) }
+	}
+
+	@Test
+	fun `probe ignores a project with no cached hash`() = runTest {
+		val def = projectDef("Delta")
+		val projectId = ProjectId("uuid-delta")
+		writeProjectSyncData(def, cleanProjectSyncData(hash = null))
+
+		val result = createSynchronizer()
+			.probeUnchangedProjects(listOf(SyncedProjectDefinition(def, projectId)))
+
+		assertTrue(result.isEmpty())
+		coVerify(exactly = 0) { serverProjectsApi.probeProjectChanges(any()) }
+	}
+
+	@Test
+	fun `probe failure falls back to syncing everything`() = runTest {
+		val def = projectDef("Epsilon")
+		val projectId = ProjectId("uuid-epsilon")
+		writeProjectSyncData(def, cleanProjectSyncData(hash = "epsilon-hash"))
+
+		coEvery { serverProjectsApi.probeProjectChanges(any()) } returns
+			Result.failure(unauthorizedException())
+
+		val result = createSynchronizer()
+			.probeUnchangedProjects(listOf(SyncedProjectDefinition(def, projectId)))
+
+		assertTrue(result.isEmpty())
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FinalizeSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FinalizeSyncOperationTest.kt
@@ -6,6 +6,8 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.FinalizeSyncOperation
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
@@ -39,6 +41,9 @@ class FinalizeSyncOperationTest : BaseTest() {
 
 	@MockK(relaxed = true)
 	private lateinit var syncDataDatasource: SyncDataDatasource
+
+	@MockK(relaxed = true)
+	private lateinit var projectDataDatasource: ProjectDataDatasource
 
 	private lateinit var strRes: TestStrRes
 
@@ -74,6 +79,7 @@ class FinalizeSyncOperationTest : BaseTest() {
 			clock = clock,
 			globalSettingsStore = globalSettingsStore,
 			syncDataDatasource = syncDataDatasource,
+			projectDataDatasource = projectDataDatasource,
 		)
 	}
 
@@ -90,7 +96,9 @@ class FinalizeSyncOperationTest : BaseTest() {
 		}
 		mockSynchronizers.synchronizers.forEach { synchronizer ->
 			coEvery { synchronizer.finalizeSync() } just Runs
+			coEvery { synchronizer.hashEntities(any()) } returns emptySet()
 		}
+		coEvery { projectDataDatasource.load() } returns StoredProjectData()
 
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -100,6 +100,121 @@ sequenceDiagram
 
 ---
 
+## Pre-Sync Change Probe
+
+Between Account Sync and Project Sync sits an optional optimization step. Account Sync brings the *set* of projects into parity; the probe then asks, in a single batched request, *which of those projects actually have content changes* — so we can skip the per-project sync entirely for the ones that don't.
+
+### Motivation
+
+A full project sync, even for a project with zero changes, costs at minimum ~4 HTTP round-trips (`begin_sync`, `project_data`, `writing_activity`, `end_sync`). On app open that is paid once *per project*. For a user with many untouched projects this is the dominant cost of "opening the app," even though nothing needs to happen.
+
+The probe collapses that to **one** request for the whole account, and lets every unchanged project jump straight to `Complete` in the UI without opening a project-level sync session at all.
+
+### The Project-Wide Hash
+
+Each project gets a single **project-wide content hash** computed over the two data sources whose divergence is unacceptable:
+
+- all of the project's **entities** (the same per-entity hashes already produced for `ClientEntityState`), and
+- the **project-data blob** (author, theme, word-count goal — hashed via `ProjectDataHasher`).
+
+The aggregate is order-independent of enumeration: sort the entity `{id, hash}` pairs by id, fold `id:hash` pairs plus the project-data hash through the same MurmurHash3 used elsewhere. The function lives in the `base` module (alongside `EntityHasher` / `ProjectDataHasher`) so the **client and server run byte-identical code**.
+
+**Writing activity is deliberately excluded.** It is per-device, conflict-free, and the project's authoritative record is the *union* of every device's slot — so no single device ever holds the full set, and a symmetric content hash that included it would never match across devices. It is also explicitly auxiliary (its sync phase already swallows errors and retries next time), so a skipped opportunistic activity sync is consistent with the existing tolerance. The trade-off: a change that touches *only* another device's writing activity will not be detected by the probe, and is picked up on the next sync that runs for any other reason.
+
+### The Comparison Is Symmetric
+
+The probe does **not** ask "did the server change since I last synced." It compares **the client's current hash against the server's current hash**:
+
+- if the client edited locally, its hash differs from the server's → sync,
+- if another device pushed changes, the server's hash differs from the client's → sync,
+- only when both currently agree do we skip.
+
+This catches changes in *both* directions with a single comparison and **zero persisted bookkeeping on the server** — the server recomputes its hash on demand from its stored (cached) entity hashes and project-data hash. This honors the protocol's "no required book keeping data" principle: the probe is a pure optimization, and losing or ignoring it changes nothing but speed.
+
+### Network Protocol
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: After Account Sync, before any Project Sync
+
+    Client->>Server: POST /api/projects/{userId}/sync_probe
+    activate Server
+    Note right of Client: ProjectsSyncProbeRequest<br/>[ { projectId, hash } ]
+    Note over Server: For each project, recompute the<br/>project-wide hash and compare
+    Server -->> Client: 200 OK
+    deactivate Server
+    activate Client
+    Note left of Server: ProjectsSyncProbeResponse<br/>{ unchangedProjects }
+
+    Note right of Client: Mark unchangedProjects → Complete (skip).<br/>Sync everything else as today.
+    deactivate Client
+```
+
+- `POST /api/projects/{userId}/sync_probe` — read-only, no `syncId` required.
+- Request `ProjectsSyncProbeRequest { projects: List<ProjectHashItem> }`, where `ProjectHashItem { projectId, hash }`.
+- Response `ProjectsSyncProbeResponse { unchangedProjects: Set<ProjectId> }`.
+
+The client sends entries **only** for projects that have a `serverProjectId` *and* a cached hash (see below). The server returns a project in `unchangedProjects` only when it is certain (project exists, hash matches); anything unknown or mismatched is simply omitted, and the client syncs it the normal way. Projects not sent in the request are never skipped.
+
+If the endpoint is unsupported (older server) or the request fails for any reason, the client silently falls back to a full per-project sync — no behavior change. The protocol version is bumped accordingly.
+
+### Client-Side Hash Cache
+
+Computing the hash requires hashing every entity, which is local disk I/O. To avoid an N-project crawl on every app open, the client **caches** each project's hash in that project's own sync journal (`ProjectSynchronizationData`):
+
+```
+cachedProjectHash: String?   // the project-wide hash as of the last successful sync
+hashAlgoVersion: Int         // bumped when the hashing algorithm changes
+```
+
+The cache has exactly one of each path:
+
+- **Write** — only in `FinalizeSyncOperation`, at the end of a successful project sync. The hash is computed from the **final, reconciled** local state (not the pre-sync snapshot, since entity transfer may have changed things). This only runs for projects that actually synced, whose entities were read/written anyway.
+- **Clear** — at the **repository / datasource layer**, wherever an entity or the project-data blob is mutated. Because every writer (editor, Android widgets, background workers) funnels through the same repositories, threading invalidation through that single chokepoint covers all of them — there are no special cases to audit per call-site.
+- **Read** — by the probe, to build its request.
+
+There is intentionally **no compute-on-the-fly and no migration path.** A missing or stale-version hash simply makes a project ineligible for the fast skip, so it syncs the normal way — which is already quick — and `FinalizeSync` writes a fresh hash on the way out. Every edge case collapses into this one self-healing path:
+
+- first run after the feature ships → no caches → today's behavior once, then cached,
+- new device / fresh install / restored backup → same,
+- `hashAlgoVersion` bump after the hasher changes → mismatched version treated as missing → one normal sync → re-cached at the new version.
+
+### Correctness
+
+The asymmetry of risk:
+
+- A **false mismatch** (hashes differ but nothing actually needs syncing) is harmless — it just runs a redundant full sync.
+- A **false match** (we skip a project that was actually divergent) does **not** lose data: skipping is a pure no-op on local and server state — nothing is deleted, overwritten, or cleared, `lastSync` does not advance, and the dirty list (with its pre-edit `originalHash`) survives, so the eventual sync still detects conflicts correctly. The only cost is that client and server **stay divergent longer than they should**, and the UI may show `Complete` prematurely.
+
+The journal backstop makes even that impossible in correct operation. A stale cache can only arise from a mutation that failed to clear it — but the *same* mutation also writes the dirty list. So:
+
+> stale cache ⟺ a mutation occurred ⟺ the journal has pending work ⟹ the project is force-synced.
+
+Therefore the rule: **never skip a project whose journal shows pending work (`dirty` / `newIds` / `deletedIds`), regardless of its cached hash.** The only way to defeat this is a write path that updates *neither* the cache *nor* the dirty list — which would already be breaking conflict detection in today's protocol, independent of this optimization. So the probe introduces no new divergence risk beyond what the dirty list already guards.
+
+Because of that, `cachedProjectHash != null` together with a non-empty journal is an **invariant violation**, not a normal state. When the backstop sees it, it forces the sync *and* logs an error so the latent bug is attributable:
+
+> `Cache/journal inconsistency for project '{name}': cached hash present despite pending journal work. A write path likely bypassed the dirty-tracking hook. Forcing full sync.`
+
+### Per-Project Skip Decision
+
+```mermaid
+flowchart TD
+    A[Project from reconciled list] --> B{serverProjectId<br/>and cached hash?}
+    B -- no --> S[Full sync today's way]
+    B -- yes --> C{Journal has<br/>pending work?}
+    C -- yes --> L[Log invariant violation] --> S
+    C -- no --> D[Include in probe request]
+    D --> E{Server says<br/>unchanged?}
+    E -- yes --> K[Mark Complete, skip]
+    E -- no --> S
+```
+
+---
+
 ## Project Sync Protocol
 
 ## Goal

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -102,13 +102,11 @@ sequenceDiagram
 
 ## Pre-Sync Change Probe
 
-Between Account Sync and Project Sync sits an optional optimization step. Account Sync brings the *set* of projects into parity; the probe then asks, in a single batched request, *which of those projects actually have content changes* — so we can skip the per-project sync entirely for the ones that don't.
+Between Account Sync and Project Sync sits an optional optimization. Account Sync brings the *set* of projects into parity; the probe then asks, in a single batched request, *which* of those projects actually have content changes — so the client can skip the per-project sync for every project that has none.
 
-### Motivation
+This matters because a full project sync costs ~4 round-trips (`begin_sync`, `project_data`, `writing_activity`, `end_sync`) even when nothing has changed, paid once per project on every app open. The probe collapses that to one request for the whole account.
 
-A full project sync, even for a project with zero changes, costs at minimum ~4 HTTP round-trips (`begin_sync`, `project_data`, `writing_activity`, `end_sync`). On app open that is paid once *per project*. For a user with many untouched projects this is the dominant cost of "opening the app," even though nothing needs to happen.
-
-The probe collapses that to **one** request for the whole account, and lets every unchanged project jump straight to `Complete` in the UI without opening a project-level sync session at all.
+The probe keeps no required state of its own: a client or server that ignores it loses nothing but speed.
 
 ### The Project-Wide Hash
 
@@ -121,15 +119,9 @@ The aggregate is order-independent of enumeration: sort the entity `{id, hash}` 
 
 **Writing activity is deliberately excluded.** It is per-device, conflict-free, and the project's authoritative record is the *union* of every device's slot — so no single device ever holds the full set, and a symmetric content hash that included it would never match across devices. It is also explicitly auxiliary (its sync phase already swallows errors and retries next time), so a skipped opportunistic activity sync is consistent with the existing tolerance. The trade-off: a change that touches *only* another device's writing activity will not be detected by the probe, and is picked up on the next sync that runs for any other reason.
 
-### The Comparison Is Symmetric
+### Symmetric Comparison
 
-The probe does **not** ask "did the server change since I last synced." It compares **the client's current hash against the server's current hash**:
-
-- if the client edited locally, its hash differs from the server's → sync,
-- if another device pushed changes, the server's hash differs from the client's → sync,
-- only when both currently agree do we skip.
-
-This catches changes in *both* directions with a single comparison and **zero persisted bookkeeping on the server** — the server recomputes its hash on demand from its stored (cached) entity hashes and project-data hash. This honors the protocol's "no required book keeping data" principle: the probe is a pure optimization, and losing or ignoring it changes nothing but speed.
+The probe compares **the client's current hash against the server's current hash** — not "did the server change since I last synced." A local edit makes the client's hash differ; another device's push makes the server's hash differ; only when both currently agree is the project skipped. One comparison covers both directions, and the server recomputes its hash on demand from its stored state — no per-client bookkeeping, in keeping with the protocol's "no required book keeping data" principle.
 
 ### Network Protocol
 
@@ -149,7 +141,7 @@ sequenceDiagram
     activate Client
     Note left of Server: ProjectsSyncProbeResponse<br/>{ unchangedProjects }
 
-    Note right of Client: Mark unchangedProjects → Complete (skip).<br/>Sync everything else as today.
+    Note right of Client: Skip unchangedProjects;<br/>sync everything else as normal.
     deactivate Client
 ```
 
@@ -157,68 +149,20 @@ sequenceDiagram
 - Request `ProjectsSyncProbeRequest { projects: List<ProjectHashItem> }`, where `ProjectHashItem { projectId, hash }`.
 - Response `ProjectsSyncProbeResponse { unchangedProjects: Set<ProjectId> }`.
 
-The client sends entries **only** for projects that have a `serverProjectId` *and* a cached hash (see below). The server returns a project in `unchangedProjects` only when it is certain (project exists, hash matches); anything unknown or mismatched is simply omitted, and the client syncs it the normal way. Projects not sent in the request are never skipped.
+The server returns a project in `unchangedProjects` **only** when it is certain it is in sync — the project exists and its freshly recomputed hash matches. It omits anything it cannot certify, including any project with an **in-flight sync session** (whose stored hashes may be mid-update). A project the client never sends, or the server never returns, is simply synced the normal way.
 
-If the endpoint is unsupported (older server) or the request fails for any reason, the client silently falls back to a full per-project sync — no behavior change. The protocol version is bumped accordingly.
-
-### Client-Side Hash Cache
-
-Computing the hash requires hashing every entity, which is local disk I/O. To avoid an N-project crawl on every app open, the client **caches** each project's hash in that project's own sync journal (`ProjectSynchronizationData`):
-
-```
-cachedProjectHash: String?   // the project-wide hash as of the last successful sync
-hashAlgoVersion: Int         // bumped when the hashing algorithm changes
-```
-
-The cache has exactly one of each path:
-
-- **Write** — only in `FinalizeSyncOperation`, at the end of a successful project sync. The hash is computed from the **final, reconciled** local state (not the pre-sync snapshot, since entity transfer may have changed things). This only runs for projects that actually synced, whose entities were read/written anyway.
-- **Clear** — at the **repository / datasource layer**, wherever an entity or the project-data blob is mutated. Because every writer (editor, Android widgets, background workers) funnels through the same repositories, threading invalidation through that single chokepoint covers all of them — there are no special cases to audit per call-site.
-- **Read** — by the probe, to build its request.
-
-There is intentionally **no compute-on-the-fly and no migration path.** A missing or stale-version hash simply makes a project ineligible for the fast skip, so it syncs the normal way — which is already quick — and `FinalizeSync` writes a fresh hash on the way out. Every edge case collapses into this one self-healing path:
-
-- first run after the feature ships → no caches → today's behavior once, then cached,
-- new device / fresh install / restored backup → same,
-- `hashAlgoVersion` bump after the hasher changes → mismatched version treated as missing → one normal sync → re-cached at the new version.
+If the endpoint is unsupported (older server) or the request fails for any reason, the client silently falls back to a full per-project sync — no behavior change.
 
 ### Correctness
 
-The asymmetry of risk:
+The risk is asymmetric:
 
-- A **false mismatch** (hashes differ but nothing actually needs syncing) is harmless — it just runs a redundant full sync.
-- A **false match** (we skip a project that was actually divergent) does **not** lose data: skipping is a pure no-op on local and server state — nothing is deleted, overwritten, or cleared, `lastSync` does not advance, and the dirty list (with its pre-edit `originalHash`) survives, so the eventual sync still detects conflicts correctly. The only cost is that client and server **stay divergent longer than they should**, and the UI may show `Complete` prematurely.
+- A **false mismatch** — the hashes differ but nothing needed syncing — is harmless: just a redundant full sync.
+- A **false match** — skipping a project that was actually divergent — loses no data: skipping is a no-op on both sides, and the next sync still reconciles through the normal dirty/conflict machinery. The only cost is that the two stay divergent longer than they should.
 
-The local backstop makes even that impossible in correct operation. A stale cache can only arise from a mutation that failed to clear it — but the *same* mutation also records pending local work. So:
+So the one rule the client must uphold is: **never skip a project that has un-synced local changes.** As long as a local change is recorded before a project could be reported unchanged, the probe can only ever *defer* a sync, never hide one — it adds no divergence risk beyond what the existing change tracking already guards.
 
-> stale cache ⟺ a mutation occurred ⟺ there is pending local work ⟹ the project is force-synced.
-
-Therefore the rule: **never skip a project that has pending local work, regardless of its cached hash.** "Pending local work" is:
-
-- **pending entity work** — `dirty` or `newIds` is non-empty (this is exactly `SyncJournal.needsSync`). `deletedIds` is *deliberately excluded*: it is a persistent tombstone set that never empties, so testing it would disqualify every project that ever deleted an entity. A pending deletion needs no separate guard — it drops the entity out of the project-wide hash (→ mismatch → sync) and `recordIdDeletion` clears the cache anyway.
-- **a project-data edit** — the project-data blob does not touch the entity journal, so it gets its own backstop: the probe compares the blob's current hash to the `lastSyncedHash` the server last confirmed (a never-synced project baselines against the default-data hash). This is what catches a stale cache if `ProjectDataRepository.updateData`'s invalidation is ever missed.
-
-The only way to defeat this is a write path that updates *neither* the cache *nor* the journal/lastSyncedHash — which would already be breaking conflict detection in today's protocol, independent of this optimization. So the probe introduces no new divergence risk beyond what the existing tracking already guards.
-
-Because of that, `cachedProjectHash != null` together with pending local work is an **invariant violation**, not a normal state. When the backstop sees it, it forces the sync *and* logs an error so the latent bug is attributable:
-
-> `Cache/journal inconsistency for project '{name}': cached hash present despite pending {journal|project-data} work. A write path likely bypassed the invalidation hook. Forcing full sync.`
-
-On the server side, the probe also skips any project with an **in-flight sync session** (e.g. a concurrent sync from another device): its stored hashes may be half-updated, so it can't be certified unchanged and is reported as changed (the client full-syncs).
-
-### Per-Project Skip Decision
-
-```mermaid
-flowchart TD
-    A[Project from reconciled list] --> B{serverProjectId<br/>and cached hash?}
-    B -- no --> S[Full sync today's way]
-    B -- yes --> C{Pending local work?<br/>dirty / newIds / project-data}
-    C -- yes --> L[Log invariant violation] --> S
-    C -- no --> D[Include in probe request]
-    D --> E{Server: known, no active<br/>session, hash matches?}
-    E -- yes --> K[Mark Complete, skip]
-    E -- no --> S
-```
+How the client decides a project is eligible — and how it caches its own project-wide hash to avoid re-hashing every entity on each open — is a client implementation detail, not part of the wire protocol.
 
 ---
 

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -189,15 +189,22 @@ The asymmetry of risk:
 - A **false mismatch** (hashes differ but nothing actually needs syncing) is harmless — it just runs a redundant full sync.
 - A **false match** (we skip a project that was actually divergent) does **not** lose data: skipping is a pure no-op on local and server state — nothing is deleted, overwritten, or cleared, `lastSync` does not advance, and the dirty list (with its pre-edit `originalHash`) survives, so the eventual sync still detects conflicts correctly. The only cost is that client and server **stay divergent longer than they should**, and the UI may show `Complete` prematurely.
 
-The journal backstop makes even that impossible in correct operation. A stale cache can only arise from a mutation that failed to clear it — but the *same* mutation also writes the dirty list. So:
+The local backstop makes even that impossible in correct operation. A stale cache can only arise from a mutation that failed to clear it — but the *same* mutation also records pending local work. So:
 
-> stale cache ⟺ a mutation occurred ⟺ the journal has pending work ⟹ the project is force-synced.
+> stale cache ⟺ a mutation occurred ⟺ there is pending local work ⟹ the project is force-synced.
 
-Therefore the rule: **never skip a project whose journal shows pending work (`dirty` / `newIds` / `deletedIds`), regardless of its cached hash.** The only way to defeat this is a write path that updates *neither* the cache *nor* the dirty list — which would already be breaking conflict detection in today's protocol, independent of this optimization. So the probe introduces no new divergence risk beyond what the dirty list already guards.
+Therefore the rule: **never skip a project that has pending local work, regardless of its cached hash.** "Pending local work" is:
 
-Because of that, `cachedProjectHash != null` together with a non-empty journal is an **invariant violation**, not a normal state. When the backstop sees it, it forces the sync *and* logs an error so the latent bug is attributable:
+- **pending entity work** — `dirty` or `newIds` is non-empty (this is exactly `SyncJournal.needsSync`). `deletedIds` is *deliberately excluded*: it is a persistent tombstone set that never empties, so testing it would disqualify every project that ever deleted an entity. A pending deletion needs no separate guard — it drops the entity out of the project-wide hash (→ mismatch → sync) and `recordIdDeletion` clears the cache anyway.
+- **a project-data edit** — the project-data blob does not touch the entity journal, so it gets its own backstop: the probe compares the blob's current hash to the `lastSyncedHash` the server last confirmed (a never-synced project baselines against the default-data hash). This is what catches a stale cache if `ProjectDataRepository.updateData`'s invalidation is ever missed.
 
-> `Cache/journal inconsistency for project '{name}': cached hash present despite pending journal work. A write path likely bypassed the dirty-tracking hook. Forcing full sync.`
+The only way to defeat this is a write path that updates *neither* the cache *nor* the journal/lastSyncedHash — which would already be breaking conflict detection in today's protocol, independent of this optimization. So the probe introduces no new divergence risk beyond what the existing tracking already guards.
+
+Because of that, `cachedProjectHash != null` together with pending local work is an **invariant violation**, not a normal state. When the backstop sees it, it forces the sync *and* logs an error so the latent bug is attributable:
+
+> `Cache/journal inconsistency for project '{name}': cached hash present despite pending {journal|project-data} work. A write path likely bypassed the invalidation hook. Forcing full sync.`
+
+On the server side, the probe also skips any project with an **in-flight sync session** (e.g. a concurrent sync from another device): its stored hashes may be half-updated, so it can't be certified unchanged and is reported as changed (the client full-syncs).
 
 ### Per-Project Skip Decision
 
@@ -205,10 +212,10 @@ Because of that, `cachedProjectHash != null` together with a non-empty journal i
 flowchart TD
     A[Project from reconciled list] --> B{serverProjectId<br/>and cached hash?}
     B -- no --> S[Full sync today's way]
-    B -- yes --> C{Journal has<br/>pending work?}
+    B -- yes --> C{Pending local work?<br/>dirty / newIds / project-data}
     C -- yes --> L[Log invariant violation] --> S
     C -- no --> D[Include in probe request]
-    D --> E{Server says<br/>unchanged?}
+    D --> E{Server: known, no active<br/>session, hash matches?}
     E -- yes --> K[Mark Complete, skip]
     E -- no --> S
 ```

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/StoryEntityDao.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/StoryEntityDao.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.database
 
 import com.darkrockstudios.apps.hammer.Story_entity
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.EntityHash
 import com.darkrockstudios.apps.hammer.project.EntityDefinition
 import com.darkrockstudios.apps.hammer.utilities.SResult
 import com.darkrockstudios.apps.hammer.utilities.injectIoDispatcher
@@ -184,5 +185,12 @@ class StoryEntityDao(
 		withContext(ioDispatcher) {
 			queries.getEntityHash(userId = userId, projectId = projectId, id = id)
 				.executeAsOneOrNull()
+		}
+
+	suspend fun getEntityHashes(userId: Long, projectId: Long): List<EntityHash> =
+		withContext(ioDispatcher) {
+			queries.getEntityHashes(userId = userId, projectId = projectId).executeAsList().map {
+				EntityHash(id = it.id.toInt(), hash = it.hash)
+			}
 		}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityDatabaseDatasource.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityDatabaseDatasource.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.project
 
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.EntityHash
 import com.darkrockstudios.apps.hammer.database.*
 import com.darkrockstudios.apps.hammer.encryption.ContentEncryptor
 import com.darkrockstudios.apps.hammer.utilities.SResult
@@ -324,5 +325,13 @@ class ProjectEntityDatabaseDatasource(
 	): String? {
 		val projectId = projectDao.getProjectId(userId, projectDef.uuid)
 		return storyEntityDao.getEntityHash(userId, projectId, entityId.toLong())
+	}
+
+	override suspend fun getEntityHashes(
+		userId: Long,
+		projectDef: ProjectDefinition,
+	): List<EntityHash> {
+		val projectId = projectDao.getProjectId(userId, projectDef.uuid)
+		return storyEntityDao.getEntityHashes(userId, projectId)
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityDatasource.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityDatasource.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.project
 
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.EntityHash
 import com.darkrockstudios.apps.hammer.utilities.SResult
 import kotlinx.serialization.KSerializer
 
@@ -74,4 +75,10 @@ interface ProjectEntityDatasource {
 		projectDef: ProjectDefinition,
 		entityId: Int
 	): String?
+
+	/** All of a project's entity ids paired with their cached hashes, in one query, sorted by id. */
+	suspend fun getEntityHashes(
+		userId: Long,
+		projectDef: ProjectDefinition,
+	): List<EntityHash>
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRepository.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHash
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.base.validate.validateProjectName
 import com.darkrockstudios.apps.hammer.dependencyinjection.PROJECTS_SYNC_MANAGER
+import com.darkrockstudios.apps.hammer.dependencyinjection.PROJECT_SYNC_MANAGER
 import com.darkrockstudios.apps.hammer.project.*
 import com.darkrockstudios.apps.hammer.syncsessionmanager.SyncSessionManager
 import com.darkrockstudios.apps.hammer.utilities.Msg
@@ -26,6 +27,11 @@ class ProjectsRepository(
 	private val syncSessionManager: SyncSessionManager<Long, ProjectsSynchronizationSession> by inject(
 		clazz = SyncSessionManager::class.java,
 		qualifier = named(PROJECTS_SYNC_MANAGER)
+	)
+
+	private val projectSyncSessionManager: SyncSessionManager<ProjectSyncKey, ProjectSynchronizationSession> by inject(
+		clazz = SyncSessionManager::class.java,
+		qualifier = named(PROJECT_SYNC_MANAGER)
 	)
 
 	suspend fun createUserData(userId: Long) = projectsDatasource.createUserData(userId)
@@ -123,6 +129,9 @@ class ProjectsRepository(
 		val unchanged = mutableSetOf<ProjectId>()
 		for (item in items) {
 			val projectDef = projectsDatasource.getProject(userId, item.projectId) ?: continue
+			// A project with an in-flight sync (e.g. from another device) may have half-updated
+			// stored hashes, so we can't certify it "unchanged". Omit it → the client full-syncs.
+			if (projectSyncSessionManager.hasActiveSyncSession(ProjectSyncKey(userId, projectDef))) continue
 			val serverHash = computeProjectContentHash(userId, projectDef) ?: continue
 			if (serverHash == item.hash) {
 				unchanged += item.projectId

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRepository.kt
@@ -1,7 +1,6 @@
 package com.darkrockstudios.apps.hammer.projects
 
 import com.darkrockstudios.apps.hammer.base.ProjectId
-import com.darkrockstudios.apps.hammer.base.http.EntityHash
 import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
@@ -149,12 +148,8 @@ class ProjectsRepository(
 		userId: Long,
 		projectDef: ProjectDefinition,
 	): String? {
-		val defs = projectEntityDatasource.getEntityDefs(userId, projectDef)
-		val entityHashes = ArrayList<EntityHash>(defs.size)
-		for (def in defs) {
-			val hash = projectEntityDatasource.getCachedHash(userId, projectDef, def.id) ?: return null
-			entityHashes += EntityHash(def.id, hash)
-		}
+		// One query for all (id, hash) pairs rather than a per-entity lookup.
+		val entityHashes = projectEntityDatasource.getEntityHashes(userId, projectDef)
 
 		val dataResult = serverProjectDataRepository.load(userId, projectDef)
 		if (!isSuccess(dataResult)) return null

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRepository.kt
@@ -1,12 +1,18 @@
 package com.darkrockstudios.apps.hammer.projects
 
 import com.darkrockstudios.apps.hammer.base.ProjectId
+import com.darkrockstudios.apps.hammer.base.http.EntityHash
+import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.base.validate.validateProjectName
 import com.darkrockstudios.apps.hammer.dependencyinjection.PROJECTS_SYNC_MANAGER
 import com.darkrockstudios.apps.hammer.project.*
 import com.darkrockstudios.apps.hammer.syncsessionmanager.SyncSessionManager
 import com.darkrockstudios.apps.hammer.utilities.Msg
 import com.darkrockstudios.apps.hammer.utilities.SResult
+import com.darkrockstudios.apps.hammer.utilities.isSuccess
 import org.koin.core.qualifier.named
 import org.koin.java.KoinJavaComponent.inject
 import kotlin.time.Clock
@@ -15,6 +21,7 @@ class ProjectsRepository(
 	private val clock: Clock,
 	private val projectsDatasource: ProjectsDatasource,
 	private val projectEntityDatasource: ProjectEntityDatasource,
+	private val serverProjectDataRepository: ServerProjectDataRepository,
 ) {
 	private val syncSessionManager: SyncSessionManager<Long, ProjectsSynchronizationSession> by inject(
 		clazz = SyncSessionManager::class.java,
@@ -98,6 +105,53 @@ class ProjectsRepository(
 
 	private suspend fun getDeletedProjects(userId: Long): Set<ProjectId> {
 		return projectsDatasource.loadSyncData(userId).deletedProjects
+	}
+
+	/**
+	 * Pre-sync change probe: returns the subset of the requested projects whose server-side
+	 * project-wide content hash matches the client's. Those are guaranteed in-sync and can skip
+	 * their full project sync this session. Read-only — no sync session required.
+	 *
+	 * A project is omitted from the result (i.e. treated as changed) whenever the server can't be
+	 * certain it matches: unknown project, a missing cached entity hash, or an unreadable
+	 * project-data blob. Worst case is a redundant full sync, never a skipped-but-divergent project.
+	 */
+	suspend fun probeProjectChanges(
+		userId: Long,
+		items: List<ProjectHashItem>,
+	): Set<ProjectId> {
+		val unchanged = mutableSetOf<ProjectId>()
+		for (item in items) {
+			val projectDef = projectsDatasource.getProject(userId, item.projectId) ?: continue
+			val serverHash = computeProjectContentHash(userId, projectDef) ?: continue
+			if (serverHash == item.hash) {
+				unchanged += item.projectId
+			}
+		}
+		return unchanged
+	}
+
+	/**
+	 * Recomputes a project's project-wide content hash from the server's stored state (cached entity
+	 * hashes + the project-data blob hash), using the same [ProjectContentHasher] the client runs.
+	 * Returns null when the hash can't be computed reliably, so the caller treats the project as changed.
+	 */
+	private suspend fun computeProjectContentHash(
+		userId: Long,
+		projectDef: ProjectDefinition,
+	): String? {
+		val defs = projectEntityDatasource.getEntityDefs(userId, projectDef)
+		val entityHashes = ArrayList<EntityHash>(defs.size)
+		for (def in defs) {
+			val hash = projectEntityDatasource.getCachedHash(userId, projectDef, def.id) ?: return null
+			entityHashes += EntityHash(def.id, hash)
+		}
+
+		val dataResult = serverProjectDataRepository.load(userId, projectDef)
+		if (!isSuccess(dataResult)) return null
+		val projectDataHash = dataResult.data?.hash ?: ProjectDataHasher.hash(ProjectData())
+
+		return ProjectContentHasher.hash(entityHashes, projectDataHash)
 	}
 
 	suspend fun deleteProject(userId: Long, syncId: String, projectId: ProjectId): SResult<Unit> {

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
@@ -5,6 +5,8 @@ import com.darkrockstudios.apps.hammer.base.http.BeginProjectsSyncResponse
 import com.darkrockstudios.apps.hammer.base.http.CreateProjectResponse
 import com.darkrockstudios.apps.hammer.base.http.HEADER_SYNC_ID
 import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
+import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeRequest
+import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeResponse
 import com.darkrockstudios.apps.hammer.plugins.ServerUserIdPrincipal
 import com.darkrockstudios.apps.hammer.plugins.USER_AUTH
 import com.darkrockstudios.apps.hammer.project.InvalidProjectName
@@ -16,6 +18,7 @@ import com.github.aymanizz.ktori18n.t
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.koin.ktor.ext.get
@@ -65,6 +68,7 @@ fun Route.projectsRoutes() {
 			deleteProject()
 			createProject()
 			renameProject()
+			syncProbe()
 		}
 	}
 }
@@ -98,6 +102,22 @@ private fun Route.beginProjectsSync() {
 				),
 			)
 		}
+	}
+}
+
+private fun Route.syncProbe() {
+	val projectsRepository: ProjectsRepository = get()
+
+	post("/sync_probe") {
+		val principal = call.principal<ServerUserIdPrincipal>()
+		if (principal == null) {
+			call.respond(HttpStatusCode.Unauthorized)
+			return@post
+		}
+
+		val request = call.receive<ProjectsSyncProbeRequest>()
+		val unchanged = projectsRepository.probeProjectChanges(principal.id, request.projects)
+		call.respond(ProjectsSyncProbeResponse(unchangedProjects = unchanged))
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
@@ -118,11 +118,9 @@ private fun Route.syncProbe() {
 
 		// A malformed body is a routine client condition, not a server error: answer 400 rather than
 		// letting it fall through to the global handler as a 500 (and a recorded monitored error).
+		// ContentNegotiation wraps any body-conversion failure in BadRequestException.
 		val request = try {
 			call.receive<ProjectsSyncProbeRequest>()
-		} catch (e: ContentTransformationException) {
-			call.respondBadRequest(ERROR_GENERIC, e.message ?: "Malformed request body")
-			return@post
 		} catch (e: BadRequestException) {
 			call.respondBadRequest(ERROR_GENERIC, e.message ?: "Malformed request body")
 			return@post

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
@@ -18,6 +18,7 @@ import com.github.aymanizz.ktori18n.t
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
+import io.ktor.server.plugins.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -115,7 +116,18 @@ private fun Route.syncProbe() {
 			return@post
 		}
 
-		val request = call.receive<ProjectsSyncProbeRequest>()
+		// A malformed body is a routine client condition, not a server error: answer 400 rather than
+		// letting it fall through to the global handler as a 500 (and a recorded monitored error).
+		val request = try {
+			call.receive<ProjectsSyncProbeRequest>()
+		} catch (e: ContentTransformationException) {
+			call.respondBadRequest(ERROR_GENERIC, e.message ?: "Malformed request body")
+			return@post
+		} catch (e: BadRequestException) {
+			call.respondBadRequest(ERROR_GENERIC, e.message ?: "Malformed request body")
+			return@post
+		}
+
 		val unchanged = projectsRepository.probeProjectChanges(principal.id, request.projects)
 		call.respond(ProjectsSyncProbeResponse(unchangedProjects = unchanged))
 	}

--- a/server/src/main/sqldelight/com/darkrockstudios/apps/hammer/StoryEntity.sq
+++ b/server/src/main/sqldelight/com/darkrockstudios/apps/hammer/StoryEntity.sq
@@ -28,6 +28,12 @@ FROM story_entity
 WHERE user_id = :userId AND project_id = :projectId AND id = :id
 LIMIT 1;
 
+getEntityHashes:
+SELECT id, hash
+FROM story_entity
+WHERE user_id = :userId AND project_id = :projectId
+ORDER BY id;
+
 getAllEntities:
 SELECT *
 FROM story_entity

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProjectsProbeTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProjectsProbeTest.kt
@@ -1,0 +1,151 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.base.ProjectId
+import com.darkrockstudios.apps.hammer.base.http.ClientEntityState
+import com.darkrockstudios.apps.hammer.base.http.EntityHash
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
+import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
+import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeRequest
+import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeResponse
+import com.darkrockstudios.apps.hammer.base.http.Token
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
+import com.darkrockstudios.apps.hammer.e2e.util.E2eTestData.createAuthToken
+import com.darkrockstudios.apps.hammer.e2e.util.TestDataSet1
+import com.darkrockstudios.apps.hammer.utils.SERVER_EMPTY_NO_WHITELIST
+import com.darkrockstudios.apps.hammer.utils.createTestServer
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProjectsProbeTest : ProjectSyncTestBase() {
+
+	private val userId = 1L
+	private val project1Id = ProjectId.fromUUID(TestDataSet1.project1.uuid)
+
+	/**
+	 * The hash a synced client would compute for project1: every live entity's hash plus the
+	 * default project-data hash (the fixture seeds no project_data row). The server must arrive at
+	 * the same value from its own stored state — that agreement is the whole point of the probe.
+	 */
+	private fun clientProjectHash(): String {
+		val entityHashes = TestDataSet1.user1Project1Entities.map { EntityHash(it.id, it.hash()) }
+		return ProjectContentHasher.hash(entityHashes, ProjectDataHasher.hash(ProjectData()))
+	}
+
+	private fun upToDateClientState() = ClientEntityState(
+		entities = TestDataSet1.user1Project1Entities.map { EntityHash(it.id, it.hash()) }.toSet(),
+	)
+
+	private suspend fun HttpClient.probeRequest(
+		authToken: Token?,
+		request: ProjectsSyncProbeRequest,
+	): HttpResponse =
+		post(api("projects/$userId/sync_probe")) {
+			headers {
+				append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+				if (authToken != null) append("Authorization", "Bearer ${authToken.auth}")
+			}
+			contentType(ContentType.Application.Json)
+			setBody(request)
+		}
+
+	@Test
+	fun `probe reports a project unchanged when the client and server hashes agree`(): Unit = runBlocking {
+		val database = database()
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database)
+		TestDataSet1.createFullDataset(database, encryptor())
+		val authToken = createAuthToken(userId, "test-install-id", database = database, tokenHasher = tokenHasher())
+		doStartServer()
+
+		client().apply {
+			val response = probeRequest(authToken, ProjectsSyncProbeRequest(listOf(ProjectHashItem(project1Id, clientProjectHash()))))
+			assertEquals(HttpStatusCode.OK, response.status)
+
+			val unchanged = response.body<ProjectsSyncProbeResponse>().unchangedProjects
+			assertTrue(project1Id in unchanged, "a genuinely in-sync project must come back unchanged")
+		}
+	}
+
+	@Test
+	fun `probe omits a project whose hash differs`(): Unit = runBlocking {
+		val database = database()
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database)
+		TestDataSet1.createFullDataset(database, encryptor())
+		val authToken = createAuthToken(userId, "test-install-id", database = database, tokenHasher = tokenHasher())
+		doStartServer()
+
+		client().apply {
+			val response = probeRequest(authToken, ProjectsSyncProbeRequest(listOf(ProjectHashItem(project1Id, "stale-hash"))))
+			assertEquals(HttpStatusCode.OK, response.status)
+
+			val unchanged = response.body<ProjectsSyncProbeResponse>().unchangedProjects
+			assertFalse(project1Id in unchanged, "a project whose hash differs must not be reported unchanged")
+		}
+	}
+
+	@Test
+	fun `probe omits a project with an in-flight sync session`(): Unit = runBlocking {
+		val database = database()
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database)
+		TestDataSet1.createFullDataset(database, encryptor())
+		val authToken = createAuthToken(userId, "test-install-id", database = database, tokenHasher = tokenHasher())
+		doStartServer()
+
+		client().apply {
+			// Open a project sync session, then probe with the otherwise-matching hash.
+			val began = projectSynchronizationBegan(userId, authToken, upToDateClientState())
+
+			val response = probeRequest(authToken, ProjectsSyncProbeRequest(listOf(ProjectHashItem(project1Id, clientProjectHash()))))
+			assertEquals(HttpStatusCode.OK, response.status)
+
+			val unchanged = response.body<ProjectsSyncProbeResponse>().unchangedProjects
+			assertFalse(project1Id in unchanged, "a project being synced must not be reported unchanged even if hashes match")
+
+			endSyncRequest(userId, authToken, began)
+		}
+	}
+
+	@Test
+	fun `probe rejects an unauthenticated request`(): Unit = runBlocking {
+		val database = database()
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database)
+		TestDataSet1.createFullDataset(database, encryptor())
+		doStartServer()
+
+		client().apply {
+			val response = probeRequest(authToken = null, request = ProjectsSyncProbeRequest(emptyList()))
+			assertEquals(HttpStatusCode.Unauthorized, response.status)
+		}
+	}
+
+	@Test
+	fun `probe returns 400 for a malformed body`(): Unit = runBlocking {
+		val database = database()
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database)
+		TestDataSet1.createFullDataset(database, encryptor())
+		val authToken = createAuthToken(userId, "test-install-id", database = database, tokenHasher = tokenHasher())
+		doStartServer()
+
+		client().apply {
+			val response = post(api("projects/$userId/sync_probe")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+					append("Authorization", "Bearer ${authToken.auth}")
+				}
+				setBody(TextContent("{ not valid json", ContentType.Application.Json))
+			}
+			assertEquals(HttpStatusCode.BadRequest, response.status)
+		}
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryBaseTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryBaseTest.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.projects.repository
 
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.dependencyinjection.PROJECTS_SYNC_MANAGER
+import com.darkrockstudios.apps.hammer.dependencyinjection.PROJECT_SYNC_MANAGER
 import com.darkrockstudios.apps.hammer.project.ProjectDefinition
 import com.darkrockstudios.apps.hammer.project.ProjectEntityDatasource
 import com.darkrockstudios.apps.hammer.project.ProjectSyncKey
@@ -14,6 +15,7 @@ import com.darkrockstudios.apps.hammer.syncsessionmanager.SyncSessionManager
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import com.darkrockstudios.apps.hammer.utils.TestClock
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.serialization.json.Json
@@ -65,6 +67,8 @@ abstract class ProjectsRepositoryBaseTest : BaseTest() {
 
 		projectsSessionManager = mockk()
 		projectSessionManager = mockk()
+		// Default: no in-flight project sync, so the probe gate lets projects through.
+		every { projectSessionManager.hasActiveSyncSession(any()) } returns false
 
 		projectsDatasource = mockk()
 		projectsRepository = mockk()
@@ -82,6 +86,12 @@ abstract class ProjectsRepositoryBaseTest : BaseTest() {
 				)
 			) {
 				projectsSessionManager
+			}
+
+			single<SyncSessionManager<ProjectSyncKey, ProjectSynchronizationSession>>(
+				named(PROJECT_SYNC_MANAGER)
+			) {
+				projectSessionManager
 			}
 		}
 		setupKoin(testModule)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryBaseTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryBaseTest.kt
@@ -6,6 +6,7 @@ import com.darkrockstudios.apps.hammer.project.ProjectDefinition
 import com.darkrockstudios.apps.hammer.project.ProjectEntityDatasource
 import com.darkrockstudios.apps.hammer.project.ProjectSyncKey
 import com.darkrockstudios.apps.hammer.project.ProjectSynchronizationSession
+import com.darkrockstudios.apps.hammer.project.ServerProjectDataRepository
 import com.darkrockstudios.apps.hammer.projects.ProjectsDatasource
 import com.darkrockstudios.apps.hammer.projects.ProjectsRepository
 import com.darkrockstudios.apps.hammer.projects.ProjectsSynchronizationSession
@@ -33,11 +34,12 @@ abstract class ProjectsRepositoryBaseTest : BaseTest() {
 	protected lateinit var projectsRepository: ProjectsRepository
 	protected lateinit var projectsDatasource: ProjectsDatasource
 	protected lateinit var projectEntityDatasource: ProjectEntityDatasource
+	protected lateinit var serverProjectDataRepository: ServerProjectDataRepository
 
 	protected val projectDefinition = ProjectDefinition("Test Project 1", ProjectId("test-uuid-1"))
 
 	protected fun createProjectsRepository(): ProjectsRepository {
-		return ProjectsRepository(clock, projectsDatasource, projectEntityDatasource)
+		return ProjectsRepository(clock, projectsDatasource, projectEntityDatasource, serverProjectDataRepository)
 	}
 
 	protected fun mockCreateSession(syncId: String) {
@@ -68,6 +70,7 @@ abstract class ProjectsRepositoryBaseTest : BaseTest() {
 		projectsRepository = mockk()
 
 		projectEntityDatasource = mockk()
+		serverProjectDataRepository = mockk()
 
 		val testModule = module {
 			single { Json } bind Json::class

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryProbeTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryProbeTest.kt
@@ -1,0 +1,101 @@
+package com.darkrockstudios.apps.hammer.projects.repository
+
+import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.EntityHash
+import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataDto
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
+import com.darkrockstudios.apps.hammer.project.EntityDefinition
+import com.darkrockstudios.apps.hammer.utilities.SResult
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProjectsRepositoryProbeTest : ProjectsRepositoryBaseTest() {
+
+	private val projectId = projectDefinition.uuid
+
+	private fun stubTwoEntities() {
+		coEvery { projectsDatasource.getProject(userId, projectId) } returns projectDefinition
+		coEvery { projectEntityDatasource.getEntityDefs(userId, projectDefinition, any()) } returns listOf(
+			EntityDefinition(1, ApiProjectEntity.Type.SCENE),
+			EntityDefinition(2, ApiProjectEntity.Type.NOTE),
+		)
+		coEvery { projectEntityDatasource.getCachedHash(userId, projectDefinition, 1) } returns "h1"
+		coEvery { projectEntityDatasource.getCachedHash(userId, projectDefinition, 2) } returns "h2"
+		coEvery { serverProjectDataRepository.load(userId, projectDefinition) } returns
+			SResult.success<ProjectDataDto?>(null)
+	}
+
+	private fun expectedServerHash(): String = ProjectContentHasher.hash(
+		listOf(EntityHash(1, "h1"), EntityHash(2, "h2")),
+		ProjectDataHasher.hash(ProjectData()),
+	)
+
+	@Test
+	fun `matching hash marks the project unchanged`() = runTest {
+		stubTwoEntities()
+		createProjectsRepository().apply {
+			val result = probeProjectChanges(userId, listOf(ProjectHashItem(projectId, expectedServerHash())))
+			assertEquals(setOf(projectId), result)
+		}
+	}
+
+	@Test
+	fun `differing hash leaves the project out`() = runTest {
+		stubTwoEntities()
+		createProjectsRepository().apply {
+			val result = probeProjectChanges(userId, listOf(ProjectHashItem(projectId, "stale-hash")))
+			assertTrue(result.isEmpty())
+		}
+	}
+
+	@Test
+	fun `a missing cached entity hash forces a full sync`() = runTest {
+		stubTwoEntities()
+		coEvery { projectEntityDatasource.getCachedHash(userId, projectDefinition, 2) } returns null
+
+		createProjectsRepository().apply {
+			val result = probeProjectChanges(userId, listOf(ProjectHashItem(projectId, expectedServerHash())))
+			assertTrue(result.isEmpty(), "an uncomputable hash must never be reported as unchanged")
+		}
+	}
+
+	@Test
+	fun `unknown project is left out`() = runTest {
+		coEvery { projectsDatasource.getProject(userId, projectId) } returns null
+
+		createProjectsRepository().apply {
+			val result = probeProjectChanges(userId, listOf(ProjectHashItem(projectId, "any")))
+			assertTrue(result.isEmpty())
+		}
+	}
+
+	@Test
+	fun `project-data changes are reflected in the hash`() = runTest {
+		stubTwoEntities()
+		val withData = ProjectDataDto(
+			data = ProjectData(authorName = "Pat"),
+			hash = ProjectDataHasher.hash(ProjectData(authorName = "Pat")),
+		)
+		coEvery { serverProjectDataRepository.load(userId, projectDefinition) } returns SResult.success(withData)
+
+		val expected = ProjectContentHasher.hash(
+			listOf(EntityHash(1, "h1"), EntityHash(2, "h2")),
+			withData.hash,
+		)
+
+		createProjectsRepository().apply {
+			// The default-project-data hash must NOT match once real project data exists.
+			val staleResult = probeProjectChanges(userId, listOf(ProjectHashItem(projectId, expectedServerHash())))
+			assertTrue(staleResult.isEmpty())
+
+			val freshResult = probeProjectChanges(userId, listOf(ProjectHashItem(projectId, expected)))
+			assertEquals(setOf(projectId), freshResult)
+		}
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryProbeTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryProbeTest.kt
@@ -1,13 +1,11 @@
 package com.darkrockstudios.apps.hammer.projects.repository
 
-import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.base.http.EntityHash
 import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataDto
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
-import com.darkrockstudios.apps.hammer.project.EntityDefinition
 import com.darkrockstudios.apps.hammer.project.ProjectSyncKey
 import com.darkrockstudios.apps.hammer.utilities.SResult
 import io.mockk.coEvery
@@ -23,12 +21,10 @@ class ProjectsRepositoryProbeTest : ProjectsRepositoryBaseTest() {
 
 	private fun stubTwoEntities() {
 		coEvery { projectsDatasource.getProject(userId, projectId) } returns projectDefinition
-		coEvery { projectEntityDatasource.getEntityDefs(userId, projectDefinition, any()) } returns listOf(
-			EntityDefinition(1, ApiProjectEntity.Type.SCENE),
-			EntityDefinition(2, ApiProjectEntity.Type.NOTE),
+		coEvery { projectEntityDatasource.getEntityHashes(userId, projectDefinition) } returns listOf(
+			EntityHash(1, "h1"),
+			EntityHash(2, "h2"),
 		)
-		coEvery { projectEntityDatasource.getCachedHash(userId, projectDefinition, 1) } returns "h1"
-		coEvery { projectEntityDatasource.getCachedHash(userId, projectDefinition, 2) } returns "h2"
 		coEvery { serverProjectDataRepository.load(userId, projectDefinition) } returns
 			SResult.success<ProjectDataDto?>(null)
 	}
@@ -57,9 +53,10 @@ class ProjectsRepositoryProbeTest : ProjectsRepositoryBaseTest() {
 	}
 
 	@Test
-	fun `a missing cached entity hash forces a full sync`() = runTest {
+	fun `an unreadable project-data blob forces a full sync`() = runTest {
 		stubTwoEntities()
-		coEvery { projectEntityDatasource.getCachedHash(userId, projectDefinition, 2) } returns null
+		coEvery { serverProjectDataRepository.load(userId, projectDefinition) } returns
+			SResult.failure(Exception("boom"))
 
 		createProjectsRepository().apply {
 			val result = probeProjectChanges(userId, listOf(ProjectHashItem(projectId, expectedServerHash())))

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryProbeTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryProbeTest.kt
@@ -8,8 +8,10 @@ import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataDto
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectContentHasher
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.project.EntityDefinition
+import com.darkrockstudios.apps.hammer.project.ProjectSyncKey
 import com.darkrockstudios.apps.hammer.utilities.SResult
 import io.mockk.coEvery
+import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -62,6 +64,19 @@ class ProjectsRepositoryProbeTest : ProjectsRepositoryBaseTest() {
 		createProjectsRepository().apply {
 			val result = probeProjectChanges(userId, listOf(ProjectHashItem(projectId, expectedServerHash())))
 			assertTrue(result.isEmpty(), "an uncomputable hash must never be reported as unchanged")
+		}
+	}
+
+	@Test
+	fun `a project with an in-flight sync session is left out`() = runTest {
+		stubTwoEntities()
+		every {
+			projectSessionManager.hasActiveSyncSession(ProjectSyncKey(userId, projectDefinition))
+		} returns true
+
+		createProjectsRepository().apply {
+			val result = probeProjectChanges(userId, listOf(ProjectHashItem(projectId, expectedServerHash())))
+			assertTrue(result.isEmpty(), "a project being synced elsewhere must not be reported unchanged")
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds a **pre-sync change probe** that eliminates the per-project HTTP round-trips on app open for projects with zero changes. Previously every project paid ~4 requests (`begin_sync`, `project_data`, `writing_activity`, `end_sync`) even when nothing changed; now the client asks in **one batched request** which projects actually differ, and unchanged projects jump straight to `Complete` in the UI.

Full design rationale is documented in the new "Pre-Sync Change Probe" section of `docs/SYNCING-PROTOCOL.md` (included in this PR).

## How it works

- Each project gets a **project-wide content hash**: an order-independent aggregate of its per-entity hashes + the project-data blob hash, computed by a shared `ProjectContentHasher` in `base` so client and server run byte-identical logic.
- The comparison is **symmetric and stateless**: current-client-hash vs current-server-hash, recomputed on demand from state the server already stores (cached entity hashes + project-data hash). No new server bookkeeping — honoring the protocol's "no required book keeping data" principle.
- New endpoint: `POST /api/projects/{userId}/sync_probe` (read-only, no syncId). Runs after Account Sync reconciliation, before per-project sync.
- The client **caches** its hash in the project journal (`cachedProjectHash` + `hashAlgoVersion`), written only at `FinalizeSync` from the final reconciled state — so app open reads N tiny journal files instead of re-hashing every entity.
- **Invalidation** is threaded through the repository chokepoint (`SyncJournal` dirty hooks, `ProjectDataRepository.updateData`), covering all writers including widgets/workers. No compute-on-the-fly: a missing/stale-version cache just syncs the normal way and self-heals.

## Safety properties

- A project is only skipped when the server is *certain* it matches; anything uncertain (unknown project, missing cached hash, unreadable data, probe failure, old server without the endpoint) falls through to a normal full sync. Worst case is a redundant sync, never a wrong skip.
- **Journal backstop:** a project with pending journal work (`dirty`/`newIds`) is never probed, regardless of its cached hash. Since any mutation writes the dirty list *and* clears the cache in the same write, "cached hash present + pending work" is an invariant violation — it forces a full sync and logs an error so the offending write path is attributable.
- **Writing activity is deliberately excluded** from the hash: it's per-device, conflict-free, and auxiliary (its sync phase already swallows errors); a symmetric hash including it would never match across devices.

## Changes

- `base`: `ProjectContentHasher`, probe request/response DTOs
- `server`: `sync_probe` route, `ProjectsRepository.probeProjectChanges` + hash recomputation
- `client`: journal cache fields, `FinalizeSync` hash write, repo-layer invalidation, `ClientAccountSynchronizer.probeUnchangedProjects`, `ProjectsListComponent` skip wiring
- `docs`: new SYNCING-PROTOCOL.md section with sequence + decision diagrams
- Tests: `ProjectContentHasherTest`, `ProjectsRepositoryProbeTest`, probe eligibility cases in `ClientAccountSynchronizerTest`

## Notes for review

- ⚠️ **Not compiled locally**: the build environment here can't resolve AGP `9.1.1` (fails at Gradle configuration, pre-existing and unrelated). Verified by close reading against existing contracts/idioms — please let CI be the arbiter.
- `HAMMER_PROTOCOL_VERSION` intentionally **not** bumped: the feature is additive and self-negotiating (old server → probe fails → silent full-sync fallback).

https://claude.ai/code/session_01FVvHNkv85RTJBmxHUTvBzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVvHNkv85RTJBmxHUTvBzj)_