### PR TITLE
Move story import into the project creation flow

### DIFF
--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/preview/ProjectSelectActivity.Preview.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/preview/ProjectSelectActivity.Preview.kt
@@ -16,6 +16,7 @@ import com.darkrockstudios.apps.hammer.common.components.projectselection.Projec
 import com.darkrockstudios.apps.hammer.common.components.projectselection.projectslist.ProjectListModalRouter
 import com.darkrockstudios.apps.hammer.common.components.projectselection.projectslist.ProjectsList
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
+import com.darkrockstudios.apps.hammer.common.data.ImportOptions
 import com.darkrockstudios.apps.hammer.common.data.Msg
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
@@ -40,6 +41,13 @@ val projectListComponent = object : ProjectsList {
 	override fun showCreate() {}
 	override fun hideCreate() {}
 	override fun createProject(projectName: String) {}
+	override fun beginProjectImport() {}
+	override fun cancelImportFilePicker() {}
+	override fun selectImportFile(name: String, content: String) {}
+	override fun updateImportProjectName(name: String) {}
+	override fun updateImportOptions(options: ImportOptions) {}
+	override fun cancelImportDialog() {}
+	override suspend fun confirmImportDialog() {}
 	override fun deleteProject(projectDef: ProjectDef) {}
 	override fun renameProject(projectDef: ProjectDef, newName: String) {}
 	override fun syncProjects(callback: (Boolean) -> Unit) {}

--- a/common/src/commonMain/composeResources/values/strings_projects_list.xml
+++ b/common/src/commonMain/composeResources/values/strings_projects_list.xml
@@ -53,6 +53,12 @@
 	<string name="create_project_button">Create Project</string>
 	<string name="create_project_cancel_button">Cancel</string>
 	<string name="create_project_import_button">Import</string>
+	<string name="create_project_import_help_title">Create from an Existing Story</string>
+	<string name="create_project_import_help_intro">Already have a manuscript? Import it to create a new project. Hammer names the project after your file and automatically splits the text into scenes.</string>
+	<string name="create_project_import_help_formats_header">Supported Formats</string>
+	<string name="create_project_import_help_format_markdown">Markdown (.md) — available now</string>
+	<string name="create_project_import_help_format_rtf">RTF — coming soon</string>
+	<string name="create_project_import_help_dismiss">Got it</string>
 	<string name="create_project_error_already_exists">Project already exists</string>
 	<string name="create_project_error_null_filename">Missing Project Name</string>
 	<string name="create_project_error_too_long">Project name too long</string>

--- a/common/src/commonMain/composeResources/values/strings_projects_list.xml
+++ b/common/src/commonMain/composeResources/values/strings_projects_list.xml
@@ -52,6 +52,7 @@
 	<string name="create_project_heading">New Project Name</string>
 	<string name="create_project_button">Create Project</string>
 	<string name="create_project_cancel_button">Cancel</string>
+	<string name="create_project_import_button">Import</string>
 	<string name="create_project_error_already_exists">Project already exists</string>
 	<string name="create_project_error_null_filename">Missing Project Name</string>
 	<string name="create_project_error_too_long">Project name too long</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHome.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHome.kt
@@ -8,10 +8,8 @@ import com.darkrockstudios.apps.hammer.common.components.ComponentToaster
 import com.darkrockstudios.apps.hammer.common.components.projectroot.Router
 import com.darkrockstudios.apps.hammer.common.data.ExportFormat
 import com.darkrockstudios.apps.hammer.common.data.ExportOptions
-import com.darkrockstudios.apps.hammer.common.data.ImportOptions
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
-import com.darkrockstudios.apps.hammer.common.data.importer.ImportPreview
 import com.darkrockstudios.apps.hammer.common.data.projectbackup.ProjectBackupDef
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.EntryAppearance
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.WritingActivityDerived
@@ -31,13 +29,6 @@ interface ProjectHome : Router, HammerComponent, BackHandlerOwner, ComponentToas
 	fun cancelExportDialog()
 	fun confirmExportDialog(options: ExportOptions)
 	fun endProjectExport()
-
-	fun beginProjectImport()
-	fun cancelImportFilePicker()
-	fun selectImportFile(name: String, content: String)
-	fun updateImportOptions(options: ImportOptions)
-	fun cancelImportDialog()
-	suspend fun confirmImportDialog()
 
 	fun startProjectSync()
 	fun showGlobalSearch()
@@ -87,12 +78,6 @@ interface ProjectHome : Router, HammerComponent, BackHandlerOwner, ComponentToas
 		val showExportFilePicker: Boolean = false,
 		val isExporting: Boolean = false,
 		val exportOptions: ExportOptions = ExportOptions(),
-		val showImportFilePicker: Boolean = false,
-		val showImportDialog: Boolean = false,
-		val importOptions: ImportOptions = ImportOptions(),
-		val importSourceName: String = "",
-		val importFileContent: String = "",
-		val importPreview: ImportPreview = ImportPreview(emptyList()),
 		val hasServer: Boolean = false,
 		val isLoadingStats: Boolean = false,
 		val isStatsDirty: Boolean = false,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
@@ -15,8 +15,6 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
-import com.darkrockstudios.apps.hammer.common.data.importer.ImportPreview
-import com.darkrockstudios.apps.hammer.common.data.importer.StoryImporter
 import com.darkrockstudios.apps.hammer.common.data.projectbackup.ProjectBackupDef
 import com.darkrockstudios.apps.hammer.common.data.projectbackup.ProjectBackupRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.EntryAppearance
@@ -61,8 +59,6 @@ class ProjectHomeComponent(
 	private val statisticsService: StatisticsService by projectInject()
 	private val tagIndexService: TagIndexService by projectInject()
 	private val referenceIndexService: ReferenceIndexService by projectInject()
-	private val importStoryUseCase: ImportStoryUseCase by projectInject()
-	private val markdownImporter: StoryImporter by inject()
 
 	private val contentRouter = ProjectHomeContentRouter(componentContext, projectDef)
 	override val contentRouterState: Value<ChildStack<ProjectHomeContentRouter.Config, ProjectHome.ContentDestination>> =
@@ -111,79 +107,6 @@ class ProjectHomeComponent(
 				showExportFilePicker = false,
 				isExporting = false,
 			)
-		}
-	}
-
-	override fun beginProjectImport() {
-		_state.getAndUpdate { it.copy(showImportFilePicker = true) }
-	}
-
-	override fun cancelImportFilePicker() {
-		_state.getAndUpdate { it.copy(showImportFilePicker = false) }
-	}
-
-	override fun selectImportFile(name: String, content: String) {
-		val sourceName = name.substringBeforeLast('.')
-		val initialOptions = ImportOptions()
-		val preview = markdownImporter.preview(sourceName, content, initialOptions)
-		_state.getAndUpdate {
-			it.copy(
-				showImportFilePicker = false,
-				showImportDialog = true,
-				importOptions = initialOptions,
-				importSourceName = sourceName,
-				importFileContent = content,
-				importPreview = preview,
-			)
-		}
-	}
-
-	override fun updateImportOptions(options: ImportOptions) {
-		val current = _state.value
-		val preview = markdownImporter.preview(
-			sourceName = current.importSourceName,
-			content = current.importFileContent,
-			options = options,
-		)
-		_state.getAndUpdate {
-			it.copy(importOptions = options, importPreview = preview)
-		}
-	}
-
-	override fun cancelImportDialog() {
-		_state.getAndUpdate {
-			it.copy(
-				showImportDialog = false,
-				importFileContent = "",
-				importSourceName = "",
-				importPreview = ImportPreview(emptyList()),
-			)
-		}
-	}
-
-	override suspend fun confirmImportDialog() {
-		val previewToImport = _state.value.importPreview
-		_state.getAndUpdate {
-			it.copy(
-				showImportDialog = false,
-				importFileContent = "",
-				importSourceName = "",
-				importPreview = ImportPreview(emptyList()),
-			)
-		}
-		try {
-			withContext(dispatcherDefault) {
-				importStoryUseCase.execute(previewToImport)
-			}
-			withContext(mainDispatcher) {
-				showToast(scope, ClientMessage.Resource(Res.string.project_home_action_import_toast_success))
-			}
-			// Import can fail many ways (parse, IO); report and show failure toast.
-		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-			io.github.aakira.napier.Napier.e("Import failed", e)
-			withContext(mainDispatcher) {
-				showToast(scope, ClientMessage.Resource(Res.string.project_home_action_import_toast_failure))
-			}
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsList.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsList.kt
@@ -6,7 +6,9 @@ import com.darkrockstudios.apps.hammer.common.components.ComponentToaster
 import com.darkrockstudios.apps.hammer.common.components.projectselection.ProjectData
 import com.darkrockstudios.apps.hammer.common.components.serverreauthentication.ServerReauthentication
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
+import com.darkrockstudios.apps.hammer.common.data.ImportOptions
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.importer.ImportPreview
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogMessage
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.HammerComponent
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
@@ -22,6 +24,13 @@ interface ProjectsList : HammerComponent, ComponentToaster {
 	fun showCreate()
 	fun hideCreate()
 	fun createProject(projectName: String)
+	fun beginProjectImport()
+	fun cancelImportFilePicker()
+	fun selectImportFile(name: String, content: String)
+	fun updateImportProjectName(name: String)
+	fun updateImportOptions(options: ImportOptions)
+	fun cancelImportDialog()
+	suspend fun confirmImportDialog()
 	fun deleteProject(projectDef: ProjectDef)
 	fun renameProject(projectDef: ProjectDef, newName: String)
 	fun syncProjects(callback: (Boolean) -> Unit)
@@ -43,6 +52,13 @@ interface ProjectsList : HammerComponent, ComponentToaster {
 		// In-flight sync progress is not meaningful after a process death; don't restore it.
 		@Transient val syncState: SyncState = SyncState(),
 		val createDialogProjectName: String = "",
+		val showImportFilePicker: Boolean = false,
+		val showImportDialog: Boolean = false,
+		val importOptions: ImportOptions = ImportOptions(),
+		val importSourceName: String = "",
+		val importProjectName: String = "",
+		val importFileContent: String = "",
+		val importPreview: ImportPreview = ImportPreview(emptyList()),
 	)
 
 	@Serializable

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
@@ -8,13 +8,18 @@ import com.darkrockstudios.apps.hammer.base.http.readTomlOrNull
 import com.darkrockstudios.apps.hammer.common.components.ComponentToaster
 import com.darkrockstudios.apps.hammer.common.components.ComponentToasterImpl
 import com.darkrockstudios.apps.hammer.common.components.SavableComponent
+import com.darkrockstudios.apps.hammer.common.components.projecthome.ImportStoryUseCase
 import com.darkrockstudios.apps.hammer.common.components.projectselection.ProjectData
 import com.darkrockstudios.apps.hammer.common.components.savableState
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
+import com.darkrockstudios.apps.hammer.common.data.ImportOptions
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SyncedProjectDefinition
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.importer.ImportPreview
+import com.darkrockstudios.apps.hammer.common.data.importer.StoryImporter
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
+import com.darkrockstudios.apps.hammer.common.data.temporaryProjectTask
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflictBroker
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
@@ -39,6 +44,8 @@ import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.util.NetworkConnectivity
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.common.util.lifecycleCoroutineScope
+import com.darkrockstudios.apps.hammer.project_home_action_import_toast_failure
+import com.darkrockstudios.apps.hammer.project_home_action_import_toast_success
 import com.darkrockstudios.apps.hammer.projects_list_toast_sync_complete
 import com.darkrockstudios.apps.hammer.projects_list_toast_sync_failed
 import com.darkrockstudios.apps.hammer.sync_log_begin_account
@@ -82,6 +89,7 @@ class ProjectsListComponent(
 	private val networkConnectivity: NetworkConnectivity by inject()
 	private val projectMetadataDatasource: ProjectMetadataDatasource by inject()
 	private val statisticsCacheReader: ProjectStatisticsCacheReader by inject()
+	private val markdownImporter: StoryImporter by inject()
 	private val fileSystem: FileSystem by inject()
 	private val toml: Toml by inject()
 	private val strRes: StrRes by inject()
@@ -307,6 +315,108 @@ class ProjectsListComponent(
 
 	override fun onProjectNameUpdate(newProjectName: String) {
 		_state.getAndUpdate { it.copy(createDialogProjectName = newProjectName) }
+	}
+
+	override fun beginProjectImport() {
+		modalRouter.dismissProjectCreate()
+		_state.getAndUpdate {
+			it.copy(createDialogProjectName = "", showImportFilePicker = true)
+		}
+	}
+
+	override fun cancelImportFilePicker() {
+		_state.getAndUpdate { it.copy(showImportFilePicker = false) }
+	}
+
+	override fun selectImportFile(name: String, content: String) {
+		val sourceName = name.substringBeforeLast('.')
+		val initialOptions = ImportOptions()
+		val preview = markdownImporter.preview(sourceName, content, initialOptions)
+		_state.getAndUpdate {
+			it.copy(
+				showImportFilePicker = false,
+				showImportDialog = true,
+				importOptions = initialOptions,
+				importSourceName = sourceName,
+				importProjectName = sourceName,
+				importFileContent = content,
+				importPreview = preview,
+			)
+		}
+	}
+
+	override fun updateImportProjectName(name: String) {
+		_state.getAndUpdate { it.copy(importProjectName = name) }
+	}
+
+	override fun updateImportOptions(options: ImportOptions) {
+		val current = _state.value
+		val preview = markdownImporter.preview(
+			sourceName = current.importSourceName,
+			content = current.importFileContent,
+			options = options,
+		)
+		_state.getAndUpdate {
+			it.copy(importOptions = options, importPreview = preview)
+		}
+	}
+
+	override fun cancelImportDialog() {
+		_state.getAndUpdate {
+			it.copy(
+				showImportDialog = false,
+				importFileContent = "",
+				importSourceName = "",
+				importProjectName = "",
+				importPreview = ImportPreview(emptyList()),
+			)
+		}
+	}
+
+	override suspend fun confirmImportDialog() {
+		val projectName = _state.value.importProjectName
+		val previewToImport = _state.value.importPreview
+
+		val result = projectsRepository.createProject(projectName)
+		if (!isSuccess(result)) {
+			result.displayMessage?.let { msg -> showToast(scope, msg) }
+			Napier.e("Import: failed to create project '$projectName'")
+			return
+		}
+		val newDef = result.data
+
+		if (projectsSynchronizer.isServerSynchronized()) {
+			projectsSynchronizer.createProject(projectName)
+		}
+
+		_state.getAndUpdate {
+			it.copy(
+				showImportDialog = false,
+				importFileContent = "",
+				importSourceName = "",
+				importProjectName = "",
+				importPreview = ImportPreview(emptyList()),
+			)
+		}
+
+		try {
+			withContext(dispatcherDefault) {
+				temporaryProjectTask(newDef) { projScope ->
+					val importStoryUseCase: ImportStoryUseCase = projScope.get()
+					importStoryUseCase.execute(previewToImport)
+				}
+			}
+			loadProjectList()
+			withContext(mainDispatcher) {
+				showToast(scope, Res.string.project_home_action_import_toast_success)
+			}
+			// Import can fail many ways (parse, IO); report and show failure toast.
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.e("Import failed", e)
+			withContext(mainDispatcher) {
+				showToast(scope, Res.string.project_home_action_import_toast_failure)
+			}
+		}
 	}
 
 	private suspend fun syncProject(

--- a/common/src/desktopTest/kotlin/components/projectselection/projectslist/ProjectsListComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/projectslist/ProjectsListComponentTest.kt
@@ -12,6 +12,8 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.SpellCheckerSettings
+import com.darkrockstudios.apps.hammer.common.data.importer.MarkdownStoryImporter
+import com.darkrockstudios.apps.hammer.common.data.importer.StoryImporter
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.ProjectStatisticsCacheReader
@@ -37,6 +39,7 @@ import org.koin.dsl.module
 import utils.ComponentTest
 import utils.TestStrRes
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Clock
@@ -95,6 +98,7 @@ class ProjectsListComponentTest : ComponentTest() {
 			single<Toml> { createTomlSerializer() }
 			single<StrRes> { TestStrRes() }
 			single<Clock> { Clock.System }
+			single<StoryImporter> { MarkdownStoryImporter() }
 		})
 
 		selectedProject = null
@@ -181,6 +185,72 @@ class ProjectsListComponentTest : ComponentTest() {
 			verify(exactly = 0) { synchronizer.createProject(any()) }
 			verify(exactly = 0) { projectsRepository.getProjects(any()) }
 			assertEquals("bad/name", comp.state.value.createDialogProjectName)
+		}
+
+	// --- import --------------------------------------------------------------
+
+	@Test
+	fun `beginProjectImport dismisses the create modal and opens the file picker`() =
+		runTest(mainTestDispatcher) {
+			val comp = newComponent()
+			comp.showCreate()
+
+			comp.beginProjectImport()
+
+			assertTrue(comp.state.value.showImportFilePicker)
+			assertEquals("", comp.state.value.createDialogProjectName)
+			assertIs<ProjectsList.ModalDestination.None>(comp.modalRouterState.value.child?.instance)
+		}
+
+	@Test
+	fun `selectImportFile derives the project name from the file name and shows the import dialog`() =
+		runTest(mainTestDispatcher) {
+			val comp = newComponent()
+
+			comp.selectImportFile("The Wreck.md", "# Chapter One\n\nText\n\n# Chapter Two\n\nMore")
+
+			assertEquals("The Wreck", comp.state.value.importProjectName)
+			assertTrue(comp.state.value.showImportDialog)
+			assertFalse(comp.state.value.showImportFilePicker)
+			assertFalse(comp.state.value.importPreview.isEmpty)
+		}
+
+	@Test
+	fun `updateImportProjectName updates the import name`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+
+		comp.updateImportProjectName("Renamed")
+
+		assertEquals("Renamed", comp.state.value.importProjectName)
+	}
+
+	@Test
+	fun `cancelImportDialog clears the import state`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		comp.selectImportFile("Draft.md", "# One\n\nText")
+
+		comp.cancelImportDialog()
+
+		assertFalse(comp.state.value.showImportDialog)
+		assertEquals("", comp.state.value.importProjectName)
+		assertTrue(comp.state.value.importPreview.isEmpty)
+	}
+
+	@Test
+	fun `confirmImportDialog leaves the dialog open and does not sync when project creation fails`() =
+		runTest(mainTestDispatcher) {
+			every { synchronizer.isServerSynchronized() } returns true
+			every { projectsRepository.createProject("Draft") } returns
+				CResult.failure(error = "exists", displayMessage = "Project already exists".toMsg())
+			val comp = newComponent()
+			comp.selectImportFile("Draft.md", "# One\n\nText")
+
+			comp.confirmImportDialog()
+			advanceUntilIdle()
+
+			assertTrue(comp.state.value.showImportDialog)
+			verify(exactly = 0) { synchronizer.createProject(any()) }
+			verify(exactly = 0) { projectsRepository.getProjects(any()) }
 		}
 
 	// --- deleteProject -------------------------------------------------------

--- a/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportFilePicker.kt
+++ b/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportFilePicker.kt
@@ -1,9 +1,8 @@
-package com.darkrockstudios.apps.hammer.common.projecthome
+package com.darkrockstudios.apps.hammer.common.projectselection
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import com.darkrockstudios.apps.hammer.common.components.projecthome.ProjectHome
-import com.darkrockstudios.apps.hammer.common.compose.rememberDefaultDispatcher
+import com.darkrockstudios.apps.hammer.common.compose.rememberIoDispatcher
 import io.github.aakira.napier.Napier
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitType
@@ -17,17 +16,18 @@ import kotlinx.coroutines.withContext
 @Composable
 actual fun ImportFilePicker(
 	show: Boolean,
-	component: ProjectHome,
 	scope: CoroutineScope,
+	onFileSelected: (name: String, content: String) -> Unit,
+	onCancel: () -> Unit,
 ) {
-	val defaultDispatcher = rememberDefaultDispatcher()
+	val ioDispatcher = rememberIoDispatcher()
 
 	val filePickerLauncher = rememberFilePickerLauncher(
 		type = FileKitType.File(extensions = listOf("md", "markdown")),
 	) { file: PlatformFile? ->
 		if (file != null) {
 			scope.launch {
-				val content = withContext(defaultDispatcher) {
+				val content = withContext(ioDispatcher) {
 					try {
 						file.readString()
 					} catch (@Suppress("TooGenericExceptionCaught") e: Exception) { // file read can fail many ways
@@ -36,13 +36,13 @@ actual fun ImportFilePicker(
 					}
 				}
 				if (content != null) {
-					component.selectImportFile(file.name, content)
+					onFileSelected(file.name, content)
 				} else {
-					component.cancelImportFilePicker()
+					onCancel()
 				}
 			}
 		} else {
-			component.cancelImportFilePicker()
+			onCancel()
 		}
 	}
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/FormDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/FormDialog.kt
@@ -66,6 +66,7 @@ fun FormDialog(
 	keyboardHint: String? = "ESC cancel",
 	implicitDismiss: Boolean = true,
 	onDismissed: () -> Unit = {},
+	mastheadAction: (@Composable () -> Unit)? = null,
 	body: @Composable ColumnScope.() -> Unit,
 ) {
 	AnimatedDialog(
@@ -113,6 +114,7 @@ fun FormDialog(
 							color = MaterialTheme.colorScheme.onSurfaceVariant,
 						)
 					}
+					mastheadAction?.invoke()
 				}
 				FolioDivider()
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/FormDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/FormDialog.kt
@@ -76,113 +76,152 @@ fun FormDialog(
 		modifier = Modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-		val accent = if (destructive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
-		Surface(
-			shape = RectangleShape,
-			color = MaterialTheme.colorScheme.surface,
-			contentColor = MaterialTheme.colorScheme.onSurface,
-			shadowElevation = Ui.Elevation.LARGE,
-			modifier = modifier
-				.padding(horizontal = Ui.Padding.XL)
-				.widthIn(max = 540.dp)
-				.fillMaxWidth(),
-		) {
-			Column {
-				// Masthead: § MARKER on the left, mono META on the right.
-				Row(
-					modifier = Modifier
-						.fillMaxWidth()
-						.padding(start = 26.dp, end = 26.dp, top = 16.dp, bottom = 14.dp),
-					verticalAlignment = Alignment.CenterVertically,
-					horizontalArrangement = Arrangement.spacedBy(12.dp),
-				) {
+		FormDialogScaffold(
+			marker = marker,
+			title = title,
+			confirmLabel = confirmLabel,
+			cancelLabel = cancelLabel,
+			onConfirm = onConfirm,
+			onCancel = onCancel,
+			modifier = modifier,
+			meta = meta,
+			destructive = destructive,
+			confirmEnabled = confirmEnabled,
+			keyboardHint = keyboardHint,
+			mastheadAction = mastheadAction,
+			body = body,
+		)
+	}
+}
+
+/**
+ * The static chrome of [FormDialog] — masthead, folio divider, titled body slot, and action
+ * footer — without the [AnimatedDialog] wrapper. [FormDialog] animates this in/out; render it
+ * directly (e.g. in a `@Preview`) to capture the dialog as a settled, opaque frame, since the
+ * Desktop preview renderer can't advance the enter animation.
+ */
+@Composable
+fun FormDialogScaffold(
+	marker: String,
+	title: String,
+	confirmLabel: String,
+	cancelLabel: String,
+	onConfirm: () -> Unit,
+	onCancel: () -> Unit,
+	modifier: Modifier = Modifier,
+	meta: String? = null,
+	destructive: Boolean = false,
+	confirmEnabled: Boolean = true,
+	keyboardHint: String? = "ESC cancel",
+	mastheadAction: (@Composable () -> Unit)? = null,
+	body: @Composable ColumnScope.() -> Unit,
+) {
+	val accent = if (destructive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+	Surface(
+		shape = RectangleShape,
+		color = MaterialTheme.colorScheme.surface,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+		shadowElevation = Ui.Elevation.LARGE,
+		modifier = modifier
+			.padding(horizontal = Ui.Padding.XL)
+			.widthIn(max = 540.dp)
+			.fillMaxWidth(),
+	) {
+		Column {
+			// Masthead: § MARKER on the left, mono META on the right.
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(start = 26.dp, end = 26.dp, top = 16.dp, bottom = 14.dp),
+				verticalAlignment = Alignment.CenterVertically,
+				horizontalArrangement = Arrangement.spacedBy(12.dp),
+			) {
+				Text(
+					text = marker,
+					fontFamily = hammerMonoFontFamily(),
+					fontSize = 10.sp,
+					fontWeight = FontWeight.Medium,
+					letterSpacing = 1.8.sp,
+					color = if (destructive) accent else MaterialTheme.colorScheme.onSurfaceVariant,
+				)
+				Spacer(modifier = Modifier.weight(1f))
+				if (!meta.isNullOrEmpty()) {
 					Text(
-						text = marker,
+						text = meta,
 						fontFamily = hammerMonoFontFamily(),
 						fontSize = 10.sp,
-						fontWeight = FontWeight.Medium,
 						letterSpacing = 1.8.sp,
-						color = if (destructive) accent else MaterialTheme.colorScheme.onSurfaceVariant,
-					)
-					Spacer(modifier = Modifier.weight(1f))
-					if (!meta.isNullOrEmpty()) {
-						Text(
-							text = meta,
-							fontFamily = hammerMonoFontFamily(),
-							fontSize = 10.sp,
-							letterSpacing = 1.8.sp,
-							color = MaterialTheme.colorScheme.onSurfaceVariant,
-						)
-					}
-					mastheadAction?.invoke()
-				}
-				FolioDivider()
-
-				// Body: title + fields slot.
-				Column(
-					modifier = Modifier.padding(start = 26.dp, end = 26.dp, top = 22.dp, bottom = 26.dp),
-					verticalArrangement = Arrangement.spacedBy(22.dp),
-				) {
-					Text(
-						text = title,
-						style = MaterialTheme.typography.headlineSmall.copy(
-							fontWeight = FontWeight.Normal,
-							letterSpacing = (-0.26).sp,
-							lineHeight = 30.sp,
-						),
-						color = MaterialTheme.colorScheme.onSurface,
-					)
-					Column(
-						verticalArrangement = Arrangement.spacedBy(20.dp),
-						content = body,
+						color = MaterialTheme.colorScheme.onSurfaceVariant,
 					)
 				}
+				mastheadAction?.invoke()
+			}
+			FolioDivider()
 
-				// Footer: keyboard hint + action buttons.
-				HorizontalDivider(
-					color = MaterialTheme.colorScheme.outlineVariant,
-					thickness = 1.dp,
+			// Body: title + fields slot.
+			Column(
+				modifier = Modifier.padding(start = 26.dp, end = 26.dp, top = 22.dp, bottom = 26.dp),
+				verticalArrangement = Arrangement.spacedBy(22.dp),
+			) {
+				Text(
+					text = title,
+					style = MaterialTheme.typography.headlineSmall.copy(
+						fontWeight = FontWeight.Normal,
+						letterSpacing = (-0.26).sp,
+						lineHeight = 30.sp,
+					),
+					color = MaterialTheme.colorScheme.onSurface,
 				)
-				Row(
-					modifier = Modifier
-						.fillMaxWidth()
-						.background(MaterialTheme.colorScheme.surfaceContainerLow)
-						.padding(start = 22.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
-					verticalAlignment = Alignment.CenterVertically,
-					horizontalArrangement = Arrangement.spacedBy(10.dp),
+				Column(
+					verticalArrangement = Arrangement.spacedBy(20.dp),
+					content = body,
+				)
+			}
+
+			// Footer: keyboard hint + action buttons.
+			HorizontalDivider(
+				color = MaterialTheme.colorScheme.outlineVariant,
+				thickness = 1.dp,
+			)
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.background(MaterialTheme.colorScheme.surfaceContainerLow)
+					.padding(start = 22.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
+				verticalAlignment = Alignment.CenterVertically,
+				horizontalArrangement = Arrangement.spacedBy(10.dp),
+			) {
+				if (keyboardHint != null) {
+					Text(
+						text = keyboardHint,
+						fontFamily = hammerMonoFontFamily(),
+						fontSize = 10.sp,
+						letterSpacing = 0.4.sp,
+						color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+					)
+				}
+				Spacer(modifier = Modifier.weight(1f))
+				TextButton(
+					onClick = onCancel,
+					shape = RoundedCornerShape(4.dp),
 				) {
-					if (keyboardHint != null) {
-						Text(
-							text = keyboardHint,
-							fontFamily = hammerMonoFontFamily(),
-							fontSize = 10.sp,
-							letterSpacing = 0.4.sp,
-							color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-						)
-					}
-					Spacer(modifier = Modifier.weight(1f))
-					TextButton(
-						onClick = onCancel,
-						shape = RoundedCornerShape(4.dp),
-					) {
-						Text(cancelLabel)
-					}
-					val confirmColors = if (destructive) {
-						ButtonDefaults.buttonColors(
-							containerColor = MaterialTheme.colorScheme.error,
-							contentColor = MaterialTheme.colorScheme.onError,
-						)
-					} else {
-						ButtonDefaults.buttonColors()
-					}
-					Button(
-						onClick = onConfirm,
-						enabled = confirmEnabled,
-						shape = RoundedCornerShape(4.dp),
-						colors = confirmColors,
-					) {
-						Text(confirmLabel)
-					}
+					Text(cancelLabel)
+				}
+				val confirmColors = if (destructive) {
+					ButtonDefaults.buttonColors(
+						containerColor = MaterialTheme.colorScheme.error,
+						contentColor = MaterialTheme.colorScheme.onError,
+					)
+				} else {
+					ButtonDefaults.buttonColors()
+				}
+				Button(
+					onClick = onConfirm,
+					enabled = confirmEnabled,
+					shape = RoundedCornerShape(4.dp),
+					colors = confirmColors,
+				) {
+					Text(confirmLabel)
 				}
 			}
 		}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectHomeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectHomeUi.kt
@@ -65,10 +65,3 @@ expect fun ExportDirectoryPicker(
 	component: ProjectHome,
 	scope: CoroutineScope,
 )
-
-@Composable
-expect fun ImportFilePicker(
-	show: Boolean,
-	component: ProjectHome,
-	scope: CoroutineScope,
-)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
@@ -50,7 +50,6 @@ import io.github.koalaplot.core.style.KoalaPlotTheme
 import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
 import io.github.koalaplot.core.util.generateHueColorPalette
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 import org.jetbrains.compose.resources.stringResource
@@ -124,16 +123,6 @@ fun ProjectStatsUi(
 		working = state.isExporting,
 	)
 	ExportDirectoryPicker(state.showExportFilePicker, component, scope)
-
-	ImportStoryDialog(
-		visible = state.showImportDialog,
-		options = state.importOptions,
-		preview = state.importPreview,
-		onCancel = component::cancelImportDialog,
-		onOptionsChange = component::updateImportOptions,
-		onConfirm = { scope.launch { component.confirmImportDialog() } },
-	)
-	ImportFilePicker(state.showImportFilePicker, component, scope)
 }
 
 @Composable
@@ -1279,14 +1268,6 @@ private fun ProjectHomeMenu(
 				text = { Text(Res.string.project_home_action_export.get()) },
 				onClick = {
 					component.beginProjectExport()
-					expanded = false
-				},
-			)
-
-			DropdownMenuItem(
-				text = { Text(Res.string.project_home_action_import.get()) },
-				onClick = {
-					component.beginProjectImport()
 					expanded = false
 				},
 			)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportFilePicker.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportFilePicker.kt
@@ -1,0 +1,12 @@
+package com.darkrockstudios.apps.hammer.common.projectselection
+
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+expect fun ImportFilePicker(
+	show: Boolean,
+	scope: CoroutineScope,
+	onFileSelected: (name: String, content: String) -> Unit,
+	onCancel: () -> Unit,
+)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportHelpDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportHelpDialog.kt
@@ -1,0 +1,125 @@
+package com.darkrockstudios.apps.hammer.common.projectselection
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import com.darkrockstudios.apps.hammer.*
+import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialogContainer
+import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
+import com.darkrockstudios.apps.hammer.common.compose.resources.get
+
+private val DialogMaxWidth = 480.dp
+
+/** Animated wrapper around [ImportHelpContent]. Preview [ImportHelpContent] directly for a static frame. */
+@Composable
+internal fun ImportHelpDialog(onDismiss: () -> Unit) {
+	var isOpen by remember { mutableStateOf(true) }
+
+	AnimatedDialogContainer(
+		isOpen = isOpen,
+		onDismissRequest = { isOpen = false },
+		onClosed = onDismiss,
+		properties = DialogProperties(
+			dismissOnBackPress = true,
+			dismissOnClickOutside = true,
+			usePlatformDefaultWidth = false,
+		),
+	) {
+		Box(modifier = Modifier.predictiveBackTransform()) {
+			ImportHelpContent(onDismiss = { isOpen = false })
+		}
+	}
+}
+
+@Composable
+internal fun ImportHelpContent(onDismiss: () -> Unit) {
+	Surface(
+		modifier = Modifier
+			.padding(Ui.Padding.XL)
+			.widthIn(max = DialogMaxWidth)
+			.fillMaxWidth(),
+		shape = RectangleShape,
+		color = MaterialTheme.colorScheme.surface,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+		border = BorderStroke(
+			width = Dp.Hairline,
+			color = MaterialTheme.colorScheme.outlineVariant,
+		),
+	) {
+		Column(modifier = Modifier.fillMaxWidth()) {
+			HdMasthead(
+				section = "HELP · IMPORT",
+				trailing = { HdMastheadAction(label = "× CLOSE", onClick = onDismiss) },
+			)
+			HdFolioDivider()
+
+			Column(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(Ui.Padding.XL),
+				verticalArrangement = Arrangement.spacedBy(Ui.Padding.L),
+			) {
+				Text(
+					text = Res.string.create_project_import_help_title.get(),
+					style = MaterialTheme.typography.headlineSmall,
+					color = MaterialTheme.colorScheme.onSurface,
+				)
+				Text(
+					text = Res.string.create_project_import_help_intro.get(),
+					style = MaterialTheme.typography.bodyMedium,
+					color = MaterialTheme.colorScheme.onSurfaceVariant,
+				)
+
+				Column(verticalArrangement = Arrangement.spacedBy(Ui.Padding.S)) {
+					HdMonoLabel(
+						text = Res.string.create_project_import_help_formats_header.get(),
+						color = MaterialTheme.colorScheme.onSurfaceVariant,
+					)
+					Text(
+						text = Res.string.create_project_import_help_format_markdown.get(),
+						style = MaterialTheme.typography.bodyMedium,
+						color = MaterialTheme.colorScheme.onSurface,
+					)
+					Text(
+						text = Res.string.create_project_import_help_format_rtf.get(),
+						style = MaterialTheme.typography.bodyMedium,
+						color = MaterialTheme.colorScheme.onSurfaceVariant,
+					)
+				}
+			}
+
+			HdFolioDivider()
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.L),
+				horizontalArrangement = Arrangement.End,
+			) {
+				HdHairlineButton(
+					label = Res.string.create_project_import_help_dismiss.get(),
+					onClick = onDismiss,
+					emphasised = true,
+				)
+			}
+		}
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportStoryDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportStoryDialog.kt
@@ -29,6 +29,7 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 private val DialogMaxWidth = 560.dp
+private val DialogMaxHeight = 720.dp
 
 @Composable
 fun ImportStoryDialog(
@@ -45,102 +46,125 @@ fun ImportStoryDialog(
 	LaunchedEffect(visible) { if (visible) renderInternal = true }
 	if (!renderInternal) return
 
-	val nameValidation = rememberNameValidation(projectName, NameKind.Project)
-
 	AnimatedDialogContainer(
 		isOpen = visible,
 		onDismissRequest = onCancel,
 		onClosed = { renderInternal = false },
 		properties = DialogProperties(usePlatformDefaultWidth = false),
 	) {
-		Surface(
-			modifier = Modifier
-				.padding(Ui.Padding.M)
-				.widthIn(max = DialogMaxWidth)
-				.fillMaxWidth()
-				.predictiveBackTransform(),
-			shape = RectangleShape,
-			color = MaterialTheme.colorScheme.surface,
-			contentColor = MaterialTheme.colorScheme.onSurface,
-			border = BorderStroke(
-				width = Dp.Hairline,
-				color = MaterialTheme.colorScheme.outlineVariant,
-			),
-		) {
-			Column {
-				ImportMasthead(
-					options = options,
-					preview = preview,
-					onClose = onCancel,
-				)
-				HdFolioDivider()
+		Box(modifier = Modifier.predictiveBackTransform()) {
+			ImportStoryContent(
+				projectName = projectName,
+				options = options,
+				preview = preview,
+				onProjectNameChange = onProjectNameChange,
+				onCancel = onCancel,
+				onOptionsChange = onOptionsChange,
+				onConfirm = onConfirm,
+			)
+		}
+	}
+}
 
+@Composable
+internal fun ImportStoryContent(
+	projectName: String,
+	options: ImportOptions,
+	preview: ImportPreview,
+	onProjectNameChange: (String) -> Unit,
+	onCancel: () -> Unit,
+	onOptionsChange: (ImportOptions) -> Unit,
+	onConfirm: () -> Unit,
+) {
+	val nameValidation = rememberNameValidation(projectName, NameKind.Project)
+
+	Surface(
+		modifier = Modifier
+			.padding(Ui.Padding.M)
+			.widthIn(max = DialogMaxWidth)
+			.heightIn(max = DialogMaxHeight)
+			.fillMaxWidth()
+			.fillMaxHeight(0.9f),
+		shape = RectangleShape,
+		color = MaterialTheme.colorScheme.surface,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+		border = BorderStroke(
+			width = Dp.Hairline,
+			color = MaterialTheme.colorScheme.outlineVariant,
+		),
+	) {
+		Column {
+			ImportMasthead(
+				options = options,
+				preview = preview,
+				onClose = onCancel,
+			)
+			HdFolioDivider()
+
+			Column(
+				modifier = Modifier
+					.weight(1f)
+					.fillMaxWidth()
+					.padding(
+						start = Ui.Padding.XL,
+						end = Ui.Padding.XL,
+						top = Ui.Padding.XL,
+						bottom = Ui.Padding.XL,
+					),
+			) {
 				Text(
 					text = stringResource(Res.string.project_home_import_dialog_title),
 					style = MaterialTheme.typography.headlineSmall,
 					color = MaterialTheme.colorScheme.onSurface,
-					modifier = Modifier.padding(
-						start = Ui.Padding.XL,
-						end = Ui.Padding.XL,
-						top = Ui.Padding.XL,
-						bottom = Ui.Padding.L,
-					),
+					modifier = Modifier.padding(bottom = Ui.Padding.L),
 				)
 
-				Column(
-					modifier = Modifier.padding(
-						start = Ui.Padding.XL,
-						end = Ui.Padding.XL,
-						bottom = Ui.Padding.XL,
-					),
-				) {
-					FormField(
-						value = projectName,
-						onValueChange = onProjectNameChange,
-						label = stringResource(Res.string.create_project_heading),
-						autoFocus = true,
-						error = nameValidation.fieldError(projectName),
-					)
-
-					Spacer(modifier = Modifier.height(Ui.Padding.XL))
-
-					HdHairlineSegmentedPicker(
-						title = stringResource(Res.string.project_home_import_format_label),
-						options = AVAILABLE_IMPORT_FORMATS,
-						selected = options.format,
-						onSelect = { onOptionsChange(options.copy(format = it)) },
-						label = { stringResource(it.labelRes()) },
-					)
-
-					Spacer(modifier = Modifier.height(Ui.Padding.XL))
-
-					HdHairlineSegmentedPicker(
-						title = stringResource(Res.string.project_home_import_heading_label),
-						options = ChapterHeadingLevel.entries,
-						selected = options.chapterHeadingLevel,
-						onSelect = { onOptionsChange(options.copy(chapterHeadingLevel = it)) },
-						label = { stringResource(it.labelRes()) },
-					)
-
-					Spacer(modifier = Modifier.height(Ui.Padding.XL))
-
-					HdHairlineToggleRow(
-						checked = options.createChapterGroups,
-						onCheckedChange = { onOptionsChange(options.copy(createChapterGroups = it)) },
-						label = stringResource(Res.string.project_home_import_create_groups_label),
-					)
-
-					Spacer(modifier = Modifier.height(Ui.Padding.XL))
-
-					ImportPreviewPane(preview)
-				}
-
-				ImportFooter(
-					onCancel = onCancel,
-					onConfirm = onConfirm,
-					confirmEnabled = !preview.isEmpty && nameValidation.isValid,
+				FormField(
+					value = projectName,
+					onValueChange = onProjectNameChange,
+					label = stringResource(Res.string.create_project_heading),
+					autoFocus = true,
+					error = nameValidation.fieldError(projectName),
 				)
+
+				Spacer(modifier = Modifier.height(Ui.Padding.XL))
+
+				HdHairlineSegmentedPicker(
+					title = stringResource(Res.string.project_home_import_format_label),
+					options = AVAILABLE_IMPORT_FORMATS,
+					selected = options.format,
+					onSelect = { onOptionsChange(options.copy(format = it)) },
+					label = { stringResource(it.labelRes()) },
+				)
+
+				Spacer(modifier = Modifier.height(Ui.Padding.XL))
+
+				HdHairlineSegmentedPicker(
+					title = stringResource(Res.string.project_home_import_heading_label),
+					options = ChapterHeadingLevel.entries,
+					selected = options.chapterHeadingLevel,
+					onSelect = { onOptionsChange(options.copy(chapterHeadingLevel = it)) },
+					label = { stringResource(it.labelRes()) },
+				)
+
+				Spacer(modifier = Modifier.height(Ui.Padding.XL))
+
+				HdHairlineToggleRow(
+					checked = options.createChapterGroups,
+					onCheckedChange = { onOptionsChange(options.copy(createChapterGroups = it)) },
+					label = stringResource(Res.string.project_home_import_create_groups_label),
+				)
+
+				Spacer(modifier = Modifier.height(Ui.Padding.XL))
+
+				ImportPreviewPane(preview, Modifier.weight(1f))
 			}
+
+			ImportFooter(
+				onCancel = onCancel,
+				onConfirm = onConfirm,
+				confirmEnabled = !preview.isEmpty && nameValidation.isValid,
+			)
 		}
 	}
 }
@@ -204,8 +228,8 @@ private fun ImportFooter(
 }
 
 @Composable
-private fun ImportPreviewPane(preview: ImportPreview) {
-	Column {
+private fun ImportPreviewPane(preview: ImportPreview, modifier: Modifier = Modifier) {
+	Column(modifier) {
 		Row(
 			modifier = Modifier.fillMaxWidth(),
 			horizontalArrangement = Arrangement.SpaceBetween,
@@ -225,12 +249,12 @@ private fun ImportPreviewPane(preview: ImportPreview) {
 		Box(
 			modifier = Modifier
 				.fillMaxWidth()
+				.weight(1f)
 				.border(
 					width = Dp.Hairline,
 					color = MaterialTheme.colorScheme.outlineVariant,
 					shape = RectangleShape,
-				)
-				.heightIn(max = 240.dp),
+				),
 		) {
 			if (preview.isEmpty) {
 				Box(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportStoryDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportStoryDialog.kt
@@ -130,16 +130,6 @@ internal fun ImportStoryContent(
 				Spacer(modifier = Modifier.height(Ui.Padding.XL))
 
 				HdHairlineSegmentedPicker(
-					title = stringResource(Res.string.project_home_import_format_label),
-					options = AVAILABLE_IMPORT_FORMATS,
-					selected = options.format,
-					onSelect = { onOptionsChange(options.copy(format = it)) },
-					label = { stringResource(it.labelRes()) },
-				)
-
-				Spacer(modifier = Modifier.height(Ui.Padding.XL))
-
-				HdHairlineSegmentedPicker(
 					title = stringResource(Res.string.project_home_import_heading_label),
 					options = ChapterHeadingLevel.entries,
 					selected = options.chapterHeadingLevel,
@@ -330,12 +320,6 @@ private fun PreviewSceneRow(name: String, indented: Boolean) {
 			color = MaterialTheme.colorScheme.onSurface,
 		)
 	}
-}
-
-private val AVAILABLE_IMPORT_FORMATS = listOf(ImportFormat.Markdown)
-
-private fun ImportFormat.labelRes(): StringResource = when (this) {
-	ImportFormat.Markdown -> Res.string.project_home_export_format_markdown
 }
 
 private fun ImportFormat.metaLabel(): String = when (this) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportStoryDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportStoryDialog.kt
@@ -1,4 +1,4 @@
-package com.darkrockstudios.apps.hammer.common.projecthome
+package com.darkrockstudios.apps.hammer.common.projectselection
 
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
@@ -15,7 +15,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialogContainer
+import com.darkrockstudios.apps.hammer.common.compose.FormField
+import com.darkrockstudios.apps.hammer.common.compose.NameKind
 import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.rememberNameValidation
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.data.ChapterHeadingLevel
 import com.darkrockstudios.apps.hammer.common.data.ImportFormat
@@ -30,8 +33,10 @@ private val DialogMaxWidth = 560.dp
 @Composable
 fun ImportStoryDialog(
 	visible: Boolean,
+	projectName: String,
 	options: ImportOptions,
 	preview: ImportPreview,
+	onProjectNameChange: (String) -> Unit,
 	onCancel: () -> Unit,
 	onOptionsChange: (ImportOptions) -> Unit,
 	onConfirm: () -> Unit,
@@ -39,6 +44,8 @@ fun ImportStoryDialog(
 	var renderInternal by remember { mutableStateOf(visible) }
 	LaunchedEffect(visible) { if (visible) renderInternal = true }
 	if (!renderInternal) return
+
+	val nameValidation = rememberNameValidation(projectName, NameKind.Project)
 
 	AnimatedDialogContainer(
 		isOpen = visible,
@@ -87,6 +94,16 @@ fun ImportStoryDialog(
 						bottom = Ui.Padding.XL,
 					),
 				) {
+					FormField(
+						value = projectName,
+						onValueChange = onProjectNameChange,
+						label = stringResource(Res.string.create_project_heading),
+						autoFocus = true,
+						error = nameValidation.fieldError(projectName),
+					)
+
+					Spacer(modifier = Modifier.height(Ui.Padding.XL))
+
 					HdHairlineSegmentedPicker(
 						title = stringResource(Res.string.project_home_import_format_label),
 						options = AVAILABLE_IMPORT_FORMATS,
@@ -121,7 +138,7 @@ fun ImportStoryDialog(
 				ImportFooter(
 					onCancel = onCancel,
 					onConfirm = onConfirm,
-					confirmEnabled = !preview.isEmpty,
+					confirmEnabled = !preview.isEmpty && nameValidation.isValid,
 				)
 			}
 		}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
@@ -34,13 +34,7 @@ fun ProjectCreateDialog(show: Boolean, component: ProjectsList, close: () -> Uni
 		onCancel = close,
 		onDismiss = close,
 		confirmEnabled = validation.isValid,
-		mastheadAction = {
-			HdHairlineButton(
-				label = "↓  ${Res.string.create_project_import_button.get()}",
-				onClick = component::beginProjectImport,
-				emphasised = true,
-			)
-		},
+		mastheadAction = { ProjectCreateImportAction(component::beginProjectImport) },
 	) {
 		FormField(
 			value = projectName,
@@ -51,4 +45,14 @@ fun ProjectCreateDialog(show: Boolean, component: ProjectsList, close: () -> Uni
 			onImeAction = ::submit,
 		)
 	}
+}
+
+/** The "Import" masthead action shared by the create dialog and its preview. */
+@Composable
+internal fun ProjectCreateImportAction(onClick: () -> Unit) {
+	HdHairlineButton(
+		label = "↓  ${Res.string.create_project_import_button.get()}",
+		onClick = onClick,
+		emphasised = true,
+	)
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.common.components.projectselection.projec
 import com.darkrockstudios.apps.hammer.common.compose.FormDialog
 import com.darkrockstudios.apps.hammer.common.compose.FormField
 import com.darkrockstudios.apps.hammer.common.compose.NameKind
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
 import com.darkrockstudios.apps.hammer.common.compose.rememberNameValidation
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 
@@ -33,6 +34,12 @@ fun ProjectCreateDialog(show: Boolean, component: ProjectsList, close: () -> Uni
 		onCancel = close,
 		onDismiss = close,
 		confirmEnabled = validation.isValid,
+		mastheadAction = {
+			HdMastheadAction(
+				label = Res.string.create_project_import_button.get(),
+				onClick = component::beginProjectImport,
+			)
+		},
 	) {
 		FormField(
 			value = projectName,

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
@@ -1,14 +1,22 @@
 package com.darkrockstudios.apps.hammer.common.projectselection
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.common.components.projectselection.projectslist.ProjectsList
 import com.darkrockstudios.apps.hammer.common.compose.FormDialog
 import com.darkrockstudios.apps.hammer.common.compose.FormField
 import com.darkrockstudios.apps.hammer.common.compose.NameKind
+import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
 import com.darkrockstudios.apps.hammer.common.compose.rememberNameValidation
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 
@@ -18,6 +26,7 @@ fun ProjectCreateDialog(show: Boolean, component: ProjectsList, close: () -> Uni
 	val projectName = state.createDialogProjectName
 
 	val validation = rememberNameValidation(projectName, NameKind.Project)
+	var showImportHelp by remember { mutableStateOf(false) }
 
 	fun submit() {
 		if (validation.isValid) component.createProject(projectName)
@@ -34,7 +43,12 @@ fun ProjectCreateDialog(show: Boolean, component: ProjectsList, close: () -> Uni
 		onCancel = close,
 		onDismiss = close,
 		confirmEnabled = validation.isValid,
-		mastheadAction = { ProjectCreateImportAction(component::beginProjectImport) },
+		mastheadAction = {
+			ProjectCreateMastheadActions(
+				onHelp = { showImportHelp = true },
+				onImport = component::beginProjectImport,
+			)
+		},
 	) {
 		FormField(
 			value = projectName,
@@ -44,6 +58,25 @@ fun ProjectCreateDialog(show: Boolean, component: ProjectsList, close: () -> Uni
 			error = validation.fieldError(projectName),
 			onImeAction = ::submit,
 		)
+	}
+
+	if (showImportHelp) {
+		ImportHelpDialog(onDismiss = { showImportHelp = false })
+	}
+}
+
+/**
+ * The create-dialog masthead actions: a help affordance and the emphasised "Import" button.
+ * Shared with the preview so both render the real affordances.
+ */
+@Composable
+internal fun ProjectCreateMastheadActions(onHelp: () -> Unit, onImport: () -> Unit) {
+	Row(
+		verticalAlignment = Alignment.CenterVertically,
+		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.S),
+	) {
+		HdMastheadAction(label = "?", onClick = onHelp)
+		ProjectCreateImportAction(onImport)
 	}
 }
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
@@ -8,7 +8,7 @@ import com.darkrockstudios.apps.hammer.common.components.projectselection.projec
 import com.darkrockstudios.apps.hammer.common.compose.FormDialog
 import com.darkrockstudios.apps.hammer.common.compose.FormField
 import com.darkrockstudios.apps.hammer.common.compose.NameKind
-import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
 import com.darkrockstudios.apps.hammer.common.compose.rememberNameValidation
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 
@@ -35,9 +35,10 @@ fun ProjectCreateDialog(show: Boolean, component: ProjectsList, close: () -> Uni
 		onDismiss = close,
 		confirmEnabled = validation.isValid,
 		mastheadAction = {
-			HdMastheadAction(
-				label = Res.string.create_project_import_button.get(),
+			HdHairlineButton(
+				label = "↓  ${Res.string.create_project_import_button.get()}",
 				onClick = component::beginProjectImport,
+				emphasised = true,
 			)
 		},
 	) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
@@ -38,6 +38,7 @@ import com.darkrockstudios.apps.hammer.common.compose.*
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.reauthentication.ReauthenticationUi
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
 import kotlin.time.Instant
 
@@ -100,6 +101,7 @@ fun ProjectListUi(
 	val widthClass = LocalScreenCharacteristic.current.windowWidthClass
 	val isWide = widthClass != WindowWidthSizeClass.Compact
 	val state by component.state.subscribeAsState()
+	val scope = rememberCoroutineScope()
 
 	Toaster(component, rootSnackbar)
 
@@ -199,6 +201,23 @@ fun ProjectListUi(
 	}
 
 	ModalContent(component, rootSnackbar)
+
+	ImportStoryDialog(
+		visible = state.showImportDialog,
+		projectName = state.importProjectName,
+		options = state.importOptions,
+		preview = state.importPreview,
+		onProjectNameChange = component::updateImportProjectName,
+		onCancel = component::cancelImportDialog,
+		onOptionsChange = component::updateImportOptions,
+		onConfirm = { scope.launch { component.confirmImportDialog() } },
+	)
+	ImportFilePicker(
+		show = state.showImportFilePicker,
+		scope = scope,
+		onFileSelected = component::selectImportFile,
+		onCancel = component::cancelImportFilePicker,
+	)
 }
 
 @Composable

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectStatsUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectStatsUi.Preview.kt
@@ -18,7 +18,6 @@ import com.darkrockstudios.apps.hammer.common.components.projectroot.CloseConfir
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.ExportFormat
 import com.darkrockstudios.apps.hammer.common.data.ExportOptions
-import com.darkrockstudios.apps.hammer.common.data.ImportOptions
 import com.darkrockstudios.apps.hammer.common.data.Msg
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.projectbackup.ProjectBackupDef
@@ -116,12 +115,6 @@ private val component = object : ProjectHome {
 	override fun cancelExportDialog() {}
 	override fun confirmExportDialog(options: ExportOptions) {}
 	override fun endProjectExport() {}
-	override fun beginProjectImport() {}
-	override fun cancelImportFilePicker() {}
-	override fun selectImportFile(name: String, content: String) {}
-	override fun updateImportOptions(options: ImportOptions) {}
-	override fun cancelImportDialog() {}
-	override suspend fun confirmImportDialog() {}
 	override fun startProjectSync() {}
 	override fun showGlobalSearch() {}
 	override fun showGlobalSearchForTag(tag: String) {}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ImportStoryDialog.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ImportStoryDialog.Preview.kt
@@ -1,0 +1,49 @@
+package com.darkrockstudios.apps.hammer.common.preview.projectselection
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.data.ImportOptions
+import com.darkrockstudios.apps.hammer.common.data.importer.ImportPreview
+import com.darkrockstudios.apps.hammer.common.data.importer.PreviewItem
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.preview.globalSettingsPreview
+import com.darkrockstudios.apps.hammer.common.projectselection.ImportStoryContent
+
+/**
+ * Rendered at a deliberately short canvas height with many scenes: the preview list scrolls within
+ * the bounded dialog while the option controls and footer buttons stay visible.
+ */
+@Preview(widthDp = 640, heightDp = 560)
+@Composable
+fun ImportStoryDialogPreview() {
+	val preview = ImportPreview(
+		items = List(14) { i -> PreviewItem.Scene(name = "Chapter ${i + 1}", markdown = "") },
+	)
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, true) {
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.background(MaterialTheme.colorScheme.background),
+				contentAlignment = Alignment.Center,
+			) {
+				ImportStoryContent(
+					projectName = "Alice In Wonderland 2",
+					options = ImportOptions(),
+					preview = preview,
+					onProjectNameChange = {},
+					onCancel = {},
+					onOptionsChange = {},
+					onConfirm = {},
+				)
+			}
+		}
+	}
+}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ProjectCreateDialog.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ProjectCreateDialog.Preview.kt
@@ -1,0 +1,61 @@
+package com.darkrockstudios.apps.hammer.common.preview.projectselection
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.common.compose.FormDialogScaffold
+import com.darkrockstudios.apps.hammer.common.compose.FormField
+import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.preview.globalSettingsPreview
+import com.darkrockstudios.apps.hammer.common.projectselection.ProjectCreateImportAction
+import com.darkrockstudios.apps.hammer.create_project_button
+import com.darkrockstudios.apps.hammer.create_project_cancel_button
+import com.darkrockstudios.apps.hammer.create_project_heading
+import com.darkrockstudios.apps.hammer.create_project_title
+
+/**
+ * The create-project dialog renders inside an animated [androidx.compose.ui.window.Dialog], which
+ * the Desktop preview renderer can't settle to a static frame. Preview its [FormDialogScaffold]
+ * chrome directly so the masthead "Import" action and footer render opaque and deterministic.
+ */
+@Preview(widthDp = 720, heightDp = 460)
+@Composable
+fun ProjectCreateDialogPreview() {
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, true) {
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.background(MaterialTheme.colorScheme.background),
+				contentAlignment = Alignment.Center,
+			) {
+				FormDialogScaffold(
+					marker = "§ NEW",
+					meta = "PROJECT",
+					title = Res.string.create_project_title.get(),
+					confirmLabel = Res.string.create_project_button.get(),
+					cancelLabel = Res.string.create_project_cancel_button.get(),
+					onConfirm = {},
+					onCancel = {},
+					confirmEnabled = true,
+					mastheadAction = { ProjectCreateImportAction {} },
+					body = {
+						FormField(
+							value = "Alice in Wonderland",
+							onValueChange = {},
+							label = Res.string.create_project_heading.get(),
+						)
+					},
+				)
+			}
+		}
+	}
+}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ProjectCreateDialog.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ProjectCreateDialog.Preview.kt
@@ -15,7 +15,8 @@ import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
 import com.darkrockstudios.apps.hammer.common.preview.globalSettingsPreview
-import com.darkrockstudios.apps.hammer.common.projectselection.ProjectCreateImportAction
+import com.darkrockstudios.apps.hammer.common.projectselection.ImportHelpContent
+import com.darkrockstudios.apps.hammer.common.projectselection.ProjectCreateMastheadActions
 import com.darkrockstudios.apps.hammer.create_project_button
 import com.darkrockstudios.apps.hammer.create_project_cancel_button
 import com.darkrockstudios.apps.hammer.create_project_heading
@@ -46,7 +47,7 @@ fun ProjectCreateDialogPreview() {
 					onConfirm = {},
 					onCancel = {},
 					confirmEnabled = true,
-					mastheadAction = { ProjectCreateImportAction {} },
+					mastheadAction = { ProjectCreateMastheadActions(onHelp = {}, onImport = {}) },
 					body = {
 						FormField(
 							value = "Alice in Wonderland",
@@ -55,6 +56,23 @@ fun ProjectCreateDialogPreview() {
 						)
 					},
 				)
+			}
+		}
+	}
+}
+
+@Preview(widthDp = 600, heightDp = 460)
+@Composable
+fun ImportHelpDialogPreview() {
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, true) {
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.background(MaterialTheme.colorScheme.background),
+				contentAlignment = Alignment.Center,
+			) {
+				ImportHelpContent(onDismiss = {})
 			}
 		}
 	}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportFilePicker.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportFilePicker.kt
@@ -1,8 +1,7 @@
-package com.darkrockstudios.apps.hammer.common.projecthome
+package com.darkrockstudios.apps.hammer.common.projectselection
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import com.darkrockstudios.apps.hammer.common.components.projecthome.ProjectHome
 import com.darkrockstudios.apps.hammer.common.compose.rememberDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.retryingFileDialog
 import io.github.aakira.napier.Napier
@@ -18,8 +17,9 @@ import kotlinx.coroutines.withContext
 @Composable
 actual fun ImportFilePicker(
 	show: Boolean,
-	component: ProjectHome,
 	scope: CoroutineScope,
+	onFileSelected: (name: String, content: String) -> Unit,
+	onCancel: () -> Unit,
 ) {
 	val defaultDispatcher = rememberDefaultDispatcher()
 
@@ -39,13 +39,13 @@ actual fun ImportFilePicker(
 						}
 					}
 					if (content != null) {
-						component.selectImportFile(file.name, content)
+						onFileSelected(file.name, content)
 					} else {
-						component.cancelImportFilePicker()
+						onCancel()
 					}
 				}
 			} else {
-				component.cancelImportFilePicker()
+				onCancel()
 			}
 		}
 	}

--- a/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportFilePicker.kt
+++ b/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportFilePicker.kt
@@ -1,9 +1,8 @@
-package com.darkrockstudios.apps.hammer.common.projecthome
+package com.darkrockstudios.apps.hammer.common.projectselection
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import com.darkrockstudios.apps.hammer.common.components.projecthome.ProjectHome
-import com.darkrockstudios.apps.hammer.common.compose.rememberIoDispatcher
+import com.darkrockstudios.apps.hammer.common.compose.rememberDefaultDispatcher
 import io.github.aakira.napier.Napier
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitType
@@ -17,17 +16,18 @@ import kotlinx.coroutines.withContext
 @Composable
 actual fun ImportFilePicker(
 	show: Boolean,
-	component: ProjectHome,
 	scope: CoroutineScope,
+	onFileSelected: (name: String, content: String) -> Unit,
+	onCancel: () -> Unit,
 ) {
-	val ioDispatcher = rememberIoDispatcher()
+	val defaultDispatcher = rememberDefaultDispatcher()
 
 	val filePickerLauncher = rememberFilePickerLauncher(
 		type = FileKitType.File(extensions = listOf("md", "markdown")),
 	) { file: PlatformFile? ->
 		if (file != null) {
 			scope.launch {
-				val content = withContext(ioDispatcher) {
+				val content = withContext(defaultDispatcher) {
 					try {
 						file.readString()
 					} catch (@Suppress("TooGenericExceptionCaught") e: Exception) { // file read can fail many ways
@@ -36,13 +36,13 @@ actual fun ImportFilePicker(
 					}
 				}
 				if (content != null) {
-					component.selectImportFile(file.name, content)
+					onFileSelected(file.name, content)
 				} else {
-					component.cancelImportFilePicker()
+					onCancel()
 				}
 			}
 		} else {
-			component.cancelImportFilePicker()
+			onCancel()
 		}
 	}
 


### PR DESCRIPTION
## Summary

"Import Story" used to live as an action *inside* the Project Home screen, which was the wrong place — importing produces a brand-new body of scenes, so it belongs at **project creation** time.

This moves the import flow into the **Create Project** dialog:

- The Create Project dialog gains an **Import** action (top-right of its masthead).
- Pressing it closes the create dialog and opens the file picker → import-preview dialog.
- The import dialog now has an **editable, validated project-name field**, pre-filled from the imported file's name (same validation as the create dialog).
- Confirming creates the project and splits the file into scenes.

The old "Import Story" menu item and dialog are removed from Project Home.

## Implementation notes

The import previously ran inside `ProjectHomeComponent`, which is **project-scoped**. The project-selection screen has no project scope, and at import time the target project doesn't exist yet. So `ProjectsListComponent.confirmImportDialog()` creates the project first, then runs the existing `ImportStoryUseCase` inside `temporaryProjectTask(newDef) { … }` — the same temporary-scope pattern the component already uses for sync. On a name collision/invalid name, project creation fails and the dialog stays open with inline validation.

## Changes

- Move import state + handlers from `ProjectHome`/`ProjectHomeComponent` to `ProjectsList`/`ProjectsListComponent`.
- Move `ImportStoryDialog` + `ImportFilePicker` (expect + 3 actuals) to the `projectselection` package; the picker is now callback-based instead of coupled to `ProjectHome`.
- Add an optional `mastheadAction` slot to `FormDialog`; wire the Import button into `ProjectCreateDialog`.
- Add the editable, validated project-name field to the import dialog.
- Keep the existing `project_home_import_*` string keys (to preserve translations); add one new `create_project_import_button` string.

## Test plan

- [x] `:common` + `:composeUi` desktop compile
- [x] `:composeUi` + `:android` Android compile
- [x] `ProjectsListComponentTest` passes (new cases: import handlers + create-failure path)
- [ ] Manual: Create Project → Import → pick a multi-heading `.md` → verify name pre-fill/validation, preview, and that the new project has the split scenes

> Note: the full happy-path import (actually writing scenes) runs through `temporaryProjectTask`, which needs the real project Koin scope + filesystem — that's integration-level and not wired into the unit harness, so it's covered by the create-failure unit test plus manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)