### PR TITLE
Expand sync + tree test coverage

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
@@ -276,6 +276,7 @@ class EntityTransferOperation(
 						projectDef
 					)
 				)
+				CResult.success()
 			} else {
 				onLog(
 					syncLogE(
@@ -283,9 +284,8 @@ class EntityTransferOperation(
 						projectDef
 					)
 				)
+				CResult.failure(IllegalStateException("Failed to store downloaded entity $id"))
 			}
-
-			CResult.success()
 		} else {
 			when (val exception = entityResponse.exceptionOrNull()) {
 				is EntityNotModifiedException -> {

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/tree/ImmutableTreeTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/tree/ImmutableTreeTest.kt
@@ -1,0 +1,205 @@
+package com.darkrockstudios.apps.hammer.common.data.tree
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ImmutableTreeTest {
+
+	/**
+	 *         0
+	 *        / \
+	 *      1a   1b
+	 *     /  \    \
+	 *   2a   2b   2c
+	 *
+	 * Depth-first global indices: 0, 1a=1, 2a=2, 2b=3, 1b=4, 2c=5
+	 */
+	private fun testTree(): ImmutableTree<String> {
+		val root = TreeNode("0")
+
+		val a1 = TreeNode("1a")
+		val b1 = TreeNode("1b")
+		root.addChild(a1)
+		root.addChild(b1)
+
+		a1.addChild(TreeNode("2a"))
+		a1.addChild(TreeNode("2b"))
+		b1.addChild(TreeNode("2c"))
+
+		val tree = Tree<String>()
+		tree.setRoot(root)
+		return tree.toImmutableTree()
+	}
+
+	@Test
+	fun `totalNodes counts root plus all descendants`() {
+		val tree = testTree()
+		assertEquals(5, tree.totalChildren)
+		assertEquals(6, tree.totalNodes)
+	}
+
+	@Test
+	fun `get by index returns the node at that global index`() {
+		val tree = testTree()
+		assertEquals("0", tree[0].value)
+		assertEquals("1a", tree[1].value)
+		assertEquals("2a", tree[2].value)
+		assertEquals("2b", tree[3].value)
+		assertEquals("1b", tree[4].value)
+		assertEquals("2c", tree[5].value)
+	}
+
+	@Test
+	fun `get with out of range index throws`() {
+		val tree = testTree()
+		assertFailsWith<IndexOutOfBoundsException> { tree[6] }
+		assertFailsWith<IndexOutOfBoundsException> { tree[-1] }
+	}
+
+	@Test
+	fun `indexOf node returns its iteration index`() {
+		val tree = testTree()
+		assertEquals(0, tree.indexOf(tree[0]))
+		assertEquals(3, tree.indexOf(tree[3]))
+		assertEquals(5, tree.indexOf(tree[5]))
+	}
+
+	@Test
+	fun `indexOf predicate returns matching index or minus one`() {
+		val tree = testTree()
+		assertEquals(2, tree.indexOf { it == "2a" })
+		assertEquals(4, tree.indexOf { it == "1b" })
+		assertEquals(-1, tree.indexOf { it == "nope" })
+	}
+
+	@Test
+	fun `findBy returns matching node or null`() {
+		val tree = testTree()
+		val found = tree.findBy { it == "2c" }
+		assertEquals("2c", found?.value)
+		assertEquals(5, found?.index)
+
+		assertNull(tree.findBy { it == "nope" })
+	}
+
+	@Test
+	fun `isAncestorOf is true for direct and transitive ancestors`() {
+		val tree = testTree()
+		// root and 1a are ancestors of 2a (index 2)
+		assertTrue(tree.isAncestorOf(needleIndex = 0, leafIndex = 2))
+		assertTrue(tree.isAncestorOf(needleIndex = 1, leafIndex = 2))
+	}
+
+	@Test
+	fun `isAncestorOf is false for non-ancestors and for self`() {
+		val tree = testTree()
+		// 1b (index 4) is in a different branch from 2a (index 2)
+		assertFalse(tree.isAncestorOf(needleIndex = 4, leafIndex = 2))
+		// a node is not its own ancestor
+		assertFalse(tree.isAncestorOf(needleIndex = 2, leafIndex = 2))
+	}
+
+	@Test
+	fun `getBranch includes the full path from root to leaf`() {
+		val tree = testTree()
+		val branch = tree.getBranch(leafIndex = 2, excludeLeaf = false)
+		assertEquals(listOf("0", "1a", "2a"), branch.map { it.value })
+	}
+
+	@Test
+	fun `getBranch can exclude the leaf`() {
+		val tree = testTree()
+		val branch = tree.getBranch(leafIndex = 2, excludeLeaf = true)
+		assertEquals(listOf("0", "1a"), branch.map { it.value })
+	}
+
+	@Test
+	fun `getBranch of root is just the root`() {
+		val tree = testTree()
+		val branch = tree.getBranch(leafIndex = 0, excludeLeaf = false)
+		assertEquals(listOf("0"), branch.map { it.value })
+	}
+
+	@Test
+	fun `getCoordinatesFor root returns Root coordinates`() {
+		val tree = testTree()
+		val coords = tree.getCoordinatesFor(tree[0])
+		assertEquals(NodeCoordinates.Root, coords)
+		assertTrue(coords.isTreeRoot())
+	}
+
+	@Test
+	fun `getCoordinatesFor child returns parent and local child index`() {
+		val tree = testTree()
+		// 2b is the second child (local index 1) of 1a (global index 1)
+		val coords = tree.getCoordinatesFor(tree[3])
+		assertEquals(3, coords.globalIndex)
+		assertEquals(1, coords.parentIndex)
+		assertEquals(1, coords.childLocalIndex)
+		assertFalse(coords.isTreeRoot())
+	}
+
+	@Test
+	fun `getByCoordinates round-trips with getCoordinatesFor`() {
+		val tree = testTree()
+		for (index in 0 until tree.totalNodes) {
+			val node = tree[index]
+			val coords = tree.getCoordinatesFor(node)
+			assertEquals(node, tree.getByCoordinates(coords))
+		}
+	}
+
+	@Test
+	fun `getByCoordinates with Root returns the root`() {
+		val tree = testTree()
+		assertEquals(tree[0], tree.getByCoordinates(NodeCoordinates.Root))
+	}
+
+	@Test
+	fun `list returns all nodes in depth-first order`() {
+		val tree = testTree()
+		assertEquals(
+			listOf("0", "1a", "2a", "2b", "1b", "2c"),
+			tree.list().map { it.value }
+		)
+	}
+
+	@Test
+	fun `iterator throws when exhausted`() {
+		val tree = testTree()
+		val iter = tree.iterator()
+		repeat(tree.totalNodes) { iter.next() }
+		assertFalse(iter.hasNext())
+		assertFailsWith<NoSuchElementException> { iter.next() }
+	}
+
+	@Test
+	fun `equal trees are equal and share a hashCode`() {
+		val a = testTree()
+		val b = testTree()
+		assertEquals(a, b)
+		assertEquals(a.hashCode(), b.hashCode())
+	}
+
+	@Test
+	fun `trees with different structure are not equal`() {
+		val a = testTree()
+
+		val root = TreeNode("0")
+		root.addChild(TreeNode("1a"))
+		val other = Tree<String>().apply { setRoot(root) }.toImmutableTree()
+
+		assertNotEquals(a, other)
+	}
+
+	@Test
+	fun `tree is not equal to a non-tree value`() {
+		val tree = testTree()
+		assertFalse(tree.equals("not a tree"))
+	}
+}

--- a/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
@@ -1,63 +1,142 @@
 package synchronizer
 
-import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import ENCYCLOPEDIA_ONLY_PROJECT_NAME
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsRepository
+import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexDatasource
+import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceRemapper
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogMessage
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.synchronizers.ClientEncyclopediaSynchronizer
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
-import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
+import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
+import createProject
+import getProjectDef
 import io.mockk.MockKAnnotations
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.coVerifyOrder
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
+import korlibs.crypto.encoding.Base64
 import kotlinx.coroutines.test.runTest
+import net.peanuuutz.tomlkt.Toml
+import okio.fakefilesystem.FakeFileSystem
 import org.jetbrains.compose.resources.StringResource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.dsl.module
+import repositories.encyclopedia.entry1
+import repositories.encyclopedia.entry2
 import utils.BaseTest
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
+/**
+ * Classical-style: drives a real [EncyclopediaRepository] / [EncyclopediaService] /
+ * [EncyclopediaDatasource] over a [FakeFileSystem] seeded from the "Encyclopedia Only"
+ * fixture (entry 1 = PERSON, entry 2 = PLACE). Only true boundaries are mocked: the
+ * network ([ServerProjectApi]) and leaf side-effect collaborators. Assertions are made
+ * against observable state (files on disk, returned entities) rather than interactions.
+ */
 class ClientEncyclopediaSynchronizerTest : BaseTest() {
 
-	private val projectDef = ProjectDef(
-		name = "Test",
-		path = HPath("/projects/Test", "Test", false),
-	)
+	private val projectDef = getProjectDef(ENCYCLOPEDIA_ONLY_PROJECT_NAME)
 
-	@MockK
+	@MockK(relaxed = true)
 	private lateinit var serverProjectApi: ServerProjectApi
 
-	@MockK
+	@MockK(relaxed = true)
 	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
 
 	@MockK(relaxed = true)
-	private lateinit var encyclopediaRepository: EncyclopediaRepository
+	private lateinit var idAllocator: IdAllocator
 
 	@MockK(relaxed = true)
-	private lateinit var referenceRemapper: ReferenceRemapper
+	private lateinit var externalFileIo: ExternalFileIo
+
+	@MockK
+	private lateinit var syncJournal: SyncJournal
+
+	@MockK(relaxed = true)
+	private lateinit var statisticsRepository: StatisticsRepository
 
 	private val strRes: StrRes = object : StrRes {
 		override suspend fun get(str: StringResource) = "test"
 		override suspend fun get(str: StringResource, vararg args: Any) = "test"
 	}
 
+	private lateinit var fileSystem: FakeFileSystem
+	private lateinit var toml: Toml
+	private lateinit var datasource: EncyclopediaDatasource
+	private lateinit var repository: EncyclopediaRepository
+	private lateinit var service: EncyclopediaService
+	private lateinit var remapper: RecordingReferenceRemapper
+
+	private class RecordingReferenceRemapper : ReferenceRemapper {
+		val remaps = mutableListOf<Pair<Int, Int>>()
+		override suspend fun remapEntryReferences(oldEntryId: Int, newEntryId: Int) {
+			remaps.add(oldEntryId to newEntryId)
+		}
+	}
+
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		MockKAnnotations.init(this)
+		MockKAnnotations.init(this, relaxUnitFun = true)
 
+		every { syncJournal.isServerSynchronized() } returns false
+
+		fileSystem = FakeFileSystem()
+		toml = createTomlSerializer()
+		createProject(fileSystem, ENCYCLOPEDIA_ONLY_PROJECT_NAME)
+
+		// Koin must be running before the repository is built — its init resolves a
+		// project scope and injects a dispatcher. The scoped providers below are lazy,
+		// so they safely close over the lateinit collaborators assigned afterward.
 		setupKoin(module {
 			scope<ProjectDefScope> {
-				scoped<ProjectDef> { projectDef }
-				scoped { encyclopediaRepository }
-				scoped<ReferenceRemapper> { referenceRemapper }
+				scoped { projectDef }
+				scoped { repository }
+				scoped { service }
+				scoped { datasource }
+				scoped<ReferenceRemapper> { remapper }
 			}
 		})
+
+		datasource = EncyclopediaDatasource(
+			projectDef = projectDef,
+			toml = toml,
+			fileSystem = fileSystem,
+			externalFileIo = externalFileIo,
+		)
+		repository = EncyclopediaRepository(
+			projectDef = projectDef,
+			idAllocator = idAllocator,
+			datasource = datasource,
+			syncJournal = syncJournal,
+		)
+		val referenceIndexDatasource = ReferenceIndexDatasource(fileSystem, toml, projectDef)
+		val referenceIndexRepository = ReferenceIndexRepository(projectDef, referenceIndexDatasource)
+		service = EncyclopediaService(
+			repository = repository,
+			statisticsRepository = statisticsRepository,
+			referenceIndexRepository = referenceIndexRepository,
+		)
+		remapper = RecordingReferenceRemapper()
 	}
 
 	private fun newSynchronizer() = ClientEncyclopediaSynchronizer(
@@ -68,22 +147,155 @@ class ClientEncyclopediaSynchronizerTest : BaseTest() {
 	)
 
 	@Test
-	fun `reIdEntity remaps references after re-IDing the entry`() = runTest {
-		// Defends the cross-entity wiring we added for sync ID-conflict resolution:
-		// when an encyclopedia entry's ID is rewritten on the client, every scene's
-		// confirmedReferences and dismissedReferences must also be rewritten or the
-		// references silently break. The order matters - the entry must be re-IDed
-		// first so the remapper sees the new ID consistent with the entry store.
-		coEvery { encyclopediaRepository.reIdEntry(5, 12) } returns Unit
-		coEvery { referenceRemapper.remapEntryReferences(5, 12) } returns Unit
+	fun `ownsEntity reflects which entries exist locally`() = runTest {
+		val sync = newSynchronizer()
+		sync.prepareForSync()
+
+		assertTrue(sync.ownsEntity(entry1().id))
+		assertTrue(sync.ownsEntity(entry2().id))
+		assertFalse(sync.ownsEntity(999))
+	}
+
+	@Test
+	fun `createEntityForId mirrors the stored entry`() = runTest {
+		val sync = newSynchronizer()
+
+		val entity = sync.createEntityForId(entry1().id)
+
+		assertEquals(entry1().id, entity.id)
+		assertEquals(entry1().name, entity.name)
+		assertEquals(EntryType.PERSON.text, entity.entryType)
+		assertEquals(entry1().text, entity.text)
+		assertEquals(entry1().tags, entity.tags)
+		assertNull(entity.image)
+	}
+
+	@Test
+	fun `createEntityForId round-trips the entry image as base64`() = runTest {
+		val imageBytes = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+		datasource.writeEntryImage(entry1().toDef(projectDef), imageBytes, "jpg")
 
 		val sync = newSynchronizer()
-		sync.reIdEntity(oldId = 5, newId = 12)
+		val entity = sync.createEntityForId(entry1().id)
 
-		coVerifyOrder {
-			encyclopediaRepository.reIdEntry(5, 12)
-			referenceRemapper.remapEntryReferences(5, 12)
-		}
-		coVerify(exactly = 1) { referenceRemapper.remapEntryReferences(5, 12) }
+		val image = entity.image
+		assertNotNull(image)
+		assertEquals("jpg", image.fileExtension)
+		assertContentEquals(imageBytes, Base64.decode(image.base64, url = true))
+	}
+
+	@Test
+	fun `getEntityHash is deterministic and entry-specific`() = runTest {
+		val sync = newSynchronizer()
+
+		assertEquals(sync.getEntityHash(entry1().id), sync.getEntityHash(entry1().id))
+		assertNotEquals(sync.getEntityHash(entry1().id), sync.getEntityHash(entry2().id))
+	}
+
+	@Test
+	fun `storeEntity creates a brand-new entry on disk`() = runTest {
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			id = 50,
+			name = "Imported",
+			text = "From the server",
+		)
+
+		val stored = sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+		assertTrue(stored)
+
+		val def = repository.findEntryDef(50)
+		assertNotNull(def)
+		val loaded = repository.loadEntry(50).entry
+		assertEquals("Imported", loaded.name)
+		assertEquals("From the server", loaded.text)
+	}
+
+	@Test
+	fun `storeEntity updates an existing entry in place`() = runTest {
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			name = entry1().name,
+			text = "Server-updated text",
+			tags = setOf("server-tag"),
+		)
+
+		val stored = sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+		assertTrue(stored)
+
+		val loaded = repository.loadEntry(entry1().id).entry
+		assertEquals("Server-updated text", loaded.text)
+		assertEquals(setOf("server-tag"), loaded.tags)
+	}
+
+	@Test
+	fun `storeEntity writes a server-provided image to disk`() = runTest {
+		val imageBytes = byteArrayOf(9, 8, 7, 6)
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(imageBytes, url = true),
+				fileExtension = "jpg",
+			)
+		)
+
+		sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		val def = entry1().toDef(projectDef)
+		assertTrue(datasource.hasEntryImage(def, "jpg"))
+		assertContentEquals(imageBytes, datasource.loadEntryImage(def, "jpg"))
+	}
+
+	@Test
+	fun `storeEntity drops a local image when the server has none`() = runTest {
+		val def = entry1().toDef(projectDef)
+		datasource.writeEntryImage(def, byteArrayOf(1, 2, 3), "jpg")
+		assertTrue(datasource.hasEntryImage(def, "jpg"))
+
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(image = null)
+
+		sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		assertFalse(datasource.hasEntryImage(def, "jpg"))
+	}
+
+	@Test
+	fun `hashEntities covers every entry except the excluded new ids`() = runTest {
+		val sync = newSynchronizer()
+		sync.prepareForSync()
+
+		val all = sync.hashEntities(emptyList())
+		assertEquals(setOf(entry1().id, entry2().id), all.map { it.id }.toSet())
+
+		val excluding2 = sync.hashEntities(listOf(entry2().id))
+		assertEquals(setOf(entry1().id), excluding2.map { it.id }.toSet())
+		assertEquals(sync.getEntityHash(entry1().id), excluding2.single().hash)
+	}
+
+	@Test
+	fun `deleteEntityLocal removes the entry and emits a log`() = runTest {
+		val logs = mutableListOf<SyncLogMessage>()
+		val sync = newSynchronizer()
+
+		sync.deleteEntityLocal(entry1().id, onLog = { logs.add(it) })
+
+		assertNull(repository.findEntryDef(entry1().id))
+		assertEquals(1, logs.size)
+	}
+
+	@Test
+	fun `reIdEntity moves the entry on disk and remaps references`() = runTest {
+		val sync = newSynchronizer()
+
+		val oldPath = datasource.getEntryPath(entry2().toDef(projectDef)).toOkioPath()
+		assertTrue(fileSystem.exists(oldPath))
+
+		sync.reIdEntity(oldId = entry2().id, newId = 7)
+
+		assertFalse(fileSystem.exists(oldPath))
+		val newPath = datasource.getEntryPath(entry2().copy(id = 7).toDef(projectDef)).toOkioPath()
+		assertTrue(fileSystem.exists(newPath))
+		assertEquals(listOf(entry2().id to 7), remapper.remaps)
 	}
 }

