### PR TITLE
Add provider-agnostic download-link click tracking

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProvider.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProvider.kt
@@ -18,6 +18,15 @@ interface AnalyticsProvider {
 	/** Raw HTML injected into `<head>`, rendered via Mustache triple-braces. */
 	fun headSnippet(): String
 
+	/**
+	 * JS body defining `window.hammerTrack(name, data)` in this provider's terms.
+	 *
+	 * The shared binder (`assets/js/analytics.js`) reads `data-track-*` attributes off clicked
+	 * elements and calls `window.hammerTrack`; this snippet forwards that to the vendor's API.
+	 * Empty when the provider has no event API.
+	 */
+	fun eventBridge(): String
+
 	/** Origins (scheme://host[:port], no path) to add to the CSP `script-src`. */
 	fun scriptSrcHosts(): List<String>
 
@@ -33,6 +42,9 @@ internal class UmamiAnalyticsProvider(config: UmamiConfig) : AnalyticsProvider {
 		"""<script defer src="${escapeAttr(config.scriptUrl)}" data-website-id="${escapeAttr(config.websiteId)}"></script>"""
 
 	override fun headSnippet(): String = snippet
+
+	override fun eventBridge(): String =
+		"window.hammerTrack=function(n,d){window.umami&&window.umami.track(n,d)};"
 
 	override fun scriptSrcHosts(): List<String> = listOf(origin)
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -328,7 +328,9 @@ suspend fun ApplicationCall.withDefaults(data: Map<String, Any> = emptyMap()): M
 	// Inject web analytics on public (logged-out) pages only
 	if (session == null) {
 		serverConfig.analytics.provider?.let { provider ->
+			model["analyticsEnabled"] = true
 			model["analyticsHead"] = provider.headSnippet()
+			model["analyticsBridge"] = provider.eventBridge()
 		}
 	}
 

--- a/server/src/main/resources/assets/js/analytics.js
+++ b/server/src/main/resources/assets/js/analytics.js
@@ -1,0 +1,16 @@
+// Vendor-agnostic event tracking. Forwards clicks on [data-track-event] elements to
+// window.hammerTrack, which the active analytics provider defines. No-ops if undefined.
+(function () {
+	document.addEventListener('click', function (e) {
+		const el = e.target.closest('[data-track-event]');
+		if (!el || typeof window.hammerTrack !== 'function') return;
+
+		const data = {};
+		for (const [key, value] of Object.entries(el.dataset)) {
+			if (key.startsWith('track') && key !== 'trackEvent') {
+				data[key.slice(5).toLowerCase()] = value;
+			}
+		}
+		window.hammerTrack(el.dataset.trackEvent, data);
+	});
+})();

--- a/server/src/main/resources/assets/js/home.js
+++ b/server/src/main/resources/assets/js/home.js
@@ -10,6 +10,9 @@
 				const selected = this.options[this.selectedIndex];
 				btn.href = selected.dataset.url;
 				icon.className = selected.dataset.icon;
+				if (btn.dataset.trackEvent) {
+					btn.dataset.trackFormat = selected.value;
+				}
 			});
 		}
 	}

