### PR TITLE
Relocate sync auth tokens out of server.json (F-5)

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/AuthTokenStore.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/AuthTokenStore.kt
@@ -1,0 +1,29 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Auth tokens for a single account. Both fields are nullable: an account can be
+ * configured before a session exists.
+ */
+@Serializable
+data class AuthTokens(
+	val bearerToken: String?,
+	val refreshToken: String?,
+)
+
+/**
+ * Per-machine storage for sync auth tokens, keyed by account (server url + userId).
+ *
+ * Tokens live here, in app-private storage, rather than in the per-workspace
+ * `server.json`, so they do not travel when a workspace folder is moved or shared.
+ */
+interface AuthTokenStore {
+	fun get(url: String, userId: Long): AuthTokens?
+	fun put(url: String, userId: Long, tokens: AuthTokens)
+	fun remove(url: String, userId: Long)
+
+	companion object {
+		fun accountKey(url: String, userId: Long): String = "$url|$userId"
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/FileAuthTokenStore.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/FileAuthTokenStore.kt
@@ -1,0 +1,59 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import com.darkrockstudios.apps.hammer.base.http.readJsonOrNull
+import com.darkrockstudios.apps.hammer.base.http.writeJson
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore.Companion.accountKey
+import com.darkrockstudios.apps.hammer.common.getConfigDirectory
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Plaintext JSON-backed [AuthTokenStore] living in the app-private config directory.
+ *
+ * The whole account-keyed map is persisted to a single file. A missing or corrupt
+ * file is tolerated by starting from an empty map.
+ *
+ * The [AuthTokenStore] seam lets an encrypted backing be substituted without
+ * touching its callers.
+ */
+class FileAuthTokenStore(
+	private val fileSystem: FileSystem,
+	private val json: Json,
+) : AuthTokenStore {
+
+	private val lock = reentrantLock()
+
+	override fun get(url: String, userId: Long): AuthTokens? = lock.withLock {
+		load()[accountKey(url, userId)]
+	}
+
+	override fun put(url: String, userId: Long, tokens: AuthTokens): Unit = lock.withLock {
+		val updated = load().toMutableMap()
+		updated[accountKey(url, userId)] = tokens
+		store(updated)
+	}
+
+	override fun remove(url: String, userId: Long): Unit = lock.withLock {
+		val updated = load().toMutableMap()
+		if (updated.remove(accountKey(url, userId)) != null) {
+			store(updated)
+		}
+	}
+
+	private fun load(): Map<String, AuthTokens> {
+		return fileSystem.readJsonOrNull<Map<String, AuthTokens>>(FILE_PATH, json) ?: emptyMap()
+	}
+
+	private fun store(tokens: Map<String, AuthTokens>) {
+		fileSystem.createDirectories(FILE_PATH.parent!!)
+		fileSystem.writeJson(FILE_PATH, json, tokens)
+	}
+
+	companion object {
+		private const val FILE_NAME = "auth_tokens.json"
+		val FILE_PATH = getConfigDirectory().toPath() / FILE_NAME
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/PersistedServerSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/PersistedServerSettings.kt
@@ -1,0 +1,35 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import kotlinx.serialization.Serializable
+import net.peanuuutz.tomlkt.TomlLiteralString
+
+/**
+ * Tokenless persisted form of [ServerSettings] written to the per-workspace
+ * `server.json`. The secret token fields live in [AuthTokenStore] instead.
+ */
+@Serializable
+data class PersistedServerSettings(
+	val ssl: Boolean,
+	@TomlLiteralString
+	val url: String,
+	@TomlLiteralString
+	val email: String,
+	val userId: Long,
+)
+
+fun ServerSettings.toPersisted(): PersistedServerSettings = PersistedServerSettings(
+	ssl = ssl,
+	url = url,
+	email = email,
+	userId = userId,
+)
+
+fun PersistedServerSettings.toServerSettings(tokens: AuthTokens?): ServerSettings = ServerSettings(
+	ssl = ssl,
+	url = url,
+	email = email,
+	userId = userId,
+	bearerToken = tokens?.bearerToken,
+	refreshToken = tokens?.refreshToken,
+)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/ServerSettingsFilesystemDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/ServerSettingsFilesystemDatasource.kt
@@ -4,14 +4,20 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import com.darkrockstudios.apps.hammer.base.http.readJsonOrNull
+import com.darkrockstudios.apps.hammer.base.http.writeJson
 import io.github.aakira.napier.Napier
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
 
 class ServerSettingsFilesystemDatasource(
 	private val fileSystem: FileSystem,
 	private val json: Json,
+	private val authTokenStore: AuthTokenStore,
 ) : ServerSettingsDatasource {
 
 	override fun serverIsSetup(projectsDir: HPath): Boolean {
@@ -22,36 +28,82 @@ class ServerSettingsFilesystemDatasource(
 		val path = getServerSettingsPath(projectsDir).toOkioPath()
 		Napier.i { "Loading Server Settings from: $path" }
 
-		return if (fileSystem.exists(path)) {
-			val settingsText: String = fileSystem.read(path) {
-				readUtf8()
-			}
+		if (!fileSystem.exists(path)) return null
 
-			try {
-				json.decodeFromString(settingsText)
-			} catch (e: SerializationException) {
-				Napier.e("Failed to load Server Settings, removing invalid file.", e)
-				fileSystem.delete(path)
-				null
-			}
-		} else {
-			null
+		val settingsText: String = fileSystem.read(path) { readUtf8() }
+
+		val persisted: PersistedServerSettings = try {
+			json.decodeFromString(settingsText)
+		} catch (e: SerializationException) {
+			Napier.e("Failed to load Server Settings, removing invalid file.", e)
+			fileSystem.delete(path)
+			return null
 		}
+
+		val migratedTokens = migrateInlineTokens(settingsText, persisted, projectsDir)
+		val tokens = migratedTokens ?: authTokenStore.get(persisted.url, persisted.userId)
+
+		return persisted.toServerSettings(tokens)
 	}
 
 	override fun storeServerSettings(settings: ServerSettings, projectsDir: HPath) {
-		val settingsText = json.encodeToString(settings)
-
 		val path = getServerSettingsPath(projectsDir).toOkioPath()
 		fileSystem.createDirectories(path.parent!!)
-		fileSystem.write(path, false) {
-			writeUtf8(settingsText)
-		}
+		fileSystem.writeJson(path, json, settings.toPersisted())
+
+		authTokenStore.put(
+			settings.url,
+			settings.userId,
+			AuthTokens(settings.bearerToken, settings.refreshToken),
+		)
 	}
 
 	override fun removeServerSettings(projectsDir: HPath) {
 		val path = getServerSettingsPath(projectsDir).toOkioPath()
+
+		val account = fileSystem.readJsonOrNull<PersistedServerSettings>(path, json)
+
 		fileSystem.delete(path)
+		account?.let { authTokenStore.remove(it.url, it.userId) }
+	}
+
+	/**
+	 * Moves inline tokens from a legacy `server.json` into the token store and
+	 * rewrites the file tokenless, so the plaintext secrets no longer live in the
+	 * workspace. Returns the extracted tokens, or null when there were none.
+	 *
+	 * On a token-store write failure the extracted tokens are still returned so the
+	 * in-memory session is never dropped.
+	 */
+	private fun migrateInlineTokens(
+		settingsText: String,
+		persisted: PersistedServerSettings,
+		projectsDir: HPath,
+	): AuthTokens? {
+		val inline = readInlineTokens(settingsText) ?: return null
+
+		val migrated = runCatching {
+			authTokenStore.put(persisted.url, persisted.userId, inline)
+			val path = getServerSettingsPath(projectsDir).toOkioPath()
+			fileSystem.writeJson(path, json, persisted)
+		}
+
+		if (migrated.isFailure) {
+			Napier.e("Failed to migrate inline auth tokens; keeping in-memory session.", migrated.exceptionOrNull())
+		}
+
+		return inline
+	}
+
+	private fun readInlineTokens(settingsText: String): AuthTokens? {
+		val obj = runCatching { json.parseToJsonElement(settingsText).jsonObject }.getOrNull() ?: return null
+		val bearer = obj["bearerToken"]?.jsonPrimitive?.contentOrNull
+		val refresh = obj["refreshToken"]?.jsonPrimitive?.contentOrNull
+		return if (bearer != null || refresh != null) {
+			AuthTokens(bearer, refresh)
+		} else {
+			null
+		}
 	}
 
 	private fun getServerSettingsPath(projectsDir: HPath): HPath {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -14,6 +14,8 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.exampleProjectModule
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.FileAuthTokenStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
@@ -113,6 +115,7 @@ val mainModule = module {
 	singleOf(::ProjectDataApi)
 	singleOf(::ServerAdminApi)
 
+	singleOf(::FileAuthTokenStore) bind AuthTokenStore::class
 	singleOf(::ServerSettingsFilesystemDatasource) bind ServerSettingsDatasource::class
 	singleOf(::GlobalSettingsFilesystemDatasource)
 	singleOf(::GlobalSettingsStore) bind GlobalSettingsStore::class

--- a/common/src/desktopTest/kotlin/repositories/globalsettings/ServerSettingsDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/globalsettings/ServerSettingsDatasourceTest.kt
@@ -3,13 +3,18 @@ package repositories.globalsettings
 import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.base.http.writeJson
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokens
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.FileAuthTokenStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsFilesystemDatasource
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -21,6 +26,7 @@ import kotlin.test.assertNull
 class ServerSettingsDatasourceTest : BaseTest() {
 	private lateinit var fileSystem: FakeFileSystem
 	private lateinit var json: Json
+	private lateinit var authTokenStore: AuthTokenStore
 
 	@BeforeEach
 	override fun setup() {
@@ -28,12 +34,19 @@ class ServerSettingsDatasourceTest : BaseTest() {
 
 		fileSystem = FakeFileSystem()
 		json = createJsonSerializer()
+		authTokenStore = FileAuthTokenStore(fileSystem, json)
+	}
+
+	@AfterEach
+	fun cleanup() {
+		fileSystem.delete(FileAuthTokenStore.FILE_PATH, mustExist = false)
 	}
 
 	private fun createDatasource(): ServerSettingsDatasource {
 		return ServerSettingsFilesystemDatasource(
 			fileSystem,
-			json
+			json,
+			authTokenStore,
 		)
 	}
 
@@ -46,10 +59,14 @@ class ServerSettingsDatasourceTest : BaseTest() {
 		refreshToken = "bnm789",
 	)
 
-	private fun configPath() =
-		(fileSystem.workingDirectory / ServerSettingsFilesystemDatasource.SERVER_FILE_NAME).toHPath()
+	private fun projectsDirPath() = fileSystem.workingDirectory / "HammerProjects"
 
-	private fun projectsDir() = fileSystem.workingDirectory.toHPath()
+	private fun configPath() =
+		(projectsDirPath() / ServerSettingsFilesystemDatasource.SERVER_FILE_NAME).toHPath()
+
+	private fun projectsDir() = projectsDirPath().toHPath()
+
+	private fun readServerJson(): String = fileSystem.read(configPath().toOkioPath()) { readUtf8() }
 
 	@Test
 	fun `Load Server Settings when none exists`() = runTest {
@@ -60,15 +77,85 @@ class ServerSettingsDatasourceTest : BaseTest() {
 	}
 
 	@Test
-	fun `Load Server Settings when one exists`() = runTest {
+	fun `Store then reload round-trips tokens via the store`() = runTest {
 		val datasource = createDatasource()
-
 		val serverConfig = createConfig()
-		fileSystem.createDirectories(projectsDir().toOkioPath())
-		fileSystem.writeJson(configPath().toOkioPath(), json, serverConfig)
+
+		datasource.storeServerSettings(serverConfig, projectsDir())
 
 		val loaded = datasource.loadServerSettings(projectsDir())
 		assertEquals(serverConfig, loaded)
+	}
+
+	@Test
+	fun `Stored server json contains no tokens`() = runTest {
+		val datasource = createDatasource()
+
+		datasource.storeServerSettings(createConfig(), projectsDir())
+
+		val jsonStr = readServerJson()
+		assertFalse(jsonStr.contains("bearerToken"))
+		assertFalse(jsonStr.contains("refreshToken"))
+		assertFalse(jsonStr.contains("zxc456"))
+		assertFalse(jsonStr.contains("bnm789"))
+	}
+
+	@Test
+	fun `Tokens are retrievable from the store keyed by account`() = runTest {
+		val datasource = createDatasource()
+		val config = createConfig()
+
+		datasource.storeServerSettings(config, projectsDir())
+
+		val tokens = authTokenStore.get(config.url, config.userId)
+		assertEquals(AuthTokens(config.bearerToken, config.refreshToken), tokens)
+	}
+
+	@Test
+	fun `A different account returns no tokens`() = runTest {
+		val datasource = createDatasource()
+		val config = createConfig()
+
+		datasource.storeServerSettings(config, projectsDir())
+
+		assertNull(authTokenStore.get("other.example.com", config.userId))
+		assertNull(authTokenStore.get(config.url, 999L))
+	}
+
+	@Test
+	fun `Token store file lives in the config directory, not projects dir`() = runTest {
+		val datasource = createDatasource()
+
+		datasource.storeServerSettings(createConfig(), projectsDir())
+
+		assertTrue(fileSystem.exists(FileAuthTokenStore.FILE_PATH))
+		assertFalse(FileAuthTokenStore.FILE_PATH.isWithin(projectsDir().toOkioPath()))
+	}
+
+	@Test
+	fun `Legacy server json with inline tokens is migrated into the store`() = runTest {
+		val legacy = createConfig()
+		fileSystem.createDirectories(projectsDir().toOkioPath())
+		fileSystem.writeJson(configPath().toOkioPath(), json, legacy)
+
+		// Precondition: the seeded file really does carry the inline tokens.
+		assertTrue(readServerJson().contains("zxc456"))
+
+		val datasource = createDatasource()
+		val loaded = datasource.loadServerSettings(projectsDir())
+
+		assertEquals(legacy, loaded)
+
+		assertEquals(
+			AuthTokens(legacy.bearerToken, legacy.refreshToken),
+			authTokenStore.get(legacy.url, legacy.userId),
+		)
+
+		val rewritten = readServerJson()
+		assertFalse(rewritten.contains("bearerToken"))
+		assertFalse(rewritten.contains("refreshToken"))
+		assertFalse(rewritten.contains("zxc456"))
+		assertFalse(rewritten.contains("bnm789"))
 	}
 
 	@Test
@@ -84,9 +171,7 @@ class ServerSettingsDatasourceTest : BaseTest() {
 	fun `Check if Server is setup when one is`() = runTest {
 		val datasource = createDatasource()
 
-		val serverConfig = createConfig()
-		fileSystem.createDirectories(projectsDir().toOkioPath())
-		fileSystem.writeJson(configPath().toOkioPath(), json, serverConfig)
+		datasource.storeServerSettings(createConfig(), projectsDir())
 
 		val isSetup = datasource.serverIsSetup(projectsDir())
 
@@ -94,31 +179,20 @@ class ServerSettingsDatasourceTest : BaseTest() {
 	}
 
 	@Test
-	fun `Store Server Settings`() = runTest {
+	fun `Remove Server Settings clears the account tokens from the store`() = runTest {
 		val datasource = createDatasource()
-		val serverConfig = createConfig()
+		val config = createConfig()
 
-		datasource.storeServerSettings(serverConfig, projectsDir())
-
-		fileSystem.read(configPath().toOkioPath()) {
-			val jsonStr = readUtf8()
-			val storedSettings: ServerSettings = json.decodeFromString(jsonStr)
-
-			assertEquals(serverConfig, storedSettings)
-		}
-	}
-
-	@Test
-	fun `Remove Server Settings when one exists`() = runTest {
-		val datasource = createDatasource()
-
-		val serverConfig = createConfig()
-		fileSystem.createDirectories(projectsDir().toOkioPath())
-		fileSystem.writeJson(configPath().toOkioPath(), json, serverConfig)
+		datasource.storeServerSettings(config, projectsDir())
+		assertEquals(
+			AuthTokens(config.bearerToken, config.refreshToken),
+			authTokenStore.get(config.url, config.userId),
+		)
 
 		datasource.removeServerSettings(projectsDir())
 
 		assertFalse(fileSystem.exists(configPath().toOkioPath()))
+		assertNull(authTokenStore.get(config.url, config.userId))
 	}
 
 	@Test


### PR DESCRIPTION
Auth bearer/refresh tokens were stored in cleartext inside the per-workspace
server.json, which on F-Droid builds can be relocated to public external
storage, exposing the secrets.

Move only the secret token fields into a new app-private, account-keyed
AuthTokenStore. server.json stays per-workspace under projectsDir with its
non-secret fields { ssl, url, email, userId } so switching the project
directory still auto-loads that workspace's configured server/account.

- AuthTokenStore interface + FileAuthTokenStore: a single JSON file under
  getConfigDirectory() holding accountKey ("url|userId") -> AuthTokens. The
  store is keyed by account so two workspaces on the same account share the
  login; tokens are per-machine and do not travel with the workspace folder.
  The interface lets an encrypted backing be substituted later.
- PersistedServerSettings: tokenless DTO written to server.json. The in-memory
  ServerSettings shape is unchanged, so token readers (Http auth/refresh,
  AccountUseCase, AccountReauthUseCase) keep reading .bearerToken/.refreshToken.
- store writes the tokenless DTO and puts tokens in the store; load composes
  tokens back in; remove deletes server.json and clears the account's tokens.
- Migration: loading a legacy server.json with inline tokens moves them into
  the store and rewrites the file tokenless. A token-store write failure is
  logged and the in-memory session is preserved (never logs the user out).

Reuses the existing readJsonOrNull/writeJson filesystem helpers, which also
tolerate corrupt/missing files. Writes route through the guarded
ContainedFileSystem; the config dir is an allowed root.