--- a/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
@@ -1,6 +1,9 @@
 package synchronizer
 
 import ENCYCLOPEDIA_ONLY_PROJECT_NAME
+import com.darkrockstudios.apps.hammer.base.ProjectId
+import com.darkrockstudios.apps.hammer.base.http.SaveEntityResponse
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityConflictException
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
@@ -24,8 +27,11 @@ import com.darkrockstudios.apps.hammer.common.util.StrRes
 import createProject
 import getProjectDef
 import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.launch
 import korlibs.crypto.encoding.Base64
 import kotlinx.coroutines.test.runTest
 import net.peanuuutz.tomlkt.Toml
@@ -99,6 +105,7 @@ class ClientEncyclopediaSynchronizerTest : BaseTest() {
 		MockKAnnotations.init(this, relaxUnitFun = true)
 
 		every { syncJournal.isServerSynchronized() } returns false
+		every { projectMetadataDatasource.requireProjectId(projectDef) } returns ProjectId("server-project")
 
 		fileSystem = FakeFileSystem()
 		toml = createTomlSerializer()
@@ -297,5 +304,136 @@ class ClientEncyclopediaSynchronizerTest : BaseTest() {
 		val newPath = datasource.getEntryPath(entry2().copy(id = 7).toDef(projectDef)).toOkioPath()
 		assertTrue(fileSystem.exists(newPath))
 		assertEquals(listOf(entry2().id to 7), remapper.remaps)
+	}
+
+	@Test
+	fun `uploadEntity sends the entity and reports the synced hash on success`() = runTest {
+		val sync = newSynchronizer()
+		coEvery {
+			serverProjectApi.uploadEntity(any(), any(), any(), any(), any(), any())
+		} returns Result.success(SaveEntityResponse(saved = true))
+
+		val synced = mutableListOf<Pair<Int, String>>()
+		val logs = mutableListOf<SyncLogMessage>()
+
+		val result = sync.uploadEntity(
+			id = entry1().id,
+			syncId = "sync",
+			originalHash = "old-hash",
+			onConflict = { error("no conflict expected") },
+			onLog = { logs.add(it) },
+			onSynced = { id, hash -> synced.add(id to hash) },
+		)
+
+		assertTrue(result)
+		assertEquals(listOf(entry1().id to sync.getEntityHash(entry1().id)), synced)
+		coVerify {
+			serverProjectApi.uploadEntity(
+				projectDef.name,
+				ProjectId("server-project"),
+				match { it.id == entry1().id },
+				"old-hash",
+				"sync",
+				false,
+			)
+		}
+	}
+
+	@Test
+	fun `uploadEntity passes the force flag through to the server`() = runTest {
+		val sync = newSynchronizer()
+		coEvery {
+			serverProjectApi.uploadEntity(any(), any(), any(), any(), any(), any())
+		} returns Result.success(SaveEntityResponse(saved = true))
+
+		sync.uploadEntity(
+			id = entry1().id,
+			syncId = "sync",
+			originalHash = null,
+			onConflict = { error("no conflict expected") },
+			onLog = {},
+			force = true,
+		)
+
+		coVerify { serverProjectApi.uploadEntity(any(), any(), any(), any(), any(), true) }
+	}
+
+	@Test
+	fun `uploadEntity returns false and does not report synced on a non-conflict failure`() = runTest {
+		val sync = newSynchronizer()
+		coEvery {
+			serverProjectApi.uploadEntity(any(), any(), any(), any(), any(), any())
+		} returns Result.failure(RuntimeException("server exploded"))
+
+		val synced = mutableListOf<Pair<Int, String>>()
+
+		val result = sync.uploadEntity(
+			id = entry1().id,
+			syncId = "sync",
+			originalHash = null,
+			onConflict = { error("no conflict expected") },
+			onLog = {},
+			onSynced = { id, hash -> synced.add(id to hash) },
+		)
+
+		assertFalse(result)
+		assertTrue(synced.isEmpty())
+	}
+
+	@Test
+	fun `uploadEntity resolves a conflict by re-uploading and storing the resolved entity`() = runTest {
+		val sync = newSynchronizer()
+		val serverVersion = sync.createEntityForId(entry1().id).copy(text = "server's version")
+		val resolved = sync.createEntityForId(entry1().id).copy(text = "merged resolution")
+
+		coEvery {
+			serverProjectApi.uploadEntity(any(), any(), any(), "old-hash", any(), false)
+		} returns Result.failure(EntityConflictException.EncyclopediaEntryConflictException(serverVersion))
+		coEvery {
+			serverProjectApi.uploadEntity(any(), any(), any(), null, any(), true)
+		} returns Result.success(SaveEntityResponse(saved = true))
+
+		val conflicted = mutableListOf<Int>()
+		val synced = mutableListOf<Pair<Int, String>>()
+
+		launch { sync.conflictResolution.send(resolved) }
+		val result = sync.uploadEntity(
+			id = entry1().id,
+			syncId = "sync",
+			originalHash = "old-hash",
+			onConflict = { conflicted.add(it.id) },
+			onLog = {},
+			onSynced = { id, hash -> synced.add(id to hash) },
+		)
+
+		assertTrue(result)
+		assertEquals(listOf(entry1().id), conflicted)
+		assertEquals(listOf(entry1().id to resolved.hash()), synced)
+		assertEquals("merged resolution", repository.loadEntry(entry1().id).entry.text)
+	}
+
+	@Test
+	fun `uploadEntity returns false when conflict resolution upload fails`() = runTest {
+		val sync = newSynchronizer()
+		val serverVersion = sync.createEntityForId(entry1().id).copy(text = "server's version")
+		val resolved = sync.createEntityForId(entry1().id).copy(text = "merged resolution")
+
+		coEvery {
+			serverProjectApi.uploadEntity(any(), any(), any(), "old-hash", any(), false)
+		} returns Result.failure(EntityConflictException.EncyclopediaEntryConflictException(serverVersion))
+		coEvery {
+			serverProjectApi.uploadEntity(any(), any(), any(), null, any(), true)
+		} returns Result.failure(RuntimeException("resolution rejected"))
+
+		launch { sync.conflictResolution.send(resolved) }
+		val result = sync.uploadEntity(
+			id = entry1().id,
+			syncId = "sync",
+			originalHash = "old-hash",
+			onConflict = {},
+			onLog = {},
+		)
+
+		assertFalse(result)
 	}
 }

