### PR TITLE
Map markdown import heading levels to scene/group hierarchy (#578)

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/MarkdownStoryImporter.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/MarkdownStoryImporter.kt
@@ -16,65 +16,55 @@ class MarkdownStoryImporter : StoryImporter {
 		val cleanSourceName = sanitizeName(sourceName)
 		val lines = content.replace("\r\n", "\n").replace("\r", "\n").split("\n")
 
-		val headingLevel = when (options.chapterHeadingLevel) {
+		val sceneLevel = when (options.chapterHeadingLevel) {
 			ChapterHeadingLevel.H1 -> 1
 			ChapterHeadingLevel.H2 -> 2
 		}
 
-		val segments = mutableListOf<Segment>()
-		var current: Segment? = null
-		val leadingBuffer = StringBuilder()
+		val builder = StructureBuilder(wrapTopLevelInGroups = options.createChapterGroups)
 		var sawHeading = false
 
 		for (line in lines) {
-			val headingTitle = matchHeading(line, headingLevel)
-			if (headingTitle != null) {
-				current?.let { segments.add(it) }
-				current = Segment(name = sanitizeName(headingTitle))
-				sawHeading = true
-			} else if (current != null) {
-				current.body.appendLine(line)
-			} else {
-				leadingBuffer.appendLine(line)
+			val heading = parseHeading(line)
+			when {
+				heading != null && heading.level < sceneLevel -> {
+					builder.startGroup(sanitizeName(heading.title))
+					sawHeading = true
+				}
+
+				heading != null && heading.level == sceneLevel -> {
+					builder.startScene(sanitizeName(heading.title))
+					sawHeading = true
+				}
+
+				else -> builder.appendBody(line)
 			}
 		}
-		current?.let { segments.add(it) }
 
 		if (!sawHeading) {
-			val body = leadingBuffer.toString().trimEnd()
-			if (body.isEmpty()) return ImportPreview(emptyList())
-			return ImportPreview(listOf(PreviewItem.Scene(name = cleanSourceName, markdown = body)))
+			val body = builder.leadingBody()
+			if (body.isBlank()) return ImportPreview(emptyList())
+			return ImportPreview(listOf(PreviewItem.Scene(name = cleanSourceName, markdown = body.trim())))
 		}
 
-		val items = mutableListOf<PreviewItem>()
-
-		val leadingBody = leadingBuffer.toString().trimEnd()
-		if (leadingBody.isNotEmpty()) {
-			items.add(PreviewItem.Scene(name = UNTITLED, markdown = leadingBody))
-		}
-
-		segments.forEach { segment ->
-			val body = segment.body.toString().trimEnd()
-			val name = segment.name
-			val item = if (options.createChapterGroups) {
-				PreviewItem.Group(
-					name = name,
-					scenes = listOf(PreviewItem.Scene(name = name, markdown = body)),
-				)
-			} else {
-				PreviewItem.Scene(name = name, markdown = body)
-			}
-			items.add(item)
-		}
-
-		return ImportPreview(items)
+		return ImportPreview(builder.build())
 	}
 
-	private fun matchHeading(line: String, level: Int): String? {
-		var i = 0
+	private fun parseHeading(line: String): Heading? {
+		var start = 0
+		if (start < line.length && line[start] == BOM) start++
+		var leadingSpaces = 0
+		while (start < line.length && line[start] == ' ' && leadingSpaces < MAX_HEADING_INDENT) {
+			start++
+			leadingSpaces++
+		}
+
+		var i = start
 		while (i < line.length && line[i] == '#') i++
-		if (i != level) return null
-		return line.substring(i).trim()
+		val level = i - start
+		if (level !in 1..MAX_HEADING_LEVEL) return null
+
+		return Heading(level = level, title = line.substring(i).trim())
 	}
 
 	private fun sanitizeName(raw: String): String {
@@ -82,12 +72,93 @@ class MarkdownStoryImporter : StoryImporter {
 		return cleaned.ifEmpty { UNTITLED }
 	}
 
-	private class Segment(
-		val name: String,
-		val body: StringBuilder = StringBuilder(),
-	)
+	private class Heading(val level: Int, val title: String)
+
+	/**
+	 * Folds the heading stream into top-level [PreviewItem]s. Headings shallower than the chosen
+	 * scene level open groups, scene-level headings open scenes, and any other line is body text
+	 * for the open scene (creating an implicit "Untitled" scene when prose appears with no scene open).
+	 */
+	private class StructureBuilder(private val wrapTopLevelInGroups: Boolean) {
+		private val items = mutableListOf<PreviewItem>()
+		private val leading = StringBuilder()
+		private var group: GroupAcc? = null
+		private var scene: SceneAcc? = null
+
+		fun appendBody(line: String) {
+			val openScene = scene
+			when {
+				openScene != null -> openScene.body.appendLine(line)
+				group != null -> scene = SceneAcc(UNTITLED, explicit = false).apply { body.appendLine(line) }
+				else -> leading.appendLine(line)
+			}
+		}
+
+		fun startGroup(name: String) {
+			flushScene()
+			flushGroup()
+			flushLeading()
+			group = GroupAcc(name)
+		}
+
+		fun startScene(name: String) {
+			flushScene()
+			flushLeading()
+			scene = SceneAcc(name, explicit = true)
+		}
+
+		fun build(): List<PreviewItem> {
+			flushScene()
+			flushGroup()
+			return items
+		}
+
+		fun leadingBody(): String = leading.toString()
+
+		private fun flushLeading() {
+			val body = leading.toString()
+			if (body.isNotBlank()) {
+				items.add(PreviewItem.Scene(name = UNTITLED, markdown = body.trim()))
+			}
+			leading.clear()
+		}
+
+		private fun flushScene() {
+			val acc = scene ?: return
+			scene = null
+			val body = acc.body.toString().trim()
+			if (!acc.explicit && body.isBlank()) return
+
+			val sceneItem = PreviewItem.Scene(name = acc.name, markdown = body)
+			val openGroup = group
+			when {
+				openGroup != null -> openGroup.scenes.add(sceneItem)
+				wrapTopLevelInGroups -> items.add(PreviewItem.Group(name = acc.name, scenes = listOf(sceneItem)))
+				else -> items.add(sceneItem)
+			}
+		}
+
+		private fun flushGroup() {
+			val acc = group ?: return
+			group = null
+			if (acc.scenes.isNotEmpty()) {
+				items.add(PreviewItem.Group(name = acc.name, scenes = acc.scenes.toList()))
+			}
+		}
+	}
+
+	private class SceneAcc(val name: String, val explicit: Boolean) {
+		val body = StringBuilder()
+	}
+
+	private class GroupAcc(val name: String) {
+		val scenes = mutableListOf<PreviewItem.Scene>()
+	}
 
 	companion object {
 		private const val UNTITLED = "Untitled"
+		private const val MAX_HEADING_LEVEL = 6
+		private const val MAX_HEADING_INDENT = 3
+		private const val BOM = '﻿'
 	}
 }

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/MarkdownStoryImporterTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/MarkdownStoryImporterTest.kt
@@ -70,7 +70,23 @@ class MarkdownStoryImporterTest {
 	}
 
 	@Test
-	fun `H2 mode treats H1 lines as body content`() {
+	fun `H2 mode treats a shallower H1 as a group wrapping its scenes`() {
+		val md = """
+			# Outer Title
+			## Real Chapter
+			Chapter body.
+		""".trimIndent()
+		val result = preview(md, level = ChapterHeadingLevel.H2)
+		assertEquals(1, result.items.size)
+		val group = result.items[0] as PreviewItem.Group
+		assertEquals("Outer Title", group.name)
+		assertEquals(1, group.scenes.size)
+		assertEquals("Real Chapter", group.scenes[0].name)
+		assertEquals("Chapter body.", group.scenes[0].markdown)
+	}
+
+	@Test
+	fun `H2 mode keeps group-intro prose as a leading Untitled scene inside the group`() {
 		val md = """
 			# Outer Title
 			Intro text.
@@ -78,14 +94,102 @@ class MarkdownStoryImporterTest {
 			Chapter body.
 		""".trimIndent()
 		val result = preview(md, level = ChapterHeadingLevel.H2)
-		// The leading H1 is body content, so it goes into the leading "Untitled" scene
+		assertEquals(1, result.items.size)
+		val group = result.items[0] as PreviewItem.Group
+		assertEquals("Outer Title", group.name)
+		assertEquals(2, group.scenes.size)
+		assertEquals("Untitled", group.scenes[0].name)
+		assertEquals("Intro text.", group.scenes[0].markdown)
+		assertEquals("Real Chapter", group.scenes[1].name)
+		assertEquals("Chapter body.", group.scenes[1].markdown)
+	}
+
+	@Test
+	fun `Headings deeper than the chosen level stay as scene body`() {
+		val md = """
+			## Chapter One
+			Intro.
+			### A subsection
+			More text.
+		""".trimIndent()
+		val result = preview(md, level = ChapterHeadingLevel.H2)
+		assertEquals(1, result.items.size)
+		val scene = result.items[0] as PreviewItem.Scene
+		assertEquals("Chapter One", scene.name)
+		assertTrue(scene.markdown.contains("### A subsection"))
+		assertTrue(scene.markdown.contains("More text."))
+	}
+
+	@Test
+	fun `Multiple H1 groups each keep their H2 scenes`() {
+		val md = """
+			# Part One
+			## Chapter A
+			a body
+			## Chapter B
+			b body
+			# Part Two
+			## Chapter C
+			c body
+		""".trimIndent()
+		val result = preview(md, level = ChapterHeadingLevel.H2)
 		assertEquals(2, result.items.size)
-		val leading = result.items[0] as PreviewItem.Scene
-		assertEquals("Untitled", leading.name)
-		assertTrue(leading.markdown.contains("# Outer Title"))
-		val real = result.items[1] as PreviewItem.Scene
-		assertEquals("Real Chapter", real.name)
-		assertEquals("Chapter body.", real.markdown)
+		val partOne = result.items[0] as PreviewItem.Group
+		assertEquals("Part One", partOne.name)
+		assertEquals(listOf("Chapter A", "Chapter B"), partOne.scenes.map { it.name })
+		val partTwo = result.items[1] as PreviewItem.Group
+		assertEquals("Part Two", partTwo.name)
+		assertEquals(listOf("Chapter C"), partTwo.scenes.map { it.name })
+	}
+
+	@Test
+	fun `H2 scenes before the first group heading stay top-level`() {
+		val md = """
+			## Chapter A
+			a body
+			# Part Two
+			## Chapter B
+			b body
+		""".trimIndent()
+		val result = preview(md, level = ChapterHeadingLevel.H2)
+		assertEquals(2, result.items.size)
+		val sceneA = result.items[0] as PreviewItem.Scene
+		assertEquals("Chapter A", sceneA.name)
+		val partTwo = result.items[1] as PreviewItem.Group
+		assertEquals("Part Two", partTwo.name)
+		assertEquals(listOf("Chapter B"), partTwo.scenes.map { it.name })
+	}
+
+	@Test
+	fun `H1 selection with no shallower headings produces flat scenes`() {
+		val md = """
+			# Chapter One
+			a
+			# Chapter Two
+			b
+		""".trimIndent()
+		val result = preview(md, level = ChapterHeadingLevel.H1)
+		assertEquals(2, result.items.size)
+		assertTrue(result.items.all { it is PreviewItem.Scene })
+		assertEquals(listOf("Chapter One", "Chapter Two"), result.items.map { it.name })
+	}
+
+	@Test
+	fun `Leading BOM does not hide the first heading`() {
+		val md = "﻿# Chapter One\nbody"
+		val result = preview(md)
+		assertEquals(1, result.items.size)
+		val scene = result.items[0] as PreviewItem.Scene
+		assertEquals("Chapter One", scene.name)
+		assertEquals("body", scene.markdown)
+	}
+
+	@Test
+	fun `Indented heading up to three spaces is still recognized`() {
+		val md = "   # Chapter One\nbody"
+		val result = preview(md)
+		assertEquals(1, result.items.size)
+		assertEquals("Chapter One", result.items[0].name)
 	}
 
 	@Test
@@ -192,6 +296,30 @@ class MarkdownStoryImporterTest {
 		val result = preview(md)
 		assertEquals(1, result.items.size)
 		assertEquals("Untitled", result.items[0].name)
+	}
+
+	@Test
+	fun `Hammer export round-trips H1 title to group and H2 chapters to scenes`() {
+		val md = """
+			# My Novel
+
+			## 1. Chapter One
+
+			Chapter one body.
+
+			## 2. Chapter Two
+
+			Chapter two body.
+		""".trimIndent()
+		val result = preview(md, level = ChapterHeadingLevel.H2)
+		assertEquals(1, result.items.size)
+		val group = result.items[0] as PreviewItem.Group
+		assertEquals("My Novel", group.name)
+		assertEquals(2, group.scenes.size)
+		assertEquals("1. Chapter One", group.scenes[0].name)
+		assertEquals("Chapter one body.", group.scenes[0].markdown)
+		assertEquals("2. Chapter Two", group.scenes[1].name)
+		assertEquals("Chapter two body.", group.scenes[1].markdown)
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #578.

## Problem
`MarkdownStoryImporter.preview()` split on a single **exact** heading level and treated every other level as plain body. Round-tripping a real document — including Hammer's own export, which writes `# Title` then `## Chapter` — produced the two reported symptoms:

- **H1 selected:** the only `#` is the title, so the whole document collapsed into one scene and the `##` chapter markers were ignored.
- **H2 selected:** chapters split, but the leading `# Title` line became a spurious **Untitled** scene.

## Fix
Fold the heading stream into a real hierarchy driven by the chosen level:

- Headings **shallower** than the chosen level → **groups**
- Headings **at** the chosen level → **scenes** (inside the current group, else top-level)
- Headings **deeper** → kept as scene **body** (sub-structure preserved)
- Leading content that is only headings/whitespace no longer creates a spurious Untitled scene; genuine preface prose still does

So a Hammer export now round-trips: pick **H2** → `# My Novel` becomes a group containing each `## Chapter` as a scene; pick **H1** on a flat document → flat scenes.

Also:
- Heading detection tolerates a leading BOM and up to three spaces of indent.
- Scene bodies are trimmed both ends, so the blank line Hammer writes after each heading no longer leaks into content.
- `createChapterGroups` still wraps top-level scenes in their own group when no shallower heading already groups them, preserving existing flat-import behavior.

No UI change needed — the import dialog already renders nested groups and re-previews live on option change.

## Tests
Followed the TDD-bugfix convention: added a failing round-trip test first, then implemented. Updated the one test whose behavior intentionally changed (H1-as-body → H1-as-group) and added coverage for groups, deeper headings as body, group-intro prose, multiple groups, top-level scenes before a group, BOM, and indented headings. All importer tests pass; the `ImportStoryUseCase` integration test is unaffected.