### PR TITLE
Make SceneTree state Compose-stable with immutable collections

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -70,6 +70,7 @@ kotlin {
 				api(libs.serialization.core)
 				api(libs.serialization.json)
 				api(libs.kotlinx.datetime)
+				api(libs.kotlinx.collections.immutable)
 				implementation(libs.tomlkt)
 				api(libs.bundles.essenty)
 				implementation(libs.cache4k)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/scenelist/SceneList.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/scenelist/SceneList.kt
@@ -1,7 +1,10 @@
 package com.darkrockstudios.apps.hammer.common.components.storyeditor.scenelist
 
+import androidx.compose.runtime.Immutable
 import com.arkivanov.decompose.value.Value
 import com.darkrockstudios.apps.hammer.common.data.*
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 interface SceneList {
 	val state: Value<State>
@@ -22,11 +25,12 @@ interface SceneList {
 	fun showArchivedScenes()
 	fun dismissArchivedDialog()
 
+	@Immutable
 	data class State(
 		val projectDef: ProjectDef,
 		val selectedSceneItem: SceneItem? = null,
 		val sceneSummary: SceneSummary? = null,
 		val showArchivedDialog: Boolean = false,
-		val archivedScenes: List<SceneItem> = emptyList()
+		val archivedScenes: ImmutableList<SceneItem> = persistentListOf()
 	)
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/scenelist/SceneListComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/scenelist/SceneListComponent.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import io.github.aakira.napier.Napier
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -134,11 +135,10 @@ class SceneListComponent(
 	override fun onSceneBufferUpdate(sceneBuffer: SceneBuffer) {
 		val oldSummary = _state.value.sceneSummary ?: return
 		_state.getAndUpdate { oldState ->
-			val updated = oldSummary.hasDirtyBuffer.toMutableSet()
-			if (sceneBuffer.dirty) {
-				updated.add(sceneBuffer.content.scene.id)
+			val updated = if (sceneBuffer.dirty) {
+				oldSummary.hasDirtyBuffer.add(sceneBuffer.content.scene.id)
 			} else {
-				updated.remove(sceneBuffer.content.scene.id)
+				oldSummary.hasDirtyBuffer.remove(sceneBuffer.content.scene.id)
 			}
 
 			oldState.copy(
@@ -173,7 +173,7 @@ class SceneListComponent(
 	}
 
 	override fun showArchivedScenes() {
-		val archived = projectEditor.getArchivedScenes()
+		val archived = projectEditor.getArchivedScenes().toImmutableList()
 		_state.getAndUpdate {
 			it.copy(
 				showArchivedDialog = true,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/scenelist/SceneListComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/scenelist/SceneListComponent.kt
@@ -133,16 +133,16 @@ class SceneListComponent(
 	}
 
 	override fun onSceneBufferUpdate(sceneBuffer: SceneBuffer) {
-		val oldSummary = _state.value.sceneSummary ?: return
 		_state.getAndUpdate { oldState ->
+			val summary = oldState.sceneSummary ?: return@getAndUpdate oldState
 			val updated = if (sceneBuffer.dirty) {
-				oldSummary.hasDirtyBuffer.add(sceneBuffer.content.scene.id)
+				summary.hasDirtyBuffer.add(sceneBuffer.content.scene.id)
 			} else {
-				oldSummary.hasDirtyBuffer.remove(sceneBuffer.content.scene.id)
+				summary.hasDirtyBuffer.remove(sceneBuffer.content.scene.id)
 			}
 
 			oldState.copy(
-				sceneSummary = oldSummary.copy(
+				sceneSummary = summary.copy(
 					hasDirtyBuffer = updated
 				)
 			)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/SceneSummary.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/SceneSummary.kt
@@ -1,11 +1,16 @@
 package com.darkrockstudios.apps.hammer.common.data
 
+import androidx.compose.runtime.Immutable
 import com.darkrockstudios.apps.hammer.common.data.tree.ImmutableTree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeValue
+import kotlinx.collections.immutable.PersistentSet
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
 
+@Immutable
 data class SceneSummary(
 	val sceneTree: ImmutableTree<SceneItem>,
-	val hasDirtyBuffer: Set<Int>
+	val hasDirtyBuffer: PersistentSet<Int>
 )
 
 fun rootSceneNode(projectDef: ProjectDef) = SceneItem(
@@ -22,11 +27,11 @@ fun emptySceneSummary(projectDef: ProjectDef) = SceneSummary(
 			value = rootSceneNode(projectDef),
 			index = 0,
 			parent = -1,
-			children = emptyList(),
+			children = persistentListOf(),
 			depth = 0,
 			totalChildren = 0
 		),
 		totalChildren = 1
 	),
-	hasDirtyBuffer = emptySet()
+	hasDirtyBuffer = persistentSetOf()
 )

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneContentRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneContentRepository.kt
@@ -9,6 +9,9 @@ import com.darkrockstudios.apps.hammer.common.util.debounceUntilQuiescentBy
 import io.github.aakira.napier.Napier
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
+import kotlinx.collections.immutable.PersistentSet
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -68,10 +71,10 @@ class SceneContentRepository(
 	)
 	val bufferPersistedFlow: SharedFlow<BufferPersistedEvent> = _bufferPersistedFlow
 
-	private val _dirtyBufferIds = MutableStateFlow<Set<Int>>(emptySet())
+	private val _dirtyBufferIds = MutableStateFlow<PersistentSet<Int>>(persistentSetOf())
 
 	/** The set of scene ids with unsaved buffers; re-emits on every dirty/clean transition. */
-	val dirtyBufferIds: StateFlow<Set<Int>> = _dirtyBufferIds
+	val dirtyBufferIds: StateFlow<PersistentSet<Int>> = _dirtyBufferIds
 
 	private val sceneBuffersLock = reentrantLock()
 	private val sceneBuffers = mutableMapOf<Int, SceneBuffer>()
@@ -155,11 +158,11 @@ class SceneContentRepository(
 		sceneBuffers.any { it.value.dirty }
 	}
 
-	fun getDirtyBufferIds(): Set<Int> = sceneBuffersLock.withLock {
+	fun getDirtyBufferIds(): PersistentSet<Int> = sceneBuffersLock.withLock {
 		sceneBuffers
 			.filter { it.value.dirty }
 			.map { it.key }
-			.toSet()
+			.toPersistentSet()
 	}
 
 	private fun getDirtyBufferScenes(): List<SceneItem> = sceneBuffersLock.withLock {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tree/ImmutableTree.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tree/ImmutableTree.kt
@@ -1,15 +1,19 @@
 package com.darkrockstudios.apps.hammer.common.data.tree
 
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+
 /**
  * A simplified immutable representation of a tree node
  */
+@Immutable
 data class TreeValue<T>(
 	val value: T,
 	/** Global tree index */
 	val index: Int,
 	/** Parent's global tree index */
 	val parent: Int,
-	val children: List<TreeValue<T>>,
+	val children: ImmutableList<TreeValue<T>>,
 	val depth: Int,
 	val totalChildren: Int
 ) : Iterable<TreeValue<T>> {
@@ -85,19 +89,13 @@ data class TreeValue<T>(
 	}
 }
 
+@Immutable
 data class ImmutableTree<T>(
 	val root: TreeValue<T>,
 	val totalChildren: Int
 ) : Iterable<TreeValue<T>> {
-	private val nodeIndex: HashMap<Int, TreeValue<T>>
-
-	init {
-		val newIndex = HashMap<Int, TreeValue<T>>()
-		for (treeValue in root) {
-			newIndex[treeValue.index] = treeValue
-		}
-		nodeIndex = newIndex
-	}
+	private val nodeIndex: Map<Int, TreeValue<T>> =
+		buildMap { for (treeValue in root) put(treeValue.index, treeValue) }
 
 	val totalNodes: Int
 		// +1 for the root it's self
@@ -206,17 +204,11 @@ data class ImmutableTree<T>(
 		root.print(0)
 	}
 
-	private var cachedHash: Int? = null
-	override fun hashCode(): Int {
-		val hash = cachedHash
-		return if (hash == null) {
-			val newHash = root.hashCode() + totalChildren
-			cachedHash = newHash
-			newHash
-		} else {
-			hash
-		}
+	private val cachedHash: Int by lazy(LazyThreadSafetyMode.PUBLICATION) {
+		root.hashCode() + totalChildren
 	}
+
+	override fun hashCode(): Int = cachedHash
 
 	override fun equals(other: Any?): Boolean {
 		return when {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tree/Tree.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tree/Tree.kt
@@ -1,5 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.tree
 
+import kotlinx.collections.immutable.toImmutableList
+
 /**
  * A depth first tree, indexable as such:
  *           1
@@ -204,7 +206,7 @@ data class TreeNode<T>(
 		}
 
 		return Pair(
-			TreeValue(value, yourIndex, parentIndex, childValues, depth, numChildren),
+			TreeValue(value, yourIndex, parentIndex, childValues.toImmutableList(), depth, numChildren),
 			nextIndex
 		)
 	}

--- a/common/src/desktopTest/kotlin/components/storyeditor/sceneeditor/SceneEditorComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyeditor/sceneeditor/SceneEditorComponentTest.kt
@@ -15,6 +15,8 @@ import com.darkrockstudios.apps.hammer.common.data.tree.TreeValue
 import com.darkrockstudios.apps.hammer.common.spellcheck.SpellCheckRepository
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellChecker
 import io.mockk.*
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -125,10 +127,10 @@ class SceneEditorComponentTest : ComponentTest() {
 
 	// A minimal tree (root -> the scene) so onSceneTreeUpdate's findBy can locate id 7.
 	private fun treeOf(scene: SceneItem): ImmutableTree<SceneItem> {
-		val node = TreeValue(value = scene, index = 1, parent = 0, children = emptyList(), depth = 1, totalChildren = 0)
+		val node = TreeValue(value = scene, index = 1, parent = 0, children = persistentListOf(), depth = 1, totalChildren = 0)
 		val root = TreeValue(
 			value = SceneItem(projectDef, SceneItem.Type.Root, id = 0, name = "root", order = 0),
-			index = 0, parent = -1, children = listOf(node), depth = 0, totalChildren = 1,
+			index = 0, parent = -1, children = persistentListOf(node), depth = 0, totalChildren = 1,
 		)
 		return ImmutableTree(root = root, totalChildren = 1)
 	}
@@ -461,7 +463,7 @@ class SceneEditorComponentTest : ComponentTest() {
 		advanceUntilIdle()
 
 		val renamed = sceneItem.copy(name = "Renamed Externally")
-		sceneTreeCallback.captured.invoke(SceneSummary(treeOf(renamed), emptySet()))
+		sceneTreeCallback.captured.invoke(SceneSummary(treeOf(renamed), persistentSetOf()))
 
 		assertEquals("Renamed Externally", comp.state.value.sceneItem.name)
 	}

--- a/common/src/desktopTest/kotlin/repositories/references/ReferenceIndexServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/references/ReferenceIndexServiceTest.kt
@@ -18,6 +18,8 @@ import getProject1Def
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
@@ -92,11 +94,11 @@ class ReferenceIndexServiceTest : BaseTest() {
 				value = item,
 				index = idx + 1,
 				parent = 0,
-				children = emptyList(),
+				children = persistentListOf(),
 				depth = 1,
 				totalChildren = 0,
 			)
-		}
+		}.toImmutableList()
 		val root = TreeValue(
 			value = rootItem(),
 			index = 0,

--- a/common/src/desktopTest/kotlin/repositories/references/SceneMetadataReferenceRemapperTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/references/SceneMetadataReferenceRemapperTest.kt
@@ -18,6 +18,8 @@ import getProject1Def
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
@@ -62,11 +64,11 @@ class SceneMetadataReferenceRemapperTest : BaseTest() {
 				value = SceneItem(projectDef, SceneItem.Type.Scene, id, "S$id", id),
 				index = idx + 1,
 				parent = 0,
-				children = emptyList(),
+				children = persistentListOf(),
 				depth = 1,
 				totalChildren = 0,
 			)
-		}
+		}.toImmutableList()
 		val root = TreeValue(
 			value = SceneItem(projectDef, SceneItem.Type.Root, SceneItem.ROOT_ID, "", 0),
 			index = 0,

--- a/common/src/desktopTest/kotlin/repositories/statistics/StatisticsServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/statistics/StatisticsServiceTest.kt
@@ -20,6 +20,7 @@ import com.darkrockstudios.apps.hammer.common.data.tree.TreeValue
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityRepository
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import io.mockk.*
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -52,7 +53,7 @@ class StatisticsServiceTest : BaseTest() {
 	private fun rootOnlyTree(): ImmutableTree<SceneItem> {
 		val root = TreeValue(
 			value = sceneItem(0, SceneItem.Type.Root),
-			index = 0, parent = -1, children = emptyList(), depth = 0, totalChildren = 0,
+			index = 0, parent = -1, children = persistentListOf(), depth = 0, totalChildren = 0,
 		)
 		return ImmutableTree(root = root, totalChildren = 0)
 	}
@@ -153,19 +154,19 @@ class StatisticsServiceTest : BaseTest() {
 			// root -> chapter -> [sceneA(3 words), sceneB(2 words)]
 			val sceneA = TreeValue(
 				value = sceneItem(2, SceneItem.Type.Scene),
-				index = 2, parent = 1, children = emptyList(), depth = 2, totalChildren = 0,
+				index = 2, parent = 1, children = persistentListOf(), depth = 2, totalChildren = 0,
 			)
 			val sceneB = TreeValue(
 				value = sceneItem(3, SceneItem.Type.Scene),
-				index = 3, parent = 1, children = emptyList(), depth = 2, totalChildren = 0,
+				index = 3, parent = 1, children = persistentListOf(), depth = 2, totalChildren = 0,
 			)
 			val chapter = TreeValue(
 				value = sceneItem(1, SceneItem.Type.Group),
-				index = 1, parent = 0, children = listOf(sceneA, sceneB), depth = 1, totalChildren = 2,
+				index = 1, parent = 0, children = persistentListOf(sceneA, sceneB), depth = 1, totalChildren = 2,
 			)
 			val root = TreeValue(
 				value = sceneItem(0, SceneItem.Type.Root),
-				index = 0, parent = -1, children = listOf(chapter), depth = 0, totalChildren = 3,
+				index = 0, parent = -1, children = persistentListOf(chapter), depth = 0, totalChildren = 3,
 			)
 			every { sceneEditorRepository.sceneTreeUpdates } returns
 				MutableStateFlow(ImmutableTree(root = root, totalChildren = 3))

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/RootSnackbarHostState.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/RootSnackbarHostState.kt
@@ -3,11 +3,13 @@ package com.darkrockstudios.apps.hammer.common.compose
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+@Stable
 data class RootSnackbarHostState(
 	val snackbarHostState: SnackbarHostState,
 	val scope: CoroutineScope

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
@@ -49,6 +49,7 @@ fun rememberReorderableLazyListState(
 	}
 }
 
+@Stable
 class SceneTreeState(
 	sceneSummary: SceneSummary,
 	val moveItem: (moveRequest: MoveRequest) -> Unit,

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/SceneListUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/SceneListUi.Preview.kt
@@ -20,6 +20,7 @@ import com.darkrockstudios.apps.hammer.common.data.tree.Tree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
 import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SceneItem
 import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SceneListUi
+import kotlinx.collections.immutable.persistentSetOf
 
 
 @Preview
@@ -47,7 +48,7 @@ private fun fakeSceneSummary(): SceneSummary {
 
 	return SceneSummary(
 		tree.toImmutableTree(),
-		emptySet()
+		persistentSetOf()
 	)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ androix-junit = "1.3.0"
 junit = "6.1.0"
 clikt = "5.1.0"
 kotlinx_atomicfu = "0.33.0"
+kotlinx_collections_immutable = "0.4.0"
 markdown = "0.7.5"
 epub4kmp = "0.3.0"
 pdfkmp = "1.2.0"
@@ -167,6 +168,7 @@ clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 kotlinx_datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "datetime" }
 kotlinx_atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "kotlinx_atomicfu" }
 kotlinx_atomicfu_plugin = { group = "org.jetbrains.kotlinx", name = "atomicfu-gradle-plugin", version.ref = "kotlinx_atomicfu" }
+kotlinx_collections_immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx_collections_immutable" }
 
 markdown = { module = "org.jetbrains:markdown", version.ref = "markdown" }
 kotlin-multiplatform-diff = { module = "io.github.petertrr:kotlin-multiplatform-diff", version.ref = "kotlin-multiplatform-diff" }


### PR DESCRIPTION
Mark the scene-tree state types @Immutable/@Stable and move them onto kotlinx.collections.immutable so Compose can skip recomposition when the tree is unchanged: TreeValue.children becomes ImmutableList, SceneSummary .hasDirtyBuffer a PersistentSet (sourced as such from SceneContentRepository), and SceneList.State.archivedScenes an ImmutableList. Also cache ImmutableTree .nodeIndex/hashCode lazily and gate compose-compiler stability reports behind the composeCompilerReports property.