### PR TITLE
Block sync path traversal via draft name and image extension (F-1)

### DIFF
--- a/android/src/fdroid/AndroidManifest.xml
+++ b/android/src/fdroid/AndroidManifest.xml
@@ -56,7 +56,7 @@
 		</activity>
 		<activity
 			android:name=".ProjectRootActivity"
-			android:exported="true"
+			android:exported="false"
 			android:windowSoftInputMode="adjustResize"/>
 		<activity
 			android:name=".widgets.AddNoteActivity"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
 		</activity>
 		<activity
 			android:name=".ProjectRootActivity"
-			android:exported="true"
+			android:exported="false"
 			android:windowSoftInputMode="adjustResize"/>
 		<activity
 			android:name=".widgets.AddNoteActivity"

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
@@ -26,8 +26,6 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.retainedComponent
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.getAndUpdate
-import com.arkivanov.essenty.statekeeper.getSerializable
-import com.arkivanov.essenty.statekeeper.putSerializable
 import com.darkrockstudios.apps.hammer.android.shortcuts.ProjectShortcutsManager
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectDeepLink
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot
@@ -122,12 +120,13 @@ class ProjectRootActivity : AppCompatActivity() {
 		}
 	}
 
+	// Resolve the target project by name against on-disk projects only. We never trust a
+	// caller-supplied project path: an exported intent could otherwise root the editor at an
+	// attacker-controlled directory (confused deputy).
 	private fun resolveProjectDef(intent: Intent): ProjectDef? {
-		intent.extras?.getSerializable(EXTRA_PROJECT, ProjectDef.serializer())?.let { return it }
-
 		val name = intent.getStringExtra(EXTRA_PROJECT_NAME)?.takeIf { it.isNotBlank() } ?: return null
 		val match = projectsRepository.getProjects().firstOrNull { it.name == name }
-		if (match == null) Napier.w("Project shortcut for missing project: $name")
+		if (match == null) Napier.w("Project intent for missing project: $name")
 		return match
 	}
 
@@ -210,7 +209,6 @@ class ProjectRootActivity : AppCompatActivity() {
 	}
 
 	companion object {
-		const val EXTRA_PROJECT = "project"
 		const val EXTRA_PROJECT_NAME = "project_name"
 		const val EXTRA_DEEP_LINK_SCENE_ID = "deep_link_scene_id"
 		const val ACTION_OPEN_PROJECT = "com.darkrockstudios.apps.hammer.android.OPEN_PROJECT"
@@ -221,11 +219,8 @@ class ProjectRootActivity : AppCompatActivity() {
 			deepLinkSceneId: Int? = null,
 		): Intent {
 			val intent = Intent(context, ProjectRootActivity::class.java)
-			val extras = Bundle().apply {
-				putSerializable(EXTRA_PROJECT, projectDef, ProjectDef.serializer())
-				if (deepLinkSceneId != null) putInt(EXTRA_DEEP_LINK_SCENE_ID, deepLinkSceneId)
-			}
-			intent.putExtras(extras)
+				.putExtra(EXTRA_PROJECT_NAME, projectDef.name)
+			if (deepLinkSceneId != null) intent.putExtra(EXTRA_DEEP_LINK_SCENE_ID, deepLinkSceneId)
 			return intent
 		}
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -148,6 +148,7 @@ kotlin {
 				implementation(libs.koin.test.junit5)
 				implementation(compose.desktop.currentOs)
 				implementation(libs.poi.ooxml)
+				implementation(libs.ktor.client.mock)
 			}
 		}
 	}

--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -194,6 +194,9 @@
 	<string name="sync_log_data_save_failed">Sync data not saved due to errors</string>
 	<string name="sync_log_failed">Failed to end sync</string>
 
+	<string name="sync_draft_rejected_invalid_name">Rejected draft %1$d from server: unsafe draft name</string>
+	<string name="sync_encyclopedia_image_rejected_invalid_extension">Skipped image for encyclopedia entry %1$d from server: unsafe file extension</string>
+
 	<string name="sync_encyclopedia_deleted">Deleted Encyclopedia ID %1$d from client</string>
 	<string name="sync_note_deleted">Deleted note ID %1$d from client</string>
 	<string name="sync_draft_deleted">Deleted draft %1$d from client</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftsDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftsDatasource.kt
