### PR TITLE
Guard timeline loading against malformed TOML files

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineDatasource.kt
@@ -6,6 +6,7 @@ import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import net.peanuuutz.tomlkt.Toml
@@ -56,7 +57,7 @@ class TimeLineDatasource(
 			return (getTimelineDir(projectDef).toOkioPath() / TIMELINE_FILENAME).toHPath()
 		}
 
-		@Suppress("SwallowedException") // Missing file means an empty timeline
+		@Suppress("SwallowedException") // Missing or corrupt file means an empty timeline
 		fun loadTimeline(hpath: HPath, fileSystem: FileSystem, toml: Toml): TimeLineContainer {
 			val path = hpath.toOkioPath()
 			return if (fileSystem.exists(path)) {
@@ -70,9 +71,13 @@ class TimeLineDatasource(
 						}
 					}
 				} catch (e: FileNotFoundException) {
-					TimeLineContainer(
-						events = emptyList()
-					)
+					TimeLineContainer(emptyList())
+				} catch (e: SerializationException) {
+					TimeLineContainer(emptyList())
+				} catch (e: IllegalArgumentException) {
+					TimeLineContainer(emptyList())
+				} catch (e: IllegalStateException) {
+					TimeLineContainer(emptyList())
 				}
 			} else {
 				TimeLineContainer(

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineDatasourceTest.kt
@@ -52,6 +52,20 @@ class TimeLineDatasourceTest : BaseTest() {
 	}
 
 	@Test
+	fun `Malformed Timeline loads as empty`() = runTest(mainTestDispatcher) {
+		val projDef = getProject1Def()
+		val file = TimeLineDatasource.getTimelineFilePath(projDef).toOkioPath()
+		ffs.createDirectories(file.parent!!)
+		ffs.write(file) {
+			writeUtf8("this is not valid timeline toml @@@")
+		}
+
+		val timeline = datasource.loadTimeline(projDef)
+
+		assertEquals(emptyList(), timeline.events)
+	}
+
+	@Test
 	fun `Store Timeline`() = runTest(mainTestDispatcher) {
 		val projDef = getProject1Def()
 		val events = fakeEvents()


### PR DESCRIPTION
loadTimeline caught only FileNotFoundException, so a present-but-malformed timeline.toml crashed the load. Extend the catch to SerializationException, IllegalArgumentException, and IllegalStateException, returning an empty timeline as with the missing/blank-file cases.
