### PR TITLE
Encode project name in cache-dir path builders (F-15/F-16)

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsCachePaths.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsCachePaths.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.projectstatistics
 
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.getCacheDirectory
 import okio.Path
 import okio.Path.Companion.toPath
@@ -9,8 +10,10 @@ internal object StatisticsCachePaths {
 	const val PROJECTS_DIRECTORY = "projects"
 	const val FILENAME = "stats.toml"
 
+	fun projectsCacheRoot(): Path = getCacheDirectory().toPath() / PROJECTS_DIRECTORY
+
 	fun projectCacheDirectory(projectDef: ProjectDef): Path =
-		getCacheDirectory().toPath() / PROJECTS_DIRECTORY / projectDef.name
+		projectsCacheRoot() / ProjectsRepository.encodeForFilename(projectDef.name)
 
 	fun statsFile(projectDef: ProjectDef): Path =
 		projectCacheDirectory(projectDef) / FILENAME

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsDatasource.kt
@@ -6,6 +6,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispatcher
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.withContext
 import net.peanuuutz.tomlkt.Toml
@@ -34,6 +35,7 @@ class StatisticsDatasource(
 	suspend fun saveStatistics(stats: ProjectStatistics) = withContext(dispatcherIo) {
 		ensureCacheDirectoryExists()
 		val file = StatisticsCachePaths.statsFile(projectDef)
+		requireWithinCacheRoot(file)
 		fileSystem.writeToml(file, toml, stats)
 		Napier.d("Statistics saved to cache")
 	}
@@ -44,6 +46,7 @@ class StatisticsDatasource(
 
 	suspend fun delete() = withContext(dispatcherIo) {
 		val file = StatisticsCachePaths.statsFile(projectDef)
+		requireWithinCacheRoot(file)
 		if (fileSystem.exists(file)) {
 			fileSystem.delete(file)
 			Napier.d("Statistics cache deleted")
@@ -52,8 +55,16 @@ class StatisticsDatasource(
 
 	private fun ensureCacheDirectoryExists() {
 		val cacheDir = StatisticsCachePaths.projectCacheDirectory(projectDef)
+		requireWithinCacheRoot(cacheDir)
 		if (!fileSystem.exists(cacheDir)) {
 			fileSystem.createDirectories(cacheDir)
+		}
+	}
+
+	private fun requireWithinCacheRoot(path: okio.Path) {
+		val cacheRoot = StatisticsCachePaths.projectsCacheRoot()
+		if (!path.isWithin(cacheRoot)) {
+			error("Refusing to access statistics cache outside the cache root: $path")
 		}
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/ReferenceIndexDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/ReferenceIndexDatasource.kt
@@ -4,8 +4,10 @@ import com.darkrockstudios.apps.hammer.base.http.readTomlOrNull
 import com.darkrockstudios.apps.hammer.base.http.writeToml
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispatcher
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.getCacheDirectory
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.withContext
@@ -37,6 +39,7 @@ class ReferenceIndexDatasource(
 	suspend fun saveIndex(index: ReferenceIndex) = withContext(dispatcherIo) {
 		ensureCacheDirectoryExists()
 		val file = getIndexPath()
+		requireWithinCacheRoot(file)
 		fileSystem.writeToml(file, toml, index)
 		Napier.d("Reference index saved to cache")
 	}
@@ -45,22 +48,31 @@ class ReferenceIndexDatasource(
 
 	suspend fun delete() = withContext(dispatcherIo) {
 		val file = getIndexPath()
+		requireWithinCacheRoot(file)
 		if (fileSystem.exists(file)) {
 			fileSystem.delete(file)
 			Napier.d("Reference index cache deleted")
 		}
 	}
 
-	private fun getProjectCacheDirectory(): Path {
-		return getCacheDirectory().toPath() / PROJECTS_DIRECTORY / projectDef.name
-	}
+	private fun getProjectsCacheRoot(): Path = getCacheDirectory().toPath() / PROJECTS_DIRECTORY
+
+	private fun getProjectCacheDirectory(): Path =
+		getProjectsCacheRoot() / ProjectsRepository.encodeForFilename(projectDef.name)
 
 	private fun getIndexPath(): Path = getProjectCacheDirectory() / FILENAME
 
 	private fun ensureCacheDirectoryExists() {
 		val cacheDir = getProjectCacheDirectory()
+		requireWithinCacheRoot(cacheDir)
 		if (!fileSystem.exists(cacheDir)) {
 			fileSystem.createDirectories(cacheDir)
+		}
+	}
+
+	private fun requireWithinCacheRoot(path: Path) {
+		if (!path.isWithin(getProjectsCacheRoot())) {
+			error("Refusing to access reference index cache outside the cache root: $path")
 		}
 	}
 

--- a/common/src/desktopTest/kotlin/repositories/statistics/StatisticsDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/statistics/StatisticsDatasourceTest.kt
@@ -1,14 +1,16 @@
-package repositories.references
+package repositories.statistics
 
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndex
-import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.ProjectStatistics
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsCachePaths
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.StatisticsDatasource
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.getCacheDirectory
 import getProject1Def
 import getProjectDef
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import net.peanuuutz.tomlkt.Toml
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -20,9 +22,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.time.Clock
 
-class ReferenceIndexDatasourceTest : BaseTest() {
+class StatisticsDatasourceTest : BaseTest() {
 
 	lateinit var ffs: FakeFileSystem
 	lateinit var toml: Toml
@@ -39,65 +40,57 @@ class ReferenceIndexDatasourceTest : BaseTest() {
 	}
 
 	private fun createDatasource(projectDef: ProjectDef = getProject1Def()) =
-		ReferenceIndexDatasource(ffs, toml, projectDef)
+		StatisticsDatasource(ffs, toml, projectDef)
+
+	private fun stats() = ProjectStatistics(
+		numberOfScenes = 3,
+		totalWords = 42,
+		wordsByChapter = mapOf(1 to 20, 2 to 22),
+		encyclopediaEntriesByType = emptyMap(),
+		isDirty = false,
+		lastCalculated = Instant.fromEpochSeconds(0),
+	)
 
 	@Test
 	fun `Load returns null when cache file is missing`() = runTest(mainTestDispatcher) {
 		val datasource = createDatasource()
-		assertNull(datasource.loadIndex())
+		assertNull(datasource.loadStatistics())
 		assertFalse(datasource.exists())
 	}
 
 	@Test
-	fun `Save then load round-trips the index`() = runTest(mainTestDispatcher) {
+	fun `Save then load round-trips the statistics`() = runTest(mainTestDispatcher) {
 		val datasource = createDatasource()
-		val original = ReferenceIndex(
-			isDirty = false,
-			lastCalculated = Clock.System.now(),
-			entryToScenes = mapOf(1 to setOf(10, 11), 2 to setOf(11, 12)),
-		)
+		val original = stats()
 
-		datasource.saveIndex(original)
+		datasource.saveStatistics(original)
 		assertTrue(datasource.exists())
 
-		val loaded = datasource.loadIndex()
-		assertEquals(original.entryToScenes, loaded?.entryToScenes)
-		assertEquals(original.isDirty, loaded?.isDirty)
-		assertEquals(original.schemaVersion, loaded?.schemaVersion)
-	}
-
-	@Test
-	fun `Load returns null when cache file is corrupt`() = runTest(mainTestDispatcher) {
-		val datasource = createDatasource()
-		datasource.saveIndex(ReferenceIndex())
-
-		val cachePath = ffs.allPaths.first { it.name == ReferenceIndexDatasource.FILENAME }
-		ffs.write(cachePath) { writeUtf8("not valid toml @@@@") }
-
-		assertNull(datasource.loadIndex())
+		val loaded = datasource.loadStatistics()
+		assertEquals(original.totalWords, loaded?.totalWords)
+		assertEquals(original.wordsByChapter, loaded?.wordsByChapter)
 	}
 
 	@Test
 	fun `Save with a traversal project name lands under the cache root`() =
 		runTest(mainTestDispatcher) {
-			val maliciousName = "a/../../../evil"
-			val datasource = createDatasource(getProjectDef(maliciousName))
+			val datasource = createDatasource(getProjectDef("a/../../../evil"))
 
-			datasource.saveIndex(ReferenceIndex())
+			datasource.saveStatistics(stats())
 
 			val cacheRoot =
-				getCacheDirectory().toPath() / ReferenceIndexDatasource.PROJECTS_DIRECTORY
-			val written = ffs.allPaths.first { it.name == ReferenceIndexDatasource.FILENAME }
+				getCacheDirectory().toPath() / StatisticsCachePaths.PROJECTS_DIRECTORY
+			val written = ffs.allPaths.first { it.name == StatisticsCachePaths.FILENAME }
 			assertTrue(
 				written.isWithin(cacheRoot),
-				"Reference index escaped the cache root: $written",
+				"Statistics cache escaped the cache root: $written",
 			)
 		}
 
 	@Test
 	fun `Delete removes the cache file`() = runTest(mainTestDispatcher) {
 		val datasource = createDatasource()
-		datasource.saveIndex(ReferenceIndex())
+		datasource.saveStatistics(stats())
 		assertTrue(datasource.exists())
 
 		datasource.delete()


### PR DESCRIPTION
A server-synced project name can contain `/` and `..` (the validator
permits them; `toLocalSafeName` leaves an already-valid name unchanged),
and two cache-path builders used `projectDef.name` raw as a path segment:
statistics and the reference index. A crafted name could place the cache
file outside the per-project cache directory (the same traversal class as
F-1), and on Windows the raw `/` could break path construction outright.

Both builders now encode the name with `ProjectsRepository.encodeForFilename`,
matching how the on-disk project directory already encodes it, and each
datasource gains an `isWithin(cacheRoot)` backstop before every write,
createDirectories, and delete.

This orphans any old raw-named cache directories on existing installs.
That is harmless: statistics and the reference index regenerate on demand.