--- a/common/src/desktopTest/kotlin/synchronizer/SceneSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/SceneSynchronizerTest.kt
@@ -10,6 +10,8 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRe
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.findById
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogLevel
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogMessage
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.synchronizers.ClientSceneSynchronizer
 import com.darkrockstudios.apps.hammer.common.data.tree.Tree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
@@ -29,8 +31,10 @@ import org.junit.jupiter.api.Test
 import utils.BaseTest
 import utils.fromApiEntity
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class SceneSynchronizerTest : BaseTest() {
 
@@ -524,5 +528,255 @@ class SceneSynchronizerTest : BaseTest() {
 		////////////////////
 		// Verify
 		kotlin.test.assertFalse(owns, "Should not own unknown scene")
+	}
+
+	@Test
+	fun `createEntityForId - builds entity from an active scene`() = runTest {
+		val sceneId = 100
+		val sceneItem = SceneItem(
+			projectDef = def,
+			type = SceneItem.Type.Scene,
+			id = sceneId,
+			name = "Chapter One",
+			order = 3,
+		)
+		val filePath = HPath("/scene.md", "scene.md", false)
+
+		every { sceneEditorRepository.getSceneItemFromId(sceneId) } returns sceneItem
+		every { sceneEditorRepository.getPathSegments(sceneItem) } returns listOf(0)
+		every {
+			sceneEditorRepository.resolveScenePathFromFilesystemIncludingArchived(sceneId)
+		} returns filePath
+		every { sceneEditorRepository.loadSceneMarkdownRaw(sceneItem, filePath) } returns "Body text"
+		coEvery { sceneEditorService.loadSceneMetadata(sceneId) } returns
+			SceneMetadata(outline = "The outline", notes = "The notes")
+
+		val sync = defaultSceneSynchronizer()
+		val entity = sync.createEntityForId(sceneId)
+
+		assertEquals(sceneId, entity.id)
+		assertEquals("Chapter One", entity.name)
+		assertEquals(3, entity.order)
+		assertEquals(ApiSceneType.Scene, entity.sceneType)
+		assertEquals("Body text", entity.content)
+		assertEquals(listOf(0), entity.path)
+		assertEquals("The outline", entity.outline)
+		assertEquals("The notes", entity.notes)
+		assertFalse(entity.archived)
+	}
+
+	@Test
+	fun `createEntityForId - a group carries no content`() = runTest {
+		val groupId = 200
+		val groupItem = SceneItem(
+			projectDef = def,
+			type = SceneItem.Type.Group,
+			id = groupId,
+			name = "Act I",
+			order = 0,
+		)
+
+		every { sceneEditorRepository.getSceneItemFromId(groupId) } returns groupItem
+		every { sceneEditorRepository.getPathSegments(groupItem) } returns listOf(0)
+		coEvery { sceneEditorService.loadSceneMetadata(groupId) } returns SceneMetadata()
+
+		val sync = defaultSceneSynchronizer()
+		val entity = sync.createEntityForId(groupId)
+
+		assertEquals(ApiSceneType.Group, entity.sceneType)
+		assertEquals("", entity.content)
+	}
+
+	@Test
+	fun `storeEntity - returns false when content fails to store`() = runTest {
+		val sceneId = 1
+		val serverEntity = ApiProjectEntity.SceneEntity(
+			id = sceneId,
+			sceneType = ApiSceneType.Scene,
+			order = 0,
+			name = "Test Scene",
+			path = listOf(0),
+			content = "Scene Content",
+			outline = "",
+			notes = "",
+		)
+		val clientEntity = SceneItem.fromApiEntity(serverEntity, def)
+		val filePath = HPath("/", "", true)
+		val content = SceneContent(clientEntity, serverEntity.content)
+
+		every { sceneEditorRepository.getSceneItemFromId(ROOT_ID) } returns rootSceneNode(def)
+		every { sceneEditorRepository.getSceneItemFromId(sceneId) } returns clientEntity
+		every { sceneEditorRepository.rawTree } returns tree
+		every { sceneEditorRepository.resolveScenePathFromFilesystem(clientEntity.id) } returns filePath
+		coEvery { sceneEditorRepository.storeSceneMarkdownRaw(content, filePath) } returns false
+
+		rootNode.addChild(TreeNode(clientEntity))
+
+		val sync = defaultSceneSynchronizer()
+		val stored = sync.storeEntity(serverEntity, syncId = "syncId", onLog = {})
+
+		assertFalse(stored)
+		coVerify(exactly = 0) { sceneEditorService.onContentChanged(any(), any()) }
+	}
+
+	@Test
+	fun `storeEntity - archived server scene that is absent locally is created in the archive`() =
+		runTest {
+			val sceneId = 5
+			val serverEntity = ApiProjectEntity.SceneEntity(
+				id = sceneId,
+				sceneType = ApiSceneType.Scene,
+				order = 2,
+				name = "Old Chapter",
+				path = emptyList(),
+				content = "Archived content",
+				outline = "",
+				notes = "",
+				archived = true,
+			)
+
+			every { sceneEditorRepository.rawTree } returns tree
+			every { sceneEditorRepository.getSceneItemFromId(sceneId) } returns null
+			every {
+				sceneEditorRepository.resolveScenePathFromFilesystemIncludingArchived(sceneId)
+			} returns null
+			coEvery {
+				sceneEditorRepository.createArchivedScene(
+					id = sceneId,
+					name = any(),
+					order = any(),
+					type = any(),
+					content = any(),
+					metadata = any(),
+				)
+			} returns SceneItem(
+				projectDef = def,
+				type = SceneItem.Type.Scene,
+				id = sceneId,
+				name = "Old Chapter",
+				order = 2,
+				archived = true,
+			)
+
+			val sync = defaultSceneSynchronizer()
+			val stored = sync.storeEntity(serverEntity, syncId = "syncId", onLog = {})
+
+			assertTrue(stored)
+			coVerify(exactly = 1) {
+				sceneEditorRepository.createArchivedScene(
+					id = sceneId,
+					name = "Old Chapter",
+					order = 2,
+					type = SceneItem.Type.Scene,
+					content = "Archived content",
+					metadata = any(),
+				)
+			}
+		}
+
+	@Test
+	fun `storeEntity - archived server scene archives the active local copy`() = runTest {
+		val sceneId = 6
+		val serverEntity = ApiProjectEntity.SceneEntity(
+			id = sceneId,
+			sceneType = ApiSceneType.Scene,
+			order = 0,
+			name = "Now Archived",
+			path = emptyList(),
+			content = "content",
+			outline = "",
+			notes = "",
+			archived = true,
+		)
+		val activeItem = SceneItem(
+			projectDef = def,
+			type = SceneItem.Type.Scene,
+			id = sceneId,
+			name = "Now Archived",
+			order = 0,
+		)
+		val archivedItem = activeItem.copy(archived = true)
+		val filePath = HPath("/archived.md", "archived.md", false)
+
+		every { sceneEditorRepository.rawTree } returns tree
+		every { sceneEditorRepository.getSceneItemFromId(sceneId) } returns activeItem
+		coEvery { sceneEditorService.archiveScene(activeItem) } returns true
+		every {
+			sceneEditorRepository.resolveScenePathFromFilesystemIncludingArchived(sceneId)
+		} returns filePath
+		every { sceneEditorRepository.getArchivedSceneFromId(sceneId) } returns archivedItem
+		coEvery { sceneEditorRepository.storeSceneMarkdownRaw(any(), filePath) } returns true
+
+		val sync = defaultSceneSynchronizer()
+		val stored = sync.storeEntity(serverEntity, syncId = "syncId", onLog = {})
+
+		assertTrue(stored)
+		coVerify(exactly = 1) { sceneEditorService.archiveScene(activeItem) }
+	}
+
+	@Test
+	fun `deleteEntityLocal - deletes an active scene`() = runTest {
+		val sceneId = 1
+		val sceneItem = SceneItem(
+			projectDef = def,
+			type = SceneItem.Type.Scene,
+			id = sceneId,
+			name = "Doomed",
+			order = 0,
+		)
+
+		every { sceneEditorRepository.getSceneItemFromId(sceneId) } returns sceneItem
+		coEvery { sceneEditorService.deleteScene(sceneItem) } returns true
+
+		val sync = defaultSceneSynchronizer()
+		sync.deleteEntityLocal(sceneId, onLog = {})
+
+		coVerify(exactly = 1) { sceneEditorService.deleteScene(sceneItem) }
+	}
+
+	@Test
+	fun `deleteEntityLocal - falls back to deleting an archived scene`() = runTest {
+		val sceneId = 2
+		val archivedItem = SceneItem(
+			projectDef = def,
+			type = SceneItem.Type.Scene,
+			id = sceneId,
+			name = "Archived Doomed",
+			order = 0,
+			archived = true,
+		)
+
+		every { sceneEditorRepository.getSceneItemFromId(sceneId) } returns null
+		every { sceneEditorRepository.getArchivedSceneFromId(sceneId) } returns archivedItem
+		coEvery { sceneEditorService.deleteScene(archivedItem) } returns true
+
+		val sync = defaultSceneSynchronizer()
+		sync.deleteEntityLocal(sceneId, onLog = {})
+
+		coVerify(exactly = 1) { sceneEditorService.deleteScene(archivedItem) }
+	}
+
+	@Test
+	fun `deleteEntityLocal - logs an error when the scene is not found`() = runTest {
+		val sceneId = 404
+		val logs = mutableListOf<SyncLogMessage>()
+
+		every { sceneEditorRepository.getSceneItemFromId(sceneId) } returns null
+		every { sceneEditorRepository.getArchivedSceneFromId(sceneId) } returns null
+
+		val sync = defaultSceneSynchronizer()
+		sync.deleteEntityLocal(sceneId, onLog = { logs.add(it) })
+
+		coVerify(exactly = 0) { sceneEditorService.deleteScene(any()) }
+		assertEquals(SyncLogLevel.ERROR, logs.single().level)
+	}
+
+	@Test
+	fun `reIdEntity - re-ids the scene and its drafts`() = runTest {
+		val sync = defaultSceneSynchronizer()
+		sync.reIdEntity(oldId = 4, newId = 9)
+
+		coVerify(exactly = 1) { sceneEditorRepository.reIdScene(4, 9) }
+		coVerify(exactly = 1) { draftRepository.reIdScene(oldId = 4, newId = 9) }
 	}
 }

