### PR TITLE
Validate downloaded entity id and type against the request (F-12/F-13)

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -176,6 +176,7 @@
 	<string name="sync_log_entity_download_failed_general">Failed to download entity %1$d</string>
 	<string name="sync_log_entity_download_failed_not_found">Entity %1$d not found on server</string>
 	<string name="sync_log_entity_download_not_modified">Entity %1$d not modified</string>
+	<string name="sync_log_entity_download_rejected_mismatch">Rejected download for entity %1$d: server returned a mismatched id or type</string>
 	<string name="sync_log_entity_upload_entity_not_owned">Failed to upload entity %1$d: type not owned by anything,
 		probably deleted
 	</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
@@ -229,6 +229,25 @@ class EntityTransferOperation(
 
 		return if (entityResponse.isSuccess) {
 			val serverEntity = entityResponse.getOrThrow().entity
+
+			// The server is asked for a specific id but the response carries its own id and
+			// type. Never trust either: a hostile server could forge a different entity over
+			// the requested one and cement the forgery as the conflict baseline. Reject any
+			// id mismatch outright, and any type mismatch when the client already owns the id.
+			val localType = entitySynchronizers.findEntityType(id)
+			val serverType = serverEntity.type.toEntityType()
+			if (serverEntity.id != id || (localType != null && localType != serverType)) {
+				onLog(
+					syncLogE(
+						strRes.get(Res.string.sync_log_entity_download_rejected_mismatch, id),
+						projectDef
+					)
+				)
+				return CResult.failure(
+					IllegalStateException("Server returned mismatched entity for requested id $id")
+				)
+			}
+
 			val success = when (serverEntity) {
 				is ApiProjectEntity.SceneEntity ->
 					entitySynchronizers.sceneSynchronizer.storeEntity(
@@ -269,7 +288,7 @@ class EntityTransferOperation(
 			if (success) {
 				// Lock the downloaded entity's hash in as the conflict baseline: it's exactly
 				// what the server holds, so a later local edit won't forge a phantom conflict.
-				syncJournal.recordSyncedHash(serverEntity.id, serverEntity.hash())
+				syncJournal.recordSyncedHash(id, serverEntity.hash())
 				onLog(
 					syncLogI(
 						strRes.get(Res.string.sync_log_entity_download_success, id),

--- a/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
@@ -115,6 +115,7 @@ class EntityTransferOperationTest : BaseTest() {
 		} returns Result.success(
 			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
 				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
 				every { hash() } returns "downloaded-hash-4"
 			})
 		)
@@ -129,6 +130,7 @@ class EntityTransferOperationTest : BaseTest() {
 		} returns Result.success(
 			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
 				every { id } returns 11
+				every { type } returns ApiProjectEntity.Type.SCENE
 				every { hash() } returns "downloaded-hash-11"
 			})
 		)
@@ -300,6 +302,7 @@ class EntityTransferOperationTest : BaseTest() {
 		} returns Result.success(
 			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
 				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
 				every { hash() } returns "h-4"
 			})
 		)
@@ -330,6 +333,7 @@ class EntityTransferOperationTest : BaseTest() {
 		} returns Result.success(
 			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
 				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
 				every { hash() } returns "h-4"
 			})
 		)
@@ -344,6 +348,123 @@ class EntityTransferOperationTest : BaseTest() {
 			assertIs<EntityTransferState>(result.data).allSuccess,
 			"A download whose store failed must not report the transfer as fully successful",
 		)
