### PR TITLE
Add tier 3 sync test coverage

### DIFF
--- a/common/src/desktopTest/kotlin/repositories/projectdata/ProjectDataRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectdata/ProjectDataRepositoryTest.kt
@@ -1,0 +1,141 @@
+package repositories.projectdata
+
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
+import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataDatasource
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
+import io.mockk.MockKAnnotations
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import net.peanuuutz.tomlkt.Toml
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.dsl.module
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Classical-style: drives a real [ProjectDataRepository] over a real [ProjectDataDatasource]
+ * backed by a [FakeFileSystem]. Only the sibling [SyncDataDatasource] (its own persistence
+ * concern) is mocked, so hash invalidation can be observed.
+ */
+class ProjectDataRepositoryTest : BaseTest() {
+
+	private val projectDef = ProjectDef(
+		name = "Test Project",
+		path = "/projects/Test Project".toPath().toHPath(),
+	)
+
+	@MockK(relaxed = true)
+	private lateinit var syncDataDatasource: SyncDataDatasource
+
+	private lateinit var fileSystem: FakeFileSystem
+	private lateinit var toml: Toml
+	private lateinit var datasource: ProjectDataDatasource
+	private lateinit var repository: ProjectDataRepository
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		MockKAnnotations.init(this, relaxUnitFun = true)
+
+		fileSystem = FakeFileSystem()
+		fileSystem.createDirectories("/projects/Test Project".toPath())
+		toml = createTomlSerializer()
+
+		setupKoin(module {
+			scope<ProjectDefScope> {
+				scoped { projectDef }
+				scoped { syncDataDatasource }
+			}
+		})
+
+		datasource = ProjectDataDatasource(fileSystem, toml, projectDef)
+		repository = ProjectDataRepository(datasource, projectDef)
+	}
+
+	@Test
+	fun `load returns defaults when nothing is stored`() = runTest {
+		val loaded = repository.load()
+
+		assertEquals(ProjectData(), loaded.data)
+		assertNull(loaded.lastSyncedHash)
+	}
+
+	@Test
+	fun `load caches the first read`() = runTest {
+		datasource.save(StoredProjectData(ProjectData(authorName = "Disk"), "h"))
+
+		val first = repository.load()
+		// A later out-of-band disk change must not be observed: load is cached.
+		datasource.save(StoredProjectData(ProjectData(authorName = "Changed"), "h2"))
+		val second = repository.load()
+
+		assertEquals("Disk", first.data.authorName)
+		assertEquals(first, second)
+		assertEquals(first, repository.state.value)
+	}
+
+	@Test
+	fun `updateData persists the edit and invalidates the project hash`() = runTest {
+		datasource.save(StoredProjectData(ProjectData(authorName = "Old"), "synced-hash"))
+
+		repository.updateData { it.copy(authorName = "New") }
+
+		val state = repository.state.value
+		assertEquals("New", state?.data?.authorName)
+		// A user edit must not disturb the conflict baseline.
+		assertEquals("synced-hash", state?.lastSyncedHash)
+		assertEquals(StoredProjectData(ProjectData(authorName = "New"), "synced-hash"), datasource.load())
+		coVerify(exactly = 1) { syncDataDatasource.invalidateProjectHash() }
+	}
+
+	@Test
+	fun `updateData is a no-op when the transform changes nothing`() = runTest {
+		datasource.save(StoredProjectData(ProjectData(authorName = "Same"), "h"))
+		repository.load()
+
+		repository.updateData { it }
+
+		assertEquals("h", repository.state.value?.lastSyncedHash)
+		coVerify(exactly = 0) { syncDataDatasource.invalidateProjectHash() }
+	}
+
+	@Test
+	fun `updateFromSync replaces both data and the synced hash`() = runTest {
+		repository.load()
+
+		repository.updateFromSync(ProjectData(authorName = "Server"), "server-hash")
+
+		assertEquals(
+			StoredProjectData(ProjectData(authorName = "Server"), "server-hash"),
+			repository.state.value,
+		)
+		assertEquals(
+			StoredProjectData(ProjectData(authorName = "Server"), "server-hash"),
+			datasource.load(),
+		)
+		// Sync-driven updates never invalidate the project hash.
+		coVerify(exactly = 0) { syncDataDatasource.invalidateProjectHash() }
+	}
+
+	@Test
+	fun `updateFromSync is idempotent`() = runTest {
+		repository.updateFromSync(ProjectData(authorName = "Server"), "server-hash")
+		repository.updateFromSync(ProjectData(authorName = "Server"), "server-hash")
+
+		assertEquals(
+			StoredProjectData(ProjectData(authorName = "Server"), "server-hash"),
+			repository.state.value,
+		)
+	}
+}

