### PR TITLE
Guard datasource writes with a contained FileSystem chokepoint

### DIFF
--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
@@ -11,6 +11,7 @@ import com.darkrockstudios.apps.hammer.common.util.*
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -24,7 +25,9 @@ actual val platformModule = module {
 		AndroidPlatformSettingsComponent(
 			componentContext = params.get(),
 			context = get(),
-			fileSystem = get(),
+			// Storage relocation moves projects into the new app-managed directory before
+			// that directory is registered as a managed root, so it uses the raw filesystem.
+			fileSystem = get(named(RAW_FILESYSTEM)),
 		)
 	} bind PlatformSettings::class
 	singleOf(::PlatformSpellCheckerFactory)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -14,6 +14,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.exampleProjectModule
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsFilesystemDatasource
@@ -55,6 +56,9 @@ import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivi
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityRepository
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingSessionTracker
 import com.darkrockstudios.apps.hammer.common.fileio.externalFileIoModule
+import com.darkrockstudios.apps.hammer.common.fileio.okio.ContainedFileSystem
+import com.darkrockstudios.apps.hammer.common.getCacheDirectory
+import com.darkrockstudios.apps.hammer.common.getConfigDirectory
 import com.darkrockstudios.apps.hammer.common.getPlatformFilesystem
 import com.darkrockstudios.apps.hammer.common.platformDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.platformIoDispatcher
@@ -66,6 +70,8 @@ import io.ktor.client.*
 import kotlinx.serialization.json.Json
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.scopedOf
 import org.koin.core.module.dsl.singleOf
@@ -77,6 +83,9 @@ import kotlin.time.Clock
 const val DISPATCHER_MAIN = "main-dispatcher"
 const val DISPATCHER_DEFAULT = "default-dispatcher"
 const val DISPATCHER_IO = "io-dispatcher"
