### PR TITLE
Fix flaky editor instrumented tests (re-inject until the edit lands)

### DIFF
--- a/android/src/androidTest/kotlin/EditorTestHarness.kt
+++ b/android/src/androidTest/kotlin/EditorTestHarness.kt
@@ -1,6 +1,8 @@
 import android.content.Context
+import android.os.SystemClock
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -66,13 +68,33 @@ fun ComposeTestRule.navigateTo(navTag: String) {
 }
 
 /**
- * Type into the tagged markdown/scene editor. It consumes hardware key events rather than
- * exposing Compose SetText semantics, so performTextInput can't drive it - focus it, then
- * inject real keystrokes via the instrumentation.
+ * Type into the tagged markdown/scene editor and wait for the edit to land.
+ *
+ * The editor consumes hardware key events rather than exposing Compose SetText semantics, so
+ * performTextInput can't drive it. Focus and the async edit flow can each still be unready when
+ * the keystrokes fire, silently dropping them; re-focus and re-inject until [propagated] confirms
+ * the change rather than trusting a single injection.
  */
-fun ComposeTestRule.typeIntoEditor(tag: String, text: String) {
-	onNodeWithTag(tag).performClick()
-	waitForIdle()
-	InstrumentationRegistry.getInstrumentation().sendStringSync(text)
-	waitForIdle()
+fun ComposeTestRule.typeIntoEditor(
+	tag: String,
+	text: String,
+	timeoutMillis: Long = 10_000L,
+	propagated: () -> Boolean,
+) {
+	val instrumentation = InstrumentationRegistry.getInstrumentation()
+	val deadline = SystemClock.uptimeMillis() + timeoutMillis
+	while (true) {
+		onNodeWithTag(tag).performClick()
+		waitForIdle()
+		instrumentation.sendStringSync(text)
+		waitForIdle()
+		try {
+			waitUntil(timeoutMillis = 1_000L) { propagated() }
+			return
+		} catch (e: ComposeTimeoutException) {
+			if (SystemClock.uptimeMillis() >= deadline) {
+				throw AssertionError("Editor input for '$tag' never propagated within ${timeoutMillis}ms", e)
+			}
+		}
+	}
 }

--- a/android/src/androidTest/kotlin/NotesWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/NotesWorkflowTest.kt
@@ -50,13 +50,10 @@ class NotesWorkflowTest {
 		composeRule.waitUntil(10_000) {
 			composeRule.onAllNodesWithTag(NOTES_CREATE_BODY_TAG).fetchSemanticsNodes().isNotEmpty()
 		}
+		// Creating an empty note silently no-ops, so confirm the word/char counter moved off
+		// its empty value before pressing create.
 		val emptyMeta = composeRule.textOf(NOTES_CREATE_META_TAG)
-		composeRule.typeIntoEditor(NOTES_CREATE_BODY_TAG, "E2E smoke note body")
-
-		// The editor reports text changes through an async flow, so the body can still be
-		// empty right after typing. Creating an empty note silently no-ops (stays on this
-		// screen), so wait for the word/char counter to change before confirming.
-		composeRule.waitUntil(10_000) {
+		composeRule.typeIntoEditor(NOTES_CREATE_BODY_TAG, "E2E smoke note body") {
 			composeRule.textOf(NOTES_CREATE_META_TAG) != emptyMeta
 		}
 		composeRule.onNodeWithTag(NOTES_CREATE_CONFIRM_TAG).performClick()

--- a/android/src/androidTest/kotlin/SceneEditorWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/SceneEditorWorkflowTest.kt
@@ -59,8 +59,8 @@ class SceneEditorWorkflowTest {
 		composeRule.waitUntil(10_000) {
 			composeRule.onAllNodesWithTag(SCENE_EDITOR_TEXT_TAG).fetchSemanticsNodes().isNotEmpty()
 		}
-		composeRule.typeIntoEditor(SCENE_EDITOR_TEXT_TAG, "Once upon a time")
-		composeRule.waitUntil(10_000) {
+		// The save action only appears once the typed edit dirties the buffer.
+		composeRule.typeIntoEditor(SCENE_EDITOR_TEXT_TAG, "Once upon a time") {
 			composeRule.onAllNodesWithTag(SCENE_EDITOR_SAVE_TAG).fetchSemanticsNodes().isNotEmpty()
 		}
 


### PR DESCRIPTION
## Problem

`NotesWorkflowTest.createNoteThenOpenIt` has been intermittently failing CI's `android-instrumented-tests` job (seen on multiple `develop` runs as well as PRs), timing out at the `waitUntil` that expects the word/char meta counter to change after typing:

```
androidx.compose.ui.test.ComposeTimeoutException: Condition still not satisfied after 10000 ms
    at NotesWorkflowTest.createNoteThenOpenIt(NotesWorkflowTest.kt:59)
```

## Root cause

The markdown/scene editor consumes hardware key events (no Compose `SetText` semantics) and reports edits through an async flow (`editOperations` collected in a `LaunchedEffect`). `sendStringSync` could fire before the field had focus — or before that collector had started — so the keystrokes were silently dropped. The observed change then never happened and `waitUntil` ran out the clock. Because the input is lost rather than merely delayed, a longer timeout cannot fix it.

## Fix

`typeIntoEditor` now re-focuses and re-injects until a caller-supplied `propagated()` lambda confirms the change actually landed (or a deadline throws a clear `AssertionError`). The two callers pass their existing change signal — the meta counter moving (`NotesWorkflowTest`) and the save action appearing (`SceneEditorWorkflowTest`) — and drop their now-redundant `waitUntil` blocks. Neither test asserts exact body text, so a retry's double-inject is harmless.

This hardens both editor-driven instrumented tests against the same race, not just the one that happened to flake.

## Verification

- `:android:compileDebugAndroidTestKotlin` builds clean.
- CI `android-instrumented-tests` on this PR.