### PR TITLE
Fix backup culling deleting the newest backups

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectbackup/ProjectBackupRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectbackup/ProjectBackupRepository.kt
@@ -121,34 +121,39 @@ open class ProjectBackupRepository(
 	}
 
 	private fun getProjectBackupDef(path: Path): ProjectBackupDef? {
-		val match = FILE_NAME_PATTERN.matchEntire(path.name)
-		return if (match != null) {
-			val backupName = match.groups[1]?.value
-			val date = match.groups[2]?.value
+		val match = FILE_NAME_PATTERN.matchEntire(path.name) ?: return null
+		val backupName = match.groups[1]?.value ?: return null
 
-			if (backupName != null && date != null) {
-				val projectName = backupNameToProjectName(backupName)
+		val projectName = backupNameToProjectName(backupName)
+		val projectDir = projectsRepository.getProjectDirectory(projectName)
 
-				val dateInstant = localDateTime(date).toInstant(TimeZone.UTC)
-				val projectDir = projectsRepository.getProjectDirectory(projectName)
+		return ProjectBackupDef(
+			path = path.toHPath(),
+			projectDef = ProjectDef(name = projectName, path = projectDir),
+			date = backupDate(path, match.groups[2]?.value)
+		)
+	}
 
-				val projectDef = ProjectDef(
-					name = projectName,
-					path = projectDir
-				)
-
-				ProjectBackupDef(
-					path = path.toHPath(),
-					projectDef = projectDef,
-					date = dateInstant
-				)
-			} else {
-				null
-			}
-		} else {
+	// Order by file modification time, not the filename's encoded date: backups written
+	// before the date-format fix can encode a time months off and would otherwise cull
+	// the newest backups instead of the oldest.
+	private fun backupDate(path: Path, encodedDate: String?): Instant {
+		val modified = try {
+			fileSystem.metadata(path).lastModifiedAtMillis
+		} catch (_: IOException) {
 			null
 		}
+		if (modified != null) return Instant.fromEpochMilliseconds(modified)
+
+		return encodedDate?.let { parseBackupDate(it) } ?: Instant.fromEpochMilliseconds(0)
 	}
+
+	private fun parseBackupDate(dateTimeStr: String): Instant? =
+		try {
+			localDateTime(dateTimeStr).toInstant(TimeZone.UTC)
+		} catch (_: IllegalArgumentException) {
+			null
+		}
 
 	open fun supportsBackup(): Boolean = true
 
@@ -211,7 +216,7 @@ open class ProjectBackupRepository(
 
 	companion object {
 		const val BACKUP_DIRECTORY = ".backups"
-		val FILE_NAME_PATTERN = Regex("^([a-zA-Z0-9_]+)-(\\d{4}-\\d{2}-\\d{2}T\\d+Z)\\.zip$")
+		val FILE_NAME_PATTERN = Regex("^(.+)-(\\d{4}-\\d{2}-\\d{2}T\\d+Z)\\.zip$")
 		val DATE_PATTERN = Regex("^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})(\\d{2})(\\d{2})Z$")
 	}
 }

--- a/common/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/data/projectbackup/ProjectBackupRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/data/projectbackup/ProjectBackupRepositoryTest.kt
@@ -22,11 +22,17 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 
 class ProjectBackupRepositoryTest {
 
-	private val fileSystem = FakeFileSystem()
+	private class MutableClock(var instant: Instant) : Clock {
+		override fun now(): Instant = instant
+	}
+
+	private val fsClock = MutableClock(Instant.parse("2020-01-01T00:00:00Z"))
+	private val fileSystem = FakeFileSystem(fsClock)
 	private val projectsRepository = mockk<ProjectsRepository>()
 	private val globalSettingsStore = mockk<GlobalSettingsStore>()
 	private val clock = mockk<Clock>()
@@ -61,11 +67,9 @@ class ProjectBackupRepositoryTest {
 
 	@Test
 	fun `test parsing backup def`() {
-		val filename = "Test_Project-2025-12-28T162900Z.zip"
-		val dir = "/projects/.backups".toPath()
-		val path = dir / filename
-		fileSystem.createDirectories(dir)
-		fileSystem.write(path) { writeUtf8("fake content") }
+		val modified = Instant.parse("2025-12-28T16:29:00Z")
+		val path = "/projects/.backups/Test_Project-2025-12-28T162900Z.zip".toPath()
+		writeBackupFileNamed(path, modified)
 
 		val projectDef = ProjectDef("Test Project", "/projects/Test Project".toPath().toHPath())
 		every { projectsRepository.getProjectsDirectory() } returns "/projects".toPath().toHPath()
@@ -78,7 +82,22 @@ class ProjectBackupRepositoryTest {
 		assertEquals(1, backups.size)
 		val backupDef = backups[0]
 		assertEquals("Test Project", backupDef.projectDef.name)
-		assertEquals(Instant.parse("2025-12-28T16:29:00Z"), backupDef.date)
+		assertEquals(modified, backupDef.date)
+	}
+
+	@Test
+	fun `getBackups recognizes project names with punctuation`() {
+		val name = "Tom's Story-Notes"
+		every { projectsRepository.getProjectsDirectory() } returns "/projects".toPath().toHPath()
+		every { projectsRepository.getProjectDirectory(name) } returns
+			"/projects/$name".toPath().toHPath()
+
+		writeBackupFile(name, Instant.parse("2026-06-20T08:00:00Z"))
+
+		val backups = realRepo().getBackups(ProjectDef(name, "/projects/$name".toPath().toHPath()))
+
+		assertEquals(1, backups.size)
+		assertEquals(name, backups.first().projectDef.name)
 	}
 
 	private fun realRepo() =
@@ -88,7 +107,13 @@ class ProjectBackupRepositoryTest {
 		val backupName = projectName.replace(" ", "_")
 		val dir = "/projects/.backups".toPath()
 		val path = dir / "$backupName-${backupDateString(instant)}.zip"
-		fileSystem.createDirectories(dir)
+		return writeBackupFileNamed(path, instant)
+	}
+
+	// Sets the file's modification time to [modified] so backup ordering is deterministic.
+	private fun writeBackupFileNamed(path: Path, modified: Instant): Path {
+		fileSystem.createDirectories(path.parent!!)
+		fsClock.instant = modified
 		fileSystem.write(path) { writeUtf8("backup content") }
 		return path
 	}
@@ -179,6 +204,64 @@ class ProjectBackupRepositoryTest {
 
 		assertFalse(fileSystem.exists(oldest))
 		assertTrue(fileSystem.exists(middle))
+		assertTrue(fileSystem.exists(newest))
+	}
+
+	@Test
+	fun `repeated createBackup keeps the newest backups`() = runTest {
+		every { projectsRepository.getProjectsDirectory() } returns "/projects".toPath().toHPath()
+		every { projectsRepository.getProjectDirectory("Test Project") } returns
+			"/projects/Test Project".toPath().toHPath()
+		every { globalSettingsStore.globalSettings } returns
+			GlobalSettings(projectsDirectory = "/projects", maxBackups = 3)
+
+		val projectDir = "/projects/Test Project".toPath()
+		fileSystem.createDirectories(projectDir)
+		fileSystem.write(projectDir / "scene.txt") { writeUtf8("once upon a time") }
+
+		val projectDef = ProjectDef("Test Project", projectDir.toHPath())
+		val repo = realRepo()
+
+		// Simulate several syncs, each creating a backup a minute apart.
+		val base = Instant.parse("2026-06-20T09:00:00Z")
+		val created = mutableListOf<ProjectBackupDef>()
+		for (i in 0 until 6) {
+			val now = base.plus(i.minutes)
+			fsClock.instant = now
+			every { clock.now() } returns now
+			repo.createBackup(projectDef)?.let { created.add(it) }
+		}
+
+		val remaining = repo.getBackups(projectDef).map { it.path.name }.toSet()
+		val newestThree = created.takeLast(3).map { it.path.name }.toSet()
+
+		assertEquals(3, remaining.size)
+		assertEquals(newestThree, remaining)
+	}
+
+	@Test
+	fun `cullBackups deletes oldest by file time even when filename dates are corrupt`() {
+		every { projectsRepository.getProjectsDirectory() } returns "/projects".toPath().toHPath()
+		every { projectsRepository.getProjectDirectory("Alice In Wonderland") } returns
+			"/projects/Alice In Wonderland".toPath().toHPath()
+		every { globalSettingsStore.globalSettings } returns
+			GlobalSettings(projectsDirectory = "/projects", maxBackups = 2)
+
+		// A legacy backup whose filename encodes a future date (the old YYYY/hh format bug)
+		// but whose file was actually written months before the others.
+		val legacy = writeBackupFileNamed(
+			"/projects/.backups/Alice_In_Wonderland-2026-12-29T122658Z.zip".toPath(),
+			Instant.parse("2025-12-28T16:26:00Z"),
+		)
+		val older = writeBackupFile("Alice In Wonderland", Instant.parse("2026-06-20T08:00:11Z"))
+		val newer = writeBackupFile("Alice In Wonderland", Instant.parse("2026-06-20T08:01:56Z"))
+		val newest = writeBackupFile("Alice In Wonderland", Instant.parse("2026-06-20T08:02:53Z"))
+
+		realRepo().cullBackups(ProjectDef("Alice In Wonderland", "/projects/Alice In Wonderland".toPath().toHPath()))
+
+		assertFalse(fileSystem.exists(legacy))
+		assertFalse(fileSystem.exists(older))
+		assertTrue(fileSystem.exists(newer))
 		assertTrue(fileSystem.exists(newest))
 	}
 


### PR DESCRIPTION
## Problem

Users reported that their **newest** project backups disappear from Manage Backups while older ones stick around. Backups visibly get created at the start of a sync, but the latest ones are gone moments later (and for some users, *no* backups ever appear — see #612).

## Root cause

The cull logic itself is correct (it deletes the oldest). The bug is **corrupt dates baked into legacy backup filenames.**

Before commit `cab419f6` (Dec 29 2025), backup filenames used the format `YYYY-MM-dd'T'hhmmss'Z'`. Two java.time bugs hide there:

- `YYYY` is **ISO week-based-year**, not calendar year — late-December-2025 dates roll forward to **2026**.
- `hh` is **12-hour without AM/PM** — afternoon/evening hours are wrong.

So a backup actually made on `2025-12-28` was written to a filename containing `2026-12-29...`. Confirmed against real data — files physically created in Dec 2025 carry `2026-12-29` filenames.

Because cull and the Manage list sorted by the **filename-encoded date**, these phantom-future files always looked "newest" and survived, while genuinely new backups looked "oldest" and got culled. With the default `maxBackups = 20`, a user at budget loses their newest backup every sync.

## Fix

- **Order by file modification time, not the filename date.** The embedded date is lossy/unrecoverable for legacy files; `lastModifiedAtMillis` (okio `FileSystem.SYSTEM` on every target) is the only reliable signal. This corrects both culling and the Manage-list ordering, since everything sorts by `ProjectBackupDef.date`.
- **Broaden `FILE_NAME_PATTERN`** from `[a-zA-Z0-9_]+` to `.+` for the project-name segment, so names with apostrophes/hyphens/non-ASCII are recognized (a likely cause of #612's empty list).
- **Stop date parsing from throwing**, so one malformed filename can't blank the entire backup list.

## Tests

- New `cullBackups deletes oldest by file time even when filename dates are corrupt` reproduces the exact production scenario (a phantom-future legacy file alongside newer real backups). Verified it **fails** before the fix and passes after.
- New `getBackups recognizes project names with punctuation`.
- Refactored the suite onto an injectable `FakeFileSystem` clock for deterministic modification times. All tests green.

## Note for existing users

After this fix, those mislabeled `2026-12-29` files correctly sort as the **oldest** and become the first culled on the next sync. Users wanting to keep them can raise `maxBackups` or move them aside first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)