--- a/common/src/desktopTest/kotlin/synchronizer/SceneSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/SceneSynchronizerTest.kt
@@ -772,6 +772,86 @@ class SceneSynchronizerTest : BaseTest() {
 	}
 
 	@Test
+	fun `Download Group - moves to a new parent`() = runTest {
+		val groupId = 1
+		val syncId = "syncId"
+		val serverEntity = ApiProjectEntity.SceneEntity(
+			id = groupId,
+			sceneType = ApiSceneType.Group,
+			order = 0,
+			name = "Roaming Group",
+			path = listOf(0),
+			content = "",
+			outline = "",
+			notes = "",
+		)
+		val clientGroupEntity = SceneItem(
+			projectDef = def,
+			type = SceneItem.Type.Group,
+			id = groupId,
+			name = "Roaming Group",
+			order = 0,
+		)
+
+		every { sceneEditorRepository.getSceneItemFromId(ROOT_ID) } returns rootSceneNode(def)
+		every { sceneEditorRepository.getSceneItemFromId(groupId) } returns clientGroupEntity
+		every { sceneEditorRepository.rawTree } returns tree
+
+		val parentGroupEntity = SceneItem(
+			projectDef = def,
+			type = SceneItem.Type.Group,
+			id = 2,
+			name = "Old Parent",
+			order = 0,
+		)
+		val parentGroupNode = TreeNode(parentGroupEntity)
+		rootNode.addChild(parentGroupNode)
+		val groupNode = TreeNode(clientGroupEntity)
+		parentGroupNode.addChild(groupNode)
+
+		val sync = defaultSceneSynchronizer()
+		sync.storeEntity(serverEntity, syncId = syncId, onLog = {})
+
+		assertEquals(0, groupNode.parent?.value?.id)
+	}
+
+	@Test
+	fun `storeEntity - unarchives a locally-archived scene the server now reports active`() = runTest {
+		val sceneId = 7
+		val syncId = "syncId"
+		val serverEntity = ApiProjectEntity.SceneEntity(
+			id = sceneId,
+			sceneType = ApiSceneType.Scene,
+			order = 0,
+			name = "Back In Play",
+			path = listOf(0),
+			content = "Scene Content",
+			outline = "",
+			notes = "",
+		)
+		val activeItem = SceneItem.fromApiEntity(serverEntity, def)
+		val archivedItem = activeItem.copy(archived = true)
+		val filePath = HPath("/", "", true)
+		val content = SceneContent(activeItem, serverEntity.content)
+
+		every { sceneEditorRepository.getSceneItemFromId(ROOT_ID) } returns rootSceneNode(def)
+		every { sceneEditorRepository.getSceneItemFromId(sceneId) } returns activeItem
+		every { sceneEditorRepository.getArchivedSceneFromId(sceneId) } returns archivedItem
+		coEvery { sceneEditorService.unarchiveScene(archivedItem) } returns activeItem
+		every { sceneEditorRepository.rawTree } returns tree
+		every { sceneEditorRepository.resolveScenePathFromFilesystem(sceneId) } returns filePath
+		coEvery { sceneEditorRepository.storeSceneMarkdownRaw(content, filePath) } returns true
+
+		rootNode.addChild(TreeNode(activeItem))
+
+		val sync = defaultSceneSynchronizer()
+		val stored = sync.storeEntity(serverEntity, syncId = syncId, onLog = {})
+
+		assertTrue(stored)
+		coVerify(exactly = 1) { sceneEditorService.unarchiveScene(archivedItem) }
+	}
+
+	@Test
 	fun `reIdEntity - re-ids the scene and its drafts`() = runTest {
 		val sync = defaultSceneSynchronizer()
 		sync.reIdEntity(oldId = 4, newId = 9)

--- a/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
@@ -2,14 +2,20 @@ package synchronizer.operations
 
 import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.ClientEntityState
+import com.darkrockstudios.apps.hammer.base.http.DeleteIdsResponse
 import com.darkrockstudios.apps.hammer.base.http.LoadEntityResponse
+import com.darkrockstudios.apps.hammer.base.http.ProjectSynchronizationBegan
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.EntityTransferOperation
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.server.EntityNotFoundException
+import com.darkrockstudios.apps.hammer.common.server.EntityNotModifiedException
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
+import com.darkrockstudios.apps.hammer.common.server.StaleServerHashException
 import getProjectDef
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
@@ -25,6 +31,7 @@ import utils.TestStrRes
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Clock
+import kotlin.time.Instant
 
 class EntityTransferOperationTest : BaseTest() {
 
@@ -186,5 +193,149 @@ class EntityTransferOperationTest : BaseTest() {
 				any()
 			)
 		} returns true
+	}
+
+	/**
+	 * Minimal state whose combined ID sequence is a single [downloadId] that the client does
+	 * not own — so [EntityTransferOperation] takes the download branch for it, letting each
+	 * test drive a specific server-response path.
+	 */
+	private fun singleDownloadState(
+		downloadId: Int,
+		onlyNew: Boolean = false,
+		newClientIds: List<Int> = emptyList(),
+	) = EntityDeleteOperationState(
+		onlyNew = onlyNew,
+		clientSyncData = ProjectSynchronizationData(
+			lastId = downloadId,
+			newIds = emptyList(),
+			lastSync = Instant.fromEpochSeconds(1),
+			dirty = emptyList(),
+			deletedIds = emptySet(),
+		),
+		entityState = ClientEntityState(emptySet()),
+		serverProjectId = projId,
+		serverSyncData = ProjectSynchronizationBegan(
+			syncId = "sync-id",
+			lastSync = Instant.fromEpochSeconds(1),
+			lastId = downloadId,
+			idSequence = listOf(downloadId),
+			deletedIds = emptySet(),
+		),
+		collatedIds = CollateIdsState.CollatedIds(
+			combinedDeletions = emptySet(),
+			serverDeletedIds = emptySet(),
+			newlyDeletedIds = emptySet(),
+			dirtyEntities = mutableListOf(),
+		),
+		maxId = downloadId,
+		newClientIds = newClientIds,
+	)
+
+	private suspend fun EntityTransferOperation.run(state: EntityDeleteOperationState) = execute(
+		state = state,
+		onProgress = { _, _ -> },
+		onLog = {},
+		onConflict = {},
+		onComplete = {},
+	)
+
+	@Test
+	fun `download - server reports not modified, transfer still succeeds`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.failure(EntityNotModifiedException(4))
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+	}
+
+	@Test
+	fun `download - entity missing from server and client is deleted remotely`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.failure(EntityNotFoundException(4))
+		coEvery { serverProjectApi.deleteId(any(), any(), 4, any()) } returns
+			Result.success(DeleteIdsResponse(deleted = true))
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+		coVerify(exactly = 1) { serverProjectApi.deleteId(any(), any(), 4, any()) }
+	}
+
+	@Test
+	fun `download - stale server hash is healed by a forced upload`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// Client owns the entity but it's neither dirty nor newer than the server, so it
+		// downloads — then the stale-hash response triggers the force-upload heal path.
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(4) } returns true
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.failure(StaleServerHashException(4, "cached", "computed"))
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.uploadEntity(4, any(), any(), any(), any(), true, any())
+		} returns true
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+		coVerify(exactly = 1) {
+			mockSynchronizers.sceneSynchronizer.uploadEntity(4, any(), any(), any(), any(), true, any())
+		}
+	}
+
+	@Test
+	fun `download - a failed store logs an error but does not record a synced hash`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 4
+				every { hash() } returns "h-4"
+			})
+		)
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any())
+		} returns false
+
+		val logs = mutableListOf<SyncLogMessage>()
+		val result = op.execute(
+			state = singleDownloadState(4),
+			onProgress = { _, _ -> },
+			onLog = { logs.add(it) },
+			onConflict = {},
+			onComplete = {},
+		)
+
+		assertTrue(isSuccess(result))
+		// A failed store is logged but never recorded as the conflict baseline.
+		coVerify(exactly = 0) { syncJournal.recordSyncedHash(4, any()) }
+		assertTrue(logs.any { it.level == SyncLogLevel.ERROR })
+	}
+
+	@Test
+	fun `onlyNew - uploads each new client entity`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(20) } returns true
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.uploadEntity(20, any(), any(), any(), any(), any(), any())
+		} returns true
+
+		val state = singleDownloadState(20, onlyNew = true, newClientIds = listOf(20))
+		val result = op.run(state)
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+		coVerify(exactly = 1) {
+			mockSynchronizers.sceneSynchronizer.uploadEntity(20, any(), any(), any(), any(), any(), any())
+		}
 	}
 }

