### PR TITLE
Client security hardening (audit follow-up)

### DIFF
--- a/android/src/fdroid/AndroidManifest.xml
+++ b/android/src/fdroid/AndroidManifest.xml
@@ -56,7 +56,7 @@
 		</activity>
 		<activity
 			android:name=".ProjectRootActivity"
-			android:exported="true"
+			android:exported="false"
 			android:windowSoftInputMode="adjustResize"/>
 		<activity
 			android:name=".widgets.AddNoteActivity"

--- a/android/src/fdroid/AndroidManifest.xml
+++ b/android/src/fdroid/AndroidManifest.xml
@@ -61,7 +61,7 @@
 		<activity
 			android:name=".widgets.AddNoteActivity"
 			android:excludeFromRecents="true"
-			android:exported="true"
+			android:exported="false"
 			android:label="@string/title_activity_add_note"
 			android:theme="@style/Theme.AppCompat.DayNight.Dialog"
 			android:windowSoftInputMode="adjustResize"/>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
 		<activity
 			android:name=".widgets.AddNoteActivity"
 			android:excludeFromRecents="true"
-			android:exported="true"
+			android:exported="false"
 			android:label="@string/title_activity_add_note"
 			android:theme="@style/Theme.AppCompat.DayNight.Dialog"
 			android:windowSoftInputMode="adjustResize"/>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
 		</activity>
 		<activity
 			android:name=".ProjectRootActivity"
-			android:exported="true"
+			android:exported="false"
 			android:windowSoftInputMode="adjustResize"/>
 		<activity
 			android:name=".widgets.AddNoteActivity"

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
@@ -26,8 +26,6 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.retainedComponent
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.getAndUpdate
-import com.arkivanov.essenty.statekeeper.getSerializable
-import com.arkivanov.essenty.statekeeper.putSerializable
 import com.darkrockstudios.apps.hammer.android.shortcuts.ProjectShortcutsManager
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectDeepLink
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot
@@ -122,12 +120,13 @@ class ProjectRootActivity : AppCompatActivity() {
 		}
 	}
 
+	// Resolve the target project by name against on-disk projects only. We never trust a
+	// caller-supplied project path: an exported intent could otherwise root the editor at an
+	// attacker-controlled directory (confused deputy).
 	private fun resolveProjectDef(intent: Intent): ProjectDef? {
-		intent.extras?.getSerializable(EXTRA_PROJECT, ProjectDef.serializer())?.let { return it }
-
 		val name = intent.getStringExtra(EXTRA_PROJECT_NAME)?.takeIf { it.isNotBlank() } ?: return null
 		val match = projectsRepository.getProjects().firstOrNull { it.name == name }
-		if (match == null) Napier.w("Project shortcut for missing project: $name")
+		if (match == null) Napier.w("Project intent for missing project: $name")
 		return match
 	}
 
