### PR TITLE
feat: add Ctrl+Alt+S save-all keyboard shortcut on desktop

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ShortcutModifiers.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ShortcutModifiers.kt
@@ -7,13 +7,15 @@ internal fun Modifier.onKeyShortcut(
 	key: Key,
 	ctrl: Boolean = false,
 	shift: Boolean = false,
+	alt: Boolean = false,
 	action: () -> Unit,
 ): Modifier = onPreviewKeyEvent { event ->
 	val ctrlOrMeta = event.isCtrlPressed || event.isMetaPressed
 	if (event.type == KeyEventType.KeyDown &&
 		event.key == key &&
 		ctrlOrMeta == ctrl &&
-		event.isShiftPressed == shift
+		event.isShiftPressed == shift &&
+		event.isAltPressed == alt
 	) {
 		action()
 		true
@@ -27,6 +29,9 @@ fun Modifier.findShortcutModifier(showFindBar: () -> Unit): Modifier =
 
 fun Modifier.saveShortcutModifier(onSave: () -> Unit): Modifier =
 	onKeyShortcut(Key.S, ctrl = true, action = onSave)
+
+fun Modifier.saveAllShortcutModifier(onSaveAll: () -> Unit): Modifier =
+	onKeyShortcut(Key.S, ctrl = true, alt = true, action = onSaveAll)
 
 fun Modifier.syncShortcutModifier(onSync: () -> Unit): Modifier =
 	onKeyShortcut(Key.F3, action = onSync)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootUi.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -23,6 +24,7 @@ import com.darkrockstudios.apps.hammer.common.compose.AnimatedFullScreenDialog
 import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.SetScreenCharacteristics
 import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.saveAllShortcutModifier
 import com.darkrockstudios.apps.hammer.common.compose.syncShortcutModifier
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdBottomBarDestination
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRailDestination
@@ -39,6 +41,7 @@ import com.darkrockstudios.apps.hammer.common.storyeditor.StoryEditorUi
 import com.darkrockstudios.apps.hammer.common.storyeditor.focusmode.FocusModeUi
 import com.darkrockstudios.apps.hammer.common.timeline.TimeLineUi
 import com.darkrockstudios.apps.hammer.common.timeline.TimelineFab
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
 
 private val WIDE_SCREEN_THRESHOLD = 650.dp
@@ -79,10 +82,13 @@ fun ProjectRootUi(
 	navWidth: Dp = Dp.Unspecified,
 	modifier: Modifier = Modifier,
 ) {
+	val scope = rememberCoroutineScope()
+
 	SetScreenCharacteristics(WIDE_SCREEN_THRESHOLD) {
 		FeatureContent(
 			modifier
 				.fillMaxSize()
+				.saveAllShortcutModifier { scope.launch { component.storeDirtyBuffers() } }
 				.syncShortcutModifier { component.showProjectSync() },
 			component,
 			rootSnackbar,


### PR DESCRIPTION
## Summary

Adds a Ctrl+Alt+S "save all" keyboard shortcut on desktop. It flushes every dirty buffer across open editors by calling the existing `ProjectRoot.storeDirtyBuffers()`. Plain Ctrl+S keeps saving only the focused scene.

## Why this matters

Issue #595 asks for Ctrl+S to save the current document and Ctrl+Alt+S to save all open/dirty documents. Ctrl+S already worked through `saveShortcutModifier`; the save-all combo was missing.

## Changes

- `ShortcutModifiers.kt`: added an `alt` flag to the internal `onKeyShortcut` helper (checked against `event.isAltPressed`, defaulting to `false`), and a new `saveAllShortcutModifier` bound to Ctrl+Alt+S. Because Ctrl+S now matches only when Alt is not held, the two shortcuts no longer collide.
- `ProjectRootUi.kt`: wired `saveAllShortcutModifier` into the root modifier chain next to `syncShortcutModifier`, launching `storeDirtyBuffers()` (a suspend function) from a `rememberCoroutineScope()`.

## Testing

No Java runtime was available in this environment, so the Gradle build/test suite was not run. Changes were verified by diff review against repo conventions: the new `alt` parameter defaults to `false`, so the existing Ctrl+S, find (Ctrl+F), bold/italic, and F3 sync shortcuts are unchanged, and the only new behavior is the Ctrl+Alt+S binding. The new modifier is placed at the same level as the existing `syncShortcutModifier`.

Fixes #595