@@ -5,6 +5,7 @@ import com.darkrockstudios.apps.hammer.common.data.SceneContent
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import io.github.aakira.napier.Napier
@@ -91,6 +92,12 @@ class SceneDraftsDatasource(
 	fun insertSyncDraft(draftEntity: ApiProjectEntity.SceneDraftEntity): DraftDef {
 		val draftDef = draftEntity.toDraftDef()
 		val path = getDraftPath(draftDef).toOkioPath()
+
+		val draftsRoot = getSceneDraftsDirectory(draftDef.sceneId).toOkioPath()
+		if (!path.isWithin(draftsRoot)) {
+			error("Refusing to write draft outside its drafts directory: $path")
+		}
+
 		val parentPath = path.parent ?: error("Draft path didn't have parent: $path")
 		fileSystem.createDirectories(parentPath)
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
@@ -9,6 +9,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.InvalidSceneFilename
 import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import io.github.aakira.napier.Napier
@@ -219,6 +220,12 @@ class EncyclopediaDatasource(
 	/** Writes raw image bytes (e.g. an image pulled from the server during sync) to the entry's image path. */
 	suspend fun writeEntryImage(entryDef: EntryDef, imageBytes: ByteArray, fileExtension: String) {
 		val targetPath = getEntryImagePath(entryDef, fileExtension).toOkioPath()
+
+		val typeDir = getTypeDirectory(entryDef.type).toOkioPath()
+		if (!targetPath.isWithin(typeDir)) {
+			error("Refusing to write entry image outside its type directory: $targetPath")
+		}
+
 		fileSystem.write(targetPath) {
 			write(imageBytes)
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/notesrepository/NotesDatasource.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data.notesrepository
 
+import com.darkrockstudios.apps.hammer.base.http.readTomlOrNull
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContainer
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
@@ -8,6 +9,7 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispat
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -31,9 +33,14 @@ class NotesDatasource(
 		val files = fileSystem.listRecursively(dir)
 		val noteFiles = files.filterNotePathsOkio()
 
-		val notes = noteFiles.map { path -> loadNote(path) }.toList()
+		val notes = noteFiles.mapNotNull { path -> loadNoteOrNull(path) }.toList()
 		return@withContext notes
 	}
+
+	private fun loadNoteOrNull(path: Path): NoteContainer? =
+		fileSystem.readTomlOrNull<NoteContainer>(path, toml) { e ->
+			Napier.e("Skipping malformed note file: ${path.toHPath().path}", e)
+		}
 
 	private fun loadNote(path: Path): NoteContainer {
 		val noteToml = fileSystem.read(path) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
@@ -18,10 +18,13 @@ import com.darkrockstudios.apps.hammer.common.data.references.ReferenceRemapper
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogI
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogW
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.sync_encyclopedia_deleted
+import com.darkrockstudios.apps.hammer.sync_encyclopedia_image_rejected_invalid_extension
+import io.github.aakira.napier.Napier
 import korlibs.crypto.encoding.Base64
 import kotlinx.coroutines.flow.first
 
@@ -138,7 +141,7 @@ class ClientEncyclopediaSynchronizer(
 			type = EntryType.fromString(serverEntity.entryType),
 		)
 
-		handleImage(oldDef, serverDef, serverEntity)
+		handleImage(oldDef, serverDef, serverEntity, onLog)
 
 		if (oldDef != null) {
 			encyclopediaService.updateEntry(
@@ -166,10 +169,21 @@ class ClientEncyclopediaSynchronizer(
 	private suspend fun handleImage(
 		oldDef: EntryDef?,
 		serverDef: EntryDef,
-		serverEntity: ApiProjectEntity.EncyclopediaEntryEntity
+		serverEntity: ApiProjectEntity.EncyclopediaEntryEntity,
+		onLog: OnSyncLog,
 	) {
 		val image = serverEntity.image
 		if (image != null) {
+			if (image.fileExtension.lowercase() !in ALLOWED_IMAGE_EXTENSIONS) {
+				Napier.w("Skipped synced image for entry ${serverEntity.id}: invalid file extension '${image.fileExtension}'")
+				onLog(
+					syncLogW(
+						strRes.get(Res.string.sync_encyclopedia_image_rejected_invalid_extension, serverEntity.id),
+						projectDef
+					)
+				)
+				return
+			}
 			val imageBytes = Base64.decode(image.base64, url = true)
 			encyclopediaDatasource.writeEntryImage(serverDef, imageBytes, image.fileExtension)
 		} else if (oldDef != null && encyclopediaDatasource.hasEntryImage(oldDef, "jpg")) {
@@ -177,5 +191,11 @@ class ClientEncyclopediaSynchronizer(
 			// sync-marking) since we're applying server state, not making a local edit.
 			encyclopediaDatasource.removeEntryImage(oldDef)
 		}
+	}
+
+	companion object {
+		val ALLOWED_IMAGE_EXTENSIONS = setOf(
+			"jpg", "jpeg", "png", "gif", "webp", "bmp", "heic", "heif",
+		)
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientSceneDraftSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientSceneDraftSynchronizer.kt
@@ -8,15 +8,18 @@ import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectInject
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogI
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogW
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.sync_draft_deleted
+import com.darkrockstudios.apps.hammer.sync_draft_rejected_invalid_name
 import io.github.aakira.napier.Napier
 
 class ClientSceneDraftSynchronizer(
@@ -90,6 +93,17 @@ class ClientSceneDraftSynchronizer(
 		syncId: String,
 		onLog: OnSyncLog
 	): Boolean {
+		if (!SceneDraftsDatasource.validDraftName(serverEntity.name)) {
+			Napier.w("Rejected synced draft ${serverEntity.id}: invalid draft name")
+			onLog(
+				syncLogW(
+					strRes.get(Res.string.sync_draft_rejected_invalid_name, serverEntity.id),
+					projectDef
+				)
+			)
+			return false
+		}
+
 		sceneDraftRepository.insertSyncDraft(serverEntity)
 		return true
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/timelinerepository/TimeLineDatasource.kt
@@ -6,6 +6,7 @@ import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import net.peanuuutz.tomlkt.Toml
@@ -56,7 +57,7 @@ class TimeLineDatasource(
 			return (getTimelineDir(projectDef).toOkioPath() / TIMELINE_FILENAME).toHPath()
 		}
 
-		@Suppress("SwallowedException") // Missing file means an empty timeline
+		@Suppress("SwallowedException") // Missing or corrupt file means an empty timeline
 		fun loadTimeline(hpath: HPath, fileSystem: FileSystem, toml: Toml): TimeLineContainer {
 			val path = hpath.toOkioPath()
 			return if (fileSystem.exists(path)) {
@@ -70,9 +71,13 @@ class TimeLineDatasource(
 						}
 					}
 				} catch (e: FileNotFoundException) {
-					TimeLineContainer(
-						events = emptyList()
-					)
+					TimeLineContainer(emptyList())
+				} catch (e: SerializationException) {
+					TimeLineContainer(emptyList())
+				} catch (e: IllegalArgumentException) {
+					TimeLineContainer(emptyList())
+				} catch (e: IllegalStateException) {
+					TimeLineContainer(emptyList())
 				}
 			} else {
 				TimeLineContainer(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/Http.kt
@@ -152,7 +152,24 @@ fun HttpRequestBuilder.url(serverSettings: ServerSettings, path: String) {
 		if (serverPort != null) {
 			port = serverPort
 		}
-		pathSegments = path.split("/")
+		encodedPath = path
+	}
+}
+
+/**
+ * Encodes a dynamic value (e.g. a project name) so it can be safely interpolated into a request
+ * path as a single opaque segment. Without this, a value containing `/` would split into extra
+ * path segments and a `..` value would act as a traversal dot-segment, letting a value reach a
+ * different endpoint than the one the template intended.
+ */
+fun String.encodeUrlPathSegment(): String {
+	val encoded = encodeURLPathPart()
+	// `encodeURLPathPart` leaves dots untouched, so a segment of only dots would still be a
+	// traversal dot-segment. Percent-encode them so the value stays a single inert segment.
+	return if (encoded.isNotEmpty() && encoded.all { it == '.' }) {
+		encoded.replace(".", "%2E")
+	} else {
+		encoded
 	}
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/PathContainment.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/PathContainment.kt
@@ -1,0 +1,23 @@
+package com.darkrockstudios.apps.hammer.common.fileio.okio
+
+import okio.Path
+
+/**
+ * Containment backstop against path traversal. Returns true only when this path,
+ * once `..`/`.` segments are collapsed, equals [root] or sits nested beneath it.
+ * A non-descendant (sibling escape, absolute reach-out, `..` climb) returns false.
+ */
+fun Path.isWithin(root: Path): Boolean {
+	val normalizedRoot = root.normalized()
+	val normalizedCandidate = normalized()
+
+	if (normalizedCandidate.isAbsolute != normalizedRoot.isAbsolute) return false
+
+	if (normalizedCandidate == normalizedRoot) return true
+
+	val rootSegments = normalizedRoot.segments
+	val candidateSegments = normalizedCandidate.segments
+	if (candidateSegments.size <= rootSegments.size) return false
+
+	return candidateSegments.subList(0, rootSegments.size) == rootSegments
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ProjectDataApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ProjectDataApi.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataDto
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectDataUploadRequest
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataConflictException
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -27,7 +28,7 @@ class ProjectDataApi(
 		projectName: String,
 		projectId: ProjectId,
 	): Result<ProjectDataDto?> = get(
-		path = "/api/project/$userId/$projectName/project_data",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/project_data",
 		parse = { response ->
 			if (response.status == HttpStatusCode.NoContent) null
 			else response.body<ProjectDataDto>()
@@ -46,7 +47,7 @@ class ProjectDataApi(
 		data: ProjectData,
 		originalHash: String?,
 	): Result<ProjectDataDto> = post(
-		path = "/api/project/$userId/$projectName/project_data",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/project_data",
 		parse = { it.body<ProjectDataDto>() },
 		failureHandler = { response ->
 			if (response.status == HttpStatusCode.Conflict) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectApi.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.*
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityConflictException
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -37,7 +38,7 @@ class ServerProjectApi(
 		}
 
 		return post(
-			path = "/api/project/$userId/$projectName/begin_sync",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/begin_sync",
 			parse = { it.body() }
 		) {
 			url {
@@ -61,7 +62,7 @@ class ServerProjectApi(
 		syncEnd: Instant?,
 	): Result<String> {
 		return post(
-			path = "/api/project/$userId/$projectName/end_sync",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/end_sync",
 			parse = { it.body() },
 			builder = {
 				headers {
@@ -91,7 +92,7 @@ class ServerProjectApi(
 		force: Boolean = false
 	): Result<SaveEntityResponse> {
 		return post(
-			path = "/api/project/$userId/$projectName/upload_entity/${entity.id}",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/upload_entity/${entity.id}",
 			parse = { it.body() },
 			builder = {
 				contentType(ContentType.Application.Json)
@@ -163,7 +164,7 @@ class ServerProjectApi(
 		syncId: String
 	): Result<LoadEntityResponse> {
 		return get(
-			path = "/api/project/$userId/$projectName/download_entity/$entityId",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/download_entity/$entityId",
 			parse = { response ->
 				if (response.status == HttpStatusCode.NotModified) {
 					throw EntityNotModifiedException(entityId)
@@ -216,7 +217,7 @@ class ServerProjectApi(
 		syncId: String
 	): Result<DeleteIdsResponse> {
 		return get(
-			path = "/api/project/$userId/$projectName/delete_entity/$id",
+			path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/delete_entity/$id",
 			parse = { it.body() },
 			builder = {
 				headers {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerProjectsApi.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.base.http.ProjectHashItem
 import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeRequest
 import com.darkrockstudios.apps.hammer.base.http.ProjectsSyncProbeResponse
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -85,7 +86,7 @@ class ServerProjectsApi(
 		syncId: String,
 	): Result<CreateProjectResponse> {
 		return get(
-			path = "/api/projects/$userId/$projectName/create",
+			path = "/api/projects/$userId/${projectName.encodeUrlPathSegment()}/create",
 			builder = {
 				headers {
 					append(HEADER_SYNC_ID, syncId)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/WritingActivityApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/WritingActivityApi.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingActivityResponse
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.encodeUrlPathSegment
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -28,7 +29,7 @@ class WritingActivityApi(
 		projectName: String,
 		projectId: ProjectId,
 	): Result<WritingActivityResponse> = get(
-		path = "/api/project/$userId/$projectName/writing_activity",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/writing_activity",
 		parse = { it.body() },
 	) {
 		url {
@@ -44,7 +45,7 @@ class WritingActivityApi(
 		deviceId: String,
 		log: DeviceLog,
 	): Result<String> = post(
-		path = "/api/project/$userId/$projectName/writing_activity/$deviceId",
+		path = "/api/project/$userId/${projectName.encodeUrlPathSegment()}/writing_activity/${deviceId.encodeUrlPathSegment()}",
 	) {
 		contentType(ContentType.Application.Json)
 		url {

--- a/common/src/desktopTest/kotlin/fileio/PathContainmentTest.kt
+++ b/common/src/desktopTest/kotlin/fileio/PathContainmentTest.kt
@@ -1,0 +1,58 @@
+package fileio
+
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PathContainmentTest {
+
+	private val root = "/projects/Test/.drafts/1".toPath()
+
+	@Test
+	fun `a genuine descendant is within the root`() {
+		assertTrue(("/projects/Test/.drafts/1/1-5-draft-100.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `the root itself is within the root`() {
+		assertTrue(root.isWithin(root))
+	}
+
+	@Test
+	fun `a parent-climbing traversal escapes the root`() {
+		val escape = ("/projects/Test/.drafts/1" / "../../../../evil").toPath()
+		assertFalse(escape.isWithin(root))
+	}
+
+	@Test
+	fun `an embedded dot-dot segment that escapes the root is rejected`() {
+		assertFalse(("/projects/Test/.drafts/1/../../evil.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `a sibling directory is not within the root`() {
+		assertFalse(("/projects/Test/.drafts/2/file.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `a prefix-sharing sibling is not within the root`() {
+		// "/projects/Test/.drafts/10" shares the textual prefix "/projects/Test/.drafts/1"
+		// but is a different directory.
+		assertFalse(("/projects/Test/.drafts/10/file.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `an absolute reach-out is not within a relative root`() {
+		val relativeRoot = ".drafts/1".toPath()
+		assertFalse(("/etc/passwd".toPath()).isWithin(relativeRoot))
+	}
+
+	@Test
+	fun `an unrelated absolute path is not within the root`() {
+		assertFalse(("/etc/passwd".toPath()).isWithin(root))
+	}
+
+	private operator fun String.div(other: String) = "$this/$other"
+}

--- a/common/src/desktopTest/kotlin/repositories/notes/NotesDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/notes/NotesDatasourceTest.kt
@@ -1,0 +1,71 @@
+package repositories.notes
+
+import PROJECT_2_NAME
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesDatasource
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import createProject
+import getProjectDef
+import kotlinx.coroutines.test.runTest
+import net.peanuuutz.tomlkt.Toml
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class NotesDatasourceTest : BaseTest() {
+
+	private val projectDef = getProjectDef(PROJECT_2_NAME)
+
+	private lateinit var ffs: FakeFileSystem
+	private lateinit var toml: Toml
+	private lateinit var datasource: NotesDatasource
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		ffs = FakeFileSystem()
+		toml = createTomlSerializer()
+		setupKoin()
+		datasource = NotesDatasource(projectDef, ffs, toml)
+	}
+
+	private fun writeNoteFile(id: Int, contents: String) {
+		val path = datasource.getNotePath(id).toOkioPath()
+		ffs.write(path, mustCreate = true) {
+			writeUtf8(contents)
+		}
+	}
+
+	@Test
+	fun `Malformed note file is skipped and other notes still load`() = runTest {
+		createProject(ffs, PROJECT_2_NAME)
+		writeNoteFile(99, "this is not valid toml @@@")
+
+		val notes = datasource.loadNotes()
+
+		assertEquals(3, notes.size)
+		assertNull(notes.find { it.note.id == 99 })
+	}
+
+	@Test
+	fun `Note with non-integer id is skipped and other notes still load`() = runTest {
+		createProject(ffs, PROJECT_2_NAME)
+		writeNoteFile(
+			98,
+			"""
+				[note]
+				id = "not-an-int"
+				created = 0
+				content = "broken"
+			""".trimIndent()
+		)
+
+		val notes = datasource.loadNotes()
+
+		assertEquals(3, notes.size)
+		assertNull(notes.find { it.note.id == 98 })
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryFindTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryFindTest.kt
@@ -84,4 +84,21 @@ class ProjectsRepositoryFindTest : ProjectsRepositoryBaseTest() {
 
 		assertEquals(proj1Def, projectDef)
 	}
+
+	// Guards the name-only intent resolution used by ProjectRootActivity: a name that does not
+	// match an on-disk project must resolve to nothing, so a forged intent cannot open an
+	// arbitrary project.
+	@Test
+	fun `Resolve project by name against on-disk projects only`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		createProject(ffs, PROJECT_2_NAME)
+
+		val repo = ProjectsRepository(ffs, settingsRepo, projectsMetaDatasource)
+
+		val known = repo.getProjects().firstOrNull { it.name == PROJECT_1_NAME }
+		val forged = repo.getProjects().firstOrNull { it.name == "../../attacker/controlled" }
+
+		assertEquals(getProjectDef(PROJECT_1_NAME), known)
+		assertNull(forged)
+	}
 }

--- a/common/src/desktopTest/kotlin/repositories/timeline/TimeLineDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/timeline/TimeLineDatasourceTest.kt
@@ -52,6 +52,20 @@ class TimeLineDatasourceTest : BaseTest() {
 	}
 
 	@Test
+	fun `Malformed Timeline loads as empty`() = runTest(mainTestDispatcher) {
+		val projDef = getProject1Def()
+		val file = TimeLineDatasource.getTimelineFilePath(projDef).toOkioPath()
+		ffs.createDirectories(file.parent!!)
+		ffs.write(file) {
+			writeUtf8("this is not valid timeline toml @@@")
+		}
+
+		val timeline = datasource.loadTimeline(projDef)
+
+		assertEquals(emptyList(), timeline.events)
+	}
+
+	@Test
 	fun `Store Timeline`() = runTest(mainTestDispatcher) {
 		val projDef = getProject1Def()
 		val events = fakeEvents()

--- a/common/src/desktopTest/kotlin/server/ServerApiPathEncodingTest.kt
+++ b/common/src/desktopTest/kotlin/server/ServerApiPathEncodingTest.kt
@@ -1,0 +1,149 @@
+package server
+
+import com.darkrockstudios.apps.hammer.base.ProjectId
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.server.ProjectDataApi
+import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
+import com.darkrockstudios.apps.hammer.common.server.WritingActivityApi
+import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.koin.dsl.module
+import utils.BaseTest
+import utils.TestStrRes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ServerApiPathEncodingTest : BaseTest() {
+
+	private val userId = 42L
+	private lateinit var json: Json
+	private lateinit var globalSettingsStore: GlobalSettingsStore
+	private var capturedUrl: Url? = null
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		json = Json { ignoreUnknownKeys = true }
+
+		globalSettingsStore = mockk(relaxed = true)
+		every { globalSettingsStore.serverSettings } returns ServerSettings(
+			ssl = false,
+			url = "example.com",
+			email = "user@example.com",
+			userId = userId,
+			bearerToken = "token",
+			refreshToken = "refresh",
+		)
+
+		setupKoin(
+			module {
+				single { DeviceLocaleResolver() }
+			}
+		)
+	}
+
+	private fun mockClient(): HttpClient {
+		val engine = MockEngine { request ->
+			capturedUrl = request.url
+			respond(
+				content = "",
+				status = HttpStatusCode.NoContent,
+				headers = headersOf("Content-Type", "application/json"),
+			)
+		}
+		return HttpClient(engine) {
+			install(ContentNegotiation) { json(json) }
+		}
+	}
+
+	private suspend fun captureUrlOf(call: suspend () -> Unit): Url {
+		runCatching { call() }
+		return requireNotNull(capturedUrl) { "No request was captured" }
+	}
+
+	/**
+	 * A project name containing slashes and dot-segments must not split into extra path
+	 * segments or escape the intended `{userId}/{projectName}/{action}` template.
+	 */
+	@Test
+	fun `malicious project name is a single encoded path segment`() = runTest {
+		val client = mockClient()
+		val api = ProjectDataApi(client, globalSettingsStore, json, TestStrRes())
+
+		val maliciousName = "p/../../../api/account/test_auth"
+
+		val url = captureUrlOf {
+			api.getProjectData(
+				userId = userId,
+				projectName = maliciousName,
+				projectId = ProjectId("proj-1"),
+			)
+		}
+
+		val expectedSegments = listOf(
+			"api", "project", userId.toString(), maliciousName, "project_data"
+		)
+		assertEquals(expectedSegments, url.rawSegments.filter { it.isNotEmpty() })
+		assertFalse(
+			url.rawSegments.any { it == ".." },
+			"Outbound path must not contain a literal '..' dot-segment: ${url.encodedPath}"
+		)
+	}
+
+	@Test
+	fun `slash in project name does not create extra segments for ServerProjectApi`() = runTest {
+		val client = mockClient()
+		val api = ServerProjectApi(client, globalSettingsStore, json, TestStrRes())
+
+		val maliciousName = "a/b/c"
+
+		val url = captureUrlOf {
+			api.downloadEntity(
+				projectName = maliciousName,
+				projectId = ProjectId("proj-1"),
+				entityId = 7,
+				localHash = null,
+				syncId = "sync-1",
+			)
+		}
+		val expectedSegments = listOf(
+			"api", "project", userId.toString(), maliciousName, "download_entity", "7"
+		)
+		assertEquals(expectedSegments, url.rawSegments.filter { it.isNotEmpty() })
+	}
+
+	@Test
+	fun `slash in project name does not create extra segments for WritingActivityApi`() = runTest {
+		val client = mockClient()
+		val api = WritingActivityApi(client, globalSettingsStore, TestStrRes())
+
+		val maliciousName = "x/../y"
+
+		val url = captureUrlOf {
+			api.getWritingActivity(
+				userId = userId,
+				projectName = maliciousName,
+				projectId = ProjectId("proj-1"),
+			)
+		}
+		val expectedSegments = listOf(
+			"api", "project", userId.toString(), maliciousName, "writing_activity"
+		)
+		assertEquals(expectedSegments, url.rawSegments.filter { it.isNotEmpty() })
+		assertFalse(url.rawSegments.any { it == ".." })
+	}
+}

--- a/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
@@ -254,6 +254,67 @@ class ClientEncyclopediaSynchronizerTest : BaseTest() {
 	}
 
 	@Test
+	fun `storeEntity rejects a traversal file extension and writes no image but still stores the entry`() = runTest {
+		val imageBytes = byteArrayOf(4, 5, 6)
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			text = "Stored anyway",
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(imageBytes, url = true),
+				fileExtension = "jpg/../../../../evil",
+			),
+		)
+
+		val before = allRegularFiles()
+
+		val stored = sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		assertTrue(stored)
+		assertEquals("Stored anyway", repository.loadEntry(entry1().id).entry.text)
+		assertEquals(before, allRegularFiles())
+	}
+
+	@Test
+	fun `storeEntity rejects an unknown image extension`() = runTest {
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(byteArrayOf(1), url = true),
+				fileExtension = "exe",
+			),
+		)
+
+		val before = allRegularFiles()
+		sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		assertEquals(before, allRegularFiles())
+	}
+
+	@Test
+	fun `storeEntity writes a png image with an allowed extension`() = runTest {
+		val imageBytes = byteArrayOf(7, 7, 7)
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(imageBytes, url = true),
+				fileExtension = "png",
+			),
+		)
+
+		sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		val def = entry1().toDef(projectDef)
+		assertTrue(datasource.hasEntryImage(def, "png"))
+		assertContentEquals(imageBytes, datasource.loadEntryImage(def, "png"))
+	}
+
+	private fun allRegularFiles(): Set<String> =
+		fileSystem.allPaths
+			.filter { fileSystem.metadataOrNull(it)?.isRegularFile == true }
+			.map { it.toString() }
+			.toSet()
+
+	@Test
 	fun `storeEntity drops a local image when the server has none`() = runTest {
 		val def = entry1().toDef(projectDef)
 		datasource.writeEntryImage(def, byteArrayOf(1, 2, 3), "jpg")

--- a/common/src/desktopTest/kotlin/synchronizer/ClientSceneDraftSynchronizerSecurityTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientSceneDraftSynchronizerSecurityTest.kt
@@ -1,0 +1,149 @@
+package synchronizer
+
+import PROJECT_2_NAME
+import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
+import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogLevel
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogMessage
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.synchronizers.ClientSceneDraftSynchronizer
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
+import com.darkrockstudios.apps.hammer.common.util.StrRes
+import createProject
+import getProjectDef
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.dsl.module
+import utils.BaseTest
+import utils.TestStrRes
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * Classical-style: drives a real [SceneDraftRepository] / [SceneDraftsDatasource] over a
+ * [FakeFileSystem] seeded from the "Test Project 2" fixture. Only the network boundary is
+ * mocked. Asserts observable filesystem outcomes (no file escapes the drafts directory).
+ */
+class ClientSceneDraftSynchronizerSecurityTest : BaseTest() {
+
+	private val projectDef = getProjectDef(PROJECT_2_NAME)
+	private val strRes: StrRes = TestStrRes()
+
+	@MockK(relaxed = true)
+	private lateinit var serverProjectApi: ServerProjectApi
+
+	@MockK(relaxed = true)
+	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
+
+	@MockK(relaxed = true)
+	private lateinit var idAllocator: IdAllocator
+
+	@MockK(relaxed = true)
+	private lateinit var sceneContentRepository: SceneContentRepository
+
+	@MockK(relaxed = true)
+	private lateinit var clock: Clock
+
+	private lateinit var ffs: FakeFileSystem
+	private lateinit var repository: SceneDraftRepository
+	private lateinit var datasource: SceneDraftsDatasource
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		MockKAnnotations.init(this, relaxUnitFun = true)
+
+		ffs = FakeFileSystem()
+		createProject(ffs, PROJECT_2_NAME)
+
+		val sceneDatasource = SceneDatasource(projectDef, ffs)
+		datasource = SceneDraftsDatasource(ffs, sceneDatasource)
+
+		setupKoin(module {
+			single { idAllocator }
+			single { clock }
+			scope<ProjectDefScope> {
+				scoped { projectDef }
+				scoped { repository }
+			}
+		})
+
+		repository = SceneDraftRepository(projectDef, sceneContentRepository, datasource, clock)
+	}
+
+	private fun newSynchronizer() = ClientSceneDraftSynchronizer(
+		projectDef = projectDef,
+		serverProjectApi = serverProjectApi,
+		projectMetadataDatasource = projectMetadataDatasource,
+		strRes = strRes,
+	)
+
+	private fun draftEntity(name: String) = ApiProjectEntity.SceneDraftEntity(
+		id = 500,
+		sceneId = 1,
+		created = Instant.fromEpochSeconds(1000),
+		name = name,
+		content = "PWNED",
+	)
+
+	private fun allFiles(): Set<String> =
+		ffs.allPaths
+			.filter { ffs.metadataOrNull(it)?.isRegularFile == true }
+			.map { it.toString() }
+			.toSet()
+
+	@Test
+	fun `a traversal draft name escaping with dot-dot is rejected and writes no file`() = runTest {
+		val before = allFiles()
+		val logs = mutableListOf<SyncLogMessage>()
+
+		val stored = newSynchronizer().storeEntity(
+			draftEntity("../../../../evil"),
+			syncId = "sync",
+			onLog = { logs.add(it) },
+		)
+
+		assertFalse(stored, "Malicious draft must be skipped")
+		assertEquals(before, allFiles(), "No file may be created anywhere on the filesystem")
+		assertTrue(logs.any { it.level == SyncLogLevel.WARN })
+	}
+
+	@Test
+	fun `a draft name with an embedded slash is rejected and writes no file`() = runTest {
+		val before = allFiles()
+
+		val stored = newSynchronizer().storeEntity(
+			draftEntity("a/b"),
+			syncId = "sync",
+			onLog = {},
+		)
+
+		assertFalse(stored)
+		assertEquals(before, allFiles())
+	}
+
+	@Test
+	fun `a normal draft name is stored and loads back`() = runTest {
+		val entity = draftEntity("Clean Name")
+
+		val stored = newSynchronizer().storeEntity(entity, syncId = "sync", onLog = {})
+
+		assertTrue(stored)
+		val def = repository.getDraftDef(500)
+		assertEquals("Clean Name", def?.draftName)
+		assertEquals("PWNED", repository.loadDraftContent(def!!))
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -228,6 +228,7 @@ ktor_client_encoding = { group = "io.ktor", name = "ktor-client-encoding", versi
 ktor_client_okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 ktor_client_darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }
 ktor_client_java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }
+ktor_client_mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 
 ktor_serialization_kotlinx_json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 


### PR DESCRIPTION
A malicious or compromised sync server could supply crafted entity
fields that were used verbatim as filename components when writing
downloaded entities to disk, with no validation on the sync path
(unlike the local-create paths). Embedded `/` or `..` escaped the
intended directory and, since file contents are attacker-controlled,
gave a write-anywhere primitive on the unsandboxed Desktop target.

Two sinks were affected:
- SceneDraftEntity.name flows into the draft filename in
  SceneDraftsDatasource.insertSyncDraft.
- EncyclopediaEntryEntity.Image.fileExtension flows into the entry
  image filename in EncyclopediaDatasource.writeEntryImage.

Defense in depth, two layers:

Layer 1 (synchronizer boundary, graceful per-entity skip):
- ClientSceneDraftSynchronizer.storeEntity rejects any draft whose
  name fails the existing validDraftName check, logs a warning, and
  returns false so only that entity is skipped (no synced hash is
  recorded, so sync state is not poisoned and the run is not aborted).
- ClientEncyclopediaSynchronizer.handleImage validates the image
  file extension against a known-image allowlist (ALLOWED_IMAGE_
  EXTENSIONS); a disallowed extension skips just the image write while
  the entry itself is still stored.

Layer 2 (containment backstop): a new Path.isWithin(root) helper
(okio normalized()) is asserted right before the write in both
datasource sinks, hard-failing any path that escapes its intended
directory. With Layer 1 in place this should never fire for the known
sinks; it fail-closes any future sink that forgets validation.

Tests (TDD, confirmed failing before the fix): traversal draft names
and image extensions are blocked with no file written outside the
target directory; isWithin rejects `..`, absolute, and sibling-escape
paths; happy-path drafts and jpg/png images still round-trip.