@@ -210,7 +209,6 @@ class ProjectRootActivity : AppCompatActivity() {
 	}
 
 	companion object {
-		const val EXTRA_PROJECT = "project"
 		const val EXTRA_PROJECT_NAME = "project_name"
 		const val EXTRA_DEEP_LINK_SCENE_ID = "deep_link_scene_id"
 		const val ACTION_OPEN_PROJECT = "com.darkrockstudios.apps.hammer.android.OPEN_PROJECT"
@@ -221,11 +219,8 @@ class ProjectRootActivity : AppCompatActivity() {
 			deepLinkSceneId: Int? = null,
 		): Intent {
 			val intent = Intent(context, ProjectRootActivity::class.java)
-			val extras = Bundle().apply {
-				putSerializable(EXTRA_PROJECT, projectDef, ProjectDef.serializer())
-				if (deepLinkSceneId != null) putInt(EXTRA_DEEP_LINK_SCENE_ID, deepLinkSceneId)
-			}
-			intent.putExtras(extras)
+				.putExtra(EXTRA_PROJECT_NAME, projectDef.name)
+			if (deepLinkSceneId != null) intent.putExtra(EXTRA_DEEP_LINK_SCENE_ID, deepLinkSceneId)
 			return intent
 		}
 

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteActivity.kt
@@ -55,6 +55,10 @@ class AddNoteActivity : ComponentActivity(), KoinComponent {
 		super.onCreate(savedInstanceState)
 		enableEdgeToEdge()
 
+		// Drop touches delivered while another app's window overlays this dialog, so a tapjacking
+		// overlay can't drive the note save into a chosen project.
+		window.decorView.filterTouchesWhenObscured = true
+
 		setFinishOnTouchOutside(false)
 		window.setBackgroundDrawableResource(android.R.color.transparent)
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -148,6 +148,7 @@ kotlin {
 				implementation(libs.koin.test.junit5)
 				implementation(compose.desktop.currentOs)
 				implementation(libs.poi.ooxml)
+				implementation(libs.ktor.client.mock)
 			}
 		}
 	}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -112,6 +112,7 @@ kotlin {
 				implementation(libs.ktor.client.okhttp)
 				implementation(libs.moko.permissions)
 				implementation(libs.moko.permissions.storage)
+				implementation(libs.androidx.security.crypto)
 			}
 		}
 		val iosMain by getting {

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/EncryptedSharedPrefsAuthTokenStore.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/EncryptedSharedPrefsAuthTokenStore.kt
@@ -1,0 +1,108 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.darkrockstudios.apps.hammer.base.http.readJsonOrNull
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore.Companion.accountKey
+import io.github.aakira.napier.Napier
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+
+/**
+ * [AuthTokenStore] backed by [EncryptedSharedPreferences] with an Android
+ * Keystore-backed master key. The account-keyed token map is stored as JSON in a
+ * single encrypted preferences entry.
+ *
+ * If a legacy plaintext token file is present in the config directory it is
+ * migrated into the encrypted store and deleted on first access.
+ */
+class EncryptedSharedPrefsAuthTokenStore(
+	context: Context,
+	private val json: Json,
+	private val fileSystem: FileSystem,
+) : AuthTokenStore {
+
+	private val lock = reentrantLock()
+	private var migrationChecked = false
+
+	private val prefs: SharedPreferences by lazy {
+		val masterKey = MasterKey.Builder(context)
+			.setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+			.build()
+
+		EncryptedSharedPreferences.create(
+			context,
+			PREFS_NAME,
+			masterKey,
+			EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+			EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+		)
+	}
+
+	override fun get(url: String, userId: Long): AuthTokens? = lock.withLock {
+		loadMap()[accountKey(url, userId)]
+	}
+
+	override fun put(url: String, userId: Long, tokens: AuthTokens): Unit = lock.withLock {
+		val updated = loadMap().toMutableMap()
+		updated[accountKey(url, userId)] = tokens
+		storeMap(updated)
+	}
+
+	override fun remove(url: String, userId: Long): Unit = lock.withLock {
+		val updated = loadMap().toMutableMap()
+		if (updated.remove(accountKey(url, userId)) != null) {
+			storeMap(updated)
+		}
+	}
+
+	private fun loadMap(): Map<String, AuthTokens> {
+		migrateLegacyPlaintext()
+		return decodeStored()
+	}
+
+	private fun decodeStored(): Map<String, AuthTokens> {
+		val stored = prefs.getString(TOKENS_KEY, null) ?: return emptyMap()
+		return try {
+			json.decodeFromString<Map<String, AuthTokens>>(stored)
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.w("Failed to parse encrypted auth tokens; treating as empty", e)
+			emptyMap()
+		}
+	}
+
+	private fun storeMap(tokens: Map<String, AuthTokens>) {
+		prefs.edit().putString(TOKENS_KEY, json.encodeToString(tokens)).apply()
+	}
+
+	// Synchronous write so the encrypted entry is durable before the plaintext file is deleted.
+	@SuppressLint("ApplySharedPref")
+	private fun migrateLegacyPlaintext() {
+		if (migrationChecked) return
+		migrationChecked = true
+
+		if (!fileSystem.exists(FileAuthTokenStore.FILE_PATH)) return
+
+		try {
+			val legacy = fileSystem.readJsonOrNull<Map<String, AuthTokens>>(FileAuthTokenStore.FILE_PATH, json)
+				?: return
+			if (legacy.isNotEmpty()) {
+				val merged = legacy + decodeStored()
+				prefs.edit().putString(TOKENS_KEY, json.encodeToString(merged)).commit()
+			}
+			fileSystem.delete(FileAuthTokenStore.FILE_PATH, mustExist = false)
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.w("Failed to migrate plaintext auth token store", e)
+		}
+	}
+
+	companion object {
+		private const val PREFS_NAME = "hammer_auth_tokens"
+		private const val TOKENS_KEY = "tokens"
+	}
+}

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -1,0 +1,15 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+actual val authTokenStoreModule = module {
+	single {
+		EncryptedSharedPrefsAuthTokenStore(
+			context = androidContext(),
+			json = get(),
+			fileSystem = get(),
+		)
+	} bind AuthTokenStore::class
+}

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
@@ -11,6 +11,7 @@ import com.darkrockstudios.apps.hammer.common.util.*
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -24,7 +25,9 @@ actual val platformModule = module {
 		AndroidPlatformSettingsComponent(
 			componentContext = params.get(),
 			context = get(),
-			fileSystem = get(),
+			// Storage relocation moves projects into the new app-managed directory before
+			// that directory is registered as a managed root, so it uses the raw filesystem.
+			fileSystem = get(named(RAW_FILESYSTEM)),
 		)
 	} bind PlatformSettings::class
 	singleOf(::PlatformSpellCheckerFactory)

--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -176,6 +176,7 @@
 	<string name="sync_log_entity_download_failed_general">Failed to download entity %1$d</string>
 	<string name="sync_log_entity_download_failed_not_found">Entity %1$d not found on server</string>
 	<string name="sync_log_entity_download_not_modified">Entity %1$d not modified</string>
+	<string name="sync_log_entity_download_rejected_mismatch">Rejected download for entity %1$d: server returned a mismatched id or type</string>
 	<string name="sync_log_entity_upload_entity_not_owned">Failed to upload entity %1$d: type not owned by anything,
 		probably deleted
 	</string>

--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -194,6 +194,9 @@
 	<string name="sync_log_data_save_failed">Sync data not saved due to errors</string>
 	<string name="sync_log_failed">Failed to end sync</string>
 
+	<string name="sync_draft_rejected_invalid_name">Rejected draft %1$d from server: unsafe draft name</string>
+	<string name="sync_encyclopedia_image_rejected_invalid_extension">Skipped image for encyclopedia entry %1$d from server: unsafe file extension</string>
+
 	<string name="sync_encyclopedia_deleted">Deleted Encyclopedia ID %1$d from client</string>
 	<string name="sync_note_deleted">Deleted note ID %1$d from client</string>
 	<string name="sync_draft_deleted">Deleted draft %1$d from client</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/BrowseEntriesComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/BrowseEntriesComponent.kt
@@ -172,11 +172,7 @@ class BrowseEntriesComponent(
 	}
 
 	override fun getImagePath(entryDef: EntryDef): String? {
-		return if (encyclopediaService.hasEntryImage(entryDef, "jpg")) {
-			encyclopediaService.getEntryImagePath(entryDef, "jpg").path
-		} else {
-			null
-		}
+		return encyclopediaService.findEntryImagePath(entryDef)?.path
 	}
 
 	override fun clearFilterText() {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
@@ -90,8 +90,10 @@ class ViewEntryComponent(
 
 	private fun reload() {
 		scope.launch {
-			val entryImagePath = getImagePath(state.value.entryDef)
-			val imageHash = encyclopediaService.calculateEntryImageHash(state.value.entryDef, "jpg")
+			val entryDef = state.value.entryDef
+			val entryImagePath = getImagePath(entryDef)
+			val imageHash = encyclopediaService.findEntryImageExtension(entryDef)
+				?.let { ext -> encyclopediaService.calculateEntryImageHash(entryDef, ext) }
 
 			val content = loadEntryContent(state.value.entryDef)
 			withContext(dispatcherMain) {
@@ -107,11 +109,7 @@ class ViewEntryComponent(
 	}
 
 	override fun getImagePath(entryDef: EntryDef): String? {
-		return if (encyclopediaService.hasEntryImage(entryDef, "jpg")) {
-			encyclopediaService.getEntryImagePath(entryDef, "jpg").path
-		} else {
-			null
-		}
+		return encyclopediaService.findEntryImagePath(entryDef)?.path
 	}
 
 	override suspend fun loadEntryContent(entryDef: EntryDef): EntryContent {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectsync/ProjectSynchronizationComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectsync/ProjectSynchronizationComponent.kt
@@ -318,10 +318,11 @@ class ProjectSynchronizationComponent(
 	private suspend fun onEncyclopediaEntryConflict(serverEntity: ApiProjectEntity.EncyclopediaEntryEntity) {
 		val local = encyclopediaService.loadEntry(serverEntity.id).entry
 		val def = local.toDef(projectDef)
-		val image = if (encyclopediaService.hasEntryImage(def, "jpg")) {
-			val imageBytes = encyclopediaService.loadEntryImage(def, "jpg")
+		val imageExtension = encyclopediaService.findEntryImageExtension(def)
+		val image = if (imageExtension != null) {
+			val imageBytes = encyclopediaService.loadEntryImage(def, imageExtension)
 			val imageBase64 = Base64.encode(imageBytes, url = true)
-			ApiProjectEntity.EncyclopediaEntryEntity.Image(imageBase64, "jpg")
+			ApiProjectEntity.EncyclopediaEntryEntity.Image(imageBase64, imageExtension)
 		} else {
 			null
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftsDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftsDatasource.kt
@@ -5,6 +5,7 @@ import com.darkrockstudios.apps.hammer.common.data.SceneContent
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import io.github.aakira.napier.Napier
@@ -91,6 +92,12 @@ class SceneDraftsDatasource(
 	fun insertSyncDraft(draftEntity: ApiProjectEntity.SceneDraftEntity): DraftDef {
 		val draftDef = draftEntity.toDraftDef()
 		val path = getDraftPath(draftDef).toOkioPath()
+
+		val draftsRoot = getSceneDraftsDirectory(draftDef.sceneId).toOkioPath()
+		if (!path.isWithin(draftsRoot)) {
+			error("Refusing to write draft outside its drafts directory: $path")
+		}
+
 		val parentPath = path.parent ?: error("Draft path didn't have parent: $path")
 		fileSystem.createDirectories(parentPath)
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
@@ -9,6 +9,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.InvalidSceneFilename
 import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import io.github.aakira.napier.Napier
@@ -219,6 +220,12 @@ class EncyclopediaDatasource(
 	/** Writes raw image bytes (e.g. an image pulled from the server during sync) to the entry's image path. */
 	suspend fun writeEntryImage(entryDef: EntryDef, imageBytes: ByteArray, fileExtension: String) {
 		val targetPath = getEntryImagePath(entryDef, fileExtension).toOkioPath()
+
+		val typeDir = getTypeDirectory(entryDef.type).toOkioPath()
+		if (!targetPath.isWithin(typeDir)) {
+			error("Refusing to write entry image outside its type directory: $targetPath")
+		}
+
 		fileSystem.write(targetPath) {
 			write(imageBytes)
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
@@ -86,8 +86,25 @@ class EncyclopediaDatasource(
 		return fileSystem.exists(path)
 	}
 
+	fun hasEntryImage(entryDef: EntryDef): Boolean = findEntryImagePath(entryDef) != null
+
+	/** Locates an entry's stored image regardless of its file extension. */
+	fun findEntryImagePath(entryDef: EntryDef): HPath? {
+		val dir = getTypeDirectory(entryDef.type).toOkioPath()
+		val prefix = "${entryDef.type.text}-${entryDef.id}-image."
+		return fileSystem.list(dir)
+			.firstOrNull { path ->
+				path.name.startsWith(prefix) &&
+					path.name.substringAfterLast('.').lowercase() in IMAGE_EXTENSIONS
+			}
+			?.toHPath()
+	}
+
+	fun findEntryImageExtension(entryDef: EntryDef): String? =
+		findEntryImagePath(entryDef)?.name?.substringAfterLast('.')
+
 	suspend fun removeEntryImage(entryDef: EntryDef): Boolean {
-		val imagePath = getEntryImagePath(entryDef, "jpg").toOkioPath()
+		val imagePath = findEntryImagePath(entryDef)?.toOkioPath() ?: return false
 
 		return try {
 			fileSystem.delete(imagePath)
@@ -155,10 +172,11 @@ class EncyclopediaDatasource(
 	suspend fun reIdEntry(oldId: Int, newId: Int) {
 		val oldDef = getEntryDef(oldId)
 		val newDef = oldDef.copy(id = newId)
-		if (hasEntryImage(oldDef, DEFAULT_IMAGE_EXT)) {
-			val oldImagePath = getEntryImagePath(oldDef, DEFAULT_IMAGE_EXT).toOkioPath()
-			val newImagePath = getEntryImagePath(newDef, DEFAULT_IMAGE_EXT).toOkioPath()
-			fileSystem.atomicMove(oldImagePath, newImagePath)
+		val oldImagePath = findEntryImagePath(oldDef)
+		if (oldImagePath != null) {
+			val extension = oldImagePath.name.substringAfterLast('.')
+			val newImagePath = getEntryImagePath(newDef, extension).toOkioPath()
+			fileSystem.atomicMove(oldImagePath.toOkioPath(), newImagePath)
 		}
 
 		val oldPath = getEntryPath(oldDef).toOkioPath()
@@ -206,15 +224,20 @@ class EncyclopediaDatasource(
 	}
 
 	suspend fun setEntryImage(entryDef: EntryDef, imagePath: String?) {
-		val targetPath = getEntryImagePath(entryDef, "jpg").toOkioPath()
+		removeEntryImage(entryDef)
 		if (imagePath != null) {
+			val extension = imageExtensionOf(imagePath)
+			val targetPath = getEntryImagePath(entryDef, extension).toOkioPath()
 			val pixelData = externalFileIo.readExternalFile(imagePath)
 			fileSystem.write(targetPath) {
 				write(pixelData)
 			}
-		} else {
-			fileSystem.delete(targetPath)
 		}
+	}
+
+	private fun imageExtensionOf(sourcePath: String): String {
+		val extension = sourcePath.substringAfterLast('.', "").lowercase()
+		return if (extension in IMAGE_EXTENSIONS) extension else DEFAULT_IMAGE_EXT
 	}
 
 	/** Writes raw image bytes (e.g. an image pulled from the server during sync) to the entry's image path. */
@@ -235,8 +258,9 @@ class EncyclopediaDatasource(
 		val path = getEntryPath(entryDef).toOkioPath()
 		fileSystem.delete(path)
 
-		val imagePath = getEntryImagePath(entryDef, "jpg").toOkioPath()
-		fileSystem.delete(imagePath)
+		findEntryImagePath(entryDef)?.let { imagePath ->
+			fileSystem.delete(imagePath.toOkioPath())
+		}
 
 		return true
 	}
@@ -345,6 +369,11 @@ class EncyclopediaDatasource(
 		}
 
 		const val DEFAULT_IMAGE_EXT = "jpg"
+
+		// Raster formats Coil renders on every target (Android BitmapFactory + desktop/iOS Skia).
+		// Doubles as the allowlist for server-supplied sync image extensions.
+		val IMAGE_EXTENSIONS = setOf("jpg", "jpeg", "png", "webp")
+
 		fun getTypeDirectory(
 			projectDef: ProjectDef,
 			type: EntryType,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
@@ -200,6 +200,12 @@ class EncyclopediaRepository(
 	fun hasEntryImage(entryDef: EntryDef, fileExension: String): Boolean =
 		datasource.hasEntryImage(entryDef, fileExension)
 
+	fun findEntryImagePath(entryDef: EntryDef): HPath? =
+		datasource.findEntryImagePath(entryDef)
+
+	fun findEntryImageExtension(entryDef: EntryDef): String? =
+		datasource.findEntryImageExtension(entryDef)
+
 	suspend fun calculateEntryImageHash(entryDef: EntryDef, fileExension: String): String? {
 		return datasource.hashEntryImage(entryDef, fileExension)
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaService.kt
@@ -83,6 +83,12 @@ class EncyclopediaService(
 	fun hasEntryImage(entryDef: EntryDef, fileExtension: String): Boolean =
 		repository.hasEntryImage(entryDef, fileExtension)
 
+	fun findEntryImagePath(entryDef: EntryDef): HPath? =
+		repository.findEntryImagePath(entryDef)
+
+	fun findEntryImageExtension(entryDef: EntryDef): String? =
+		repository.findEntryImageExtension(entryDef)
+
 	suspend fun calculateEntryImageHash(entryDef: EntryDef, fileExtension: String): String? =
 		repository.calculateEntryImageHash(entryDef, fileExtension)
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/AuthTokenStore.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/AuthTokenStore.kt
@@ -1,0 +1,29 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Auth tokens for a single account. Both fields are nullable: an account can be
+ * configured before a session exists.
+ */
+@Serializable
+data class AuthTokens(
+	val bearerToken: String?,
+	val refreshToken: String?,
+)
+
+/**
+ * Per-machine storage for sync auth tokens, keyed by account (server url + userId).
+ *
+ * Tokens live here, in app-private storage, rather than in the per-workspace
+ * `server.json`, so they do not travel when a workspace folder is moved or shared.
+ */
+interface AuthTokenStore {
+	fun get(url: String, userId: Long): AuthTokens?
+	fun put(url: String, userId: Long, tokens: AuthTokens)
+	fun remove(url: String, userId: Long)
+
+	companion object {
+		fun accountKey(url: String, userId: Long): String = "$url|$userId"
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/FileAuthTokenStore.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/FileAuthTokenStore.kt
@@ -1,0 +1,59 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import com.darkrockstudios.apps.hammer.base.http.readJsonOrNull
+import com.darkrockstudios.apps.hammer.base.http.writeJson
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore.Companion.accountKey
+import com.darkrockstudios.apps.hammer.common.getConfigDirectory
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Plaintext JSON-backed [AuthTokenStore] living in the app-private config directory.
+ *
+ * The whole account-keyed map is persisted to a single file. A missing or corrupt
+ * file is tolerated by starting from an empty map.
+ *
+ * The [AuthTokenStore] seam lets an encrypted backing be substituted without
+ * touching its callers.
+ */
+class FileAuthTokenStore(
+	private val fileSystem: FileSystem,
+	private val json: Json,
+) : AuthTokenStore {
+
+	private val lock = reentrantLock()
+
+	override fun get(url: String, userId: Long): AuthTokens? = lock.withLock {
+		load()[accountKey(url, userId)]
+	}
+
+	override fun put(url: String, userId: Long, tokens: AuthTokens): Unit = lock.withLock {
+		val updated = load().toMutableMap()
+		updated[accountKey(url, userId)] = tokens
+		store(updated)
+	}
+
+	override fun remove(url: String, userId: Long): Unit = lock.withLock {
+		val updated = load().toMutableMap()
+		if (updated.remove(accountKey(url, userId)) != null) {
+			store(updated)
+		}
+	}
+
+	private fun load(): Map<String, AuthTokens> {
+		return fileSystem.readJsonOrNull<Map<String, AuthTokens>>(FILE_PATH, json) ?: emptyMap()
+	}
+
+	private fun store(tokens: Map<String, AuthTokens>) {
+		fileSystem.createDirectories(FILE_PATH.parent!!)
+		fileSystem.writeJson(FILE_PATH, json, tokens)
+	}
+
+	companion object {
+		private const val FILE_NAME = "auth_tokens.json"
+		val FILE_PATH = getConfigDirectory().toPath() / FILE_NAME
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/PersistedServerSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/PersistedServerSettings.kt
@@ -1,0 +1,35 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import kotlinx.serialization.Serializable
+import net.peanuuutz.tomlkt.TomlLiteralString
+
+/**
+ * Tokenless persisted form of [ServerSettings] written to the per-workspace
+ * `server.json`. The secret token fields live in [AuthTokenStore] instead.
+ */
+@Serializable
+data class PersistedServerSettings(
+	val ssl: Boolean,
+	@TomlLiteralString
+	val url: String,
+	@TomlLiteralString
+	val email: String,
+	val userId: Long,
+)
+
+fun ServerSettings.toPersisted(): PersistedServerSettings = PersistedServerSettings(
+	ssl = ssl,
+	url = url,
+	email = email,
+	userId = userId,
+)
+
+fun PersistedServerSettings.toServerSettings(tokens: AuthTokens?): ServerSettings = ServerSettings(
+	ssl = ssl,
+	url = url,
+	email = email,
+	userId = userId,
+	bearerToken = tokens?.bearerToken,
+	refreshToken = tokens?.refreshToken,
+)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/ServerSettingsFilesystemDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/ServerSettingsFilesystemDatasource.kt
@@ -4,14 +4,20 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import com.darkrockstudios.apps.hammer.base.http.readJsonOrNull
+import com.darkrockstudios.apps.hammer.base.http.writeJson
 import io.github.aakira.napier.Napier
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
 
 class ServerSettingsFilesystemDatasource(
 	private val fileSystem: FileSystem,
 	private val json: Json,
+	private val authTokenStore: AuthTokenStore,
 ) : ServerSettingsDatasource {
 
 	override fun serverIsSetup(projectsDir: HPath): Boolean {
@@ -22,36 +28,82 @@ class ServerSettingsFilesystemDatasource(
 		val path = getServerSettingsPath(projectsDir).toOkioPath()
 		Napier.i { "Loading Server Settings from: $path" }
 
-		return if (fileSystem.exists(path)) {
-			val settingsText: String = fileSystem.read(path) {
-				readUtf8()
-			}
+		if (!fileSystem.exists(path)) return null
 
-			try {
-				json.decodeFromString(settingsText)
-			} catch (e: SerializationException) {
-				Napier.e("Failed to load Server Settings, removing invalid file.", e)
-				fileSystem.delete(path)
-				null
-			}
-		} else {
-			null
+		val settingsText: String = fileSystem.read(path) { readUtf8() }
+
+		val persisted: PersistedServerSettings = try {
+			json.decodeFromString(settingsText)
+		} catch (e: SerializationException) {
+			Napier.e("Failed to load Server Settings, removing invalid file.", e)
+			fileSystem.delete(path)
+			return null
 		}
+
+		val migratedTokens = migrateInlineTokens(settingsText, persisted, projectsDir)
+		val tokens = migratedTokens ?: authTokenStore.get(persisted.url, persisted.userId)
+
+		return persisted.toServerSettings(tokens)
 	}
 
 	override fun storeServerSettings(settings: ServerSettings, projectsDir: HPath) {
-		val settingsText = json.encodeToString(settings)
-
 		val path = getServerSettingsPath(projectsDir).toOkioPath()
 		fileSystem.createDirectories(path.parent!!)
-		fileSystem.write(path, false) {
-			writeUtf8(settingsText)
-		}
+		fileSystem.writeJson(path, json, settings.toPersisted())
+
+		authTokenStore.put(
+			settings.url,
+			settings.userId,
+			AuthTokens(settings.bearerToken, settings.refreshToken),
+		)
 	}
 
 	override fun removeServerSettings(projectsDir: HPath) {
 		val path = getServerSettingsPath(projectsDir).toOkioPath()
+
+		val account = fileSystem.readJsonOrNull<PersistedServerSettings>(path, json)
+
 		fileSystem.delete(path)
+		account?.let { authTokenStore.remove(it.url, it.userId) }
+	}
+
+	/**
+	 * Moves inline tokens from a legacy `server.json` into the token store and
+	 * rewrites the file tokenless, so the plaintext secrets no longer live in the
+	 * workspace. Returns the extracted tokens, or null when there were none.
+	 *
+	 * On a token-store write failure the extracted tokens are still returned so the
+	 * in-memory session is never dropped.
+	 */
+	private fun migrateInlineTokens(
+		settingsText: String,
+		persisted: PersistedServerSettings,
+		projectsDir: HPath,
+	): AuthTokens? {
+		val inline = readInlineTokens(settingsText) ?: return null
+
+		val migrated = runCatching {
+			authTokenStore.put(persisted.url, persisted.userId, inline)
+			val path = getServerSettingsPath(projectsDir).toOkioPath()
+			fileSystem.writeJson(path, json, persisted)
+		}
+
+		if (migrated.isFailure) {
+			Napier.e("Failed to migrate inline auth tokens; keeping in-memory session.", migrated.exceptionOrNull())
+		}
+
+		return inline
+	}
+
+	private fun readInlineTokens(settingsText: String): AuthTokens? {
+		val obj = runCatching { json.parseToJsonElement(settingsText).jsonObject }.getOrNull() ?: return null
+		val bearer = obj["bearerToken"]?.jsonPrimitive?.contentOrNull
+		val refresh = obj["refreshToken"]?.jsonPrimitive?.contentOrNull
+		return if (bearer != null || refresh != null) {
+			AuthTokens(bearer, refresh)
+		} else {
+			null
+		}
 	}
 
 	private fun getServerSettingsPath(projectsDir: HPath): HPath {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -1,0 +1,10 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import org.koin.core.module.Module
+
+/**
+ * Provides the platform's [AuthTokenStore] binding. Each platform supplies an
+ * encrypted implementation where one exists; iOS currently falls back to the
+ * plaintext file store pending a Keychain-backed implementation.
+ */
+expect val authTokenStoreModule: Module

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesDatasource.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data.notesrepository
 
+import com.darkrockstudios.apps.hammer.base.http.readTomlOrNull
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContainer
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
@@ -8,6 +9,7 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispat
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -31,9 +33,14 @@ class NotesDatasource(
 		val files = fileSystem.listRecursively(dir)
 		val noteFiles = files.filterNotePathsOkio()
 
-		val notes = noteFiles.map { path -> loadNote(path) }.toList()
+		val notes = noteFiles.mapNotNull { path -> loadNoteOrNull(path) }.toList()
 		return@withContext notes
 	}
+
+	private fun loadNoteOrNull(path: Path): NoteContainer? =
+		fileSystem.readTomlOrNull<NoteContainer>(path, toml) { e ->
+			Napier.e("Skipping malformed note file: ${path.toHPath().path}", e)
+		}
 
 	private fun loadNote(path: Path): NoteContainer {
 		val noteToml = fileSystem.read(path) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsCachePaths.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsCachePaths.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.projectstatistics
 
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.getCacheDirectory
 import okio.Path
 import okio.Path.Companion.toPath
@@ -9,8 +10,10 @@ internal object StatisticsCachePaths {
 	const val PROJECTS_DIRECTORY = "projects"
 	const val FILENAME = "stats.toml"
 
+	fun projectsCacheRoot(): Path = getCacheDirectory().toPath() / PROJECTS_DIRECTORY
+
 	fun projectCacheDirectory(projectDef: ProjectDef): Path =
-		getCacheDirectory().toPath() / PROJECTS_DIRECTORY / projectDef.name
+		projectsCacheRoot() / ProjectsRepository.encodeForFilename(projectDef.name)
 
 	fun statsFile(projectDef: ProjectDef): Path =
 		projectCacheDirectory(projectDef) / FILENAME

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsDatasource.kt
@@ -6,6 +6,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispatcher
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.withContext
 import net.peanuuutz.tomlkt.Toml
@@ -34,6 +35,7 @@ class StatisticsDatasource(
 	suspend fun saveStatistics(stats: ProjectStatistics) = withContext(dispatcherIo) {
 		ensureCacheDirectoryExists()
 		val file = StatisticsCachePaths.statsFile(projectDef)
+		requireWithinCacheRoot(file)
 		fileSystem.writeToml(file, toml, stats)
 		Napier.d("Statistics saved to cache")
 	}
@@ -44,6 +46,7 @@ class StatisticsDatasource(
 
 	suspend fun delete() = withContext(dispatcherIo) {
 		val file = StatisticsCachePaths.statsFile(projectDef)
+		requireWithinCacheRoot(file)
 		if (fileSystem.exists(file)) {
 			fileSystem.delete(file)
 			Napier.d("Statistics cache deleted")
@@ -52,8 +55,16 @@ class StatisticsDatasource(
 
 	private fun ensureCacheDirectoryExists() {
 		val cacheDir = StatisticsCachePaths.projectCacheDirectory(projectDef)
+		requireWithinCacheRoot(cacheDir)
 		if (!fileSystem.exists(cacheDir)) {
 			fileSystem.createDirectories(cacheDir)
+		}
+	}
+
+	private fun requireWithinCacheRoot(path: okio.Path) {
+		val cacheRoot = StatisticsCachePaths.projectsCacheRoot()
+		if (!path.isWithin(cacheRoot)) {
+			error("Refusing to access statistics cache outside the cache root: $path")
 		}
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/ReferenceIndexDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/ReferenceIndexDatasource.kt
@@ -4,8 +4,10 @@ import com.darkrockstudios.apps.hammer.base.http.readTomlOrNull
 import com.darkrockstudios.apps.hammer.base.http.writeToml
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispatcher
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.getCacheDirectory
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.withContext
@@ -37,6 +39,7 @@ class ReferenceIndexDatasource(
 	suspend fun saveIndex(index: ReferenceIndex) = withContext(dispatcherIo) {
 		ensureCacheDirectoryExists()
 		val file = getIndexPath()
+		requireWithinCacheRoot(file)
 		fileSystem.writeToml(file, toml, index)
 		Napier.d("Reference index saved to cache")
 	}
@@ -45,22 +48,31 @@ class ReferenceIndexDatasource(
 
 	suspend fun delete() = withContext(dispatcherIo) {
 		val file = getIndexPath()
+		requireWithinCacheRoot(file)
 		if (fileSystem.exists(file)) {
 			fileSystem.delete(file)
 			Napier.d("Reference index cache deleted")
 		}
 	}
 
-	private fun getProjectCacheDirectory(): Path {
-		return getCacheDirectory().toPath() / PROJECTS_DIRECTORY / projectDef.name
-	}
+	private fun getProjectsCacheRoot(): Path = getCacheDirectory().toPath() / PROJECTS_DIRECTORY
+
+	private fun getProjectCacheDirectory(): Path =
+		getProjectsCacheRoot() / ProjectsRepository.encodeForFilename(projectDef.name)
 
 	private fun getIndexPath(): Path = getProjectCacheDirectory() / FILENAME
 
 	private fun ensureCacheDirectoryExists() {
 		val cacheDir = getProjectCacheDirectory()
+		requireWithinCacheRoot(cacheDir)
 		if (!fileSystem.exists(cacheDir)) {
 			fileSystem.createDirectories(cacheDir)
+		}
+	}
+
+	private fun requireWithinCacheRoot(path: Path) {
+		if (!path.isWithin(getProjectsCacheRoot())) {
+			error("Refusing to access reference index cache outside the cache root: $path")
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
@@ -229,6 +229,25 @@ class EntityTransferOperation(
 
 		return if (entityResponse.isSuccess) {
 			val serverEntity = entityResponse.getOrThrow().entity
+
+			// The server is asked for a specific id but the response carries its own id and
+			// type. Never trust either: a hostile server could forge a different entity over
+			// the requested one and cement the forgery as the conflict baseline. Reject any
+			// id mismatch outright, and any type mismatch when the client already owns the id.
+			val localType = entitySynchronizers.findEntityType(id)
+			val serverType = serverEntity.type.toEntityType()
+			if (serverEntity.id != id || (localType != null && localType != serverType)) {
+				onLog(
+					syncLogE(
+						strRes.get(Res.string.sync_log_entity_download_rejected_mismatch, id),
+						projectDef
+					)
+				)
+				return CResult.failure(
+					IllegalStateException("Server returned mismatched entity for requested id $id")
+				)
+			}
+
 			val success = when (serverEntity) {
 				is ApiProjectEntity.SceneEntity ->
 					entitySynchronizers.sceneSynchronizer.storeEntity(
@@ -269,7 +288,7 @@ class EntityTransferOperation(
 			if (success) {
 				// Lock the downloaded entity's hash in as the conflict baseline: it's exactly
 				// what the server holds, so a later local edit won't forge a phantom conflict.
-				syncJournal.recordSyncedHash(serverEntity.id, serverEntity.hash())
+				syncJournal.recordSyncedHash(id, serverEntity.hash())
 				onLog(
 					syncLogI(
 						strRes.get(Res.string.sync_log_entity_download_success, id),

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
@@ -76,14 +76,14 @@ class ClientEncyclopediaSynchronizer(
 		val entry = encyclopediaRepository.loadEntry(id).entry
 		val def = entry.toDef(projectDef)
 
-		val DEFAULT_EXTENSION = "jpg"
-		val image = if (encyclopediaDatasource.hasEntryImage(def, DEFAULT_EXTENSION)) {
-			val imageBytes = encyclopediaDatasource.loadEntryImage(def, DEFAULT_EXTENSION)
+		val imageExtension = encyclopediaDatasource.findEntryImageExtension(def)
+		val image = if (imageExtension != null) {
+			val imageBytes = encyclopediaDatasource.loadEntryImage(def, imageExtension)
 			val imageBase64 = Base64.encode(imageBytes, url = true)
 
 			ApiProjectEntity.EncyclopediaEntryEntity.Image(
 				base64 = imageBase64,
-				fileExtension = DEFAULT_EXTENSION,
+				fileExtension = imageExtension,
 			)
 		} else {
 			null
@@ -185,8 +185,10 @@ class ClientEncyclopediaSynchronizer(
 				return
 			}
 			val imageBytes = Base64.decode(image.base64, url = true)
+			// Clear any prior image first so a changed extension can't leave an orphan file.
+			encyclopediaDatasource.removeEntryImage(serverDef)
 			encyclopediaDatasource.writeEntryImage(serverDef, imageBytes, image.fileExtension)
-		} else if (oldDef != null && encyclopediaDatasource.hasEntryImage(oldDef, "jpg")) {
+		} else if (oldDef != null && encyclopediaDatasource.hasEntryImage(oldDef)) {
 			// Server reports no image; drop the local one. Raw datasource delete (no
 			// sync-marking) since we're applying server state, not making a local edit.
 			encyclopediaDatasource.removeEntryImage(oldDef)
@@ -194,8 +196,6 @@ class ClientEncyclopediaSynchronizer(
 	}
 
 	companion object {
-		val ALLOWED_IMAGE_EXTENSIONS = setOf(
-			"jpg", "jpeg", "png", "gif", "webp", "bmp", "heic", "heif",
-		)
+		val ALLOWED_IMAGE_EXTENSIONS = EncyclopediaDatasource.IMAGE_EXTENSIONS
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
@@ -18,10 +18,13 @@ import com.darkrockstudios.apps.hammer.common.data.references.ReferenceRemapper
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogI
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogW
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.sync_encyclopedia_deleted
+import com.darkrockstudios.apps.hammer.sync_encyclopedia_image_rejected_invalid_extension
+import io.github.aakira.napier.Napier
 import korlibs.crypto.encoding.Base64
 import kotlinx.coroutines.flow.first
 
@@ -138,7 +141,7 @@ class ClientEncyclopediaSynchronizer(
 			type = EntryType.fromString(serverEntity.entryType),
 		)
 
-		handleImage(oldDef, serverDef, serverEntity)
+		handleImage(oldDef, serverDef, serverEntity, onLog)
 
 		if (oldDef != null) {
 			encyclopediaService.updateEntry(
@@ -166,10 +169,21 @@ class ClientEncyclopediaSynchronizer(
 	private suspend fun handleImage(
 		oldDef: EntryDef?,
 		serverDef: EntryDef,
-		serverEntity: ApiProjectEntity.EncyclopediaEntryEntity
+		serverEntity: ApiProjectEntity.EncyclopediaEntryEntity,
+		onLog: OnSyncLog,
 	) {
 		val image = serverEntity.image
 		if (image != null) {
+			if (image.fileExtension.lowercase() !in ALLOWED_IMAGE_EXTENSIONS) {
+				Napier.w("Skipped synced image for entry ${serverEntity.id}: invalid file extension '${image.fileExtension}'")
+				onLog(
+					syncLogW(
+						strRes.get(Res.string.sync_encyclopedia_image_rejected_invalid_extension, serverEntity.id),
+						projectDef
+					)
+				)
+				return
+			}
 			val imageBytes = Base64.decode(image.base64, url = true)
 			encyclopediaDatasource.writeEntryImage(serverDef, imageBytes, image.fileExtension)
 		} else if (oldDef != null && encyclopediaDatasource.hasEntryImage(oldDef, "jpg")) {
@@ -177,5 +191,11 @@ class ClientEncyclopediaSynchronizer(
 			// sync-marking) since we're applying server state, not making a local edit.
 			encyclopediaDatasource.removeEntryImage(oldDef)
 		}
+	}
+
+	companion object {
+		val ALLOWED_IMAGE_EXTENSIONS = setOf(
+			"jpg", "jpeg", "png", "gif", "webp", "bmp", "heic", "heif",
+		)
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientSceneDraftSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientSceneDraftSynchronizer.kt
@@ -8,15 +8,18 @@ import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectInject
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogI
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogW
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.sync_draft_deleted
+import com.darkrockstudios.apps.hammer.sync_draft_rejected_invalid_name
 import io.github.aakira.napier.Napier
 
 class ClientSceneDraftSynchronizer(
@@ -90,6 +93,17 @@ class ClientSceneDraftSynchronizer(
 		syncId: String,
 		onLog: OnSyncLog
 	): Boolean {
+		if (!SceneDraftsDatasource.validDraftName(serverEntity.name)) {
+			Napier.w("Rejected synced draft ${serverEntity.id}: invalid draft name")
+			onLog(
+				syncLogW(
+					strRes.get(Res.string.sync_draft_rejected_invalid_name, serverEntity.id),
+					projectDef
+				)
+			)
+			return false
+		}
+
 		sceneDraftRepository.insertSyncDraft(serverEntity)
 		return true
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineDatasource.kt
@@ -6,6 +6,7 @@ import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import net.peanuuutz.tomlkt.Toml
@@ -56,7 +57,7 @@ class TimeLineDatasource(
 			return (getTimelineDir(projectDef).toOkioPath() / TIMELINE_FILENAME).toHPath()
 		}
 
-		@Suppress("SwallowedException") // Missing file means an empty timeline
+		@Suppress("SwallowedException") // Missing or corrupt file means an empty timeline
 		fun loadTimeline(hpath: HPath, fileSystem: FileSystem, toml: Toml): TimeLineContainer {
 			val path = hpath.toOkioPath()
 			return if (fileSystem.exists(path)) {
@@ -70,9 +71,13 @@ class TimeLineDatasource(
 						}
 					}
 				} catch (e: FileNotFoundException) {
-					TimeLineContainer(
-						events = emptyList()
-					)
+					TimeLineContainer(emptyList())
+				} catch (e: SerializationException) {
+					TimeLineContainer(emptyList())
+				} catch (e: IllegalArgumentException) {
+					TimeLineContainer(emptyList())
+				} catch (e: IllegalStateException) {
+					TimeLineContainer(emptyList())
 				}
 			} else {
 				TimeLineContainer(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
@@ -152,7 +152,24 @@ fun HttpRequestBuilder.url(serverSettings: ServerSettings, path: String) {
 		if (serverPort != null) {
 			port = serverPort
 		}
-		pathSegments = path.split("/")
+		encodedPath = path
+	}
+}
+
+/**
+ * Encodes a dynamic value (e.g. a project name) so it can be safely interpolated into a request
+ * path as a single opaque segment. Without this, a value containing `/` would split into extra
+ * path segments and a `..` value would act as a traversal dot-segment, letting a value reach a
+ * different endpoint than the one the template intended.
+ */
+fun String.encodeUrlPathSegment(): String {
+	val encoded = encodeURLPathPart()
+	// `encodeURLPathPart` leaves dots untouched, so a segment of only dots would still be a
+	// traversal dot-segment. Percent-encode them so the value stays a single inert segment.
+	return if (encoded.isNotEmpty() && encoded.all { it == '.' }) {
+		encoded.replace(".", "%2E")
+	} else {
+		encoded
 	}
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -14,6 +14,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.exampleProjectModule
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsFilesystemDatasource
@@ -55,6 +56,9 @@ import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivi
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityRepository
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
 import com.darkrockstudios.apps.hammer.common.fileio.externalFileIoModule
+import com.darkrockstudios.apps.hammer.common.fileio.okio.ContainedFileSystem
+import com.darkrockstudios.apps.hammer.common.getCacheDirectory
+import com.darkrockstudios.apps.hammer.common.getConfigDirectory
 import com.darkrockstudios.apps.hammer.common.getPlatformFilesystem
 import com.darkrockstudios.apps.hammer.common.platformDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.platformIoDispatcher
@@ -66,6 +70,8 @@ import io.ktor.client.*
 import kotlinx.serialization.json.Json
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.scopedOf
 import org.koin.core.module.dsl.singleOf
@@ -77,6 +83,13 @@ import kotlin.time.Clock
 const val DISPATCHER_MAIN = "main-dispatcher"
 const val DISPATCHER_DEFAULT = "default-dispatcher"
 const val DISPATCHER_IO = "io-dispatcher"
+
+/**
+ * Qualifier for the unguarded platform [FileSystem]. Only consumers that
+ * legitimately write outside the app's managed storage (user-chosen export
+ * targets) should request this; everything else uses the default guarded binding.
+ */
+const val RAW_FILESYSTEM = "raw-filesystem"
 
 /**
  * This is the main module containing most of the DI objects
@@ -115,7 +128,19 @@ val mainModule = module {
 	factory { AccountUseCase(get(), get(), get(), get()) }
 	factoryOf(::AccountReauthUseCase)
 
-	singleOf(::getPlatformFilesystem) bind FileSystem::class
+	// Raw, unguarded platform filesystem for user-chosen external write targets.
+	single(named(RAW_FILESYSTEM)) { getPlatformFilesystem() } bind FileSystem::class
+
+	// Guarded filesystem: every datasource write is checked against the app's
+	// managed storage roots. allowedRoots is re-evaluated per check because the
+	// projects directory is user-relocatable at runtime. The projects-dir lookup
+	// is best-effort to avoid a construction-time cycle (the settings store and
+	// its datasource write to the config root before they are fully built, and
+	// those config-root writes don't need the projects dir).
+	single<FileSystem> {
+		val koin = getKoin()
+		ContainedFileSystem(getPlatformFilesystem()) { managedStorageRoots(koin) }
+	}
 
 	singleOf(::ProjectsRepository)
 
@@ -147,7 +172,16 @@ val mainModule = module {
 		scopedOf(::SceneRepository)
 		scopedOf(::SceneEditorService)
 		scopedOf(::ImportStoryUseCase)
-		scopedOf(::ExportStoryUseCase)
+		// Export writes to a user-chosen path outside the app's managed storage, so it
+		// must use the raw, unguarded filesystem.
+		scoped {
+			ExportStoryUseCase(
+				sceneEditorRepository = get(),
+				projectDataDatasource = get(),
+				fileSystem = get(named(RAW_FILESYSTEM)),
+				localeResolver = get(),
+			)
+		}
 		scopedOf(::SceneDraftsDatasource)
 		scopedOf(::SceneDraftRepository)
 		scopedOf(::SceneMetadataDatasource)
@@ -222,4 +256,31 @@ val mainModule = module {
 
 		scopedOf(::EntitySynchronizers)
 	}
+}
+
+/**
+ * The app's managed storage roots: the cache and config directories plus the
+ * current projects directory. Writes outside these are rejected by
+ * [ContainedFileSystem].
+ *
+ * The projects directory is resolved per call (it is user-relocatable) and
+ * cycle-safe: the fully built [GlobalSettingsStore] is preferred, but during its
+ * own construction the store isn't resolvable yet, so we fall back to reading the
+ * persisted settings via the already-built [GlobalSettingsDatasource], then to the
+ * default location. The datasource read is unguarded (reads bypass the guard), so
+ * it can't recurse into this function.
+ */
+internal fun managedStorageRoots(koin: org.koin.core.Koin): List<Path> {
+	val cacheRoot = getCacheDirectory().toPath()
+	val configRoot = getConfigDirectory().toPath()
+
+	val projectsRoot = runCatching {
+		koin.get<GlobalSettingsStore>().globalSettings.projectsDirectory.toPath()
+	}.recoverCatching {
+		koin.get<GlobalSettingsDatasource>().loadSettings().projectsDirectory.toPath()
+	}.getOrElse {
+		GlobalSettingsStore.defaultProjectDir()
+	}
+
+	return listOf(cacheRoot, configRoot, projectsRoot)
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -14,9 +14,8 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.exampleProjectModule
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.FileAuthTokenStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.authTokenStoreModule
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsFilesystemDatasource
@@ -98,6 +97,7 @@ const val RAW_FILESYSTEM = "raw-filesystem"
  */
 val mainModule = module {
 	includes(externalFileIoModule)
+	includes(authTokenStoreModule)
 	includes(exampleProjectModule)
 
 	single(named(DISPATCHER_MAIN)) { platformMainDispatcher }
@@ -119,7 +119,6 @@ val mainModule = module {
 	singleOf(::ProjectDataApi)
 	singleOf(::ServerAdminApi)
 
-	singleOf(::FileAuthTokenStore) bind AuthTokenStore::class
 	singleOf(::ServerSettingsFilesystemDatasource) bind ServerSettingsDatasource::class
 	singleOf(::GlobalSettingsFilesystemDatasource)
 	singleOf(::GlobalSettingsStore) bind GlobalSettingsStore::class

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -14,6 +14,8 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.exampleProjectModule
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.FileAuthTokenStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
@@ -117,6 +119,7 @@ val mainModule = module {
 	singleOf(::ProjectDataApi)
 	singleOf(::ServerAdminApi)
 
+	singleOf(::FileAuthTokenStore) bind AuthTokenStore::class
 	singleOf(::ServerSettingsFilesystemDatasource) bind ServerSettingsDatasource::class
 	singleOf(::GlobalSettingsFilesystemDatasource)
 	singleOf(::GlobalSettingsStore) bind GlobalSettingsStore::class

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/ContainedFileSystem.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/ContainedFileSystem.kt
@@ -1,0 +1,94 @@
+package com.darkrockstudios.apps.hammer.common.fileio.okio
+
+import okio.FileHandle
+import okio.FileSystem
+import okio.ForwardingFileSystem
+import okio.Path
+import okio.Sink
+
+/**
+ * Fail-closed containment guard for filesystem mutations. Every write, append,
+ * move, delete, or directory creation routed through this filesystem must land
+ * within one of [allowedRoots]; anything else throws.
+ *
+ * Reads, listings, and metadata are deliberately not guarded — they are not the
+ * traversal hazard and gating them would break legitimate inspection of paths
+ * outside the managed roots.
+ *
+ * [allowedRoots] is a lambda re-evaluated on every check: the projects directory
+ * is user-relocatable at runtime (external-storage toggle, dev mode, app-store
+ * sandbox), so a snapshot taken at construction time would go stale.
+ *
+ * External, user-chosen write targets (e.g. exporting a story to a folder the
+ * user picked) must bypass this guard by using the raw platform filesystem
+ * directly, not this decorator.
+ */
+class ContainedFileSystem(
+	delegate: FileSystem,
+	private val allowedRoots: () -> List<Path>,
+) : ForwardingFileSystem(delegate) {
+
+	override fun sink(file: Path, mustCreate: Boolean): Sink {
+		requireContained(file, "sink")
+		return super.sink(file, mustCreate)
+	}
+
+	override fun appendingSink(file: Path, mustExist: Boolean): Sink {
+		requireContained(file, "appendingSink")
+		return super.appendingSink(file, mustExist)
+	}
+
+	override fun atomicMove(source: Path, target: Path) {
+		requireContained(source, "atomicMove(source)")
+		requireContained(target, "atomicMove(target)")
+		super.atomicMove(source, target)
+	}
+
+	override fun delete(path: Path, mustExist: Boolean) {
+		requireContained(path, "delete")
+		super.delete(path, mustExist)
+	}
+
+	override fun createDirectory(dir: Path, mustCreate: Boolean) {
+		requireDirectoryAllowed(dir)
+		super.createDirectory(dir, mustCreate)
+	}
+
+	override fun createSymlink(source: Path, target: Path) {
+		requireContained(source, "createSymlink")
+		super.createSymlink(source, target)
+	}
+
+	override fun openReadWrite(file: Path, mustCreate: Boolean, mustExist: Boolean): FileHandle {
+		requireContained(file, "openReadWrite")
+		return super.openReadWrite(file, mustCreate, mustExist)
+	}
+
+	private fun requireContained(path: Path, operation: String) {
+		val roots = allowedRoots()
+		if (roots.none { path.isWithin(it) }) {
+			throw ContainmentViolationException(
+				"Refusing to $operation outside the app's managed storage: $path"
+			)
+		}
+	}
+
+	/**
+	 * `createDirectories` materializes a root's missing ancestors one [createDirectory]
+	 * at a time. Creating an ancestor of a root (e.g. the parent of the cache dir on
+	 * first run) is legitimate scaffolding, so allow a directory that contains a root
+	 * as well as one nested within a root. A sibling escape (neither within nor an
+	 * ancestor of any root) is still blocked.
+	 */
+	private fun requireDirectoryAllowed(dir: Path) {
+		val roots = allowedRoots()
+		val allowed = roots.any { root -> dir.isWithin(root) || root.isWithin(dir) }
+		if (!allowed) {
+			throw ContainmentViolationException(
+				"Refusing to create a directory outside the app's managed storage: $dir"
+			)
+		}
+	}
+}
+
+class ContainmentViolationException(message: String) : okio.IOException(message)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/PathContainment.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/PathContainment.kt
@@ -1,0 +1,23 @@
+package com.darkrockstudios.apps.hammer.common.fileio.okio
+
+import okio.Path
+
+/**
+ * Containment backstop against path traversal. Returns true only when this path,
+ * once `..`/`.` segments are collapsed, equals [root] or sits nested beneath it.
+ * A non-descendant (sibling escape, absolute reach-out, `..` climb) returns false.
+ */
+fun Path.isWithin(root: Path): Boolean {
+	val normalizedRoot = root.normalized()
+	val normalizedCandidate = normalized()
+
+	if (normalizedCandidate.isAbsolute != normalizedRoot.isAbsolute) return false
+
+	if (normalizedCandidate == normalizedRoot) return true
+
+	val rootSegments = normalizedRoot.segments
+	val candidateSegments = normalizedCandidate.segments
+	if (candidateSegments.size <= rootSegments.size) return false
+
+	return candidateSegments.subList(0, rootSegments.size) == rootSegments
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ProjectDataApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ProjectDataApi.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataDto
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataUploadRequest
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataConflictException
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -27,7 +28,7 @@ class ProjectDataApi(
 		projectName: String,
 		projectId: ProjectId,
 	): Result<ProjectDataDto?> = get(
-		path = "/api/project/$userId/$projectName/project_data",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/project_data",
 		parse = { response ->
 			if (response.status == HttpStatusCode.NoContent) null
 			else response.body<ProjectDataDto>()
@@ -46,7 +47,7 @@ class ProjectDataApi(
 		data: ProjectData,
 		originalHash: String?,
 	): Result<ProjectDataDto> = post(
-		path = "/api/project/$userId/$projectName/project_data",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/project_data",
 		parse = { it.body<ProjectDataDto>() },
 		failureHandler = { response ->
 			if (response.status == HttpStatusCode.Conflict) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectApi.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.*
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityConflictException
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -37,7 +38,7 @@ class ServerProjectApi(
 		}
 
 		return post(
-			path = "/api/project/$userId/$projectName/begin_sync",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/begin_sync",
 			parse = { it.body() }
 		) {
 			url {
@@ -61,7 +62,7 @@ class ServerProjectApi(
 		syncEnd: Instant?,
 	): Result<String> {
 		return post(
-			path = "/api/project/$userId/$projectName/end_sync",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/end_sync",
 			parse = { it.body() },
 			builder = {
 				headers {
@@ -91,7 +92,7 @@ class ServerProjectApi(
 		force: Boolean = false
 	): Result<SaveEntityResponse> {
 		return post(
-			path = "/api/project/$userId/$projectName/upload_entity/${entity.id}",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/upload_entity/${entity.id}",
 			parse = { it.body() },
 			builder = {
 				contentType(ContentType.Application.Json)
@@ -163,7 +164,7 @@ class ServerProjectApi(
 		syncId: String
 	): Result<LoadEntityResponse> {
 		return get(
-			path = "/api/project/$userId/$projectName/download_entity/$entityId",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/download_entity/$entityId",
 			parse = { response ->
 				if (response.status == HttpStatusCode.NotModified) {
 					throw EntityNotModifiedException(entityId)
@@ -216,7 +217,7 @@ class ServerProjectApi(
 		syncId: String
 	): Result<DeleteIdsResponse> {
 		return get(
-			path = "/api/project/$userId/$projectName/delete_entity/$id",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/delete_entity/$id",
 			parse = { it.body() },
 			builder = {
 				headers {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
 import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeRequest
 import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeResponse
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -85,7 +86,7 @@ class ServerProjectsApi(
 		syncId: String,
 	): Result<CreateProjectResponse> {
 		return get(
-			path = "/api/projects/$userId/$projectName/create",
+			path = "/api/projects/$userId/${projectName.encodeUrlPathSegment()}/create",
 			builder = {
 				headers {
 					append(HEADER_SYNC_ID, syncId)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/WritingActivityApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/WritingActivityApi.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingActivityResponse
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -28,7 +29,7 @@ class WritingActivityApi(
 		projectName: String,
 		projectId: ProjectId,
 	): Result<WritingActivityResponse> = get(
-		path = "/api/project/$userId/$projectName/writing_activity",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/writing_activity",
 		parse = { it.body() },
 	) {
 		url {
@@ -44,7 +45,7 @@ class WritingActivityApi(
 		deviceId: String,
 		log: DeviceLog,
 	): Result<String> = post(
-		path = "/api/project/$userId/$projectName/writing_activity/$deviceId",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/writing_activity/${deviceId.encodeUrlPathSegment()}",
 	) {
 		contentType(ContentType.Application.Json)
 		url {

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/EncryptedFileAuthTokenStore.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/EncryptedFileAuthTokenStore.kt
@@ -1,0 +1,167 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import com.darkrockstudios.apps.hammer.base.http.readJsonOrNull
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore.Companion.accountKey
+import com.darkrockstudios.apps.hammer.common.getConfigDirectory
+import io.github.aakira.napier.Napier
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import java.nio.file.attribute.PosixFilePermission
+import java.security.SecureRandom
+import java.security.spec.KeySpec
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * AES-GCM encrypted [AuthTokenStore] for desktop. The account-keyed token map is
+ * serialized to JSON, encrypted, and written to the app-private config directory.
+ *
+ * The encryption key is derived (PBKDF2) from stable per-user/per-machine inputs
+ * (OS user name + home directory) plus a static app salt; no key material is
+ * written to disk. A token file copied to another machine or user therefore can't
+ * be decrypted.
+ *
+ * Threat model: this protects against casual disk scraping, config-dir backup or
+ * exfiltration, and off-machine copies. It does NOT defend against same-user local
+ * malware, which can re-derive the key from the same inputs.
+ */
+class EncryptedFileAuthTokenStore(
+	private val fileSystem: FileSystem,
+	private val json: Json,
+	private val filePath: Path = DEFAULT_FILE_PATH,
+	private val legacyPlaintextPath: Path = LEGACY_PLAINTEXT_PATH,
+	keyUserName: String = System.getProperty("user.name").orEmpty(),
+	keyHomeDir: String = System.getProperty("user.home").orEmpty(),
+	keySalt: ByteArray = APP_SALT,
+) : AuthTokenStore {
+
+	private val lock = reentrantLock()
+	private val secretKey: SecretKeySpec = deriveKey(keyUserName, keyHomeDir, keySalt)
+	private val secureRandom = SecureRandom()
+	private var migrationChecked = false
+
+	override fun get(url: String, userId: Long): AuthTokens? = lock.withLock {
+		load()[accountKey(url, userId)]
+	}
+
+	override fun put(url: String, userId: Long, tokens: AuthTokens): Unit = lock.withLock {
+		val updated = load().toMutableMap()
+		updated[accountKey(url, userId)] = tokens
+		store(updated)
+	}
+
+	override fun remove(url: String, userId: Long): Unit = lock.withLock {
+		val updated = load().toMutableMap()
+		if (updated.remove(accountKey(url, userId)) != null) {
+			store(updated)
+		}
+	}
+
+	private fun load(): Map<String, AuthTokens> {
+		migrateLegacyPlaintext()
+		return decryptStored()
+	}
+
+	private fun decryptStored(): Map<String, AuthTokens> {
+		if (!fileSystem.exists(filePath)) return emptyMap()
+		return try {
+			val encrypted = fileSystem.read(filePath) { readByteArray() }
+			json.decodeFromString<Map<String, AuthTokens>>(decrypt(encrypted).decodeToString())
+			// Wrong machine/user, corruption, or tampering: treat as no tokens (forces re-login).
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.w("Failed to decrypt auth token store; treating as empty", e)
+			emptyMap()
+		}
+	}
+
+	private fun store(tokens: Map<String, AuthTokens>) {
+		fileSystem.createDirectories(filePath.parent!!)
+		val plaintext = json.encodeToString(tokens).encodeToByteArray()
+		fileSystem.write(filePath) { write(encrypt(plaintext)) }
+		restrictPermissions(filePath)
+	}
+
+	/**
+	 * Migrates a legacy plaintext token file, if present, into the encrypted store
+	 * and deletes it. Existing encrypted tokens win on key collision. Runs once per
+	 * instance; failures degrade to a no-op rather than dropping the session.
+	 */
+	private fun migrateLegacyPlaintext() {
+		if (migrationChecked) return
+		migrationChecked = true
+
+		if (!fileSystem.exists(legacyPlaintextPath)) return
+
+		try {
+			val legacy = fileSystem.readJsonOrNull<Map<String, AuthTokens>>(legacyPlaintextPath, json)
+				?: return
+			if (legacy.isNotEmpty()) {
+				store(legacy + decryptStored())
+			}
+			fileSystem.delete(legacyPlaintextPath, mustExist = false)
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.w("Failed to migrate plaintext auth token store", e)
+		}
+	}
+
+	private fun encrypt(plaintext: ByteArray): ByteArray {
+		val iv = ByteArray(IV_LENGTH).also { secureRandom.nextBytes(it) }
+		val cipher = Cipher.getInstance(TRANSFORMATION)
+		cipher.init(Cipher.ENCRYPT_MODE, secretKey, GCMParameterSpec(GCM_TAG_BITS, iv))
+		val ciphertext = cipher.doFinal(plaintext)
+		return iv + ciphertext
+	}
+
+	private fun decrypt(input: ByteArray): ByteArray {
+		require(input.size >= IV_LENGTH + GCM_TAG_BITS / 8) { "Ciphertext too short" }
+		val iv = input.copyOfRange(0, IV_LENGTH)
+		val ciphertext = input.copyOfRange(IV_LENGTH, input.size)
+		val cipher = Cipher.getInstance(TRANSFORMATION)
+		cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(GCM_TAG_BITS, iv))
+		return cipher.doFinal(ciphertext)
+	}
+
+	private fun restrictPermissions(path: Path) {
+		try {
+			val nioPath = java.nio.file.Paths.get(path.toString())
+			val fs = nioPath.fileSystem
+			if (fs.supportedFileAttributeViews().contains("posix")) {
+				java.nio.file.Files.setPosixFilePermissions(
+					nioPath,
+					setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+				)
+			}
+			// Best-effort: unsupported (e.g. Windows) or denied perms are non-fatal.
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.d("Could not restrict auth token file permissions", e)
+		}
+	}
+
+	private fun deriveKey(userName: String, homeDir: String, salt: ByteArray): SecretKeySpec {
+		val password = "$userName|$homeDir".toCharArray()
+		val spec: KeySpec = PBEKeySpec(password, salt, PBKDF2_ITERATIONS, KEY_LENGTH_BITS)
+		val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+		val keyBytes = factory.generateSecret(spec).encoded
+		return SecretKeySpec(keyBytes, "AES")
+	}
+
+	companion object {
+		private const val FILE_NAME = "auth_tokens.enc"
+		private const val TRANSFORMATION = "AES/GCM/NoPadding"
+		private const val IV_LENGTH = 12
+		private const val GCM_TAG_BITS = 128
+		private const val KEY_LENGTH_BITS = 256
+		private const val PBKDF2_ITERATIONS = 120_000
+		private val APP_SALT = "hammer-editor::auth-token-store::v1".encodeToByteArray()
+
+		val DEFAULT_FILE_PATH = getConfigDirectory().toPath() / FILE_NAME
+		val LEGACY_PLAINTEXT_PATH = FileAuthTokenStore.FILE_PATH
+	}
+}

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -1,0 +1,8 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+actual val authTokenStoreModule = module {
+	single { EncryptedFileAuthTokenStore(fileSystem = get(), json = get()) } bind AuthTokenStore::class
+}

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/externalFileIoModule.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/externalFileIoModule.kt
@@ -1,14 +1,16 @@
 package com.darkrockstudios.apps.hammer.common.fileio
 
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.RAW_FILESYSTEM
 import io.github.aakira.napier.Napier
 import okio.FileSystem
 import okio.Path.Companion.toPath
-import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 actual val externalFileIoModule = module {
-	singleOf(::DesktopExternalFileIo) bind ExternalFileIo::class
+	// Raw filesystem: this writes to user-chosen paths outside the app's managed storage.
+	single { DesktopExternalFileIo(get(named(RAW_FILESYSTEM))) } bind ExternalFileIo::class
 }
 
 private class DesktopExternalFileIo(private val fileSystem: FileSystem) : ExternalFileIo {

--- a/common/src/desktopTest/kotlin/components/encyclopedia/ViewEntryComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/encyclopedia/ViewEntryComponentTest.kt
@@ -73,7 +73,8 @@ class ViewEntryComponentTest : BaseTest() {
 		val newEntry = oldEntry.copy(name = newName)
 		val newContainer = EntryContainer(newEntry)
 
-		every { encyclopediaService.hasEntryImage(any(), any()) } returns false
+		every { encyclopediaService.findEntryImagePath(any()) } returns null
+		every { encyclopediaService.findEntryImageExtension(any()) } returns null
 		coEvery { encyclopediaService.calculateEntryImageHash(any(), any()) } returns null
 		coEvery { encyclopediaService.loadEntry(entryDef = any()) } returns newContainer
 		coEvery {
@@ -114,7 +115,8 @@ class ViewEntryComponentTest : BaseTest() {
 		val newEntry = oldEntry.copy(name = newName)
 		val newContainer = EntryContainer(newEntry)
 
-		every { encyclopediaService.hasEntryImage(any(), any()) } returns false
+		every { encyclopediaService.findEntryImagePath(any()) } returns null
+		every { encyclopediaService.findEntryImageExtension(any()) } returns null
 		coEvery { encyclopediaService.loadEntry(entryDef = any()) } returns newContainer
 		coEvery {
 			encyclopediaService.updateEntry(

--- a/common/src/desktopTest/kotlin/dependencyinjection/ManagedStorageRootsTest.kt
+++ b/common/src/desktopTest/kotlin/dependencyinjection/ManagedStorageRootsTest.kt
@@ -1,0 +1,68 @@
+package dependencyinjection
+
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.managedStorageRoots
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
+import com.darkrockstudios.apps.hammer.common.getCacheDirectory
+import com.darkrockstudios.apps.hammer.common.getConfigDirectory
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.assertTrue
+
+/**
+ * Pins the cycle-safe roots resolution used by the production guarded FileSystem
+ * binding: it must surface the configured projects directory without requiring a
+ * fully built GlobalSettingsStore.
+ */
+class ManagedStorageRootsTest {
+
+	@AfterEach
+	fun tearDown() {
+		stopKoin()
+	}
+
+	@Test
+	fun `roots include cache, config, and the configured projects directory`() {
+		val projectsDir = "/home/user/Documents/MyProjects"
+		val settings = GlobalSettings(projectsDirectory = projectsDir)
+
+		val koin = startKoin {
+			modules(
+				module {
+					single<GlobalSettingsDatasource> { FixedSettingsDatasource(settings) }
+				}
+			)
+		}.koin
+
+		val roots = managedStorageRoots(koin)
+
+		assertTrue(roots.any { getCacheDirectory().toPath().isWithin(it) || it == getCacheDirectory().toPath() })
+		assertTrue(roots.contains(getConfigDirectory().toPath()))
+		assertTrue(roots.contains(projectsDir.toPath()))
+	}
+
+	@Test
+	fun `falls back to the default projects dir when nothing is registered`() {
+		val koin = startKoin { modules(module {}) }.koin
+
+		val roots = managedStorageRoots(koin)
+
+		// Cache and config roots are always present even with no settings source.
+		assertTrue(roots.contains(getCacheDirectory().toPath()))
+		assertTrue(roots.contains(getConfigDirectory().toPath()))
+		assertTrue(roots.contains(GlobalSettingsStore.defaultProjectDir()))
+	}
+
+	private class FixedSettingsDatasource(
+		private val settings: GlobalSettings,
+	) : GlobalSettingsDatasource {
+		override fun loadSettings(): GlobalSettings = settings
+		override fun storeSettings(settings: GlobalSettings) = Unit
+	}
+}

--- a/common/src/desktopTest/kotlin/fileio/ContainedFileSystemTest.kt
+++ b/common/src/desktopTest/kotlin/fileio/ContainedFileSystemTest.kt
@@ -1,0 +1,159 @@
+package fileio
+
+import com.darkrockstudios.apps.hammer.common.fileio.okio.ContainedFileSystem
+import com.darkrockstudios.apps.hammer.common.fileio.okio.ContainmentViolationException
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ContainedFileSystemTest {
+
+	private val cacheRoot = "/app/cache".toPath()
+	private val configRoot = "/app/config".toPath()
+	private val projectsRoot = "/home/user/Documents/Projects".toPath()
+
+	private fun fs(roots: List<Path> = listOf(cacheRoot, configRoot, projectsRoot)): Pair<FakeFileSystem, ContainedFileSystem> {
+		val delegate = FakeFileSystem()
+		roots.forEach { delegate.createDirectories(it) }
+		return delegate to ContainedFileSystem(delegate) { roots }
+	}
+
+	@Test
+	fun `write within a root succeeds`() {
+		val (delegate, guarded) = fs()
+		val target = projectsRoot / "story.md"
+
+		guarded.write(target) { writeUtf8("hello") }
+
+		assertTrue(delegate.exists(target))
+	}
+
+	@Test
+	fun `write within each configured root succeeds`() {
+		val (_, guarded) = fs()
+		guarded.write(cacheRoot / "a.toml") { writeUtf8("a") }
+		guarded.write(configRoot / "b.toml") { writeUtf8("b") }
+		guarded.write(projectsRoot / "c.md") { writeUtf8("c") }
+	}
+
+	@Test
+	fun `write outside all roots throws`() {
+		val (_, guarded) = fs()
+		assertFailsWith<ContainmentViolationException> {
+			guarded.write("/etc/passwd".toPath()) { writeUtf8("evil") }
+		}
+	}
+
+	@Test
+	fun `delete outside all roots throws`() {
+		val (delegate, guarded) = fs()
+		delegate.createDirectories("/etc".toPath())
+		delegate.write("/etc/passwd".toPath()) { writeUtf8("x") }
+
+		assertFailsWith<ContainmentViolationException> {
+			guarded.delete("/etc/passwd".toPath())
+		}
+	}
+
+	@Test
+	fun `atomicMove with a target outside all roots throws`() {
+		val (_, guarded) = fs()
+		val source = projectsRoot / "a.md"
+		guarded.write(source) { writeUtf8("x") }
+
+		assertFailsWith<ContainmentViolationException> {
+			guarded.atomicMove(source, "/tmp/escape.md".toPath())
+		}
+	}
+
+	@Test
+	fun `atomicMove within a root succeeds`() {
+		val (delegate, guarded) = fs()
+		val source = projectsRoot / "a.md"
+		val target = projectsRoot / "b.md"
+		guarded.write(source) { writeUtf8("x") }
+
+		guarded.atomicMove(source, target)
+
+		assertTrue(delegate.exists(target))
+	}
+
+	@Test
+	fun `creating a root itself succeeds on a clean filesystem`() {
+		val delegate = FakeFileSystem()
+		val guarded = ContainedFileSystem(delegate) { listOf(cacheRoot) }
+
+		// First run: nothing exists yet. createDirectories must scaffold the root
+		// (and its ancestors) without being blocked.
+		guarded.createDirectories(cacheRoot / "projects" / "MyProject")
+
+		assertTrue(delegate.exists(cacheRoot / "projects" / "MyProject"))
+	}
+
+	@Test
+	fun `creating an ancestor of a root is allowed`() {
+		val delegate = FakeFileSystem()
+		val guarded = ContainedFileSystem(delegate) { listOf(cacheRoot) }
+
+		guarded.createDirectory("/app".toPath())
+
+		assertTrue(delegate.exists("/app".toPath()))
+	}
+
+	@Test
+	fun `creating a sibling-escape directory is blocked`() {
+		val delegate = FakeFileSystem()
+		delegate.createDirectories("/app".toPath())
+		val guarded = ContainedFileSystem(delegate) { listOf(cacheRoot) }
+
+		assertFailsWith<ContainmentViolationException> {
+			guarded.createDirectory("/app/evil".toPath())
+		}
+	}
+
+	@Test
+	fun `openReadWrite outside all roots throws`() {
+		val (_, guarded) = fs()
+		assertFailsWith<ContainmentViolationException> {
+			guarded.openReadWrite("/etc/passwd".toPath())
+		}
+	}
+
+	@Test
+	fun `openReadWrite within a root succeeds`() {
+		val (delegate, guarded) = fs()
+		val target = projectsRoot / "handle.bin"
+
+		guarded.openReadWrite(target, mustCreate = true).use { it.write(0, ByteArray(4), 0, 4) }
+
+		assertTrue(delegate.exists(target))
+	}
+
+	@Test
+	fun `a traversal write that escapes a root throws`() {
+		val (_, guarded) = fs()
+		assertFailsWith<ContainmentViolationException> {
+			guarded.write(projectsRoot / ".." / ".." / "evil.md") { writeUtf8("x") }
+		}
+	}
+
+	@Test
+	fun `allowed roots are re-evaluated per call`() {
+		val delegate = FakeFileSystem()
+		var roots = listOf(cacheRoot)
+		delegate.createDirectories(cacheRoot)
+		delegate.createDirectories(projectsRoot)
+		val guarded = ContainedFileSystem(delegate) { roots }
+
+		assertFailsWith<ContainmentViolationException> {
+			guarded.write(projectsRoot / "a.md") { writeUtf8("x") }
+		}
+
+		roots = listOf(cacheRoot, projectsRoot)
+		guarded.write(projectsRoot / "a.md") { writeUtf8("x") }
+		assertTrue(delegate.exists(projectsRoot / "a.md"))
+	}
+}

--- a/common/src/desktopTest/kotlin/fileio/PathContainmentTest.kt
+++ b/common/src/desktopTest/kotlin/fileio/PathContainmentTest.kt
@@ -1,0 +1,58 @@
+package fileio
+
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PathContainmentTest {
+
+	private val root = "/projects/Test/.drafts/1".toPath()
+
+	@Test
+	fun `a genuine descendant is within the root`() {
+		assertTrue(("/projects/Test/.drafts/1/1-5-draft-100.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `the root itself is within the root`() {
+		assertTrue(root.isWithin(root))
+	}
+
+	@Test
+	fun `a parent-climbing traversal escapes the root`() {
+		val escape = ("/projects/Test/.drafts/1" / "../../../../evil").toPath()
+		assertFalse(escape.isWithin(root))
+	}
+
+	@Test
+	fun `an embedded dot-dot segment that escapes the root is rejected`() {
+		assertFalse(("/projects/Test/.drafts/1/../../evil.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `a sibling directory is not within the root`() {
+		assertFalse(("/projects/Test/.drafts/2/file.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `a prefix-sharing sibling is not within the root`() {
+		// "/projects/Test/.drafts/10" shares the textual prefix "/projects/Test/.drafts/1"
+		// but is a different directory.
+		assertFalse(("/projects/Test/.drafts/10/file.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `an absolute reach-out is not within a relative root`() {
+		val relativeRoot = ".drafts/1".toPath()
+		assertFalse(("/etc/passwd".toPath()).isWithin(relativeRoot))
+	}
+
+	@Test
+	fun `an unrelated absolute path is not within the root`() {
+		assertFalse(("/etc/passwd".toPath()).isWithin(root))
+	}
+
+	private operator fun String.div(other: String) = "$this/$other"
+}

--- a/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryImageTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryImageTest.kt
@@ -86,6 +86,34 @@ class EncyclopediaRepositoryImageTest : BaseTest() {
 	}
 
 	@Test
+	fun `setEntryImage preserves a supported source extension`() = runTest {
+		val pngSource = "/external/art.png"
+		every { externalFileIo.readExternalFile(pngSource) } returns imageBytes
+
+		val repo = repository()
+		val def = entry1().toDef(projDef)
+
+		repo.setEntryImage(def, pngSource)
+
+		assertTrue(repo.hasEntryImage(def, "png"))
+		assertFalse(repo.hasEntryImage(def, "jpg"))
+		assertTrue(datasource.findEntryImagePath(def)!!.name.endsWith(".png"))
+	}
+
+	@Test
+	fun `setEntryImage falls back to jpg for an unsupported source extension`() = runTest {
+		val heicSource = "/external/photo.heic"
+		every { externalFileIo.readExternalFile(heicSource) } returns imageBytes
+
+		val repo = repository()
+		val def = entry1().toDef(projDef)
+
+		repo.setEntryImage(def, heicSource)
+
+		assertTrue(datasource.findEntryImagePath(def)!!.name.endsWith(".jpg"))
+	}
+
+	@Test
 	fun `setEntryImage with a null path removes the existing image`() = runTest {
 		val repo = repository()
 		val def = entry1().toDef(projDef)

--- a/common/src/desktopTest/kotlin/repositories/globalsettings/EncryptedFileAuthTokenStoreTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/globalsettings/EncryptedFileAuthTokenStoreTest.kt
@@ -1,0 +1,148 @@
+package repositories.globalsettings
+
+import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
+import com.darkrockstudios.apps.hammer.base.http.writeJson
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokens
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.EncryptedFileAuthTokenStore
+import kotlinx.serialization.json.Json
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EncryptedFileAuthTokenStoreTest : BaseTest() {
+
+	private lateinit var fileSystem: FakeFileSystem
+	private lateinit var json: Json
+
+	private val encPath: Path = "/config/auth_tokens.enc".toPath()
+	private val legacyPath: Path = "/config/auth_tokens.json".toPath()
+
+	private val url = "hammer.ink"
+	private val userId = 1L
+	private val tokens = AuthTokens(bearerToken = "zxc456", refreshToken = "bnm789")
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		fileSystem = FakeFileSystem()
+		json = createJsonSerializer()
+	}
+
+	private fun createStore(
+		userName: String = "alice",
+		homeDir: String = "/home/alice",
+		salt: ByteArray = "test-salt".encodeToByteArray(),
+	) = EncryptedFileAuthTokenStore(
+		fileSystem = fileSystem,
+		json = json,
+		filePath = encPath,
+		legacyPlaintextPath = legacyPath,
+		keyUserName = userName,
+		keyHomeDir = homeDir,
+		keySalt = salt,
+	)
+
+	@Test
+	fun `Tokens round-trip through the encrypted store`() {
+		val store = createStore()
+
+		store.put(url, userId, tokens)
+
+		val loaded = store.get(url, userId)
+		assertEquals(tokens, loaded)
+	}
+
+	@Test
+	fun `On-disk file contains no plaintext token substrings`() {
+		val store = createStore()
+
+		store.put(url, userId, tokens)
+
+		val bytes = fileSystem.read(encPath) { readByteArray() }
+		val asText = bytes.decodeToString()
+		assertFalse(asText.contains("zxc456"))
+		assertFalse(asText.contains("bnm789"))
+		assertFalse(asText.contains("bearerToken"))
+		assertFalse(asText.contains(url))
+	}
+
+	@Test
+	fun `Different key inputs cannot decrypt and return null without crashing`() {
+		createStore(userName = "alice", homeDir = "/home/alice").put(url, userId, tokens)
+
+		val otherUser = createStore(userName = "mallory", homeDir = "/home/mallory")
+		assertNull(otherUser.get(url, userId))
+
+		val otherSalt = createStore(salt = "different-salt".encodeToByteArray())
+		assertNull(otherSalt.get(url, userId))
+	}
+
+	@Test
+	fun `Keying by url and userId isolates accounts`() {
+		val store = createStore()
+		store.put(url, userId, tokens)
+
+		assertEquals(tokens, store.get(url, userId))
+		assertNull(store.get("other.example.com", userId))
+		assertNull(store.get(url, 999L))
+	}
+
+	@Test
+	fun `Remove clears a single account`() {
+		val store = createStore()
+		store.put(url, userId, tokens)
+		store.put("other.example.com", 2L, AuthTokens("a", "b"))
+
+		store.remove(url, userId)
+
+		assertNull(store.get(url, userId))
+		assertEquals(AuthTokens("a", "b"), store.get("other.example.com", 2L))
+	}
+
+	@Test
+	fun `Legacy plaintext file is imported then deleted`() {
+		fileSystem.createDirectories(legacyPath.parent!!)
+		val legacyMap = mapOf("$url|$userId" to tokens)
+		fileSystem.writeJson(legacyPath, json, legacyMap)
+		assertTrue(fileSystem.exists(legacyPath))
+
+		val store = createStore()
+		val loaded = store.get(url, userId)
+
+		assertEquals(tokens, loaded)
+		assertFalse(fileSystem.exists(legacyPath))
+		assertTrue(fileSystem.exists(encPath))
+
+		// Re-reading the encrypted file confirms the imported tokens persisted.
+		assertFalse(fileSystem.read(encPath) { readByteArray() }.decodeToString().contains("zxc456"))
+	}
+
+	@Test
+	fun `Existing encrypted tokens win over a stale legacy plaintext entry`() {
+		val fresh = AuthTokens(bearerToken = "fresh-bearer", refreshToken = "fresh-refresh")
+		createStore().put(url, userId, fresh)
+
+		fileSystem.createDirectories(legacyPath.parent!!)
+		val staleMap = mapOf("$url|$userId" to AuthTokens("stale-bearer", "stale-refresh"))
+		fileSystem.writeJson(legacyPath, json, staleMap)
+
+		// A fresh instance triggers migration on first access.
+		val migrated = createStore().get(url, userId)
+
+		assertEquals(fresh, migrated)
+		assertFalse(fileSystem.exists(legacyPath))
+	}
+
+	@Test
+	fun `Missing file yields no tokens`() {
+		val store = createStore()
+		assertNull(store.get(url, userId))
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/globalsettings/ServerSettingsDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/globalsettings/ServerSettingsDatasourceTest.kt
@@ -3,13 +3,18 @@ package repositories.globalsettings
 import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.base.http.writeJson
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokens
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.FileAuthTokenStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsFilesystemDatasource
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -21,6 +26,7 @@ import kotlin.test.assertNull
 class ServerSettingsDatasourceTest : BaseTest() {
 	private lateinit var fileSystem: FakeFileSystem
 	private lateinit var json: Json
+	private lateinit var authTokenStore: AuthTokenStore
 
 	@BeforeEach
 	override fun setup() {
@@ -28,12 +34,19 @@ class ServerSettingsDatasourceTest : BaseTest() {
 
 		fileSystem = FakeFileSystem()
 		json = createJsonSerializer()
+		authTokenStore = FileAuthTokenStore(fileSystem, json)
+	}
+
+	@AfterEach
+	fun cleanup() {
+		fileSystem.delete(FileAuthTokenStore.FILE_PATH, mustExist = false)
 	}
 
 	private fun createDatasource(): ServerSettingsDatasource {
 		return ServerSettingsFilesystemDatasource(
 			fileSystem,
-			json
+			json,
+			authTokenStore,
 		)
 	}
 
@@ -46,10 +59,14 @@ class ServerSettingsDatasourceTest : BaseTest() {
 		refreshToken = "bnm789",
 	)
 
-	private fun configPath() =
-		(fileSystem.workingDirectory / ServerSettingsFilesystemDatasource.SERVER_FILE_NAME).toHPath()
+	private fun projectsDirPath() = fileSystem.workingDirectory / "HammerProjects"
 
-	private fun projectsDir() = fileSystem.workingDirectory.toHPath()
+	private fun configPath() =
+		(projectsDirPath() / ServerSettingsFilesystemDatasource.SERVER_FILE_NAME).toHPath()
+
+	private fun projectsDir() = projectsDirPath().toHPath()
+
+	private fun readServerJson(): String = fileSystem.read(configPath().toOkioPath()) { readUtf8() }
 
 	@Test
 	fun `Load Server Settings when none exists`() = runTest {
@@ -60,15 +77,85 @@ class ServerSettingsDatasourceTest : BaseTest() {
 	}
 
 	@Test
-	fun `Load Server Settings when one exists`() = runTest {
+	fun `Store then reload round-trips tokens via the store`() = runTest {
 		val datasource = createDatasource()
-
 		val serverConfig = createConfig()
-		fileSystem.createDirectories(projectsDir().toOkioPath())
-		fileSystem.writeJson(configPath().toOkioPath(), json, serverConfig)
+
+		datasource.storeServerSettings(serverConfig, projectsDir())
 
 		val loaded = datasource.loadServerSettings(projectsDir())
 		assertEquals(serverConfig, loaded)
+	}
+
+	@Test
+	fun `Stored server json contains no tokens`() = runTest {
+		val datasource = createDatasource()
+
+		datasource.storeServerSettings(createConfig(), projectsDir())
+
+		val jsonStr = readServerJson()
+		assertFalse(jsonStr.contains("bearerToken"))
+		assertFalse(jsonStr.contains("refreshToken"))
+		assertFalse(jsonStr.contains("zxc456"))
+		assertFalse(jsonStr.contains("bnm789"))
+	}
+
+	@Test
+	fun `Tokens are retrievable from the store keyed by account`() = runTest {
+		val datasource = createDatasource()
+		val config = createConfig()
+
+		datasource.storeServerSettings(config, projectsDir())
+
+		val tokens = authTokenStore.get(config.url, config.userId)
+		assertEquals(AuthTokens(config.bearerToken, config.refreshToken), tokens)
+	}
+
+	@Test
+	fun `A different account returns no tokens`() = runTest {
+		val datasource = createDatasource()
+		val config = createConfig()
+
+		datasource.storeServerSettings(config, projectsDir())
+
+		assertNull(authTokenStore.get("other.example.com", config.userId))
+		assertNull(authTokenStore.get(config.url, 999L))
+	}
+
+	@Test
+	fun `Token store file lives in the config directory, not projects dir`() = runTest {
+		val datasource = createDatasource()
+
+		datasource.storeServerSettings(createConfig(), projectsDir())
+
+		assertTrue(fileSystem.exists(FileAuthTokenStore.FILE_PATH))
+		assertFalse(FileAuthTokenStore.FILE_PATH.isWithin(projectsDir().toOkioPath()))
+	}
+
+	@Test
+	fun `Legacy server json with inline tokens is migrated into the store`() = runTest {
+		val legacy = createConfig()
+		fileSystem.createDirectories(projectsDir().toOkioPath())
+		fileSystem.writeJson(configPath().toOkioPath(), json, legacy)
+
+		// Precondition: the seeded file really does carry the inline tokens.
+		assertTrue(readServerJson().contains("zxc456"))
+
+		val datasource = createDatasource()
+		val loaded = datasource.loadServerSettings(projectsDir())
+
+		assertEquals(legacy, loaded)
+
+		assertEquals(
+			AuthTokens(legacy.bearerToken, legacy.refreshToken),
+			authTokenStore.get(legacy.url, legacy.userId),
+		)
+
+		val rewritten = readServerJson()
+		assertFalse(rewritten.contains("bearerToken"))
+		assertFalse(rewritten.contains("refreshToken"))
+		assertFalse(rewritten.contains("zxc456"))
+		assertFalse(rewritten.contains("bnm789"))
 	}
 
 	@Test
@@ -84,9 +171,7 @@ class ServerSettingsDatasourceTest : BaseTest() {
 	fun `Check if Server is setup when one is`() = runTest {
 		val datasource = createDatasource()
 
-		val serverConfig = createConfig()
-		fileSystem.createDirectories(projectsDir().toOkioPath())
-		fileSystem.writeJson(configPath().toOkioPath(), json, serverConfig)
+		datasource.storeServerSettings(createConfig(), projectsDir())
 
 		val isSetup = datasource.serverIsSetup(projectsDir())
 
@@ -94,31 +179,20 @@ class ServerSettingsDatasourceTest : BaseTest() {
 	}
 
 	@Test
-	fun `Store Server Settings`() = runTest {
+	fun `Remove Server Settings clears the account tokens from the store`() = runTest {
 		val datasource = createDatasource()
-		val serverConfig = createConfig()
+		val config = createConfig()
 
-		datasource.storeServerSettings(serverConfig, projectsDir())
-
-		fileSystem.read(configPath().toOkioPath()) {
-			val jsonStr = readUtf8()
-			val storedSettings: ServerSettings = json.decodeFromString(jsonStr)
-
-			assertEquals(serverConfig, storedSettings)
-		}
-	}
-
-	@Test
-	fun `Remove Server Settings when one exists`() = runTest {
-		val datasource = createDatasource()
-
-		val serverConfig = createConfig()
-		fileSystem.createDirectories(projectsDir().toOkioPath())
-		fileSystem.writeJson(configPath().toOkioPath(), json, serverConfig)
+		datasource.storeServerSettings(config, projectsDir())
+		assertEquals(
+			AuthTokens(config.bearerToken, config.refreshToken),
+			authTokenStore.get(config.url, config.userId),
+		)
 
 		datasource.removeServerSettings(projectsDir())
 
 		assertFalse(fileSystem.exists(configPath().toOkioPath()))
+		assertNull(authTokenStore.get(config.url, config.userId))
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/repositories/notes/NotesDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/notes/NotesDatasourceTest.kt
@@ -1,0 +1,71 @@
+package repositories.notes
+
+import PROJECT_2_NAME
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesDatasource
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import createProject
+import getProjectDef
+import kotlinx.coroutines.test.runTest
+import net.peanuuutz.tomlkt.Toml
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class NotesDatasourceTest : BaseTest() {
+
+	private val projectDef = getProjectDef(PROJECT_2_NAME)
+
+	private lateinit var ffs: FakeFileSystem
+	private lateinit var toml: Toml
+	private lateinit var datasource: NotesDatasource
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		ffs = FakeFileSystem()
+		toml = createTomlSerializer()
+		setupKoin()
+		datasource = NotesDatasource(projectDef, ffs, toml)
+	}
+
+	private fun writeNoteFile(id: Int, contents: String) {
+		val path = datasource.getNotePath(id).toOkioPath()
+		ffs.write(path, mustCreate = true) {
+			writeUtf8(contents)
+		}
+	}
+
+	@Test
+	fun `Malformed note file is skipped and other notes still load`() = runTest {
+		createProject(ffs, PROJECT_2_NAME)
+		writeNoteFile(99, "this is not valid toml @@@")
+
+		val notes = datasource.loadNotes()
+
+		assertEquals(3, notes.size)
+		assertNull(notes.find { it.note.id == 99 })
+	}
+
+	@Test
+	fun `Note with non-integer id is skipped and other notes still load`() = runTest {
+		createProject(ffs, PROJECT_2_NAME)
+		writeNoteFile(
+			98,
+			"""
+				[note]
+				id = "not-an-int"
+				created = 0
+				content = "broken"
+			""".trimIndent()
+		)
+
+		val notes = datasource.loadNotes()
+
+		assertEquals(3, notes.size)
+		assertNull(notes.find { it.note.id == 98 })
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryFindTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryFindTest.kt
@@ -84,4 +84,21 @@ class ProjectsRepositoryFindTest : ProjectsRepositoryBaseTest() {
 
 		assertEquals(proj1Def, projectDef)
 	}
+
+	// Guards the name-only intent resolution used by ProjectRootActivity: a name that does not
+	// match an on-disk project must resolve to nothing, so a forged intent cannot open an
+	// arbitrary project.
+	@Test
+	fun `Resolve project by name against on-disk projects only`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		createProject(ffs, PROJECT_2_NAME)
+
+		val repo = ProjectsRepository(ffs, settingsRepo, projectsMetaDatasource)
+
+		val known = repo.getProjects().firstOrNull { it.name == PROJECT_1_NAME }
+		val forged = repo.getProjects().firstOrNull { it.name == "../../attacker/controlled" }
+
+		assertEquals(getProjectDef(PROJECT_1_NAME), known)
+		assertNull(forged)
+	}
 }

--- a/common/src/desktopTest/kotlin/repositories/statistics/StatisticsDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/statistics/StatisticsDatasourceTest.kt
@@ -1,14 +1,16 @@
-package repositories.references
+package repositories.statistics
 
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndex
-import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.ProjectStatistics
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsCachePaths
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsDatasource
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.getCacheDirectory
 import getProject1Def
 import getProjectDef
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import net.peanuuutz.tomlkt.Toml
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -20,9 +22,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.time.Clock
 
-class ReferenceIndexDatasourceTest : BaseTest() {
+class StatisticsDatasourceTest : BaseTest() {
 
 	lateinit var ffs: FakeFileSystem
 	lateinit var toml: Toml
@@ -39,65 +40,57 @@ class ReferenceIndexDatasourceTest : BaseTest() {
 	}
 
 	private fun createDatasource(projectDef: ProjectDef = getProject1Def()) =
-		ReferenceIndexDatasource(ffs, toml, projectDef)
+		StatisticsDatasource(ffs, toml, projectDef)
+
+	private fun stats() = ProjectStatistics(
+		numberOfScenes = 3,
+		totalWords = 42,
+		wordsByChapter = mapOf(1 to 20, 2 to 22),
+		encyclopediaEntriesByType = emptyMap(),
+		isDirty = false,
+		lastCalculated = Instant.fromEpochSeconds(0),
+	)
 
 	@Test
 	fun `Load returns null when cache file is missing`() = runTest(mainTestDispatcher) {
 		val datasource = createDatasource()
-		assertNull(datasource.loadIndex())
+		assertNull(datasource.loadStatistics())
 		assertFalse(datasource.exists())
 	}
 
 	@Test
-	fun `Save then load round-trips the index`() = runTest(mainTestDispatcher) {
+	fun `Save then load round-trips the statistics`() = runTest(mainTestDispatcher) {
 		val datasource = createDatasource()
-		val original = ReferenceIndex(
-			isDirty = false,
-			lastCalculated = Clock.System.now(),
-			entryToScenes = mapOf(1 to setOf(10, 11), 2 to setOf(11, 12)),
-		)
+		val original = stats()
 
-		datasource.saveIndex(original)
+		datasource.saveStatistics(original)
 		assertTrue(datasource.exists())
 
-		val loaded = datasource.loadIndex()
-		assertEquals(original.entryToScenes, loaded?.entryToScenes)
-		assertEquals(original.isDirty, loaded?.isDirty)
-		assertEquals(original.schemaVersion, loaded?.schemaVersion)
-	}
-
-	@Test
-	fun `Load returns null when cache file is corrupt`() = runTest(mainTestDispatcher) {
-		val datasource = createDatasource()
-		datasource.saveIndex(ReferenceIndex())
-
-		val cachePath = ffs.allPaths.first { it.name == ReferenceIndexDatasource.FILENAME }
-		ffs.write(cachePath) { writeUtf8("not valid toml @@@@") }
-
-		assertNull(datasource.loadIndex())
+		val loaded = datasource.loadStatistics()
+		assertEquals(original.totalWords, loaded?.totalWords)
+		assertEquals(original.wordsByChapter, loaded?.wordsByChapter)
 	}
 
 	@Test
 	fun `Save with a traversal project name lands under the cache root`() =
 		runTest(mainTestDispatcher) {
-			val maliciousName = "a/../../../evil"
-			val datasource = createDatasource(getProjectDef(maliciousName))
+			val datasource = createDatasource(getProjectDef("a/../../../evil"))
 
-			datasource.saveIndex(ReferenceIndex())
+			datasource.saveStatistics(stats())
 
 			val cacheRoot =
-				getCacheDirectory().toPath() / ReferenceIndexDatasource.PROJECTS_DIRECTORY
-			val written = ffs.allPaths.first { it.name == ReferenceIndexDatasource.FILENAME }
+				getCacheDirectory().toPath() / StatisticsCachePaths.PROJECTS_DIRECTORY
+			val written = ffs.allPaths.first { it.name == StatisticsCachePaths.FILENAME }
 			assertTrue(
 				written.isWithin(cacheRoot),
-				"Reference index escaped the cache root: $written",
+				"Statistics cache escaped the cache root: $written",
 			)
 		}
 
 	@Test
 	fun `Delete removes the cache file`() = runTest(mainTestDispatcher) {
 		val datasource = createDatasource()
-		datasource.saveIndex(ReferenceIndex())
+		datasource.saveStatistics(stats())
 		assertTrue(datasource.exists())
 
 		datasource.delete()

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineDatasourceTest.kt
@@ -52,6 +52,20 @@ class TimeLineDatasourceTest : BaseTest() {
 	}
 
 	@Test
+	fun `Malformed Timeline loads as empty`() = runTest(mainTestDispatcher) {
+		val projDef = getProject1Def()
+		val file = TimeLineDatasource.getTimelineFilePath(projDef).toOkioPath()
+		ffs.createDirectories(file.parent!!)
+		ffs.write(file) {
+			writeUtf8("this is not valid timeline toml @@@")
+		}
+
+		val timeline = datasource.loadTimeline(projDef)
+
+		assertEquals(emptyList(), timeline.events)
+	}
+
+	@Test
 	fun `Store Timeline`() = runTest(mainTestDispatcher) {
 		val projDef = getProject1Def()
 		val events = fakeEvents()

--- a/common/src/desktopTest/kotlin/server/ServerApiPathEncodingTest.kt
+++ b/common/src/desktopTest/kotlin/server/ServerApiPathEncodingTest.kt
@@ -1,0 +1,149 @@
+package server
+
+import com.darkrockstudios.apps.hammer.base.ProjectId
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.server.ProjectDataApi
+import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
+import com.darkrockstudios.apps.hammer.common.server.WritingActivityApi
+import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.koin.dsl.module
+import utils.BaseTest
+import utils.TestStrRes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ServerApiPathEncodingTest : BaseTest() {
+
+	private val userId = 42L
+	private lateinit var json: Json
+	private lateinit var globalSettingsStore: GlobalSettingsStore
+	private var capturedUrl: Url? = null
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		json = Json { ignoreUnknownKeys = true }
+
+		globalSettingsStore = mockk(relaxed = true)
+		every { globalSettingsStore.serverSettings } returns ServerSettings(
+			ssl = false,
+			url = "example.com",
+			email = "user@example.com",
+			userId = userId,
+			bearerToken = "token",
+			refreshToken = "refresh",
+		)
+
+		setupKoin(
+			module {
+				single { DeviceLocaleResolver() }
+			}
+		)
+	}
+
+	private fun mockClient(): HttpClient {
+		val engine = MockEngine { request ->
+			capturedUrl = request.url
+			respond(
+				content = "",
+				status = HttpStatusCode.NoContent,
+				headers = headersOf("Content-Type", "application/json"),
+			)
+		}
+		return HttpClient(engine) {
+			install(ContentNegotiation) { json(json) }
+		}
+	}
+
+	private suspend fun captureUrlOf(call: suspend () -> Unit): Url {
+		runCatching { call() }
+		return requireNotNull(capturedUrl) { "No request was captured" }
+	}
+
+	/**
+	 * A project name containing slashes and dot-segments must not split into extra path
+	 * segments or escape the intended `{userId}/{projectName}/{action}` template.
+	 */
+	@Test
+	fun `malicious project name is a single encoded path segment`() = runTest {
+		val client = mockClient()
+		val api = ProjectDataApi(client, globalSettingsStore, json, TestStrRes())
+
+		val maliciousName = "p/../../../api/account/test_auth"
+
+		val url = captureUrlOf {
+			api.getProjectData(
+				userId = userId,
+				projectName = maliciousName,
+				projectId = ProjectId("proj-1"),
+			)
+		}
+
+		val expectedSegments = listOf(
+			"api", "project", userId.toString(), maliciousName, "project_data"
+		)
+		assertEquals(expectedSegments, url.rawSegments.filter { it.isNotEmpty() })
+		assertFalse(
+			url.rawSegments.any { it == ".." },
+			"Outbound path must not contain a literal '..' dot-segment: ${url.encodedPath}"
+		)
+	}
+
+	@Test
+	fun `slash in project name does not create extra segments for ServerProjectApi`() = runTest {
+		val client = mockClient()
+		val api = ServerProjectApi(client, globalSettingsStore, json, TestStrRes())
+
+		val maliciousName = "a/b/c"
+
+		val url = captureUrlOf {
+			api.downloadEntity(
+				projectName = maliciousName,
+				projectId = ProjectId("proj-1"),
+				entityId = 7,
+				localHash = null,
+				syncId = "sync-1",
+			)
+		}
+		val expectedSegments = listOf(
+			"api", "project", userId.toString(), maliciousName, "download_entity", "7"
+		)
+		assertEquals(expectedSegments, url.rawSegments.filter { it.isNotEmpty() })
+	}
+
+	@Test
+	fun `slash in project name does not create extra segments for WritingActivityApi`() = runTest {
+		val client = mockClient()
+		val api = WritingActivityApi(client, globalSettingsStore, TestStrRes())
+
+		val maliciousName = "x/../y"
+
+		val url = captureUrlOf {
+			api.getWritingActivity(
+				userId = userId,
+				projectName = maliciousName,
+				projectId = ProjectId("proj-1"),
+			)
+		}
+		val expectedSegments = listOf(
+			"api", "project", userId.toString(), maliciousName, "writing_activity"
+		)
+		assertEquals(expectedSegments, url.rawSegments.filter { it.isNotEmpty() })
+		assertFalse(url.rawSegments.any { it == ".." })
+	}
+}

--- a/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
@@ -308,6 +308,38 @@ class ClientEncyclopediaSynchronizerTest : BaseTest() {
 		assertContentEquals(imageBytes, datasource.loadEntryImage(def, "png"))
 	}
 
+	@Test
+	fun `a non-jpg synced image round-trips with a stable hash and is cleared on server-clear`() = runTest {
+		val imageBytes = byteArrayOf(10, 20, 30, 40)
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(imageBytes, url = true),
+				fileExtension = "png",
+			),
+		)
+
+		// Download: the png is stored under its real extension, no stray jpg.
+		sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+		val def = entry1().toDef(projectDef)
+		assertTrue(datasource.hasEntryImage(def, "png"))
+		assertFalse(datasource.hasEntryImage(def, "jpg"))
+
+		// The locally recomputed hash agrees with the server's, so the entry is not
+		// flagged dirty and re-synced on every run.
+		assertEquals(serverEntity.hash(), sync.getEntityHash(entry1().id))
+
+		// Re-upload reports the real extension and the original bytes.
+		val reuploaded = sync.createEntityForId(entry1().id)
+		assertEquals("png", reuploaded.image?.fileExtension)
+		assertContentEquals(imageBytes, Base64.decode(reuploaded.image!!.base64, url = true))
+
+		// Server-clear removes the stored file rather than orphaning it.
+		sync.storeEntity(serverEntity.copy(image = null), syncId = "sync", onLog = {})
+		assertNull(datasource.findEntryImagePath(def))
+		assertFalse(datasource.hasEntryImage(def, "png"))
+	}
+
 	private fun allRegularFiles(): Set<String> =
 		fileSystem.allPaths
 			.filter { fileSystem.metadataOrNull(it)?.isRegularFile == true }

--- a/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
@@ -254,6 +254,67 @@ class ClientEncyclopediaSynchronizerTest : BaseTest() {
 	}
 
 	@Test
+	fun `storeEntity rejects a traversal file extension and writes no image but still stores the entry`() = runTest {
+		val imageBytes = byteArrayOf(4, 5, 6)
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			text = "Stored anyway",
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(imageBytes, url = true),
+				fileExtension = "jpg/../../../../evil",
+			),
+		)
+
+		val before = allRegularFiles()
+
+		val stored = sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		assertTrue(stored)
+		assertEquals("Stored anyway", repository.loadEntry(entry1().id).entry.text)
+		assertEquals(before, allRegularFiles())
+	}
+
+	@Test
+	fun `storeEntity rejects an unknown image extension`() = runTest {
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(byteArrayOf(1), url = true),
+				fileExtension = "exe",
+			),
+		)
+
+		val before = allRegularFiles()
+		sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		assertEquals(before, allRegularFiles())
+	}
+
+	@Test
+	fun `storeEntity writes a png image with an allowed extension`() = runTest {
+		val imageBytes = byteArrayOf(7, 7, 7)
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(imageBytes, url = true),
+				fileExtension = "png",
+			),
+		)
+
+		sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		val def = entry1().toDef(projectDef)
+		assertTrue(datasource.hasEntryImage(def, "png"))
+		assertContentEquals(imageBytes, datasource.loadEntryImage(def, "png"))
+	}
+
+	private fun allRegularFiles(): Set<String> =
+		fileSystem.allPaths
+			.filter { fileSystem.metadataOrNull(it)?.isRegularFile == true }
+			.map { it.toString() }
+			.toSet()
+
+	@Test
 	fun `storeEntity drops a local image when the server has none`() = runTest {
 		val def = entry1().toDef(projectDef)
 		datasource.writeEntryImage(def, byteArrayOf(1, 2, 3), "jpg")

--- a/common/src/desktopTest/kotlin/synchronizer/ClientSceneDraftSynchronizerSecurityTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientSceneDraftSynchronizerSecurityTest.kt
@@ -1,0 +1,149 @@
+package synchronizer
+
+import PROJECT_2_NAME
+import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
+import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogLevel
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogMessage
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.synchronizers.ClientSceneDraftSynchronizer
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
+import com.darkrockstudios.apps.hammer.common.util.StrRes
+import createProject
+import getProjectDef
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.dsl.module
+import utils.BaseTest
+import utils.TestStrRes
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * Classical-style: drives a real [SceneDraftRepository] / [SceneDraftsDatasource] over a
+ * [FakeFileSystem] seeded from the "Test Project 2" fixture. Only the network boundary is
+ * mocked. Asserts observable filesystem outcomes (no file escapes the drafts directory).
+ */
+class ClientSceneDraftSynchronizerSecurityTest : BaseTest() {
+
+	private val projectDef = getProjectDef(PROJECT_2_NAME)
+	private val strRes: StrRes = TestStrRes()
+
+	@MockK(relaxed = true)
+	private lateinit var serverProjectApi: ServerProjectApi
+
+	@MockK(relaxed = true)
+	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
+
+	@MockK(relaxed = true)
+	private lateinit var idAllocator: IdAllocator
+
+	@MockK(relaxed = true)
+	private lateinit var sceneContentRepository: SceneContentRepository
+
+	@MockK(relaxed = true)
+	private lateinit var clock: Clock
+
+	private lateinit var ffs: FakeFileSystem
+	private lateinit var repository: SceneDraftRepository
+	private lateinit var datasource: SceneDraftsDatasource
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		MockKAnnotations.init(this, relaxUnitFun = true)
+
+		ffs = FakeFileSystem()
+		createProject(ffs, PROJECT_2_NAME)
+
+		val sceneDatasource = SceneDatasource(projectDef, ffs)
+		datasource = SceneDraftsDatasource(ffs, sceneDatasource)
+
+		setupKoin(module {
+			single { idAllocator }
+			single { clock }
+			scope<ProjectDefScope> {
+				scoped { projectDef }
+				scoped { repository }
+			}
+		})
+
+		repository = SceneDraftRepository(projectDef, sceneContentRepository, datasource, clock)
+	}
+
+	private fun newSynchronizer() = ClientSceneDraftSynchronizer(
+		projectDef = projectDef,
+		serverProjectApi = serverProjectApi,
+		projectMetadataDatasource = projectMetadataDatasource,
+		strRes = strRes,
+	)
+
+	private fun draftEntity(name: String) = ApiProjectEntity.SceneDraftEntity(
+		id = 500,
+		sceneId = 1,
+		created = Instant.fromEpochSeconds(1000),
+		name = name,
+		content = "PWNED",
+	)
+
+	private fun allFiles(): Set<String> =
+		ffs.allPaths
+			.filter { ffs.metadataOrNull(it)?.isRegularFile == true }
+			.map { it.toString() }
+			.toSet()
+
+	@Test
+	fun `a traversal draft name escaping with dot-dot is rejected and writes no file`() = runTest {
+		val before = allFiles()
+		val logs = mutableListOf<SyncLogMessage>()
+
+		val stored = newSynchronizer().storeEntity(
+			draftEntity("../../../../evil"),
+			syncId = "sync",
+			onLog = { logs.add(it) },
+		)
+
+		assertFalse(stored, "Malicious draft must be skipped")
+		assertEquals(before, allFiles(), "No file may be created anywhere on the filesystem")
+		assertTrue(logs.any { it.level == SyncLogLevel.WARN })
+	}
+
+	@Test
+	fun `a draft name with an embedded slash is rejected and writes no file`() = runTest {
+		val before = allFiles()
+
+		val stored = newSynchronizer().storeEntity(
+			draftEntity("a/b"),
+			syncId = "sync",
+			onLog = {},
+		)
+
+		assertFalse(stored)
+		assertEquals(before, allFiles())
+	}
+
+	@Test
+	fun `a normal draft name is stored and loads back`() = runTest {
+		val entity = draftEntity("Clean Name")
+
+		val stored = newSynchronizer().storeEntity(entity, syncId = "sync", onLog = {})
+
+		assertTrue(stored)
+		val def = repository.getDraftDef(500)
+		assertEquals("Clean Name", def?.draftName)
+		assertEquals("PWNED", repository.loadDraftContent(def!!))
+	}
+}

--- a/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
@@ -115,6 +115,7 @@ class EntityTransferOperationTest : BaseTest() {
 		} returns Result.success(
 			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
 				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
 				every { hash() } returns "downloaded-hash-4"
 			})
 		)
@@ -129,6 +130,7 @@ class EntityTransferOperationTest : BaseTest() {
 		} returns Result.success(
 			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
 				every { id } returns 11
+				every { type } returns ApiProjectEntity.Type.SCENE
 				every { hash() } returns "downloaded-hash-11"
 			})
 		)
@@ -300,6 +302,7 @@ class EntityTransferOperationTest : BaseTest() {
 		} returns Result.success(
 			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
 				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
 				every { hash() } returns "h-4"
 			})
 		)
@@ -330,6 +333,7 @@ class EntityTransferOperationTest : BaseTest() {
 		} returns Result.success(
 			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
 				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
 				every { hash() } returns "h-4"
 			})
 		)
@@ -344,6 +348,123 @@ class EntityTransferOperationTest : BaseTest() {
 			assertIs<EntityTransferState>(result.data).allSuccess,
 			"A download whose store failed must not report the transfer as fully successful",
 		)
+	}
+
+	@Test
+	fun `download - server returns a different id than requested is rejected`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// Requested id 4, but a hostile server answers with a forged entity carrying id 7.
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 7
+				every { type } returns ApiProjectEntity.Type.SCENE
+				every { hash() } returns "forged-hash-7"
+			})
+		)
+
+		val logs = mutableListOf<SyncLogMessage>()
+		val result = op.execute(
+			state = singleDownloadState(4),
+			onProgress = { _, _ -> },
+			onLog = { logs.add(it) },
+			onConflict = {},
+			onComplete = {},
+		)
+
+		assertTrue(isSuccess(result))
+		assertFalse(assertIs<EntityTransferState>(result.data).allSuccess)
+		// The forged entity is never stored and never poisons the conflict baseline.
+		coVerify(exactly = 0) { mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 0) { syncJournal.recordSyncedHash(7, any()) }
+		coVerify(exactly = 0) { syncJournal.recordSyncedHash(4, any()) }
+		assertTrue(logs.any { it.level == SyncLogLevel.ERROR })
+	}
+
+	@Test
+	fun `download - server returns a different type than the client owns is rejected`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// The client already owns id 4 as a Scene...
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(4) } returns true
+		// ...but the server steers the same id into a Note, attempting a type confusion.
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.NoteEntity> {
+				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.NOTE
+				every { hash() } returns "wrong-type-hash-4"
+			})
+		)
+
+		val logs = mutableListOf<SyncLogMessage>()
+		val result = op.execute(
+			state = singleDownloadState(4),
+			onProgress = { _, _ -> },
+			onLog = { logs.add(it) },
+			onConflict = {},
+			onComplete = {},
+		)
+
+		assertTrue(isSuccess(result))
+		assertFalse(assertIs<EntityTransferState>(result.data).allSuccess)
+		// Neither repository is written, and no hash is recorded for the contested id.
+		coVerify(exactly = 0) { mockSynchronizers.noteSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 0) { mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 0) { syncJournal.recordSyncedHash(4, any()) }
+		assertTrue(logs.any { it.level == SyncLogLevel.ERROR })
+	}
+
+	@Test
+	fun `download - a new entity the client does not own is stored and its hash recorded`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// No synchronizer owns id 4 (findEntityType == null), so the type check must allow it.
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
+				every { hash() } returns "new-hash-4"
+			})
+		)
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any())
+		} returns true
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+		coVerify(exactly = 1) { mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 1) { syncJournal.recordSyncedHash(4, "new-hash-4") }
+	}
+
+	@Test
+	fun `download - matching id and owned type is stored and its hash recorded`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// Client owns id 4 as a Scene and the server agrees on both id and type.
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(4) } returns true
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
+				every { hash() } returns "matching-hash-4"
+			})
+		)
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any())
+		} returns true
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+		coVerify(exactly = 1) { mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 1) { syncJournal.recordSyncedHash(4, "matching-hash-4") }
 	}
 
 	@Test

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -1,0 +1,11 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+// TODO(F-4): iOS Keychain-backed AuthTokenStore. iOS still uses the plaintext
+//  file store; replace with a Keychain implementation.
+actual val authTokenStoreModule = module {
+	singleOf(::FileAuthTokenStore) bind AuthTokenStore::class
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ cache4k = "0.14.0"
 core = "1.7.0"
 coreKtx = "1.19.0"
 cryptohash = "1.0.2"
+androidx-security-crypto = "1.1.0"
 glance = "1.2.0-rc01"
 androix-junit = "1.3.0"
 junit = "6.1.0"
@@ -112,6 +113,7 @@ cache4k = { module = "io.github.reactivecircus.cache4k:cache4k", version.ref = "
 core = { module = "androidx.test:core", version.ref = "core" }
 core-ktx = { module = "androidx.test:core-ktx", version.ref = "core" }
 cryptohash = { module = "com.appmattus.crypto:cryptohash", version.ref = "cryptohash" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 flatlaf = { module = "com.formdev:flatlaf", version.ref = "flatlaf" }
 glance = { module = "androidx.glance:glance", version.ref = "glance" }
 glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -228,6 +228,7 @@ ktor_client_encoding = { group = "io.ktor", name = "ktor-client-encoding", versi
 ktor_client_okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 ktor_client_darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }
 ktor_client_java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }
+ktor_client_mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 
 ktor_serialization_kotlinx_json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 


### PR DESCRIPTION
## Client security hardening (audit follow-up)

A pass over the client modules (`base` / `common` / `composeUi` / `desktop` / `android` / `ios`) focused on the inverted client trust boundary — treating the sync server, imported/synced project data, and other on-device apps as untrusted. This PR lands the fixes that are self-contained; deeper items needing data migration or protocol changes are tracked separately.

Every change is TDD'd (reproducing test first), and the full `:common:desktopTest` plus `:integrationTests:jvmTest` suites pass.

### Sync trust — don't trust server-supplied data
The throughline of the audit: the client applied server sync responses without validating them against what it requested.
- **Path traversal via draft name / image extension** — sync-download write sinks used server-supplied strings verbatim as filename components. Now validated + skipped, with a containment backstop.
- **Entity id & type validation** — `downloadEntry` now rejects a response whose id (or, for an already-owned id, type) doesn't match the request, so a hostile server can't forge over an unrelated local entity or steer it into the wrong repository.
- **Cache-dir path encoding** — statistics/reference cache directories encoded the project name like the on-disk project dir does.
- **Central `FileSystem` containment chokepoint** — a `ForwardingFileSystem` decorator asserts every datasource write lands within the app's managed storage roots, so a future sink can't silently regress.

### Robustness
- **TOML load guards** — a malformed/imported notes or timeline file no longer crashes project load; the bad file is skipped / treated as empty.

### Platform surface
- **Exported `ProjectRootActivity`** — no longer accepts a caller-supplied project path; resolves by name against on-disk projects and is no longer exported.
- **Outbound URL path encoding** — dynamic project-name segments are percent-encoded so they can't inject extra path segments.

### Quality
- **Encyclopedia images** are now resolved by their actual extension (fixing orphaned non-jpg images) and restricted to the raster formats Coil renders on every target (`jpg`/`jpeg`/`png`/`webp`).