--- a/common/src/desktopTest/kotlin/synchronizer/EntitySynchronizersTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/EntitySynchronizersTest.kt
@@ -1,0 +1,187 @@
+package synchronizer
+
+import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.EntityType
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizers
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import getProjectDef
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.dsl.module
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class EntitySynchronizersTest : BaseTest() {
+
+	private val projectDef: ProjectDef = getProjectDef("Test Project 2")
+	private lateinit var mocks: MockSynchronizers
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		mocks = MockSynchronizers(true)
+		setupKoin(module {
+			scope<ProjectDefScope> {
+				scoped<ProjectDef> { projectDef }
+				addSynchronizers(mocks)
+			}
+		})
+	}
+
+	private fun entitySynchronizers() = EntitySynchronizers(projectDef)
+
+	@Test
+	fun `get returns the synchronizer registered for each type`() {
+		val es = entitySynchronizers()
+
+		assertSame(mocks.sceneSynchronizer, es[EntityType.Scene])
+		assertSame(mocks.noteSynchronizer, es[EntityType.Note])
+		assertSame(mocks.timelineSynchronizer, es[EntityType.TimelineEvent])
+		assertSame(mocks.encyclopediaSynchronizer, es[EntityType.EncyclopediaEntry])
+		assertSame(mocks.sceneDraftSynchronizer, es[EntityType.SceneDraft])
+	}
+
+	@Test
+	fun `findEntityType reports the owning type and null when unowned`() = runTest {
+		coEvery { mocks.noteSynchronizer.ownsEntity(7) } returns true
+
+		val es = entitySynchronizers()
+
+		assertEquals(EntityType.Note, es.findEntityType(7))
+		assertNull(es.findEntityType(999))
+	}
+
+	@Test
+	fun `clientHasEntity reflects ownership`() = runTest {
+		coEvery { mocks.timelineSynchronizer.ownsEntity(3) } returns true
+
+		val es = entitySynchronizers()
+
+		assertTrue(es.clientHasEntity(3))
+		assertTrue(!es.clientHasEntity(4))
+	}
+
+	@Test
+	fun `findById returns the owning synchronizer and null when unowned`() = runTest {
+		coEvery { mocks.encyclopediaSynchronizer.ownsEntity(11) } returns true
+
+		val es = entitySynchronizers()
+
+		assertSame(mocks.encyclopediaSynchronizer, es.findById(11))
+		assertNull(es.findById(12))
+	}
+
+	@Test
+	fun `getLocalEntityHash routes to the owner for every type and is null when unowned`() = runTest {
+		val cases = listOf(
+			Triple(mocks.sceneSynchronizer, 1, "scene-hash"),
+			Triple(mocks.noteSynchronizer, 2, "note-hash"),
+			Triple(mocks.timelineSynchronizer, 3, "timeline-hash"),
+			Triple(mocks.encyclopediaSynchronizer, 4, "encyclopedia-hash"),
+			Triple(mocks.sceneDraftSynchronizer, 5, "draft-hash"),
+		)
+		cases.forEach { (sync, id, hash) ->
+			coEvery { sync.ownsEntity(id) } returns true
+			coEvery { sync.getEntityHash(id) } returns hash
+		}
+
+		val es = entitySynchronizers()
+
+		cases.forEach { (_, id, hash) -> assertEquals(hash, es.getLocalEntityHash(id)) }
+		assertNull(es.getLocalEntityHash(404))
+	}
+
+	@Test
+	fun `deleteEntityLocal routes to the owning synchronizer`() = runTest {
+		coEvery { mocks.noteSynchronizer.ownsEntity(8) } returns true
+
+		val es = entitySynchronizers()
+		es.deleteEntityLocal(8, onLog = {})
+
+		coVerify(exactly = 1) { mocks.noteSynchronizer.deleteEntityLocal(8, any()) }
+	}
+
+	@Test
+	fun `deleteEntityLocal is a no-op for an unowned id`() = runTest {
+		val es = entitySynchronizers()
+		es.deleteEntityLocal(404, onLog = {})
+
+		coVerify(exactly = 0) { mocks.sceneSynchronizer.deleteEntityLocal(any(), any()) }
+		coVerify(exactly = 0) { mocks.noteSynchronizer.deleteEntityLocal(any(), any()) }
+	}
+
+	@Test
+	fun `reIdEntry routes to the owning synchronizer for every type`() = runTest {
+		val cases = listOf(
+			mocks.sceneSynchronizer to 1,
+			mocks.noteSynchronizer to 2,
+			mocks.timelineSynchronizer to 3,
+			mocks.encyclopediaSynchronizer to 4,
+			mocks.sceneDraftSynchronizer to 5,
+		)
+		cases.forEach { (sync, id) -> coEvery { sync.ownsEntity(id) } returns true }
+
+		val es = entitySynchronizers()
+		cases.forEach { (_, id) -> es.reIdEntry(oldId = id, newId = id + 100) }
+
+		cases.forEach { (sync, id) ->
+			coVerify(exactly = 1) { sync.reIdEntity(oldId = id, newId = id + 100) }
+		}
+	}
+
+	@Test
+	fun `reIdEntry skips a phantom id that no synchronizer owns`() = runTest {
+		val es = entitySynchronizers()
+		es.reIdEntry(oldId = 404, newId = 9)
+
+		coVerify(exactly = 0) { mocks.sceneSynchronizer.reIdEntity(any(), any()) }
+		coVerify(exactly = 0) { mocks.noteSynchronizer.reIdEntity(any(), any()) }
+		coVerify(exactly = 0) { mocks.timelineSynchronizer.reIdEntity(any(), any()) }
+		coVerify(exactly = 0) { mocks.encyclopediaSynchronizer.reIdEntity(any(), any()) }
+		coVerify(exactly = 0) { mocks.sceneDraftSynchronizer.reIdEntity(any(), any()) }
+	}
+
+	@Test
+	fun `handleConflict routes each entity to its synchronizer's resolution channel`() = runTest {
+		val sceneCh = Channel<ApiProjectEntity.SceneEntity>(Channel.UNLIMITED)
+		val noteCh = Channel<ApiProjectEntity.NoteEntity>(Channel.UNLIMITED)
+		val timelineCh = Channel<ApiProjectEntity.TimelineEventEntity>(Channel.UNLIMITED)
+		val encyclopediaCh = Channel<ApiProjectEntity.EncyclopediaEntryEntity>(Channel.UNLIMITED)
+		val draftCh = Channel<ApiProjectEntity.SceneDraftEntity>(Channel.UNLIMITED)
+
+		every { mocks.sceneSynchronizer.conflictResolution } returns sceneCh
+		every { mocks.noteSynchronizer.conflictResolution } returns noteCh
+		every { mocks.timelineSynchronizer.conflictResolution } returns timelineCh
+		every { mocks.encyclopediaSynchronizer.conflictResolution } returns encyclopediaCh
+		every { mocks.sceneDraftSynchronizer.conflictResolution } returns draftCh
+
+		val scene = mockk<ApiProjectEntity.SceneEntity>()
+		val note = mockk<ApiProjectEntity.NoteEntity>()
+		val timeline = mockk<ApiProjectEntity.TimelineEventEntity>()
+		val encyclopedia = mockk<ApiProjectEntity.EncyclopediaEntryEntity>()
+		val draft = mockk<ApiProjectEntity.SceneDraftEntity>()
+
+		val es = entitySynchronizers()
+		es.handleConflict(scene)
+		es.handleConflict(note)
+		es.handleConflict(timeline)
+		es.handleConflict(encyclopedia)
+		es.handleConflict(draft)
+
+		assertSame(scene, sceneCh.tryReceive().getOrNull())
+		assertSame(note, noteCh.tryReceive().getOrNull())
+		assertSame(timeline, timelineCh.tryReceive().getOrNull())
+		assertSame(encyclopedia, encyclopediaCh.tryReceive().getOrNull())
+		assertSame(draft, draftCh.tryReceive().getOrNull())
+	}
+}

