### PR TITLE
Add a Google Analytics provider

### DIFF
--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -472,8 +472,11 @@ public web pages.
 Analytics is only served on **public (logged-out) pages**. It is never injected
 into the dashboard, story, or admin pages of signed-in users.
 
-By default analytics is disabled (`type = "none"`). Currently, the only supported
-provider is [Umami](https://umami.is).
+By default analytics is disabled (`type = "none"`). Supported providers are
+[Umami](https://umami.is) and [Google Analytics](https://analytics.google.com).
+
+Both providers report a `download` event, broken down by `platform` and `format`,
+when a visitor clicks a download button on the home page.
 
 ### Umami
 
@@ -494,6 +497,23 @@ scriptUrl = "https://umami.example.com/script.js"
 # it without a code release, e.g.:
 connectSrc = ["https://gateway.umami.is"]
 ```
+
+### Google Analytics
+
+Create a GA4 property, copy its **Measurement ID** (`G-XXXXXXXXXX`) from the data
+stream, and add:
+
+```toml
+[analytics]
+type = "google"
+
+[analytics.google]
+measurementId = "G-XXXXXXXXXX"
+```
+
+The `platform` and `format` event parameters are sent automatically, but GA4 only
+shows them in reports once you register them as **custom dimensions** in the GA
+admin console.
 
 The configuration is designed to grow: support for additional providers can be
 added under the `[analytics]` section in the future by selecting a different

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -44,7 +44,8 @@ data class ServerConfig(
 @Serializable(with = AnalyticsProviderType.Serializer::class)
 enum class AnalyticsProviderType(val serial: String) {
 	NONE("none"),
-	UMAMI("umami");
+	UMAMI("umami"),
+	GOOGLE("google");
 
 	object Serializer : CaseInsensitiveEnumSerializer<AnalyticsProviderType>(
 		"AnalyticsProviderType", entries.toTypedArray(), { it.serial }
@@ -55,6 +56,7 @@ enum class AnalyticsProviderType(val serial: String) {
 data class AnalyticsConfig(
 	val type: AnalyticsProviderType = AnalyticsProviderType.NONE,
 	val umami: UmamiConfig? = null,
+	val google: GoogleConfig? = null,
 ) {
 	/** The active provider, resolved once when the config is loaded. Null when analytics is off. */
 	@Transient
@@ -66,6 +68,10 @@ data class AnalyticsConfig(
 			AnalyticsProviderType.UMAMI -> {
 				requireNotNull(umami) { "analytics.type=umami requires an [analytics.umami] config block" }
 				umami.validate()
+			}
+			AnalyticsProviderType.GOOGLE -> {
+				requireNotNull(google) { "analytics.type=google requires an [analytics.google] config block" }
+				google.validate()
 			}
 		}
 	}
@@ -108,6 +114,24 @@ data class UmamiConfig(
 				"$label must be a bare origin (scheme://host[:port], no path): $value"
 			}
 		}
+	}
+}
+
+@Serializable
+data class GoogleConfig(
+	/** The GA4 Measurement ID, e.g. "G-XXXXXXXXXX", from the Google Analytics data stream. */
+	val measurementId: String,
+) {
+	fun validate() {
+		require(measurementId.isNotBlank()) { "analytics.google.measurementId must not be blank" }
+		// Strict format keeps the id safe to interpolate verbatim into the inline gtag init script.
+		require(MEASUREMENT_ID_REGEX.matches(measurementId)) {
+			"analytics.google.measurementId must look like a GA4 id (G-XXXXXXXXXX): $measurementId"
+		}
+	}
+
+	private companion object {
+		val MEASUREMENT_ID_REGEX = Regex("^G-[A-Za-z0-9]+$")
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProvider.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProvider.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.analytics
 
 import com.darkrockstudios.apps.hammer.AnalyticsConfig
 import com.darkrockstudios.apps.hammer.AnalyticsProviderType
+import com.darkrockstudios.apps.hammer.GoogleConfig
 import com.darkrockstudios.apps.hammer.UmamiConfig
 import java.net.URI
 import java.net.URISyntaxException
@@ -32,6 +33,9 @@ interface AnalyticsProvider {
 
 	/** Origins to add to the CSP `connect-src` (where the provider POSTs events). */
 	fun connectSrcHosts(): List<String>
+
+	/** Origins to add to the CSP `img-src` (where the provider loads tracking pixels). */
+	fun imgSrcHosts(): List<String>
 }
 
 internal class UmamiAnalyticsProvider(config: UmamiConfig) : AnalyticsProvider {
@@ -55,7 +59,43 @@ internal class UmamiAnalyticsProvider(config: UmamiConfig) : AnalyticsProvider {
 		configuredConnectSrc.ifEmpty {
 			if (origin == UMAMI_CLOUD_ORIGIN) UMAMI_CLOUD_EVENT_ORIGINS else listOf(origin)
 		}
+
+	override fun imgSrcHosts(): List<String> = emptyList()
 }
+
+internal class GoogleAnalyticsProvider(config: GoogleConfig) : AnalyticsProvider {
+	// Validated to ^G-[A-Za-z0-9]+$, so it is safe to interpolate into both the attribute and the inline script.
+	private val id = escapeAttr(config.measurementId)
+	private val snippet =
+		"""<script async src="https://www.googletagmanager.com/gtag/js?id=$id"></script>""" +
+			"<script>window.dataLayer=window.dataLayer||[];" +
+			"function gtag(){dataLayer.push(arguments);}" +
+			"gtag('js',new Date());gtag('config','$id');</script>"
+
+	override fun headSnippet(): String = snippet
+
+	override fun eventBridge(): String =
+		"window.hammerTrack=function(n,d){window.gtag&&window.gtag('event',n,d)};"
+
+	override fun scriptSrcHosts(): List<String> = GOOGLE_SCRIPT_HOSTS
+
+	override fun connectSrcHosts(): List<String> = GOOGLE_CONNECT_HOSTS
+
+	override fun imgSrcHosts(): List<String> = GOOGLE_IMG_HOSTS
+}
+
+// CSP origins for gtag.js, per Google's documented Content-Security-Policy guidance. GA4 beacons
+// to *.google-analytics.com / *.analytics.google.com and falls back to pixel loads on img-src.
+private val GOOGLE_SCRIPT_HOSTS = listOf("https://*.googletagmanager.com")
+private val GOOGLE_CONNECT_HOSTS = listOf(
+	"https://*.google-analytics.com",
+	"https://*.analytics.google.com",
+	"https://*.googletagmanager.com",
+)
+private val GOOGLE_IMG_HOSTS = listOf(
+	"https://*.google-analytics.com",
+	"https://*.googletagmanager.com",
+)
 
 private const val UMAMI_CLOUD_ORIGIN = "https://cloud.umami.is"
 
@@ -75,6 +115,7 @@ object AnalyticsProviderFactory {
 	fun create(config: AnalyticsConfig): AnalyticsProvider? = when (config.type) {
 		AnalyticsProviderType.NONE -> null
 		AnalyticsProviderType.UMAMI -> config.umami?.let { UmamiAnalyticsProvider(it) }
+		AnalyticsProviderType.GOOGLE -> config.google?.let { GoogleAnalyticsProvider(it) }
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
@@ -21,6 +21,7 @@ fun Application.configureHTTP(config: ServerConfig) {
 	val analyticsProvider = config.analytics.provider
 	val analyticsScriptHosts = analyticsProvider?.scriptSrcHosts().orEmpty()
 	val analyticsConnectHosts = analyticsProvider?.connectSrcHosts().orEmpty()
+	val analyticsImgHosts = analyticsProvider?.imgSrcHosts().orEmpty()
 
 	install(DefaultHeaders) {
 		header(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
@@ -40,12 +41,14 @@ fun Application.configureHTTP(config: ServerConfig) {
 			.joinToString(" ") // HTMX + inline scripts + dynamic eval + analytics
 		val connectSrc = (listOf("'self'") + analyticsConnectHosts)
 			.joinToString(" ") // HTMX requests stay on same origin + analytics event endpoint
+		val imgSrc = (listOf("'self'", "data:") + analyticsImgHosts)
+			.joinToString(" ") // Local images + data URIs + analytics pixels
 		val cspDirectives = listOf(
 			"default-src 'self'",
 			"script-src $scriptSrc",
 			"style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com 'unsafe-inline'", // Font Awesome + Google Fonts + inline styles
 			"font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com data:", // Custom fonts + Font Awesome + Google Fonts
-			"img-src 'self' data:", // Local images + data URIs
+			"img-src $imgSrc",
 			"connect-src $connectSrc",
 			"frame-ancestors 'self'" // Additional clickjacking protection
 		).joinToString("; ")

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsConfigTest.kt
@@ -61,6 +61,47 @@ class AnalyticsConfigTest {
 	}
 
 	@Test
+	fun `Google block parses the measurement id`() {
+		val config = parse(
+			"""
+			[analytics]
+			type = "google"
+
+			[analytics.google]
+			measurementId = "G-ABC123"
+			""".trimIndent()
+		)
+		assertEquals(AnalyticsProviderType.GOOGLE, config.analytics.type)
+		assertEquals("G-ABC123", config.analytics.google?.measurementId)
+		config.analytics.validate()
+	}
+
+	@Test
+	fun `validate throws when google selected without config block`() {
+		val config = parse(
+			"""
+			[analytics]
+			type = "google"
+			""".trimIndent()
+		)
+		assertThrows<IllegalArgumentException> { config.analytics.validate() }
+	}
+
+	@Test
+	fun `validate throws on a malformed measurement id`() {
+		val config = parse(
+			"""
+			[analytics]
+			type = "google"
+
+			[analytics.google]
+			measurementId = "UA-123-4"
+			""".trimIndent()
+		)
+		assertThrows<IllegalArgumentException> { config.analytics.validate() }
+	}
+
+	@Test
 	fun `validate succeeds for NONE`() {
 		parse("").analytics.validate()
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsCspTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsCspTest.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.analytics
 
 import com.darkrockstudios.apps.hammer.AnalyticsConfig
 import com.darkrockstudios.apps.hammer.AnalyticsProviderType
+import com.darkrockstudios.apps.hammer.GoogleConfig
 import com.darkrockstudios.apps.hammer.ServerConfig
 import com.darkrockstudios.apps.hammer.UmamiConfig
 import com.darkrockstudios.apps.hammer.plugins.configureHTTP
@@ -41,6 +42,23 @@ class AnalyticsCspTest {
 		assertContains(scriptSrc, "https://cloud.umami.is")
 		// Cloud events go to the gateway origin, so that — not the script host — must be in connect-src.
 		assertContains(connectSrc, "https://gateway.umami.is")
+	}
+
+	@Test
+	fun `google hosts are added to script-src, connect-src, and img-src`() = testApplication {
+		val config = ServerConfig(
+			analytics = AnalyticsConfig(
+				type = AnalyticsProviderType.GOOGLE,
+				google = GoogleConfig(measurementId = "G-ABC123"),
+			)
+		)
+		val csp = cspFor(config)
+		val scriptSrc = csp.split(";").first { it.trim().startsWith("script-src") }
+		val connectSrc = csp.split(";").first { it.trim().startsWith("connect-src") }
+		val imgSrc = csp.split(";").first { it.trim().startsWith("img-src") }
+		assertContains(scriptSrc, "https://*.googletagmanager.com")
+		assertContains(connectSrc, "https://*.google-analytics.com")
+		assertContains(imgSrc, "https://*.google-analytics.com")
 	}
 
 	@Test

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProviderTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/analytics/AnalyticsProviderTest.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.analytics
 
 import com.darkrockstudios.apps.hammer.AnalyticsConfig
 import com.darkrockstudios.apps.hammer.AnalyticsProviderType
+import com.darkrockstudios.apps.hammer.GoogleConfig
 import com.darkrockstudios.apps.hammer.UmamiConfig
 import org.junit.jupiter.api.Test
 import kotlin.test.assertContains
@@ -85,6 +86,43 @@ class AnalyticsProviderTest {
 	@Test
 	fun `originOf keeps an explicit port and strips the path`() {
 		assertEquals("https://umami.example.com:3000", originOf("https://umami.example.com:3000/script.js"))
+	}
+
+	@Test
+	fun `google head snippet loads gtag and configures the measurement id`() {
+		val provider = GoogleAnalyticsProvider(GoogleConfig(measurementId = "G-ABC123"))
+		val snippet = provider.headSnippet()
+		assertContains(snippet, """src="https://www.googletagmanager.com/gtag/js?id=G-ABC123"""")
+		assertContains(snippet, "gtag('config','G-ABC123')")
+	}
+
+	@Test
+	fun `google event bridge forwards hammerTrack calls to gtag`() {
+		val provider = GoogleAnalyticsProvider(GoogleConfig(measurementId = "G-ABC123"))
+		val bridge = provider.eventBridge()
+		assertContains(bridge, "window.hammerTrack")
+		assertContains(bridge, "gtag('event',n,d)")
+	}
+
+	@Test
+	fun `google declares google CSP hosts across script, connect, and img`() {
+		val provider = GoogleAnalyticsProvider(GoogleConfig(measurementId = "G-ABC123"))
+		assertEquals(listOf("https://*.googletagmanager.com"), provider.scriptSrcHosts())
+		assertContains(provider.connectSrcHosts(), "https://*.google-analytics.com")
+		assertContains(provider.imgSrcHosts(), "https://*.google-analytics.com")
+	}
+
+	@Test
+	fun `factory returns a google provider when configured`() {
+		val provider = AnalyticsProviderFactory.create(
+			AnalyticsConfig(type = AnalyticsProviderType.GOOGLE, google = GoogleConfig(measurementId = "G-ABC123"))
+		)
+		assertIs<GoogleAnalyticsProvider>(provider)
+	}
+
+	@Test
+	fun `factory returns null for google type with no config block`() {
+		assertNull(AnalyticsProviderFactory.create(AnalyticsConfig(type = AnalyticsProviderType.GOOGLE, google = null)))
 	}
 
 	@Test


### PR DESCRIPTION
## What

Adds **Google Analytics (GA4)** as a second web-analytics provider alongside Umami, selected via config:

```toml
[analytics]
type = "google"

[analytics.google]
measurementId = "G-XXXXXXXXXX"
```

Builds directly on the provider-agnostic tracking from #642 — download-click events flow through the existing neutral `data-track-*` markup and the `window.hammerTrack` bridge with **zero template changes**.

## Changes

- **Config** (`ServerConfig.kt`) — `GOOGLE` enum entry, `google: GoogleConfig?` block, `validate()` branch. `GoogleConfig` validates the measurement ID against `^G-[A-Za-z0-9]+$`, which also makes it safe to interpolate verbatim into the inline gtag init.
- **Provider** (`AnalyticsProvider.kt`) — `GoogleAnalyticsProvider` emits the async `gtag/js` loader + inline `gtag('config', …)`, and bridges `hammerTrack` → `gtag('event', …)`. Factory branch added (compiler-forced via the exhaustive `when`).
- **CSP** — GA4 can fall back to tracking-pixel loads, which `script-src`/`connect-src` don't cover. The `AnalyticsProvider` interface gains `imgSrcHosts()` (empty for Umami) and the CSP builder folds it into `img-src`. GA's origins follow Google's documented CSP guidance (`*.googletagmanager.com`, `*.google-analytics.com`, `*.analytics.google.com`).
- **Docs** — new Google Analytics section in `HOW-TO-RUN-A-SERVER.md`, including the GA4 custom-dimensions caveat.

## Caveat worth knowing

GA4 sends the `platform` / `format` event params automatically, but won't surface them in reports until they're registered as **custom dimensions** in the GA admin console.

## Testing

New cases across `AnalyticsProviderTest`, `AnalyticsConfigTest`, and `AnalyticsCspTest` (head snippet, event bridge, all three CSP directives, TOML parsing, and validation including rejection of a `UA-` id). Full \`:server:test\` suite passes.