### PR TITLE
Encrypt auth tokens at rest per platform (F-4)

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -112,6 +112,7 @@ kotlin {
 				implementation(libs.ktor.client.okhttp)
 				implementation(libs.moko.permissions)
 				implementation(libs.moko.permissions.storage)
+				implementation(libs.androidx.security.crypto)
 			}
 		}
 		val iosMain by getting {

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/EncryptedSharedPrefsAuthTokenStore.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/EncryptedSharedPrefsAuthTokenStore.kt
@@ -1,0 +1,108 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.darkrockstudios.apps.hammer.base.http.readJsonOrNull
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore.Companion.accountKey
+import io.github.aakira.napier.Napier
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+
+/**
+ * [AuthTokenStore] backed by [EncryptedSharedPreferences] with an Android
+ * Keystore-backed master key. The account-keyed token map is stored as JSON in a
+ * single encrypted preferences entry.
+ *
+ * If a legacy plaintext token file is present in the config directory it is
+ * migrated into the encrypted store and deleted on first access.
+ */
+class EncryptedSharedPrefsAuthTokenStore(
+	context: Context,
+	private val json: Json,
+	private val fileSystem: FileSystem,
+) : AuthTokenStore {
+
+	private val lock = reentrantLock()
+	private var migrationChecked = false
+
+	private val prefs: SharedPreferences by lazy {
+		val masterKey = MasterKey.Builder(context)
+			.setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+			.build()
+
+		EncryptedSharedPreferences.create(
+			context,
+			PREFS_NAME,
+			masterKey,
+			EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+			EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+		)
+	}
+
+	override fun get(url: String, userId: Long): AuthTokens? = lock.withLock {
+		loadMap()[accountKey(url, userId)]
+	}
+
+	override fun put(url: String, userId: Long, tokens: AuthTokens): Unit = lock.withLock {
+		val updated = loadMap().toMutableMap()
+		updated[accountKey(url, userId)] = tokens
+		storeMap(updated)
+	}
+
+	override fun remove(url: String, userId: Long): Unit = lock.withLock {
+		val updated = loadMap().toMutableMap()
+		if (updated.remove(accountKey(url, userId)) != null) {
+			storeMap(updated)
+		}
+	}
+
+	private fun loadMap(): Map<String, AuthTokens> {
+		migrateLegacyPlaintext()
+		return decodeStored()
+	}
+
+	private fun decodeStored(): Map<String, AuthTokens> {
+		val stored = prefs.getString(TOKENS_KEY, null) ?: return emptyMap()
+		return try {
+			json.decodeFromString<Map<String, AuthTokens>>(stored)
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.w("Failed to parse encrypted auth tokens; treating as empty", e)
+			emptyMap()
+		}
+	}
+
+	private fun storeMap(tokens: Map<String, AuthTokens>) {
+		prefs.edit().putString(TOKENS_KEY, json.encodeToString(tokens)).apply()
+	}
+
+	// Synchronous write so the encrypted entry is durable before the plaintext file is deleted.
+	@SuppressLint("ApplySharedPref")
+	private fun migrateLegacyPlaintext() {
+		if (migrationChecked) return
+		migrationChecked = true
+
+		if (!fileSystem.exists(FileAuthTokenStore.FILE_PATH)) return
+
+		try {
+			val legacy = fileSystem.readJsonOrNull<Map<String, AuthTokens>>(FileAuthTokenStore.FILE_PATH, json)
+				?: return
+			if (legacy.isNotEmpty()) {
+				val merged = legacy + decodeStored()
+				prefs.edit().putString(TOKENS_KEY, json.encodeToString(merged)).commit()
+			}
+			fileSystem.delete(FileAuthTokenStore.FILE_PATH, mustExist = false)
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.w("Failed to migrate plaintext auth token store", e)
+		}
+	}
+
+	companion object {
+		private const val PREFS_NAME = "hammer_auth_tokens"
+		private const val TOKENS_KEY = "tokens"
+	}
+}

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -1,0 +1,15 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+actual val authTokenStoreModule = module {
+	single {
+		EncryptedSharedPrefsAuthTokenStore(
+			context = androidContext(),
+			json = get(),
+			fileSystem = get(),
+		)
+	} bind AuthTokenStore::class
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -1,0 +1,10 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import org.koin.core.module.Module
+
+/**
+ * Provides the platform's [AuthTokenStore] binding. Each platform supplies an
+ * encrypted implementation where one exists; iOS currently falls back to the
+ * plaintext file store pending a Keychain-backed implementation.
+ */
+expect val authTokenStoreModule: Module

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -14,9 +14,8 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.exampleProjectModule
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.FileAuthTokenStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.authTokenStoreModule
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsFilesystemDatasource
@@ -94,6 +93,7 @@ const val RAW_FILESYSTEM = "raw-filesystem"
  */
 val mainModule = module {
 	includes(externalFileIoModule)
+	includes(authTokenStoreModule)
 	includes(exampleProjectModule)
 
 	single(named(DISPATCHER_MAIN)) { platformMainDispatcher }
@@ -115,7 +115,6 @@ val mainModule = module {
 	singleOf(::ProjectDataApi)
 	singleOf(::ServerAdminApi)
 
-	singleOf(::FileAuthTokenStore) bind AuthTokenStore::class
 	singleOf(::ServerSettingsFilesystemDatasource) bind ServerSettingsDatasource::class
 	singleOf(::GlobalSettingsFilesystemDatasource)
 	singleOf(::GlobalSettingsStore) bind GlobalSettingsStore::class

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/EncryptedFileAuthTokenStore.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/EncryptedFileAuthTokenStore.kt
@@ -1,0 +1,167 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import com.darkrockstudios.apps.hammer.base.http.readJsonOrNull
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore.Companion.accountKey
+import com.darkrockstudios.apps.hammer.common.getConfigDirectory
+import io.github.aakira.napier.Napier
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import java.nio.file.attribute.PosixFilePermission
+import java.security.SecureRandom
+import java.security.spec.KeySpec
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * AES-GCM encrypted [AuthTokenStore] for desktop. The account-keyed token map is
+ * serialized to JSON, encrypted, and written to the app-private config directory.
+ *
+ * The encryption key is derived (PBKDF2) from stable per-user/per-machine inputs
+ * (OS user name + home directory) plus a static app salt; no key material is
+ * written to disk. A token file copied to another machine or user therefore can't
+ * be decrypted.
+ *
+ * Threat model: this protects against casual disk scraping, config-dir backup or
+ * exfiltration, and off-machine copies. It does NOT defend against same-user local
+ * malware, which can re-derive the key from the same inputs.
+ */
+class EncryptedFileAuthTokenStore(
+	private val fileSystem: FileSystem,
+	private val json: Json,
+	private val filePath: Path = DEFAULT_FILE_PATH,
+	private val legacyPlaintextPath: Path = LEGACY_PLAINTEXT_PATH,
+	keyUserName: String = System.getProperty("user.name").orEmpty(),
+	keyHomeDir: String = System.getProperty("user.home").orEmpty(),
+	keySalt: ByteArray = APP_SALT,
+) : AuthTokenStore {
+
+	private val lock = reentrantLock()
+	private val secretKey: SecretKeySpec = deriveKey(keyUserName, keyHomeDir, keySalt)
+	private val secureRandom = SecureRandom()
+	private var migrationChecked = false
+
+	override fun get(url: String, userId: Long): AuthTokens? = lock.withLock {
+		load()[accountKey(url, userId)]
+	}
+
+	override fun put(url: String, userId: Long, tokens: AuthTokens): Unit = lock.withLock {
+		val updated = load().toMutableMap()
+		updated[accountKey(url, userId)] = tokens
+		store(updated)
+	}
+
+	override fun remove(url: String, userId: Long): Unit = lock.withLock {
+		val updated = load().toMutableMap()
+		if (updated.remove(accountKey(url, userId)) != null) {
+			store(updated)
+		}
+	}
+
+	private fun load(): Map<String, AuthTokens> {
+		migrateLegacyPlaintext()
+		return decryptStored()
+	}
+
+	private fun decryptStored(): Map<String, AuthTokens> {
+		if (!fileSystem.exists(filePath)) return emptyMap()
+		return try {
+			val encrypted = fileSystem.read(filePath) { readByteArray() }
+			json.decodeFromString<Map<String, AuthTokens>>(decrypt(encrypted).decodeToString())
+			// Wrong machine/user, corruption, or tampering: treat as no tokens (forces re-login).
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.w("Failed to decrypt auth token store; treating as empty", e)
+			emptyMap()
+		}
+	}
+
+	private fun store(tokens: Map<String, AuthTokens>) {
+		fileSystem.createDirectories(filePath.parent!!)
+		val plaintext = json.encodeToString(tokens).encodeToByteArray()
+		fileSystem.write(filePath) { write(encrypt(plaintext)) }
+		restrictPermissions(filePath)
+	}
+
+	/**
+	 * Migrates a legacy plaintext token file, if present, into the encrypted store
+	 * and deletes it. Existing encrypted tokens win on key collision. Runs once per
+	 * instance; failures degrade to a no-op rather than dropping the session.
+	 */
+	private fun migrateLegacyPlaintext() {
+		if (migrationChecked) return
+		migrationChecked = true
+
+		if (!fileSystem.exists(legacyPlaintextPath)) return
+
+		try {
+			val legacy = fileSystem.readJsonOrNull<Map<String, AuthTokens>>(legacyPlaintextPath, json)
+				?: return
+			if (legacy.isNotEmpty()) {
+				store(legacy + decryptStored())
+			}
+			fileSystem.delete(legacyPlaintextPath, mustExist = false)
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.w("Failed to migrate plaintext auth token store", e)
+		}
+	}
+
+	private fun encrypt(plaintext: ByteArray): ByteArray {
+		val iv = ByteArray(IV_LENGTH).also { secureRandom.nextBytes(it) }
+		val cipher = Cipher.getInstance(TRANSFORMATION)
+		cipher.init(Cipher.ENCRYPT_MODE, secretKey, GCMParameterSpec(GCM_TAG_BITS, iv))
+		val ciphertext = cipher.doFinal(plaintext)
+		return iv + ciphertext
+	}
+
+	private fun decrypt(input: ByteArray): ByteArray {
+		require(input.size >= IV_LENGTH + GCM_TAG_BITS / 8) { "Ciphertext too short" }
+		val iv = input.copyOfRange(0, IV_LENGTH)
+		val ciphertext = input.copyOfRange(IV_LENGTH, input.size)
+		val cipher = Cipher.getInstance(TRANSFORMATION)
+		cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(GCM_TAG_BITS, iv))
+		return cipher.doFinal(ciphertext)
+	}
+
+	private fun restrictPermissions(path: Path) {
+		try {
+			val nioPath = java.nio.file.Paths.get(path.toString())
+			val fs = nioPath.fileSystem
+			if (fs.supportedFileAttributeViews().contains("posix")) {
+				java.nio.file.Files.setPosixFilePermissions(
+					nioPath,
+					setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+				)
+			}
+			// Best-effort: unsupported (e.g. Windows) or denied perms are non-fatal.
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.d("Could not restrict auth token file permissions", e)
+		}
+	}
+
+	private fun deriveKey(userName: String, homeDir: String, salt: ByteArray): SecretKeySpec {
+		val password = "$userName|$homeDir".toCharArray()
+		val spec: KeySpec = PBEKeySpec(password, salt, PBKDF2_ITERATIONS, KEY_LENGTH_BITS)
+		val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+		val keyBytes = factory.generateSecret(spec).encoded
+		return SecretKeySpec(keyBytes, "AES")
+	}
+
+	companion object {
+		private const val FILE_NAME = "auth_tokens.enc"
+		private const val TRANSFORMATION = "AES/GCM/NoPadding"
+		private const val IV_LENGTH = 12
+		private const val GCM_TAG_BITS = 128
+		private const val KEY_LENGTH_BITS = 256
+		private const val PBKDF2_ITERATIONS = 120_000
+		private val APP_SALT = "hammer-editor::auth-token-store::v1".encodeToByteArray()
+
+		val DEFAULT_FILE_PATH = getConfigDirectory().toPath() / FILE_NAME
+		val LEGACY_PLAINTEXT_PATH = FileAuthTokenStore.FILE_PATH
+	}
+}

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -1,0 +1,8 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+actual val authTokenStoreModule = module {
+	single { EncryptedFileAuthTokenStore(fileSystem = get(), json = get()) } bind AuthTokenStore::class
+}

--- a/common/src/desktopTest/kotlin/repositories/globalsettings/EncryptedFileAuthTokenStoreTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/globalsettings/EncryptedFileAuthTokenStoreTest.kt
@@ -1,0 +1,148 @@
+package repositories.globalsettings
+
+import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
+import com.darkrockstudios.apps.hammer.base.http.writeJson
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokens
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.EncryptedFileAuthTokenStore
+import kotlinx.serialization.json.Json
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EncryptedFileAuthTokenStoreTest : BaseTest() {
+
+	private lateinit var fileSystem: FakeFileSystem
+	private lateinit var json: Json
+
+	private val encPath: Path = "/config/auth_tokens.enc".toPath()
+	private val legacyPath: Path = "/config/auth_tokens.json".toPath()
+
+	private val url = "hammer.ink"
+	private val userId = 1L
+	private val tokens = AuthTokens(bearerToken = "zxc456", refreshToken = "bnm789")
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		fileSystem = FakeFileSystem()
+		json = createJsonSerializer()
+	}
+
+	private fun createStore(
+		userName: String = "alice",
+		homeDir: String = "/home/alice",
+		salt: ByteArray = "test-salt".encodeToByteArray(),
+	) = EncryptedFileAuthTokenStore(
+		fileSystem = fileSystem,
+		json = json,
+		filePath = encPath,
+		legacyPlaintextPath = legacyPath,
+		keyUserName = userName,
+		keyHomeDir = homeDir,
+		keySalt = salt,
+	)
+
+	@Test
+	fun `Tokens round-trip through the encrypted store`() {
+		val store = createStore()
+
+		store.put(url, userId, tokens)
+
+		val loaded = store.get(url, userId)
+		assertEquals(tokens, loaded)
+	}
+
+	@Test
+	fun `On-disk file contains no plaintext token substrings`() {
+		val store = createStore()
+
+		store.put(url, userId, tokens)
+
+		val bytes = fileSystem.read(encPath) { readByteArray() }
+		val asText = bytes.decodeToString()
+		assertFalse(asText.contains("zxc456"))
+		assertFalse(asText.contains("bnm789"))
+		assertFalse(asText.contains("bearerToken"))
+		assertFalse(asText.contains(url))
+	}
+
+	@Test
+	fun `Different key inputs cannot decrypt and return null without crashing`() {
+		createStore(userName = "alice", homeDir = "/home/alice").put(url, userId, tokens)
+
+		val otherUser = createStore(userName = "mallory", homeDir = "/home/mallory")
+		assertNull(otherUser.get(url, userId))
+
+		val otherSalt = createStore(salt = "different-salt".encodeToByteArray())
+		assertNull(otherSalt.get(url, userId))
+	}
+
+	@Test
+	fun `Keying by url and userId isolates accounts`() {
+		val store = createStore()
+		store.put(url, userId, tokens)
+
+		assertEquals(tokens, store.get(url, userId))
+		assertNull(store.get("other.example.com", userId))
+		assertNull(store.get(url, 999L))
+	}
+
+	@Test
+	fun `Remove clears a single account`() {
+		val store = createStore()
+		store.put(url, userId, tokens)
+		store.put("other.example.com", 2L, AuthTokens("a", "b"))
+
+		store.remove(url, userId)
+
+		assertNull(store.get(url, userId))
+		assertEquals(AuthTokens("a", "b"), store.get("other.example.com", 2L))
+	}
+
+	@Test
+	fun `Legacy plaintext file is imported then deleted`() {
+		fileSystem.createDirectories(legacyPath.parent!!)
+		val legacyMap = mapOf("$url|$userId" to tokens)
+		fileSystem.writeJson(legacyPath, json, legacyMap)
+		assertTrue(fileSystem.exists(legacyPath))
+
+		val store = createStore()
+		val loaded = store.get(url, userId)
+
+		assertEquals(tokens, loaded)
+		assertFalse(fileSystem.exists(legacyPath))
+		assertTrue(fileSystem.exists(encPath))
+
+		// Re-reading the encrypted file confirms the imported tokens persisted.
+		assertFalse(fileSystem.read(encPath) { readByteArray() }.decodeToString().contains("zxc456"))
+	}
+
+	@Test
+	fun `Existing encrypted tokens win over a stale legacy plaintext entry`() {
+		val fresh = AuthTokens(bearerToken = "fresh-bearer", refreshToken = "fresh-refresh")
+		createStore().put(url, userId, fresh)
+
+		fileSystem.createDirectories(legacyPath.parent!!)
+		val staleMap = mapOf("$url|$userId" to AuthTokens("stale-bearer", "stale-refresh"))
+		fileSystem.writeJson(legacyPath, json, staleMap)
+
+		// A fresh instance triggers migration on first access.
+		val migrated = createStore().get(url, userId)
+
+		assertEquals(fresh, migrated)
+		assertFalse(fileSystem.exists(legacyPath))
+	}
+
+	@Test
+	fun `Missing file yields no tokens`() {
+		val store = createStore()
+		assertNull(store.get(url, userId))
+	}
+}

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -1,0 +1,11 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+// TODO(F-4): iOS Keychain-backed AuthTokenStore. iOS still uses the plaintext
+//  file store; replace with a Keychain implementation.
+actual val authTokenStoreModule = module {
+	singleOf(::FileAuthTokenStore) bind AuthTokenStore::class
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ cache4k = "0.14.0"
 core = "1.7.0"
 coreKtx = "1.19.0"
 cryptohash = "1.0.2"
+androidx-security-crypto = "1.1.0"
 glance = "1.2.0-rc01"
 androix-junit = "1.3.0"
 junit = "6.1.0"
@@ -112,6 +113,7 @@ cache4k = { module = "io.github.reactivecircus.cache4k:cache4k", version.ref = "
 core = { module = "androidx.test:core", version.ref = "core" }
 core-ktx = { module = "androidx.test:core-ktx", version.ref = "core" }
 cryptohash = { module = "com.appmattus.crypto:cryptohash", version.ref = "cryptohash" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 flatlaf = { module = "com.formdev:flatlaf", version.ref = "flatlaf" }
 glance = { module = "androidx.glance:glance", version.ref = "glance" }
 glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }


### PR DESCRIPTION
Replace the plaintext FileAuthTokenStore binding with platform-specific
encrypted stores behind the same AuthTokenStore interface, wired via a new
expect/actual authTokenStoreModule.

Android: EncryptedSharedPrefsAuthTokenStore backed by EncryptedSharedPreferences
with a Keystore-backed AES256_GCM master key (androidx.security:security-crypto).

Desktop: EncryptedFileAuthTokenStore writes the token-map JSON as AES/GCM/NoPadding
to the config directory. The key is derived (PBKDF2WithHmacSHA256) from the OS user
name and home dir plus a static salt, with no key file on disk, so a copied token
file is useless on another machine or user. A random 12-byte IV is prepended per
write and owner-only POSIX perms are applied best-effort. Decryption failure is
treated as no tokens rather than crashing. This guards against casual disk
scraping and off-machine copies, not same-user local malware that can re-derive
the key.

iOS: still uses the plaintext file store pending a Keychain-backed implementation
(TODO marker in the iOS binding).

Migration: a legacy plaintext auth_tokens.json from an intermediate build is
imported into the encrypted store and deleted on first access; existing encrypted
tokens win on key collision so a stale plaintext entry cannot clobber a fresh
session.
