### PR TITLE
Add keyboard shortcuts for bold, italic and strikethrough

### DIFF
--- a/common/src/commonMain/composeResources/values/strings.xml
+++ b/common/src/commonMain/composeResources/values/strings.xml
@@ -35,4 +35,15 @@
 	<string name="markdown_format_bar_decrease_text_size">Decrease text size</string>
 	<string name="markdown_format_bar_increase_text_size">Increase text size</string>
 	<string name="markdown_format_bar_reset_text_size">Reset text size</string>
+
+	<string name="markdown_format_bar_bold">Bold</string>
+	<string name="markdown_format_bar_italic">Italic</string>
+	<string name="markdown_format_bar_strikethrough">Strikethrough</string>
+	<string name="markdown_format_bar_heading">Heading</string>
+	<string name="markdown_format_bar_blockquote">Quote</string>
+	<string name="markdown_format_bar_bullet_list">Bulleted list</string>
+	<string name="markdown_format_bar_numbered_list">Numbered list</string>
+	<string name="markdown_format_bar_horizontal_rule">Horizontal rule</string>
+	<string name="markdown_format_bar_undo">Undo</string>
+	<string name="markdown_format_bar_redo">Redo</string>
 </resources>

--- a/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/ShortcutHint.kt
+++ b/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/ShortcutHint.kt
@@ -1,0 +1,4 @@
+package com.darkrockstudios.apps.hammer.common.compose.markdowneditor
+
+internal actual fun shortcutHint(key: String, shift: Boolean): String =
+	"Ctrl+${if (shift) "Shift+" else ""}$key"

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ShortcutModifiers.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ShortcutModifiers.kt
@@ -30,3 +30,12 @@ fun Modifier.saveShortcutModifier(onSave: () -> Unit): Modifier =
 
 fun Modifier.syncShortcutModifier(onSync: () -> Unit): Modifier =
 	onKeyShortcut(Key.F3, action = onSync)
+
+fun Modifier.boldShortcutModifier(onBold: () -> Unit): Modifier =
+	onKeyShortcut(Key.B, ctrl = true, action = onBold)
+
+fun Modifier.italicShortcutModifier(onItalic: () -> Unit): Modifier =
+	onKeyShortcut(Key.I, ctrl = true, action = onItalic)
+
+fun Modifier.strikethroughShortcutModifier(onStrikethrough: () -> Unit): Modifier =
+	onKeyShortcut(Key.X, ctrl = true, shift = true, action = onStrikethrough)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditField.kt
@@ -71,7 +71,13 @@ fun MarkdownEditField(
 		markdownExtension.updateMarkdownConfiguration(markdownConfig)
 	}
 
