### PR TITLE
Stop ProjectRootActivity from opening caller-supplied project paths

### DIFF
--- a/android/src/fdroid/AndroidManifest.xml
+++ b/android/src/fdroid/AndroidManifest.xml
@@ -56,7 +56,7 @@
 		</activity>
 		<activity
 			android:name=".ProjectRootActivity"
-			android:exported="true"
+			android:exported="false"
 			android:windowSoftInputMode="adjustResize"/>
 		<activity
 			android:name=".widgets.AddNoteActivity"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
 		</activity>
 		<activity
 			android:name=".ProjectRootActivity"
-			android:exported="true"
+			android:exported="false"
 			android:windowSoftInputMode="adjustResize"/>
 		<activity
 			android:name=".widgets.AddNoteActivity"

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
@@ -26,8 +26,6 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.retainedComponent
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.getAndUpdate
-import com.arkivanov.essenty.statekeeper.getSerializable
-import com.arkivanov.essenty.statekeeper.putSerializable
 import com.darkrockstudios.apps.hammer.android.shortcuts.ProjectShortcutsManager
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectDeepLink
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot
@@ -122,12 +120,13 @@ class ProjectRootActivity : AppCompatActivity() {
 		}
 	}
 
+	// Resolve the target project by name against on-disk projects only. We never trust a
+	// caller-supplied project path: an exported intent could otherwise root the editor at an
+	// attacker-controlled directory (confused deputy).
 	private fun resolveProjectDef(intent: Intent): ProjectDef? {
-		intent.extras?.getSerializable(EXTRA_PROJECT, ProjectDef.serializer())?.let { return it }
-
 		val name = intent.getStringExtra(EXTRA_PROJECT_NAME)?.takeIf { it.isNotBlank() } ?: return null
 		val match = projectsRepository.getProjects().firstOrNull { it.name == name }
-		if (match == null) Napier.w("Project shortcut for missing project: $name")
+		if (match == null) Napier.w("Project intent for missing project: $name")
 		return match
 	}
 
@@ -210,7 +209,6 @@ class ProjectRootActivity : AppCompatActivity() {
 	}
 
 	companion object {
-		const val EXTRA_PROJECT = "project"
 		const val EXTRA_PROJECT_NAME = "project_name"
 		const val EXTRA_DEEP_LINK_SCENE_ID = "deep_link_scene_id"
 		const val ACTION_OPEN_PROJECT = "com.darkrockstudios.apps.hammer.android.OPEN_PROJECT"
@@ -221,11 +219,8 @@ class ProjectRootActivity : AppCompatActivity() {
 			deepLinkSceneId: Int? = null,
 		): Intent {
 			val intent = Intent(context, ProjectRootActivity::class.java)
-			val extras = Bundle().apply {
-				putSerializable(EXTRA_PROJECT, projectDef, ProjectDef.serializer())
-				if (deepLinkSceneId != null) putInt(EXTRA_DEEP_LINK_SCENE_ID, deepLinkSceneId)
-			}
-			intent.putExtras(extras)
+				.putExtra(EXTRA_PROJECT_NAME, projectDef.name)
+			if (deepLinkSceneId != null) intent.putExtra(EXTRA_DEEP_LINK_SCENE_ID, deepLinkSceneId)
 			return intent
 		}
 

--- a/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryFindTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryFindTest.kt
@@ -84,4 +84,21 @@ class ProjectsRepositoryFindTest : ProjectsRepositoryBaseTest() {
 
 		assertEquals(proj1Def, projectDef)
 	}
+
+	// Guards the name-only intent resolution used by ProjectRootActivity: a name that does not
+	// match an on-disk project must resolve to nothing, so a forged intent cannot open an
+	// arbitrary project.
+	@Test
+	fun `Resolve project by name against on-disk projects only`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		createProject(ffs, PROJECT_2_NAME)
+
+		val repo = ProjectsRepository(ffs, settingsRepo, projectsMetaDatasource)
+
+		val known = repo.getProjects().firstOrNull { it.name == PROJECT_1_NAME }
+		val forged = repo.getProjects().firstOrNull { it.name == "../../attacker/controlled" }
+
+		assertEquals(getProjectDef(PROJECT_1_NAME), known)
+		assertNull(forged)
+	}
 }


### PR DESCRIPTION
ProjectRootActivity was exported and resolveProjectDef deserialized a caller-supplied ProjectDef whose free-form path was used verbatim for all project file I/O, letting any installed app root the editor at an attacker-controlled directory (confused deputy, CWE-926/CWE-22). Resolve the target project by name against on-disk projects only, drop the serialized EXTRA_PROJECT path extra, and mark the activity exported=false; it is only launched in-process via explicit intents and PendingIntents from widgets and shortcuts.