+	}
+
+	@Test
+	fun `download - server returns a different id than requested is rejected`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// Requested id 4, but a hostile server answers with a forged entity carrying id 7.
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 7
+				every { type } returns ApiProjectEntity.Type.SCENE
+				every { hash() } returns "forged-hash-7"
+			})
+		)
+
+		val logs = mutableListOf<SyncLogMessage>()
+		val result = op.execute(
+			state = singleDownloadState(4),
+			onProgress = { _, _ -> },
+			onLog = { logs.add(it) },
+			onConflict = {},
+			onComplete = {},
+		)
+
+		assertTrue(isSuccess(result))
+		assertFalse(assertIs<EntityTransferState>(result.data).allSuccess)
+		// The forged entity is never stored and never poisons the conflict baseline.
+		coVerify(exactly = 0) { mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 0) { syncJournal.recordSyncedHash(7, any()) }
+		coVerify(exactly = 0) { syncJournal.recordSyncedHash(4, any()) }
+		assertTrue(logs.any { it.level == SyncLogLevel.ERROR })
+	}
+
+	@Test
+	fun `download - server returns a different type than the client owns is rejected`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// The client already owns id 4 as a Scene...
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(4) } returns true
+		// ...but the server steers the same id into a Note, attempting a type confusion.
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.NoteEntity> {
+				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.NOTE
+				every { hash() } returns "wrong-type-hash-4"
+			})
+		)
+
+		val logs = mutableListOf<SyncLogMessage>()
+		val result = op.execute(
+			state = singleDownloadState(4),
+			onProgress = { _, _ -> },
+			onLog = { logs.add(it) },
+			onConflict = {},
+			onComplete = {},
+		)
+
+		assertTrue(isSuccess(result))
+		assertFalse(assertIs<EntityTransferState>(result.data).allSuccess)
+		// Neither repository is written, and no hash is recorded for the contested id.
+		coVerify(exactly = 0) { mockSynchronizers.noteSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 0) { mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 0) { syncJournal.recordSyncedHash(4, any()) }
+		assertTrue(logs.any { it.level == SyncLogLevel.ERROR })
+	}
+
+	@Test
+	fun `download - a new entity the client does not own is stored and its hash recorded`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// No synchronizer owns id 4 (findEntityType == null), so the type check must allow it.
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
+				every { hash() } returns "new-hash-4"
+			})
+		)
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any())
+		} returns true
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+		coVerify(exactly = 1) { mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 1) { syncJournal.recordSyncedHash(4, "new-hash-4") }
+	}
+
+	@Test
+	fun `download - matching id and owned type is stored and its hash recorded`() = runTest {
+		val op = createOperation(getProjectDef(PROJECT_2_NAME))
+		// Client owns id 4 as a Scene and the server agrees on both id and type.
+		coEvery { mockSynchronizers.sceneSynchronizer.ownsEntity(4) } returns true
+		coEvery {
+			serverProjectApi.downloadEntity(any(), any(), 4, any(), any())
+		} returns Result.success(
+			LoadEntityResponse(mockk<ApiProjectEntity.SceneEntity> {
+				every { id } returns 4
+				every { type } returns ApiProjectEntity.Type.SCENE
+				every { hash() } returns "matching-hash-4"
+			})
+		)
+		coEvery {
+			mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any())
+		} returns true
+
+		val result = op.run(singleDownloadState(4))
+
+		assertTrue(isSuccess(result))
+		assertTrue(assertIs<EntityTransferState>(result.data).allSuccess)
+		coVerify(exactly = 1) { mockSynchronizers.sceneSynchronizer.storeEntity(any(), any(), any()) }
+		coVerify(exactly = 1) { syncJournal.recordSyncedHash(4, "matching-hash-4") }
 	}
 
 	@Test


### PR DESCRIPTION
downloadEntry asks the server for a specific entity id but took the
returned entity's identity and type entirely from the response, then
keyed storeEntity and recordSyncedHash off the server-chosen values.

F-12 (id forgery): a hostile server asked for entity N could answer with
id M and attacker content. The client would overwrite/forge local entity
M and record the forged hash as the conflict baseline, concealing the
tampering and re-propagating it to the user's other devices.

F-13 (type confusion): the subtype was chosen purely from the server's
entity-type header, so the server could steer the same id into the wrong
repository.

Add two checks right after reading the server entity, before dispatch:
- reject any response whose id differs from the requested id, and
- reject a type mismatch when the client already owns the id
  (findEntityType non-null). When the client does not yet own the id, a
  legitimate new-entity download has no local type to compare against, so
  it is allowed through.

A rejected entity returns CResult.failure, which the fullEntityTransfer
loop already tolerates without aborting the sync or recording a hash, so
one bad entity skips cleanly. The synced hash is now recorded under the
requested id, which provably equals the server's id once the guard passes.