--- a/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
@@ -28,6 +28,7 @@ import synchronizer.addSynchronizers
 import utils.BaseTest
 import utils.TestClock
 import utils.TestStrRes
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Clock
@@ -319,6 +320,30 @@ class EntityTransferOperationTest : BaseTest() {
 		// A failed store is logged but never recorded as the conflict baseline.
 		coVerify(exactly = 0) { syncJournal.recordSyncedHash(4, any()) }
 		assertTrue(logs.any { it.level == SyncLogLevel.ERROR })
+	}
+
+	@Test
+	fun `download - a failed store marks the transfer unsuccessful`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 4
+				every { hash() } returns "h-4"
+			})
+		)
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any())
+		} returns false
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertFalse(
+			assertIs<EntityTransferState>(result.data).allSuccess,
+			"A download whose store failed must not report the transfer as fully successful",
+		)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
@@ -347,6 +347,106 @@ class EntityTransferOperationTest : BaseTest() {
 	}
 
 	@Test
+	fun `download - entity missing from server but present locally is not resolved and fails`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// Owned locally, but not dirty/new and not newer than the server, so it takes the
+		// download branch — then the server reports it gone while we still hold a copy.
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(4) } returns true
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.failure(EntityNotFoundException(4))
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertFalse(assertIs<EntityTransferState>(result.data).allSuccess)
+		coVerify(exactly = 0) { serverProjectApi.deleteId(any(), any(), 4, any()) }
+	}
+
+	@Test
+	fun `download - a generic server failure marks the transfer unsuccessful`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.failure(RuntimeException("network down"))
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertFalse(assertIs<EntityTransferState>(result.data).allSuccess)
+	}
+
+	@Test
+	fun `download - a failed stale-hash heal marks the transfer unsuccessful`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(4) } returns true
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.failure(StaleServerHashException(4, "cached", "computed"))
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.uploadEntity(4, any(), any(), any(), any(), true, any())
+		} returns false
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertFalse(assertIs<EntityTransferState>(result.data).allSuccess)
+	}
+
+	@Test
+	fun `upload - a failed entity upload marks the transfer unsuccessful`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// Owned and newly created, so it takes the upload branch — which then fails.
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(4) } returns true
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.uploadEntity(4, any(), any(), any(), any(), any(), any())
+		} returns false
+
+		val result = op.run(singleDownloadState(4, newClientIds = listOf(4)))
+
+		assertTrue(isSuccess(result))
+		assertFalse(assertIs<EntityTransferState>(result.data).allSuccess)
+	}
+
+	@Test
+	fun `onlyNew - an unowned new id is skipped as a successful no-op`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// No synchronizer owns 99, so the upload helper logs a warning and skips it.
+
+		val result = op.run(singleDownloadState(99, onlyNew = true, newClientIds = listOf(99)))
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+		coVerify(exactly = 0) {
+			mockSynchronizers.sceneSynchronizer.uploadEntity(99, any(), any(), any(), any(), any(), any())
+		}
+	}
+
+	@Test
+	fun `download - a failed remote delete during cleanup still completes the transfer`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// Missing from both server and client, so it's cleaned up remotely — but the delete fails.
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.failure(EntityNotFoundException(4))
+		coEvery { serverProjectApi.deleteId(any(), any(), 4, any()) } returns
+			Result.failure(RuntimeException("delete rejected"))
+
+		val logs = mutableListOf<SyncLogMessage>()
+		val result = op.execute(
+			state = singleDownloadState(4),
+			onProgress = { _, _ -> },
+			onLog = { logs.add(it) },
+			onConflict = {},
+			onComplete = {},
+		)
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+		assertTrue(logs.any { it.level == SyncLogLevel.ERROR })
+	}
+
+	@Test
 	fun `onlyNew - uploads each new client entity`() = runTest {
 		val op = createOperation(getProjectDef(PROJECT_2_NAME))
 		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(20) } returns true


