### PR TITLE
Guard note loading against malformed TOML files

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesDatasource.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data.notesrepository
 
+import com.darkrockstudios.apps.hammer.base.http.readTomlOrNull
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContainer
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
@@ -8,6 +9,7 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispat
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -31,9 +33,14 @@ class NotesDatasource(
 		val files = fileSystem.listRecursively(dir)
 		val noteFiles = files.filterNotePathsOkio()
 
-		val notes = noteFiles.map { path -> loadNote(path) }.toList()
+		val notes = noteFiles.mapNotNull { path -> loadNoteOrNull(path) }.toList()
 		return@withContext notes
 	}
+
+	private fun loadNoteOrNull(path: Path): NoteContainer? =
+		fileSystem.readTomlOrNull<NoteContainer>(path, toml) { e ->
+			Napier.e("Skipping malformed note file: ${path.toHPath().path}", e)
+		}
 
 	private fun loadNote(path: Path): NoteContainer {
 		val noteToml = fileSystem.read(path) {

--- a/common/src/desktopTest/kotlin/repositories/notes/NotesDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/notes/NotesDatasourceTest.kt
@@ -1,0 +1,71 @@
+package repositories.notes
+
+import PROJECT_2_NAME
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesDatasource
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import createProject
+import getProjectDef
+import kotlinx.coroutines.test.runTest
+import net.peanuuutz.tomlkt.Toml
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class NotesDatasourceTest : BaseTest() {
+
+	private val projectDef = getProjectDef(PROJECT_2_NAME)
+
+	private lateinit var ffs: FakeFileSystem
+	private lateinit var toml: Toml
+	private lateinit var datasource: NotesDatasource
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		ffs = FakeFileSystem()
+		toml = createTomlSerializer()
+		setupKoin()
+		datasource = NotesDatasource(projectDef, ffs, toml)
+	}
+
+	private fun writeNoteFile(id: Int, contents: String) {
+		val path = datasource.getNotePath(id).toOkioPath()
+		ffs.write(path, mustCreate = true) {
+			writeUtf8(contents)
+		}
+	}
+
+	@Test
+	fun `Malformed note file is skipped and other notes still load`() = runTest {
+		createProject(ffs, PROJECT_2_NAME)
+		writeNoteFile(99, "this is not valid toml @@@")
+
+		val notes = datasource.loadNotes()
+
+		assertEquals(3, notes.size)
+		assertNull(notes.find { it.note.id == 99 })
+	}
+
+	@Test
+	fun `Note with non-integer id is skipped and other notes still load`() = runTest {
+		createProject(ffs, PROJECT_2_NAME)
+		writeNoteFile(
+			98,
+			"""
+				[note]
+				id = "not-an-int"
+				created = 0
+				content = "broken"
+			""".trimIndent()
+		)
+
+		val notes = datasource.loadNotes()
+
+		assertEquals(3, notes.size)
+		assertNull(notes.find { it.note.id == 98 })
+	}
+}


### PR DESCRIPTION
A malformed note file, or one with a non-integer id, threw uncaught from tomlkt (IllegalStateException/IllegalArgumentException beyond SerializationException) and aborted the entire notes load. loadNotes now skips unparseable files via readTomlOrNull and loads the rest.