--- a/server/src/main/resources/templates/header.mustache
+++ b/server/src/main/resources/templates/header.mustache
@@ -12,9 +12,11 @@
 	{{#page_stylesheet}}
 		<link rel="stylesheet" href="{{page_stylesheet}}">
 	{{/page_stylesheet}}
-	{{#analyticsHead}}
+	{{#analyticsEnabled}}
 		{{{analyticsHead}}}
-	{{/analyticsHead}}
+		<script>{{{analyticsBridge}}}</script>
+		<script defer src="/assets/js/analytics.js"></script>
+	{{/analyticsEnabled}}
 </head>
 <body>
 <header class="site-header">

--- a/server/src/main/resources/templates/home.mustache
+++ b/server/src/main/resources/templates/home.mustache
@@ -186,7 +186,8 @@
 					</select>
 					<a id="windows-download-btn"
 					   href="https://apps.microsoft.com/detail/9p84lm8qv5x6"
-					   class="download-link download-btn">
+					   class="download-link download-btn"{{#analyticsEnabled}}
+					   data-track-event="download" data-track-platform="windows" data-track-format="store"{{/analyticsEnabled}}>
 						<i id="windows-download-icon" class="fa-brands fa-windows"></i>
 						<span>{{msg.home_download_link}}</span>
 					</a>
@@ -209,7 +210,8 @@
 					</select>
 					<a id="macos-download-btn"
 					   href="https://apps.apple.com/us/app/hammer-editor/id6770841038"
-					   class="download-link download-btn">
+					   class="download-link download-btn"{{#analyticsEnabled}}
+					   data-track-event="download" data-track-platform="macos" data-track-format="store"{{/analyticsEnabled}}>
 						<i id="macos-download-icon" class="fa-brands fa-app-store-ios"></i>
 						<span>{{msg.home_download_link}}</span>
 					</a>
@@ -249,7 +251,8 @@
 					</select>
 					<a id="linux-download-btn"
 					   href="https://github.com/Wavesonics/hammer-editor/releases/latest/download/hammer.deb"
-					   class="download-link download-btn">
+					   class="download-link download-btn"{{#analyticsEnabled}}
+					   data-track-event="download" data-track-platform="linux" data-track-format="deb"{{/analyticsEnabled}}>
 						<i id="linux-download-icon" class="fa-brands fa-debian"></i>
 						<span>{{msg.home_download_link}}</span>
 					</a>
@@ -277,7 +280,8 @@
 					</select>
 					<a id="android-download-btn"
 					   href="https://play.google.com/store/apps/details?id=com.darkrockstudios.apps.hammer.android"
-					   class="download-link download-btn">
+					   class="download-link download-btn"{{#analyticsEnabled}}
+					   data-track-event="download" data-track-platform="android" data-track-format="playstore"{{/analyticsEnabled}}>
 						<i id="android-download-icon" class="fa-brands fa-google-play"></i>
 						<span>{{msg.home_download_link}}</span>
 					</a>
@@ -289,7 +293,8 @@
 				<h3>iOS</h3>
 				<span class="download-source"><i class="fa-brands fa-app-store-ios"></i> App Store</span>
 				<a href="https://apps.apple.com/us/app/hammer-editor/id6771650681"
-				   class="download-link download-btn">
+				   class="download-link download-btn"{{#analyticsEnabled}}
+				   data-track-event="download" data-track-platform="ios" data-track-format="appstore"{{/analyticsEnabled}}>
 					<i class="fa-brands fa-app-store-ios"></i>
 					<span>{{msg.home_download_link}}</span>
 				</a>

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProviderTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProviderTest.kt
@@ -28,6 +28,14 @@ class AnalyticsProviderTest {
 	}
 
 	@Test
+	fun `umami event bridge forwards hammerTrack calls to umami track`() {
+		val provider = UmamiAnalyticsProvider(UmamiConfig(websiteId = "x"))
+		val bridge = provider.eventBridge()
+		assertContains(bridge, "window.hammerTrack")
+		assertContains(bridge, "umami.track(n,d)")
+	}
+
+	@Test
 	fun `umami cloud posts events to the gateway host, not the script host`() {
 		// Umami Cloud serves the script from cloud.umami.is but POSTs events to a separate
 		// gateway origin (baked into cloud.umami.is/script.js). connect-src must allow it.


### PR DESCRIPTION
## What

Instruments clicks on the home-page download buttons so we can see how many people download each platform/format — built through the existing `AnalyticsProvider` abstraction so a future provider (e.g. Google Analytics) works **without touching any templates**.

## How it stays provider-agnostic

- **Neutral markup** — download links declare generic `data-track-event="download"` + `data-track-platform` / `data-track-format`. No vendor names in the templates.
- **Shared binder** — new `assets/js/analytics.js` reads those attributes on click and forwards to `window.hammerTrack(name, data)`. It knows nothing about any vendor and no-ops if no hook is defined.
- **One per-provider hook** — new `AnalyticsProvider.eventBridge()` returns the JS that defines `window.hammerTrack` in the vendor's terms. Umami → `umami.track(...)`; a future GA provider is a one-line `gtag('event', ...)` and the `when` branch in the factory.

## Gated on config

All tracking markup and scripts are gated behind `analyticsEnabled`, which is only set when an analytics provider is configured (and, as before, only on public/logged-out pages). When analytics is off in server config, the `data-track-*` attributes aren't even emitted and the binder never loads.

## What you get in Umami

A single `download` event with `platform` and `format` breakdowns. Caveat: fires on click, not completed download, and doesn't capture right-click/copy-link.

## Files

- `AnalyticsProvider.kt` — new `eventBridge()` interface method + Umami impl
- `analytics.js` — vendor-agnostic click binder (new)
- `home.mustache` — gated `data-track-*` on all five download links
- `home.js` — reflects dropdown format selection into `data-track-format`
- `header.mustache` / `Frontend.kt` — wiring, gated on `analyticsEnabled`
- `AnalyticsProviderTest.kt` — coverage for the bridge

## Testing

Full `:server:test` suite passes.