### PR TITLE
Encode dynamic project-name path segments to stop URL segment injection

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -148,6 +148,7 @@ kotlin {
 				implementation(libs.koin.test.junit5)
 				implementation(compose.desktop.currentOs)
 				implementation(libs.poi.ooxml)
+				implementation(libs.ktor.client.mock)
 			}
 		}
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
@@ -152,7 +152,24 @@ fun HttpRequestBuilder.url(serverSettings: ServerSettings, path: String) {
 		if (serverPort != null) {
 			port = serverPort
 		}
-		pathSegments = path.split("/")
+		encodedPath = path
+	}
+}
+
+/**
+ * Encodes a dynamic value (e.g. a project name) so it can be safely interpolated into a request
+ * path as a single opaque segment. Without this, a value containing `/` would split into extra
+ * path segments and a `..` value would act as a traversal dot-segment, letting a value reach a
+ * different endpoint than the one the template intended.
+ */
+fun String.encodeUrlPathSegment(): String {
+	val encoded = encodeURLPathPart()
+	// `encodeURLPathPart` leaves dots untouched, so a segment of only dots would still be a
+	// traversal dot-segment. Percent-encode them so the value stays a single inert segment.
+	return if (encoded.isNotEmpty() && encoded.all { it == '.' }) {
+		encoded.replace(".", "%2E")
+	} else {
+		encoded
 	}
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ProjectDataApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ProjectDataApi.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataDto
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataUploadRequest
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataConflictException
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -27,7 +28,7 @@ class ProjectDataApi(
 		projectName: String,
 		projectId: ProjectId,
 	): Result<ProjectDataDto?> = get(
-		path = "/api/project/$userId/$projectName/project_data",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/project_data",
 		parse = { response ->
 			if (response.status == HttpStatusCode.NoContent) null
 			else response.body<ProjectDataDto>()
@@ -46,7 +47,7 @@ class ProjectDataApi(
 		data: ProjectData,
 		originalHash: String?,
 	): Result<ProjectDataDto> = post(
-		path = "/api/project/$userId/$projectName/project_data",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/project_data",
 		parse = { it.body<ProjectDataDto>() },
 		failureHandler = { response ->
 			if (response.status == HttpStatusCode.Conflict) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectApi.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.*
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityConflictException
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -37,7 +38,7 @@ class ServerProjectApi(
 		}
 
 		return post(
-			path = "/api/project/$userId/$projectName/begin_sync",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/begin_sync",
 			parse = { it.body() }
 		) {
 			url {
@@ -61,7 +62,7 @@ class ServerProjectApi(
 		syncEnd: Instant?,
 	): Result<String> {
 		return post(
-			path = "/api/project/$userId/$projectName/end_sync",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/end_sync",
 			parse = { it.body() },
 			builder = {
 				headers {
@@ -91,7 +92,7 @@ class ServerProjectApi(
 		force: Boolean = false
 	): Result<SaveEntityResponse> {
 		return post(
-			path = "/api/project/$userId/$projectName/upload_entity/${entity.id}",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/upload_entity/${entity.id}",
 			parse = { it.body() },
 			builder = {
 				contentType(ContentType.Application.Json)
@@ -163,7 +164,7 @@ class ServerProjectApi(
 		syncId: String
 	): Result<LoadEntityResponse> {
 		return get(
-			path = "/api/project/$userId/$projectName/download_entity/$entityId",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/download_entity/$entityId",
 			parse = { response ->
 				if (response.status == HttpStatusCode.NotModified) {
 					throw EntityNotModifiedException(entityId)
@@ -216,7 +217,7 @@ class ServerProjectApi(
 		syncId: String
 	): Result<DeleteIdsResponse> {
 		return get(
-			path = "/api/project/$userId/$projectName/delete_entity/$id",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/delete_entity/$id",
 			parse = { it.body() },
 			builder = {
 				headers {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
 import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeRequest
 import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeResponse
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -85,7 +86,7 @@ class ServerProjectsApi(
 		syncId: String,
 	): Result<CreateProjectResponse> {
 		return get(
-			path = "/api/projects/$userId/$projectName/create",
+			path = "/api/projects/$userId/${projectName.encodeUrlPathSegment()}/create",
 			builder = {
 				headers {
 					append(HEADER_SYNC_ID, syncId)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/WritingActivityApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/WritingActivityApi.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingActivityResponse
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -28,7 +29,7 @@ class WritingActivityApi(
 		projectName: String,
 		projectId: ProjectId,
 	): Result<WritingActivityResponse> = get(
-		path = "/api/project/$userId/$projectName/writing_activity",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/writing_activity",
 		parse = { it.body() },
 	) {
 		url {
@@ -44,7 +45,7 @@ class WritingActivityApi(
 		deviceId: String,
 		log: DeviceLog,
 	): Result<String> = post(
-		path = "/api/project/$userId/$projectName/writing_activity/$deviceId",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/writing_activity/${deviceId.encodeUrlPathSegment()}",
 	) {
 		contentType(ContentType.Application.Json)
 		url {

--- a/common/src/desktopTest/kotlin/server/ServerApiPathEncodingTest.kt
+++ b/common/src/desktopTest/kotlin/server/ServerApiPathEncodingTest.kt
@@ -1,0 +1,149 @@
+package server
+
+import com.darkrockstudios.apps.hammer.base.ProjectId
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.server.ProjectDataApi
+import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
+import com.darkrockstudios.apps.hammer.common.server.WritingActivityApi
+import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.koin.dsl.module
+import utils.BaseTest
+import utils.TestStrRes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ServerApiPathEncodingTest : BaseTest() {
+
+	private val userId = 42L
+	private lateinit var json: Json
+	private lateinit var globalSettingsStore: GlobalSettingsStore
+	private var capturedUrl: Url? = null
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		json = Json { ignoreUnknownKeys = true }
+
+		globalSettingsStore = mockk(relaxed = true)
+		every { globalSettingsStore.serverSettings } returns ServerSettings(
+			ssl = false,
+			url = "example.com",
+			email = "user@example.com",
+			userId = userId,
+			bearerToken = "token",
+			refreshToken = "refresh",
+		)
+
+		setupKoin(
+			module {
+				single { DeviceLocaleResolver() }
+			}
+		)
+	}
+
+	private fun mockClient(): HttpClient {
+		val engine = MockEngine { request ->
+			capturedUrl = request.url
+			respond(
+				content = "",
+				status = HttpStatusCode.NoContent,
+				headers = headersOf("Content-Type", "application/json"),
+			)
+		}
+		return HttpClient(engine) {
+			install(ContentNegotiation) { json(json) }
+		}
+	}
+
+	private suspend fun captureUrlOf(call: suspend () -> Unit): Url {
+		runCatching { call() }
+		return requireNotNull(capturedUrl) { "No request was captured" }
+	}
+
+	/**
+	 * A project name containing slashes and dot-segments must not split into extra path
+	 * segments or escape the intended `{userId}/{projectName}/{action}` template.
+	 */
+	@Test
+	fun `malicious project name is a single encoded path segment`() = runTest {
+		val client = mockClient()
+		val api = ProjectDataApi(client, globalSettingsStore, json, TestStrRes())
+
+		val maliciousName = "p/../../../api/account/test_auth"
+
+		val url = captureUrlOf {
+			api.getProjectData(
+				userId = userId,
+				projectName = maliciousName,
+				projectId = ProjectId("proj-1"),
+			)
+		}
+
+		val expectedSegments = listOf(
+			"api", "project", userId.toString(), maliciousName, "project_data"
+		)
+		assertEquals(expectedSegments, url.rawSegments.filter { it.isNotEmpty() })
+		assertFalse(
+			url.rawSegments.any { it == ".." },
+			"Outbound path must not contain a literal '..' dot-segment: ${url.encodedPath}"
+		)
+	}
+
+	@Test
+	fun `slash in project name does not create extra segments for ServerProjectApi`() = runTest {
+		val client = mockClient()
+		val api = ServerProjectApi(client, globalSettingsStore, json, TestStrRes())
+
+		val maliciousName = "a/b/c"
+
+		val url = captureUrlOf {
+			api.downloadEntity(
+				projectName = maliciousName,
+				projectId = ProjectId("proj-1"),
+				entityId = 7,
+				localHash = null,
+				syncId = "sync-1",
+			)
+		}
+		val expectedSegments = listOf(
+			"api", "project", userId.toString(), maliciousName, "download_entity", "7"
+		)
+		assertEquals(expectedSegments, url.rawSegments.filter { it.isNotEmpty() })
+	}
+
+	@Test
+	fun `slash in project name does not create extra segments for WritingActivityApi`() = runTest {
+		val client = mockClient()
+		val api = WritingActivityApi(client, globalSettingsStore, TestStrRes())
+
+		val maliciousName = "x/../y"
+
+		val url = captureUrlOf {
+			api.getWritingActivity(
+				userId = userId,
+				projectName = maliciousName,
+				projectId = ProjectId("proj-1"),
+			)
+		}
+		val expectedSegments = listOf(
+			"api", "project", userId.toString(), maliciousName, "writing_activity"
+		)
+		assertEquals(expectedSegments, url.rawSegments.filter { it.isNotEmpty() })
+		assertFalse(url.rawSegments.any { it == ".." })
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -228,6 +228,7 @@ ktor_client_encoding = { group = "io.ktor", name = "ktor-client-encoding", versi
 ktor_client_okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 ktor_client_darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }
 ktor_client_java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }
+ktor_client_mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 
 ktor_serialization_kotlinx_json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 


### PR DESCRIPTION
Every project-scoped client API built its request path by raw string
interpolation of projectName, e.g. "/api/project/$userId/$projectName/begin_sync".
That string reached the shared url() builder whose only path handling was
pathSegments = path.split("/"). Because the split ran on the already-interpolated
string, a projectName containing "/" was split into extra discrete path segments
and a ".." survived as a literal traversal dot-segment, so the outbound request
could target a different endpoint than the {userId}/{projectName}/{action}
template intended (e.g. a malicious sync server returning a project named
"p/../../../api/account/test_auth").

The shared ProjectNameValidator permits "/", "\" and "." (they are encoded to
disk-safe lookalikes only when used as a directory name), so a server-supplied
project name persists verbatim and then injects into every subsequent
project-scoped request under the same host with the bearer token attached.

Fix: each dynamic value is now percent-encoded into a single opaque path
segment via String.encodeUrlPathSegment() before interpolation, and the sink
sets encodedPath directly. Embedded "/" becomes %2F so it cannot create extra
segments, and an all-dots segment is encoded to %2E so a ".." name cannot act as
a traversal segment. The validator is intentionally left unchanged: tightening
it to reject "/" or "." would break syncing for already-valid existing project
names, so encoding is the backward-compatible fix and the on-disk
encodeForFilename behavior is untouched.

Adds a MockEngine test asserting a malicious projectName collapses to a single
encoded segment in the outbound URL across ProjectDataApi, ServerProjectApi and
WritingActivityApi.