--- a/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
@@ -5,35 +5,50 @@ import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataConflictDto
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataDto
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataConflictException
+import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.isFailure
+import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflictBroker
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflictUnresolvedException
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
 import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.IdConflictResolutionState
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogMessage
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.ProjectDataSyncOperation
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.server.ProjectDataApi
+import createProjectDirectories
 import getProjectDef
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import net.peanuuutz.tomlkt.Toml
+import okio.fakefilesystem.FakeFileSystem
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.dsl.module
 import utils.BaseTest
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
+/**
+ * Classical-style: drives a real [ProjectDataRepository] / [ProjectDataDatasource] over a
+ * [FakeFileSystem] and a real [ProjectDataConflictBroker]. Only the network ([ProjectDataApi])
+ * and the global settings store are mocked. Disk-backed [StoredProjectData] is the observable
+ * outcome.
+ */
 class ProjectDataSyncOperationTest : BaseTest() {
 
-	@MockK
-	private lateinit var repository: ProjectDataRepository
+	private val projectDef = getProjectDef(PROJECT_2_NAME)
 
 	@MockK
 	private lateinit var api: ProjectDataApi
@@ -41,35 +56,47 @@ class ProjectDataSyncOperationTest : BaseTest() {
 	@MockK(relaxed = true)
 	private lateinit var globalSettingsStore: GlobalSettingsStore
 
+	@MockK(relaxed = true)
+	private lateinit var syncDataDatasource: SyncDataDatasource
+
+	private lateinit var fileSystem: FakeFileSystem
+	private lateinit var toml: Toml
+	private lateinit var datasource: ProjectDataDatasource
+	private lateinit var repository: ProjectDataRepository
+	private lateinit var broker: ProjectDataConflictBroker
+
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		MockKAnnotations.init(this)
-	}
+		MockKAnnotations.init(this, relaxUnitFun = true)
 
-	private fun configureKoin(projectDef: ProjectDef) {
+		coEvery { globalSettingsStore.userIdOrThrow() } returns 1L
+
+		fileSystem = FakeFileSystem()
+		toml = createTomlSerializer()
+		createProjectDirectories(fileSystem)
+
 		setupKoin(module {
 			scope<ProjectDefScope> {
-				scoped<ProjectDef> { projectDef }
+				scoped { projectDef }
+				scoped { syncDataDatasource }
 			}
 		})
+
+		datasource = ProjectDataDatasource(fileSystem, toml, projectDef)
+		repository = ProjectDataRepository(datasource, projectDef)
+		broker = ProjectDataConflictBroker(projectDef)
 	}
 
-	private fun createOperation(
-		projectDef: ProjectDef,
-		broker: ProjectDataConflictBroker,
-	): ProjectDataSyncOperation {
-		configureKoin(projectDef)
-		return ProjectDataSyncOperation(
-			projectDef = projectDef,
-			repository = repository,
-			api = api,
-			broker = broker,
-			globalSettingsStore = globalSettingsStore,
-		)
-	}
+	private fun createOperation() = ProjectDataSyncOperation(
+		projectDef = projectDef,
+		repository = repository,
+		api = api,
+		broker = broker,
+		globalSettingsStore = globalSettingsStore,
+	)
 
-	private fun conflictState(projectDef: ProjectDef) = IdConflictResolutionState(
+	private fun state() = IdConflictResolutionState(
 		onlyNew = false,
 		clientSyncData = projectData,
 		entityState = entityState,
@@ -80,46 +107,210 @@ class ProjectDataSyncOperationTest : BaseTest() {
 		newClientIds = emptyList(),
 	)
 
+	private suspend fun ProjectDataSyncOperation.run() = execute(
+		state = state(),
+		onProgress = { _, _ -> },
+		onLog = {},
+		onConflict = {},
+		onComplete = {},
+	)
+
 	@Test
-	fun `Data conflict with no resolver fails instead of hanging when aborted`() = runTest {
-		val projectDef = getProjectDef(PROJECT_2_NAME)
-		val broker = ProjectDataConflictBroker(projectDef)
-		val op = createOperation(projectDef, broker)
+	fun `server has no data and local is empty is a no-op success`() = runTest {
+		coEvery { api.getProjectData(any(), any(), any()) } returns Result.success(null)
 
-		coEvery { globalSettingsStore.userIdOrThrow() } returns 1L
-		coEvery { repository.load() } returns StoredProjectData(
-			data = ProjectData(authorName = "local"),
-			lastSyncedHash = "old-hash",
-		)
-		coEvery { api.getProjectData(any(), any(), any()) } returns Result.success(
-			ProjectDataDto(data = ProjectData(authorName = "server"), hash = "server-hash"),
-		)
-		coEvery { api.uploadProjectData(any(), any(), any(), any(), any()) } returns Result.failure(
-			ProjectDataConflictException(
-				ProjectDataConflictDto(
-					server = ProjectData(authorName = "server"),
-					serverHash = "server-hash",
-				),
-			),
-		)
+		val result = createOperation().run()
 
-		// Simulate the bulk-sync flow which has no resolver: abort the conflict.
+		assertTrue(isSuccess(result))
+		coVerify(exactly = 0) { api.uploadProjectData(any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `server has no data but local has data uploads with no original hash`() = runTest {
+		val local = ProjectData(authorName = "Author")
+		datasource.save(StoredProjectData(local, lastSyncedHash = null))
+		coEvery { api.getProjectData(any(), any(), any()) } returns Result.success(null)
+		coEvery {
+			api.uploadProjectData(any(), any(), any(), local, null)
+		} returns Result.success(ProjectDataDto(local, "uploaded-hash"))
+
+		val result = createOperation().run()
+
+		assertTrue(isSuccess(result))
+		assertEquals("uploaded-hash", repository.state.value?.lastSyncedHash)
+		coVerify(exactly = 1) { api.uploadProjectData(any(), any(), any(), local, null) }
+	}
+
+	@Test
+	fun `server hash matching local records the synced hash when it was missing`() = runTest {
+		val local = ProjectData(authorName = "Author")
+		val hash = ProjectDataHasher.hash(local)
+		datasource.save(StoredProjectData(local, lastSyncedHash = null))
+		coEvery { api.getProjectData(any(), any(), any()) } returns
+			Result.success(ProjectDataDto(local, hash))
+
+		val result = createOperation().run()
+
+		assertTrue(isSuccess(result))
+		assertEquals(hash, repository.state.value?.lastSyncedHash)
+		coVerify(exactly = 0) { api.uploadProjectData(any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `server hash matching local already recorded is a pure no-op`() = runTest {
+		val local = ProjectData(authorName = "Author")
+		val hash = ProjectDataHasher.hash(local)
+		datasource.save(StoredProjectData(local, lastSyncedHash = hash))
+		coEvery { api.getProjectData(any(), any(), any()) } returns
+			Result.success(ProjectDataDto(local, hash))
+
+		val result = createOperation().run()
+
+		assertTrue(isSuccess(result))
+		assertEquals(StoredProjectData(local, hash), repository.state.value)
+	}
+
+	@Test
+	fun `local unchanged since last sync fast-forwards to the server copy`() = runTest {
+		val local = ProjectData(authorName = "Author")
+		val localHash = ProjectDataHasher.hash(local)
+		datasource.save(StoredProjectData(local, lastSyncedHash = localHash))
+		val server = ProjectData(authorName = "Server Author")
+		coEvery { api.getProjectData(any(), any(), any()) } returns
+			Result.success(ProjectDataDto(server, "server-hash"))
+
+		val result = createOperation().run()
+
+		assertTrue(isSuccess(result))
+		assertEquals(StoredProjectData(server, "server-hash"), repository.state.value)
+	}
+
+	@Test
+	fun `local diverged from server uploads with the last synced hash as baseline`() = runTest {
+		val local = ProjectData(authorName = "Local Edit")
+		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))
+		val server = ProjectData(authorName = "Server")
+		coEvery { api.getProjectData(any(), any(), any()) } returns
+			Result.success(ProjectDataDto(server, "server-hash"))
+		coEvery {
+			api.uploadProjectData(any(), any(), any(), local, "stale-hash")
+		} returns Result.success(ProjectDataDto(local, "new-hash"))
+
+		val result = createOperation().run()
+
+		assertTrue(isSuccess(result))
+		assertEquals("new-hash", repository.state.value?.lastSyncedHash)
+		coVerify(exactly = 1) { api.uploadProjectData(any(), any(), any(), local, "stale-hash") }
+	}
+
+	@Test
+	fun `a non-conflict upload failure fails the sync`() = runTest {
+		val local = ProjectData(authorName = "Local Edit")
+		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))
+		coEvery { api.getProjectData(any(), any(), any()) } returns
+			Result.success(ProjectDataDto(ProjectData(authorName = "Server"), "server-hash"))
+		coEvery {
+			api.uploadProjectData(any(), any(), any(), any(), any())
+		} returns Result.failure(RuntimeException("upload exploded"))
+
+		val result = createOperation().run()
+
+		assertTrue(isFailure(result))
+	}
+
+	@Test
+	fun `a failure to load remote data fails the sync`() = runTest {
+		coEvery { api.getProjectData(any(), any(), any()) } returns
+			Result.failure(RuntimeException("network down"))
+
+		val result = createOperation().run()
+
+		assertTrue(isFailure(result))
+	}
+
+	@Test
+	fun `a resolved conflict re-uploads against the server hash and succeeds`() = runTest {
+		val local = ProjectData(authorName = "Local Edit")
+		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))
+		val server = ProjectData(authorName = "Server")
+		coEvery { api.getProjectData(any(), any(), any()) } returns
+			Result.success(ProjectDataDto(server, "server-hash"))
+		coEvery {
+			api.uploadProjectData(any(), any(), any(), local, "stale-hash")
+		} returns Result.failure(
+			ProjectDataConflictException(ProjectDataConflictDto(server, "server-hash"))
+		)
+		val resolved = ProjectData(authorName = "Merged")
+		coEvery {
+			api.uploadProjectData(any(), any(), any(), resolved, "server-hash")
+		} returns Result.success(ProjectDataDto(resolved, "resolved-hash"))
+
 		val watcher = launch {
-			for (conflict in broker.conflicts) {
-				broker.abort()
-			}
+			broker.conflicts.receive()
+			broker.resolve(resolved)
 		}
 
-		val onLog = mockk<OnSyncLog>(relaxed = true)
+		val result = createOperation().run()
 
-		// Aborting unblocks the operation with a failure (it would otherwise hang here forever).
-		// ClientProjectSynchronizer.execute() catches this and reports the project as failed.
+		assertTrue(isSuccess(result))
+		assertEquals(StoredProjectData(resolved, "resolved-hash"), repository.state.value)
+		coVerify(exactly = 1) { api.uploadProjectData(any(), any(), any(), resolved, "server-hash") }
+		watcher.cancel()
+	}
+
+	@Test
+	fun `a failed conflict-resolution upload fails the sync`() = runTest {
+		val local = ProjectData(authorName = "Local Edit")
+		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))
+		val server = ProjectData(authorName = "Server")
+		coEvery { api.getProjectData(any(), any(), any()) } returns
+			Result.success(ProjectDataDto(server, "server-hash"))
+		coEvery {
+			api.uploadProjectData(any(), any(), any(), local, "stale-hash")
+		} returns Result.failure(
+			ProjectDataConflictException(ProjectDataConflictDto(server, "server-hash"))
+		)
+		val resolved = ProjectData(authorName = "Merged")
+		coEvery {
+			api.uploadProjectData(any(), any(), any(), resolved, "server-hash")
+		} returns Result.failure(RuntimeException("resolution rejected"))
+
+		val watcher = launch {
+			broker.conflicts.receive()
+			broker.resolve(resolved)
+		}
+
+		val result = createOperation().run()
+
+		assertTrue(isFailure(result))
+		watcher.cancel()
+	}
+
+	@Test
+	fun `an aborted conflict fails instead of hanging`() = runTest {
+		val local = ProjectData(authorName = "Local Edit")
+		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))
+		val server = ProjectData(authorName = "Server")
+		coEvery { api.getProjectData(any(), any(), any()) } returns
+			Result.success(ProjectDataDto(server, "server-hash"))
+		coEvery {
+			api.uploadProjectData(any(), any(), any(), any(), any())
+		} returns Result.failure(
+			ProjectDataConflictException(ProjectDataConflictDto(server, "server-hash"))
+		)
+
+		// Bulk-sync flow has no resolver: abort the conflict so the sync fails rather than hangs.
+		val watcher = launch {
+			broker.conflicts.receive()
+			broker.abort()
+		}
+
 		assertFailsWith<ProjectDataConflictUnresolvedException> {
-			op.execute(
-				state = conflictState(projectDef),
+			createOperation().execute(
+				state = state(),
 				onProgress = { _: Float, _: SyncLogMessage? -> },
-				onLog = onLog,
-				onConflict = mockk(relaxed = true),
+				onLog = {},
+				onConflict = {},
 				onComplete = {},
 			)
 		}


### PR DESCRIPTION
## Summary

Follow-up to #604. Closes the next tier of test-coverage gaps in the project-sync layer, again classical-style — real repository/datasource/broker collaborators over a `FakeFileSystem`, mocking only true boundaries (network, the sibling sync-journal datasource).

### Coverage added
- **`ProjectDataRepository` (0% → 100%)** — load caching (a later out-of-band disk change is not observed), `updateData` persisting edits and invalidating the project hash (and the no-op when nothing changed), `updateFromSync` replacing data + hash without invalidating, and its idempotent early-return.
- **`ProjectDataSyncOperation` (47% → 98.5%)** — every `execute` branch: server-empty no-op, server-empty upload, server-hash-matches (record-when-missing + pure no-op), fast-forward, and diverged upload; plus the `upload` paths: success, non-conflict failure, remote-load failure, conflict resolved via the broker, failed resolution, and abort.
- **`EntitySynchronizers` (52% → 100%)** — facade type dispatch: `get`, `findEntityType`, `clientHasEntity`, `findById`, `getLocalEntityHash`, `deleteEntityLocal`, `reIdEntry` (including the phantom-id skip), and `handleConflict` routing — across all five entity types.

### Testing
- `./gradlew :common:desktopTest`