### PR TITLE
Fix timeline reorder snapping back after the first move

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/reorderable/DragDropList.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/reorderable/DragDropList.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
@@ -50,8 +51,12 @@ fun <T> DragDropList(
 		data = items
 	}
 
+	// rememberDragDropListState captures its callbacks once, so route the
+	// external one through rememberUpdatedState; otherwise it keeps invoking a
+	// stale closure and moves the wrong item once the list order has changed.
+	val currentOnMove by rememberUpdatedState(onMove)
 	val dragDropListState = rememberDragDropListState(
-		confirmReorder = onMove,
+		confirmReorder = { from, to -> currentOnMove(from, to) },
 		onMove = { from, to ->
 			data = data.toMutableList().apply {
 				add(to, removeAt(from))

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/reorderable/DragDropList.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/reorderable/DragDropList.kt
@@ -94,18 +94,20 @@ fun <T> DragDropList(
 	) {
 		itemsIndexed(data, key) { index, item ->
 			val isDragging = index == dragDropListState.currentIndexOfDraggedItem
+			val isReordering = dragDropListState.currentIndexOfDraggedItem != null
 			val zIndex = if (isDragging) {
 				1f
 			} else {
 				0f
 			}
-			// Only the displaced items animate into place.
-			val itemModifier = if (isDragging) {
-				Modifier.graphicsLayer {
+			// Animate placement only while reordering, so the displaced items
+			// slide into place; otherwise plain scrolling would animate them too.
+			val itemModifier = when {
+				isDragging -> Modifier.graphicsLayer {
 					translationY = dragDropListState.elementDisplacement ?: 0f
 				}
-			} else {
-				Modifier.animateItem()
+				isReordering -> Modifier.animateItem()
+				else -> Modifier
 			}
 			Box(
 				modifier = Modifier

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/reorderable/DragDropList.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/reorderable/DragDropList.kt
@@ -35,7 +35,9 @@ fun <T> DragDropList(
 	val scope = rememberCoroutineScope()
 
 	var overscrollJob by remember { mutableStateOf<Job?>(null) }
-	var currentExternalList = remember { items }
+	// Must be state-backed: it tracks the last external list so the guard below
+	// resets the drag preview only on a real external change, not every recompose.
+	var currentExternalList by remember { mutableStateOf(items) }
 
 	var data by remember {
 		mutableStateOf<List<T>>(


### PR DESCRIPTION
## Problem

Reported by a user: dragging to reorder timeline events works the first time, but subsequent reorders behave wrong — items snap back, or a confusing flurry of animation leaves the order unclear.

This turned out to be **two** distinct bugs in the shared `DragDropList` widget (not in the timeline repository — `moveEvent` correctly reorders, persists, and emits).

## Bug 1 — drag preview reset on every recompose

`DragDropList` resets its internal drag-preview list from the external `items` whenever the source list changes:

```kotlin
var currentExternalList = remember { items }   // plain var, NOT state-backed
var data by remember { mutableStateOf(items.toMutableList()) }

if (items != currentExternalList) {
    currentExternalList = items   // assignment thrown away
    data = items
}
```

`currentExternalList` was a plain `var` from `remember { items }`, so it stayed frozen at the first composition and the reassignment never persisted. After the first committed reorder the guard was permanently true, so every recompose ran `data = items` — clobbering the in-progress drag preview and snapping items back.

**Fix:** make `currentExternalList` state-backed so the guard fires only on a real external change.

## Bug 2 — stale callback moves the wrong item

`rememberDragDropListState` stores its callbacks in a keyless `remember { DragDropListState(confirmReorder, onMove) }`, so it captures the **first** composition's `confirmReorder` closure forever. That closure indexes into `visibleEvents`:

```kotlin
onMove = { from, to ->
    visibleEvents.getOrNull(from)?.let { event ->   // frozen at first composition
        scope.launch { component.moveEvent(event, to, from < to) }
    }
}
```

Once the order changes, `visibleEvents.getOrNull(from)` resolves `from` against the stale original list and moves the *wrong event*. The first move is correct (list unchanged); every move after picks the wrong item — the "stuff animating around, can't tell what moved" symptom. Fixing Bug 1 made the live preview work, which exposed this one clearly.

**Fix:** route the external callback through `rememberUpdatedState` so the remembered state always invokes the latest closure.

Both fixes live in the shared `DragDropList`, so they apply to any screen using it, not just the timeline.

## Testing

- `:composeUi:compileKotlinDesktop` and the desktop test suite pass.
- Manual: open the timeline, reorder several events in a row, confirm each move targets the dragged item, sticks, and survives navigating away and back (disk round-trip).