### PR TITLE
Emit keyring JSON compactly for single-line env vars

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/secret/KeyringCodec.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/secret/KeyringCodec.kt
@@ -10,7 +10,7 @@ class KeyringCodec(
 	private val base64: Base64,
 ) {
 	private val parser = Json { ignoreUnknownKeys = true }
-	private val writer = Json { prettyPrint = true }
+	private val writer = Json
 
 	fun parse(json: String): Keyring = parser.decodeFromString(Keyring.serializer(), json).also { it.validate() }
 


### PR DESCRIPTION
## Summary
The keyring serializer used `Json { prettyPrint = true }`, producing multi-line output. Generated keyrings are meant to be dropped into an environment variable, where a concise single-line representation fits neatly. This switches the writer to compact JSON (no whitespace).

All callers — `GenerateKeyringCommand`, rotate/prune/migrate commands, file/config writes — consume the output as opaque JSON, and parsing is unaffected (the parser ignores whitespace either way).

## Test plan
- Existing `KeyringCodec` round-trip tests pass (parse(serialize(x)) == x).
- No tests assert on pretty-printed formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)