### PR DESCRIPTION
## Summary

Closes meaningful test-coverage gaps in the project-sync layer and the `ImmutableTree` query API, and fixes one real bug found along the way. Tests follow the project's classical style — real datasource/repo/service over a `FakeFileSystem`, mocking only true boundaries (network, leaf side-effects).

### Bug fix
- **A failed download-store no longer masquerades as success.** `EntityTransferOperation.downloadEntry` previously returned `CResult.success()` even when `storeEntity` failed, so a partial sync could report fully successful. It now returns a failure, which flows through to `FinalizeSyncOperation` (sync marked failed, dirty entities preserved for retry).

### Coverage added
- **`EntitySynchronizer.uploadEntity` (11.6% → 100%)** — driven end-to-end through the encyclopedia synchronizer: success, `force`, plain failure, conflict resolution (resolved entity actually persisted), and failed resolution.
- **`EntityTransferOperation` (44.5% → 86.3%)** — download/upload failure branches: missing-on-server-but-present-locally, generic failure, failed stale-hash heal, failed upload, unowned-new-id no-op, failed remote delete during cleanup.
- **`ClientSceneSynchronizer` (62.7% → 92.5%)** — group move-to-new-parent and unarchive-on-active branches, plus `createEntityForId`/`deleteEntityLocal`/`reIdEntity`.
- **`ClientEncyclopediaSynchronizer` (14.5% → 97.6%)** — full classical rewrite over a fake filesystem.
- **`ImmutableTree` (29.7% → 98.6%)** — pure, zero-mock tests for the query API.

### Testing
- `./gradlew :common:desktopTest`