### PR TITLE
Add configurable server bind addresses (bindHosts)

### DIFF
--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -29,6 +29,21 @@ The Hammer server is a Java application that runs on Windows, Linux, and macOS.
 6. **IMPORTANT!** You must now download one of the clients and create an account on the server. The first account
    created will be the admin account.
 
+## Network binding
+
+By default the server binds to all IPv4 interfaces (`0.0.0.0`), so it accepts connections from the
+network. To isolate it — for example when a reverse proxy on the same host is the only thing that
+should reach it — restrict the bind to loopback with `bindHosts`:
+
+```toml
+# Accept loopback connections only (IPv4 and IPv6). Default is ["0.0.0.0"].
+bindHosts = ["127.0.0.1", "::1"]
+```
+
+`bindHosts` is the network interface(s) to listen on, and is distinct from `host`, which is the
+public name shown to users. Each address gets its own listener (and its own HTTPS listener when an
+SSL cert is configured).
+
 ## Storage
 
 The server persists its data in a PostgreSQL database. It supports two modes:

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -173,12 +173,10 @@ private fun startServer(config: ServerConfig, devMode: Boolean, logLevel: Level?
 	//		System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
 	//	}
 
-	val bindHost = "0.0.0.0"
-
 	embeddedServer(
 		Jetty,
 		configure = {
-			configureServer(config, bindHost)
+			configureServer(config)
 		},
 		module = {
 			appMain(config, logLevel = logLevel)
@@ -187,12 +185,15 @@ private fun startServer(config: ServerConfig, devMode: Boolean, logLevel: Level?
 }
 
 private fun JettyApplicationEngineBase.Configuration.configureServer(
-	config: ServerConfig,
-	bindHost: String
+	config: ServerConfig
 ) {
-	connector {
-		port = config.port
-		host = bindHost
+	require(config.bindHosts.isNotEmpty()) { "bindHosts must list at least one address" }
+
+	config.bindHosts.forEach { bindHost ->
+		connector {
+			port = config.port
+			host = bindHost
+		}
 	}
 
 	config.sslCert?.apply {
@@ -203,17 +204,19 @@ private fun JettyApplicationEngineBase.Configuration.configureServer(
 		val storePass = if (usePem()) "" else (storePassword ?: "")
 		val keyPass = if (usePem()) "" else (keyPassword ?: "")
 
-		sslConnector(
-			keyStore = keyStore,
-			keyAlias = alias,
-			keyStorePassword = { storePass.toCharArray() },
-			privateKeyPassword = { keyPass.toCharArray() }
-		) {
-			if (!usePem() && path != null) {
-				this.keyStorePath = File(path)
+		config.bindHosts.forEach { bindHost ->
+			sslConnector(
+				keyStore = keyStore,
+				keyAlias = alias,
+				keyStorePassword = { storePass.toCharArray() },
+				privateKeyPassword = { keyPass.toCharArray() }
+			) {
+				if (!usePem() && path != null) {
+					this.keyStorePath = File(path)
+				}
+				host = bindHost
+				port = config.sslPort
 			}
-			host = bindHost
-			port = config.sslPort
 		}
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -11,6 +11,13 @@ import java.net.URISyntaxException
 @Serializable
 data class ServerConfig(
 	val host: String = "localhost",
+	/**
+	 * Network interfaces the server binds to. Defaults to all IPv4 interfaces.
+	 * Set to `["127.0.0.1", "::1"]` to accept loopback connections only, e.g.
+	 * when running behind a reverse proxy on the same host. Distinct from [host],
+	 * which is the public name shown to users.
+	 */
+	val bindHosts: List<String> = listOf("0.0.0.0"),
 	val port: Int = 8080,
 	val sslPort: Int = 443,
 	/**

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
@@ -1,0 +1,24 @@
+package com.darkrockstudios.apps.hammer
+
+import net.peanuuutz.tomlkt.Toml
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ServerConfigTest {
+
+	private val toml = Toml { ignoreUnknownKeys = true }
+
+	private fun parse(tomlString: String): ServerConfig =
+		toml.decodeFromString(ServerConfig.serializer(), tomlString)
+
+	@Test
+	fun `Omitted bindHosts defaults to all IPv4 interfaces`() {
+		assertEquals(listOf("0.0.0.0"), parse("").bindHosts)
+	}
+
+	@Test
+	fun `bindHosts parses loopback addresses`() {
+		val config = parse("""bindHosts = ["127.0.0.1", "::1"]""")
+		assertEquals(listOf("127.0.0.1", "::1"), config.bindHosts)
+	}
+}


### PR DESCRIPTION
Closes #590

## What
Adds a `bindHosts` option to `serverConfig.toml` so self-hosters can restrict the sync server to specific network interfaces — in particular loopback only, for an isolated/reverse-proxied deployment.

```toml
# Accept loopback connections only (IPv4 and IPv6). Default is ["0.0.0.0"].
bindHosts = ["127.0.0.1", "::1"]
```

## Why
The bind address was hardcoded to `0.0.0.0` (all IPv4 interfaces), so there was no way to keep the raw server port off the network when fronting it with a reverse proxy on the same host.

## How
- `ServerConfig.bindHosts: List<String>` defaults to `["0.0.0.0"]`, preserving existing behavior.
- `configureServer` emits one HTTP listener per address, and one HTTPS listener per address when an SSL cert is configured (keystore setup hoisted out of the loop). A `require(bindHosts.isNotEmpty())` guard rejects an empty list.
- A list (rather than a single value) is used so both loopback stacks (`127.0.0.1` and `::1`) can be bound at once, as requested in the issue.

`bindHosts` is deliberately separate from the existing `host` field, which remains the public display name shown on the setup page (a reverse-proxy box binds loopback but still displays a public hostname).

## Tests / docs
- `ServerConfigTest`: default resolves to `["0.0.0.0"]`; `["127.0.0.1", "::1"]` parses to both entries.
- "Network binding" section added to `docs/HOW-TO-RUN-A-SERVER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)