+
+/** Unguarded platform [FileSystem] for user-chosen external write targets (exports). */
+const val RAW_FILESYSTEM = "raw-filesystem"
 
 /**
  * This is the main module containing most of the DI objects
@@ -115,7 +124,13 @@ val mainModule = module {
 	factory { AccountUseCase(get(), get(), get(), get()) }
 	factoryOf(::AccountReauthUseCase)
 
-	singleOf(::getPlatformFilesystem) bind FileSystem::class
+	single(named(RAW_FILESYSTEM)) { getPlatformFilesystem() } bind FileSystem::class
+
+	// Default filesystem: guards every write against the app's managed storage roots.
+	single<FileSystem> {
+		val koin = getKoin()
+		ContainedFileSystem(getPlatformFilesystem()) { managedStorageRoots(koin) }
+	}
 
 	singleOf(::ProjectsRepository)
 
@@ -147,7 +162,15 @@ val mainModule = module {
 		scopedOf(::SceneRepository)
 		scopedOf(::SceneEditorService)
 		scopedOf(::ImportStoryUseCase)
-		scopedOf(::ExportStoryUseCase)
+		// Export writes to a user-chosen path, so it uses the unguarded filesystem.
+		scoped {
+			ExportStoryUseCase(
+				sceneEditorRepository = get(),
+				projectDataDatasource = get(),
+				fileSystem = get(named(RAW_FILESYSTEM)),
+				localeResolver = get(),
+			)
+		}
 		scopedOf(::SceneDraftsDatasource)
 		scopedOf(::SceneDraftRepository)
 		scopedOf(::SceneMetadataDatasource)
@@ -222,4 +245,25 @@ val mainModule = module {
 
 		scopedOf(::EntitySynchronizers)
 	}
+}
+
+/**
+ * Managed storage roots checked by [ContainedFileSystem]: cache, config, and the
+ * (user-relocatable, resolved per call) projects directory. Projects resolution is
+ * cycle-safe — store, then persisted settings, then default — so config-root writes
+ * during the store's own construction aren't blocked.
+ */
+internal fun managedStorageRoots(koin: org.koin.core.Koin): List<Path> {
+	val cacheRoot = getCacheDirectory().toPath()
+	val configRoot = getConfigDirectory().toPath()
+
+	val projectsRoot = runCatching {
+		koin.get<GlobalSettingsStore>().globalSettings.projectsDirectory.toPath()
+	}.recoverCatching {
+		koin.get<GlobalSettingsDatasource>().loadSettings().projectsDirectory.toPath()
+	}.getOrElse {
+		GlobalSettingsStore.defaultProjectDir()
+	}
+
+	return listOf(cacheRoot, configRoot, projectsRoot)
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/ContainedFileSystem.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/ContainedFileSystem.kt
@@ -1,0 +1,91 @@
+package com.darkrockstudios.apps.hammer.common.fileio.okio
+
+import okio.FileHandle
+import okio.FileSystem
+import okio.ForwardingFileSystem
+import okio.Path
+import okio.Sink
+
+/**
+ * Fail-closed containment guard for filesystem mutations. Every write, append,
+ * move, delete, or directory creation routed through this filesystem must land
+ * within one of [allowedRoots]; anything else throws.
+ *
+ * Reads, listings, and metadata are deliberately not guarded — they are not the
+ * traversal hazard and gating them would break legitimate inspection of paths
+ * outside the managed roots.
+ *
+ * [allowedRoots] is a lambda re-evaluated on every check: the projects directory
+ * is user-relocatable at runtime (external-storage toggle, dev mode, app-store
+ * sandbox), so a snapshot taken at construction time would go stale.
+ *
+ * External, user-chosen write targets (e.g. exporting a story to a folder the
+ * user picked) must bypass this guard by using the raw platform filesystem
+ * directly, not this decorator.
+ */
+class ContainedFileSystem(
+	delegate: FileSystem,
+	private val allowedRoots: () -> List<Path>,
+) : ForwardingFileSystem(delegate) {
+
+	override fun sink(file: Path, mustCreate: Boolean): Sink {
+		requireContained(file, "sink")
+		return super.sink(file, mustCreate)
+	}
+
+	override fun appendingSink(file: Path, mustExist: Boolean): Sink {
+		requireContained(file, "appendingSink")
+		return super.appendingSink(file, mustExist)
+	}
+
+	override fun atomicMove(source: Path, target: Path) {
+		requireContained(source, "atomicMove(source)")
+		requireContained(target, "atomicMove(target)")
+		super.atomicMove(source, target)
+	}
+
+	override fun delete(path: Path, mustExist: Boolean) {
+		requireContained(path, "delete")
+		super.delete(path, mustExist)
+	}
+
+	override fun createDirectory(dir: Path, mustCreate: Boolean) {
+		requireDirectoryAllowed(dir)
+		super.createDirectory(dir, mustCreate)
+	}
+
+	override fun createSymlink(source: Path, target: Path) {
+		requireContained(source, "createSymlink")
+		super.createSymlink(source, target)
+	}
+
+	override fun openReadWrite(file: Path, mustCreate: Boolean, mustExist: Boolean): FileHandle {
+		requireContained(file, "openReadWrite")
+		return super.openReadWrite(file, mustCreate, mustExist)
+	}
+
+	private fun requireContained(path: Path, operation: String) {
+		val roots = allowedRoots()
+		if (roots.none { path.isWithin(it) }) {
+			throw ContainmentViolationException(
+				"Refusing to $operation outside the app's managed storage: $path"
+			)
+		}
+	}
+
+	/**
+	 * Also permits a root's ancestors: `createDirectories` scaffolds a root's missing
+	 * parents one at a time on first run. Sibling escapes stay blocked.
+	 */
+	private fun requireDirectoryAllowed(dir: Path) {
+		val roots = allowedRoots()
+		val allowed = roots.any { root -> dir.isWithin(root) || root.isWithin(dir) }
+		if (!allowed) {
+			throw ContainmentViolationException(
+				"Refusing to create a directory outside the app's managed storage: $dir"
+			)
+		}
+	}
+}
+
+class ContainmentViolationException(message: String) : okio.IOException(message)

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/externalFileIoModule.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/externalFileIoModule.kt
@@ -1,14 +1,16 @@
 package com.darkrockstudios.apps.hammer.common.fileio
 
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.RAW_FILESYSTEM
 import io.github.aakira.napier.Napier
 import okio.FileSystem
 import okio.Path.Companion.toPath
-import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 actual val externalFileIoModule = module {
-	singleOf(::DesktopExternalFileIo) bind ExternalFileIo::class
+	// Raw filesystem: this writes to user-chosen paths outside the app's managed storage.
+	single { DesktopExternalFileIo(get(named(RAW_FILESYSTEM))) } bind ExternalFileIo::class
 }
 
 private class DesktopExternalFileIo(private val fileSystem: FileSystem) : ExternalFileIo {

--- a/common/src/desktopTest/kotlin/dependencyinjection/ManagedStorageRootsTest.kt
+++ b/common/src/desktopTest/kotlin/dependencyinjection/ManagedStorageRootsTest.kt
@@ -1,0 +1,68 @@
+package dependencyinjection
+
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.managedStorageRoots
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
+import com.darkrockstudios.apps.hammer.common.getCacheDirectory
+import com.darkrockstudios.apps.hammer.common.getConfigDirectory
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.assertTrue
+
+/**
+ * Pins the cycle-safe roots resolution used by the production guarded FileSystem
+ * binding: it must surface the configured projects directory without requiring a
+ * fully built GlobalSettingsStore.
+ */
+class ManagedStorageRootsTest {
+
+	@AfterEach
+	fun tearDown() {
+		stopKoin()
+	}
+
+	@Test
+	fun `roots include cache, config, and the configured projects directory`() {
+		val projectsDir = "/home/user/Documents/MyProjects"
+		val settings = GlobalSettings(projectsDirectory = projectsDir)
+
+		val koin = startKoin {
+			modules(
+				module {
+					single<GlobalSettingsDatasource> { FixedSettingsDatasource(settings) }
+				}
+			)
+		}.koin
+
+		val roots = managedStorageRoots(koin)
+
+		assertTrue(roots.any { getCacheDirectory().toPath().isWithin(it) || it == getCacheDirectory().toPath() })
+		assertTrue(roots.contains(getConfigDirectory().toPath()))
+		assertTrue(roots.contains(projectsDir.toPath()))
+	}
+
+	@Test
+	fun `falls back to the default projects dir when nothing is registered`() {
+		val koin = startKoin { modules(module {}) }.koin
+
+		val roots = managedStorageRoots(koin)
+
+		// Cache and config roots are always present even with no settings source.
+		assertTrue(roots.contains(getCacheDirectory().toPath()))
+		assertTrue(roots.contains(getConfigDirectory().toPath()))
+		assertTrue(roots.contains(GlobalSettingsStore.defaultProjectDir()))
+	}
+
+	private class FixedSettingsDatasource(
+		private val settings: GlobalSettings,
+	) : GlobalSettingsDatasource {
+		override fun loadSettings(): GlobalSettings = settings
+		override fun storeSettings(settings: GlobalSettings) = Unit
+	}
+}

--- a/common/src/desktopTest/kotlin/fileio/ContainedFileSystemTest.kt
+++ b/common/src/desktopTest/kotlin/fileio/ContainedFileSystemTest.kt
@@ -1,0 +1,159 @@
+package fileio
+
+import com.darkrockstudios.apps.hammer.common.fileio.okio.ContainedFileSystem
+import com.darkrockstudios.apps.hammer.common.fileio.okio.ContainmentViolationException
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ContainedFileSystemTest {
+
+	private val cacheRoot = "/app/cache".toPath()
+	private val configRoot = "/app/config".toPath()
+	private val projectsRoot = "/home/user/Documents/Projects".toPath()
+
+	private fun fs(roots: List<Path> = listOf(cacheRoot, configRoot, projectsRoot)): Pair<FakeFileSystem, ContainedFileSystem> {
+		val delegate = FakeFileSystem()
+		roots.forEach { delegate.createDirectories(it) }
+		return delegate to ContainedFileSystem(delegate) { roots }
+	}
+
+	@Test
+	fun `write within a root succeeds`() {
+		val (delegate, guarded) = fs()
+		val target = projectsRoot / "story.md"
+
+		guarded.write(target) { writeUtf8("hello") }
+
+		assertTrue(delegate.exists(target))
+	}
+
+	@Test
+	fun `write within each configured root succeeds`() {
+		val (_, guarded) = fs()
+		guarded.write(cacheRoot / "a.toml") { writeUtf8("a") }
+		guarded.write(configRoot / "b.toml") { writeUtf8("b") }
+		guarded.write(projectsRoot / "c.md") { writeUtf8("c") }
+	}
+
+	@Test
+	fun `write outside all roots throws`() {
+		val (_, guarded) = fs()
+		assertFailsWith<ContainmentViolationException> {
+			guarded.write("/etc/passwd".toPath()) { writeUtf8("evil") }
+		}
+	}
+
+	@Test
+	fun `delete outside all roots throws`() {
+		val (delegate, guarded) = fs()
+		delegate.createDirectories("/etc".toPath())
+		delegate.write("/etc/passwd".toPath()) { writeUtf8("x") }
+
+		assertFailsWith<ContainmentViolationException> {
+			guarded.delete("/etc/passwd".toPath())
+		}
+	}
+
+	@Test
+	fun `atomicMove with a target outside all roots throws`() {
+		val (_, guarded) = fs()
+		val source = projectsRoot / "a.md"
+		guarded.write(source) { writeUtf8("x") }
+
+		assertFailsWith<ContainmentViolationException> {
+			guarded.atomicMove(source, "/tmp/escape.md".toPath())
+		}
+	}
+
+	@Test
+	fun `atomicMove within a root succeeds`() {
+		val (delegate, guarded) = fs()
+		val source = projectsRoot / "a.md"
+		val target = projectsRoot / "b.md"
+		guarded.write(source) { writeUtf8("x") }
+
+		guarded.atomicMove(source, target)
+
+		assertTrue(delegate.exists(target))
+	}
+
+	@Test
+	fun `creating a root itself succeeds on a clean filesystem`() {
+		val delegate = FakeFileSystem()
+		val guarded = ContainedFileSystem(delegate) { listOf(cacheRoot) }
+
+		// First run: nothing exists yet. createDirectories must scaffold the root
+		// (and its ancestors) without being blocked.
+		guarded.createDirectories(cacheRoot / "projects" / "MyProject")
+
+		assertTrue(delegate.exists(cacheRoot / "projects" / "MyProject"))
+	}
+
+	@Test
+	fun `creating an ancestor of a root is allowed`() {
+		val delegate = FakeFileSystem()
+		val guarded = ContainedFileSystem(delegate) { listOf(cacheRoot) }
+
+		guarded.createDirectory("/app".toPath())
+
+		assertTrue(delegate.exists("/app".toPath()))
+	}
+
+	@Test
+	fun `creating a sibling-escape directory is blocked`() {
+		val delegate = FakeFileSystem()
+		delegate.createDirectories("/app".toPath())
+		val guarded = ContainedFileSystem(delegate) { listOf(cacheRoot) }
+
+		assertFailsWith<ContainmentViolationException> {
+			guarded.createDirectory("/app/evil".toPath())
+		}
+	}
+
+	@Test
+	fun `openReadWrite outside all roots throws`() {
+		val (_, guarded) = fs()
+		assertFailsWith<ContainmentViolationException> {
+			guarded.openReadWrite("/etc/passwd".toPath())
+		}
+	}
+
+	@Test
+	fun `openReadWrite within a root succeeds`() {
+		val (delegate, guarded) = fs()
+		val target = projectsRoot / "handle.bin"
+
+		guarded.openReadWrite(target, mustCreate = true).use { it.write(0, ByteArray(4), 0, 4) }
+
+		assertTrue(delegate.exists(target))
+	}
+
+	@Test
+	fun `a traversal write that escapes a root throws`() {
+		val (_, guarded) = fs()
+		assertFailsWith<ContainmentViolationException> {
+			guarded.write(projectsRoot / ".." / ".." / "evil.md") { writeUtf8("x") }
+		}
+	}
+
+	@Test
+	fun `allowed roots are re-evaluated per call`() {
+		val delegate = FakeFileSystem()
+		var roots = listOf(cacheRoot)
+		delegate.createDirectories(cacheRoot)
+		delegate.createDirectories(projectsRoot)
+		val guarded = ContainedFileSystem(delegate) { roots }
+
+		assertFailsWith<ContainmentViolationException> {
+			guarded.write(projectsRoot / "a.md") { writeUtf8("x") }
+		}
+
+		roots = listOf(cacheRoot, projectsRoot)
+		guarded.write(projectsRoot / "a.md") { writeUtf8("x") }
+		assertTrue(delegate.exists(projectsRoot / "a.md"))
+	}
+}


### PR DESCRIPTION
Replaces the raw platform FileSystem singleton with a ForwardingFileSystem
decorator, ContainedFileSystem, that fail-closes every mutation (sink,
appendingSink, atomicMove source+target, delete, createDirectory,
createSymlink, openReadWrite) to the app's managed storage: the cache,
config, and current projects directories. A write outside all roots throws.
Reads, listings, and metadata are deliberately not guarded.

Allowed roots are supplied as a lambda re-evaluated per check because the
projects directory is user-relocatable at runtime. The projects-dir lookup
is cycle-safe: it prefers the built GlobalSettingsStore, falls back to the
settings datasource, then to the default dir, so config-root writes during
bootstrap (before the store exists) are not blocked. Directory creation uses
a relaxed rule that also permits a root's ancestors, so a clean first run can
scaffold the roots while a sibling escape stays blocked.

Consumers that legitimately write outside managed storage get a raw,
unguarded FileSystem via the RAW_FILESYSTEM qualifier:
- ExportStoryUseCase (desktop/iOS export to a user-chosen path)
- DesktopExternalFileIo (desktop docx/pdf export)
- AndroidPlatformSettingsComponent (storage relocation moves projects into
  the new managed directory before it is registered as a root)
