### PR TITLE
Unexport AddNoteActivity and filter obscured touches (F-8)

### DIFF
--- a/android/src/fdroid/AndroidManifest.xml
+++ b/android/src/fdroid/AndroidManifest.xml
@@ -61,7 +61,7 @@
 		<activity
 			android:name=".widgets.AddNoteActivity"
 			android:excludeFromRecents="true"
-			android:exported="true"
+			android:exported="false"
 			android:label="@string/title_activity_add_note"
 			android:theme="@style/Theme.AppCompat.DayNight.Dialog"
 			android:windowSoftInputMode="adjustResize"/>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
 		<activity
 			android:name=".widgets.AddNoteActivity"
 			android:excludeFromRecents="true"
-			android:exported="true"
+			android:exported="false"
 			android:label="@string/title_activity_add_note"
 			android:theme="@style/Theme.AppCompat.DayNight.Dialog"
 			android:windowSoftInputMode="adjustResize"/>

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/widgets/AddNoteActivity.kt
@@ -55,6 +55,10 @@ class AddNoteActivity : ComponentActivity(), KoinComponent {
 		super.onCreate(savedInstanceState)
 		enableEdgeToEdge()
 
+		// Drop touches delivered while another app's window overlays this dialog, so a tapjacking
+		// overlay can't drive the note save into a chosen project.
+		window.decorView.filterTouchesWhenObscured = true
+
 		setFinishOnTouchOutside(false)
 		window.setBackgroundDrawableResource(android.R.color.transparent)
 


### PR DESCRIPTION
AddNoteActivity was exported with no permission, so any installed app could pop the Add Note dialog over the user pre-locked to a chosen project; a tapjacking overlay tricking a Save tap would write a note and push it to the sync server. It is only ever launched in-process (ProjectSelectActivity) or via the home-screen widgets' PendingIntents, neither of which needs export. Set android:exported=false in both manifests and filter touches delivered while the window is obscured.