-	Column(modifier = modifier) {
+	Column(
+		modifier = if (enabled) {
+			modifier.markdownFormatShortcuts(markdownExtension)
+		} else {
+			modifier
+		}
+	) {
 		if (enabled && showFormatBar) {
 			MarkdownFormatBar(markdownState = markdownExtension)
 		}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownFormatBar.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownFormatBar.kt
@@ -2,7 +2,13 @@ package com.darkrockstudios.apps.hammer.common.compose.markdowneditor
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.FormatListBulleted
@@ -10,20 +16,53 @@ import androidx.compose.material.icons.filled.FormatListNumbered
 import androidx.compose.material.icons.filled.FormatQuote
 import androidx.compose.material.icons.filled.HorizontalRule
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.compose.boldShortcutModifier
-import com.darkrockstudios.apps.hammer.common.compose.icons.*
+import com.darkrockstudios.apps.hammer.common.compose.icons.EditorIcons
+import com.darkrockstudios.apps.hammer.common.compose.icons.IconBold
+import com.darkrockstudios.apps.hammer.common.compose.icons.IconItalic
+import com.darkrockstudios.apps.hammer.common.compose.icons.IconRedo
+import com.darkrockstudios.apps.hammer.common.compose.icons.IconStrikethrough
+import com.darkrockstudios.apps.hammer.common.compose.icons.IconTextDecrease
+import com.darkrockstudios.apps.hammer.common.compose.icons.IconTextIncrease
+import com.darkrockstudios.apps.hammer.common.compose.icons.IconTextReset
+import com.darkrockstudios.apps.hammer.common.compose.icons.IconUndo
 import com.darkrockstudios.apps.hammer.common.compose.italicShortcutModifier
-import com.darkrockstudios.apps.hammer.common.compose.strikethroughShortcutModifier
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.strikethroughShortcutModifier
+import com.darkrockstudios.apps.hammer.markdown_format_bar_blockquote
+import com.darkrockstudios.apps.hammer.markdown_format_bar_bold
+import com.darkrockstudios.apps.hammer.markdown_format_bar_bullet_list
 import com.darkrockstudios.apps.hammer.markdown_format_bar_decrease_text_size
+import com.darkrockstudios.apps.hammer.markdown_format_bar_heading
+import com.darkrockstudios.apps.hammer.markdown_format_bar_horizontal_rule
 import com.darkrockstudios.apps.hammer.markdown_format_bar_increase_text_size
+import com.darkrockstudios.apps.hammer.markdown_format_bar_italic
+import com.darkrockstudios.apps.hammer.markdown_format_bar_numbered_list
+import com.darkrockstudios.apps.hammer.markdown_format_bar_redo
 import com.darkrockstudios.apps.hammer.markdown_format_bar_reset_text_size
+import com.darkrockstudios.apps.hammer.markdown_format_bar_strikethrough
+import com.darkrockstudios.apps.hammer.markdown_format_bar_undo
+import com.darkrockstudios.apps.hammer.more_menu_button
 import com.darkrockstudios.texteditor.markdown.MarkdownExtension
 import com.darkrockstudios.texteditor.richstyle.OrderedListSpanStyle
 import com.darkrockstudios.texteditor.state.TextEditorState
@@ -127,53 +166,91 @@ private fun RowScope.FormatButtons(
 	isOrderedListActive: Boolean,
 	currentHeaderLevel: Int,
 ) {
-	EditorAction(
-		icon = EditorIcons.IconBold,
-		active = isBoldActive,
-	) {
-		toggleStyle(state, markdownState.markdownStyles.BOLD)
+	EditorTooltip("${Res.string.markdown_format_bar_bold.get()} (${shortcutHint("B")})") {
+		EditorAction(
+			icon = EditorIcons.IconBold,
+			active = isBoldActive,
+		) {
+			toggleStyle(state, markdownState.markdownStyles.BOLD)
+		}
 	}
-	EditorAction(
-		icon = EditorIcons.IconItalic,
-		active = isItalicActive,
-	) {
-		toggleStyle(state, markdownState.markdownStyles.ITALICS)
+	EditorTooltip("${Res.string.markdown_format_bar_italic.get()} (${shortcutHint("I")})") {
+		EditorAction(
+			icon = EditorIcons.IconItalic,
+			active = isItalicActive,
+		) {
+			toggleStyle(state, markdownState.markdownStyles.ITALICS)
+		}
 	}
-	EditorAction(
-		icon = EditorIcons.IconStrikethrough,
-		active = isStrikethroughActive,
+	EditorTooltip(
+		"${Res.string.markdown_format_bar_strikethrough.get()} (${
+			shortcutHint(
+				"X",
+				shift = true
+			)
+		})"
 	) {
-		toggleStyle(state, markdownState.markdownStyles.STRIKETHROUGH)
+		EditorAction(
+			icon = EditorIcons.IconStrikethrough,
+			active = isStrikethroughActive,
+		) {
+			toggleStyle(state, markdownState.markdownStyles.STRIKETHROUGH)
+		}
 	}
-	EditorTextAction(
-		label = if (currentHeaderLevel == 0) "H" else "H$currentHeaderLevel",
-		active = currentHeaderLevel != 0,
-	) {
-		cycleHeader(state, markdownState, currentHeaderLevel)
+	EditorTooltip(Res.string.markdown_format_bar_heading.get()) {
+		EditorTextAction(
+			label = if (currentHeaderLevel == 0) "H" else "H$currentHeaderLevel",
+			active = currentHeaderLevel != 0,
+		) {
+			cycleHeader(state, markdownState, currentHeaderLevel)
+		}
 	}
-	EditorAction(
-		icon = Icons.Default.FormatQuote,
-		active = isBlockquoteActive,
-	) {
-		toggleStyle(state, markdownState.markdownStyles.BLOCKQUOTE)
+	EditorTooltip(Res.string.markdown_format_bar_blockquote.get()) {
+		EditorAction(
+			icon = Icons.Default.FormatQuote,
+			active = isBlockquoteActive,
+		) {
+			toggleStyle(state, markdownState.markdownStyles.BLOCKQUOTE)
+		}
 	}
-	EditorAction(
-		icon = Icons.AutoMirrored.Filled.FormatListBulleted,
-		active = false,
-	) {
-		insertLineBullet(state)
+	EditorTooltip(Res.string.markdown_format_bar_bullet_list.get()) {
+		EditorAction(
+			icon = Icons.AutoMirrored.Filled.FormatListBulleted,
+			active = false,
+		) {
+			insertLineBullet(state)
+		}
 	}
-	EditorAction(
-		icon = Icons.Default.FormatListNumbered,
-		active = isOrderedListActive,
-	) {
-		toggleOrderedList(state, markdownState)
+	EditorTooltip(Res.string.markdown_format_bar_numbered_list.get()) {
+		EditorAction(
+			icon = Icons.Default.FormatListNumbered,
+			active = isOrderedListActive,
+		) {
+			toggleOrderedList(state, markdownState)
+		}
 	}
-	EditorAction(
-		icon = Icons.Default.HorizontalRule,
-		active = false,
+	EditorTooltip(Res.string.markdown_format_bar_horizontal_rule.get()) {
+		EditorAction(
+			icon = Icons.Default.HorizontalRule,
+			active = false,
+		) {
+			insertHorizontalRule(state)
+		}
+	}
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditorTooltip(
+	text: String,
+	content: @Composable () -> Unit,
+) {
+	TooltipBox(
+		positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+		tooltip = { PlainTooltip { Text(text) } },
+		state = rememberTooltipState(),
 	) {
-		insertHorizontalRule(state)
+		content()
 	}
 }
 
@@ -185,28 +262,34 @@ private fun HistoryAndOverflow(
 	resetTextSize: (() -> Unit)?,
 	showOverflow: Boolean,
 ) {
-	EditorAction(
-		icon = EditorIcons.IconUndo,
-		active = state.canUndo
-	) {
-		state.undo()
+	EditorTooltip(Res.string.markdown_format_bar_undo.get()) {
+		EditorAction(
+			icon = EditorIcons.IconUndo,
+			active = state.canUndo
+		) {
+			state.undo()
+		}
 	}
-	EditorAction(
-		icon = EditorIcons.IconRedo,
-		active = state.canRedo
-	) {
-		state.redo()
+	EditorTooltip(Res.string.markdown_format_bar_redo.get()) {
+		EditorAction(
+			icon = EditorIcons.IconRedo,
+			active = state.canRedo
+		) {
+			state.redo()
+		}
 	}
 
 	if (!showOverflow) return
 
 	var menuExpanded by remember { mutableStateOf(false) }
 	Box {
-		EditorAction(
-			icon = Icons.Default.MoreVert,
-			active = false,
-		) {
-			menuExpanded = true
+		EditorTooltip(Res.string.more_menu_button.get()) {
+			EditorAction(
+				icon = Icons.Default.MoreVert,
+				active = false,
+			) {
+				menuExpanded = true
+			}
 		}
 		DropdownMenu(
 			expanded = menuExpanded,

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownFormatBar.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownFormatBar.kt
@@ -16,7 +16,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.common.compose.boldShortcutModifier
 import com.darkrockstudios.apps.hammer.common.compose.icons.*
+import com.darkrockstudios.apps.hammer.common.compose.italicShortcutModifier
+import com.darkrockstudios.apps.hammer.common.compose.strikethroughShortcutModifier
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.markdown_format_bar_decrease_text_size
 import com.darkrockstudios.apps.hammer.markdown_format_bar_increase_text_size
@@ -128,19 +131,19 @@ private fun RowScope.FormatButtons(
 		icon = EditorIcons.IconBold,
 		active = isBoldActive,
 	) {
-		toggleStyle(state, isBoldActive, markdownState.markdownStyles.BOLD)
+		toggleStyle(state, markdownState.markdownStyles.BOLD)
 	}
 	EditorAction(
 		icon = EditorIcons.IconItalic,
 		active = isItalicActive,
 	) {
-		toggleStyle(state, isItalicActive, markdownState.markdownStyles.ITALICS)
+		toggleStyle(state, markdownState.markdownStyles.ITALICS)
 	}
 	EditorAction(
 		icon = EditorIcons.IconStrikethrough,
 		active = isStrikethroughActive,
 	) {
-		toggleStyle(state, isStrikethroughActive, markdownState.markdownStyles.STRIKETHROUGH)
+		toggleStyle(state, markdownState.markdownStyles.STRIKETHROUGH)
 	}
 	EditorTextAction(
 		label = if (currentHeaderLevel == 0) "H" else "H$currentHeaderLevel",
@@ -152,7 +155,7 @@ private fun RowScope.FormatButtons(
 		icon = Icons.Default.FormatQuote,
 		active = isBlockquoteActive,
 	) {
-		toggleStyle(state, isBlockquoteActive, markdownState.markdownStyles.BLOCKQUOTE)
+		toggleStyle(state, markdownState.markdownStyles.BLOCKQUOTE)
 	}
 	EditorAction(
 		icon = Icons.AutoMirrored.Filled.FormatListBulleted,
@@ -258,19 +261,39 @@ private fun HistoryAndOverflow(
 	}
 }
 
+/**
+ * Hooks Ctrl/Cmd+B, Ctrl/Cmd+I and Ctrl/Cmd+Shift+X up to bold, italic and
+ * strikethrough so the inline styles in the format bar are also reachable from
+ * the keyboard. Apply to an ancestor of the editor (the events are caught in the
+ * preview phase, before the editor's own key handling sees them).
+ */
+fun Modifier.markdownFormatShortcuts(markdownExtension: MarkdownExtension): Modifier {
+	val state = markdownExtension.editorState
+	return this
+		.boldShortcutModifier { toggleStyle(state, markdownExtension.markdownStyles.BOLD) }
+		.italicShortcutModifier { toggleStyle(state, markdownExtension.markdownStyles.ITALICS) }
+		.strikethroughShortcutModifier { toggleStyle(state, markdownExtension.markdownStyles.STRIKETHROUGH) }
+}
+
+/**
+ * Toggles [spanStyle] over the current selection, or at the cursor when there is
+ * no selection. The active state is read synchronously from the editor so this is
+ * safe to call from a keyboard shortcut as well as a toolbar button.
+ */
 private fun toggleStyle(
 	state: TextEditorState,
-	isActive: Boolean,
-	spanStyle: SpanStyle
+	spanStyle: SpanStyle,
 ) {
 	val selection = state.selector.selection
 	if (selection != null) {
+		val isActive = state.getSpanStylesInRange(selection).contains(spanStyle)
 		if (isActive) {
 			state.removeStyleSpan(selection, spanStyle)
 		} else {
 			state.addStyleSpan(selection, spanStyle)
 		}
 	} else {
+		val isActive = state.cursor.styles.contains(spanStyle)
 		if (isActive) {
 			state.cursor.removeStyle(spanStyle)
 		} else {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/ShortcutHint.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/ShortcutHint.kt
@@ -1,0 +1,4 @@
+package com.darkrockstudios.apps.hammer.common.compose.markdowneditor
+
+/** Renders a Ctrl/Cmd[+Shift]+key shortcut for display, using ⌘/⇧ on Apple platforms. */
+internal expect fun shortcutHint(key: String, shift: Boolean = false): String

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -57,6 +57,7 @@ import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.findShortcutModifier
 import com.darkrockstudios.apps.hammer.common.compose.markdown.updateMarkdownConfiguration
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownFormatBar
+import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.markdownFormatShortcuts
 import com.darkrockstudios.apps.hammer.common.compose.saveShortcutModifier
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
 import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SceneDeleteDialog
@@ -155,6 +156,7 @@ fun SceneEditorUi(
 					.fillMaxHeight()
 					.findShortcutModifier { showFindBar = true }
 					.saveShortcutModifier { scope.launch { component.storeSceneContent() } }
+					.markdownFormatShortcuts(markdownExtension)
 			) {
 				EditorTopBar(
 					component = component,

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/ShortcutHint.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/ShortcutHint.kt
@@ -1,0 +1,11 @@
+package com.darkrockstudios.apps.hammer.common.compose.markdowneditor
+
+import com.darkrockstudios.apps.hammer.common.HostOs
+import com.darkrockstudios.apps.hammer.common.hostOs
+
+internal actual fun shortcutHint(key: String, shift: Boolean): String =
+	if (hostOs == HostOs.MacOs) {
+		"⌘${if (shift) "⇧" else ""}$key"
+	} else {
+		"Ctrl+${if (shift) "Shift+" else ""}$key"
+	}

--- a/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/ShortcutHint.kt
+++ b/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/ShortcutHint.kt
@@ -1,0 +1,4 @@
+package com.darkrockstudios.apps.hammer.common.compose.markdowneditor
+
+internal actual fun shortcutHint(key: String, shift: Boolean): String =
+	"⌘${if (shift) "⇧" else ""}$key"


### PR DESCRIPTION
The markdown editor only exposed inline styles through format-bar buttons;
the underlying composetexteditor library handles editing/navigation shortcuts
(Ctrl+C/V/X/Z/Y, arrows, etc.) but has no bindings for bold/italic, so those
keys were simply dropped.

Hook Ctrl/Cmd+B, Ctrl/Cmd+I and Ctrl/Cmd+Shift+X to bold, italic and
strikethrough via a markdownFormatShortcuts modifier applied to an ancestor of
the editor, so the events are caught in the preview phase before the editor's
own key handling. Share a single synchronous toggleStyle implementation between
the format-bar buttons and the shortcuts. Wired into both the scene editor and
the reusable MarkdownEditField.