### PR TITLE
Block sync path traversal via draft name and image extension (F-1)

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -194,6 +194,9 @@
 	<string name="sync_log_data_save_failed">Sync data not saved due to errors</string>
 	<string name="sync_log_failed">Failed to end sync</string>
 
+	<string name="sync_draft_rejected_invalid_name">Rejected draft %1$d from server: unsafe draft name</string>
+	<string name="sync_encyclopedia_image_rejected_invalid_extension">Skipped image for encyclopedia entry %1$d from server: unsafe file extension</string>
+
 	<string name="sync_encyclopedia_deleted">Deleted Encyclopedia ID %1$d from client</string>
 	<string name="sync_note_deleted">Deleted note ID %1$d from client</string>
 	<string name="sync_draft_deleted">Deleted draft %1$d from client</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftsDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/drafts/SceneDraftsDatasource.kt
@@ -5,6 +5,7 @@ import com.darkrockstudios.apps.hammer.common.data.SceneContent
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import io.github.aakira.napier.Napier
@@ -91,6 +92,12 @@ class SceneDraftsDatasource(
 	fun insertSyncDraft(draftEntity: ApiProjectEntity.SceneDraftEntity): DraftDef {
 		val draftDef = draftEntity.toDraftDef()
 		val path = getDraftPath(draftDef).toOkioPath()
+
+		val draftsRoot = getSceneDraftsDirectory(draftDef.sceneId).toOkioPath()
+		if (!path.isWithin(draftsRoot)) {
+			error("Refusing to write draft outside its drafts directory: $path")
+		}
+
 		val parentPath = path.parent ?: error("Draft path didn't have parent: $path")
 		fileSystem.createDirectories(parentPath)
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
@@ -9,6 +9,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.InvalidSceneFilename
 import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import io.github.aakira.napier.Napier
@@ -219,6 +220,12 @@ class EncyclopediaDatasource(
 	/** Writes raw image bytes (e.g. an image pulled from the server during sync) to the entry's image path. */
 	suspend fun writeEntryImage(entryDef: EntryDef, imageBytes: ByteArray, fileExtension: String) {
 		val targetPath = getEntryImagePath(entryDef, fileExtension).toOkioPath()
+
+		val typeDir = getTypeDirectory(entryDef.type).toOkioPath()
+		if (!targetPath.isWithin(typeDir)) {
+			error("Refusing to write entry image outside its type directory: $targetPath")
+		}
+
 		fileSystem.write(targetPath) {
 			write(imageBytes)
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
@@ -195,7 +195,7 @@ class ClientEncyclopediaSynchronizer(
 
 	companion object {
 		val ALLOWED_IMAGE_EXTENSIONS = setOf(
-			"jpg", "jpeg", "png", "gif", "webp", "bmp", "heic", "heif",
+			"jpg", "jpeg", "png", "gif", "webp",
 		)
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
@@ -18,10 +18,13 @@ import com.darkrockstudios.apps.hammer.common.data.references.ReferenceRemapper
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogI
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogW
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.sync_encyclopedia_deleted
+import com.darkrockstudios.apps.hammer.sync_encyclopedia_image_rejected_invalid_extension
+import io.github.aakira.napier.Napier
 import korlibs.crypto.encoding.Base64
 import kotlinx.coroutines.flow.first
 
@@ -138,7 +141,7 @@ class ClientEncyclopediaSynchronizer(
 			type = EntryType.fromString(serverEntity.entryType),
 		)
 
-		handleImage(oldDef, serverDef, serverEntity)
+		handleImage(oldDef, serverDef, serverEntity, onLog)
 
 		if (oldDef != null) {
 			encyclopediaService.updateEntry(
@@ -166,10 +169,21 @@ class ClientEncyclopediaSynchronizer(
 	private suspend fun handleImage(
 		oldDef: EntryDef?,
 		serverDef: EntryDef,
-		serverEntity: ApiProjectEntity.EncyclopediaEntryEntity
+		serverEntity: ApiProjectEntity.EncyclopediaEntryEntity,
+		onLog: OnSyncLog,
 	) {
 		val image = serverEntity.image
 		if (image != null) {
+			if (image.fileExtension.lowercase() !in ALLOWED_IMAGE_EXTENSIONS) {
+				Napier.w("Skipped synced image for entry ${serverEntity.id}: invalid file extension '${image.fileExtension}'")
+				onLog(
+					syncLogW(
+						strRes.get(Res.string.sync_encyclopedia_image_rejected_invalid_extension, serverEntity.id),
+						projectDef
+					)
+				)
+				return
+			}
 			val imageBytes = Base64.decode(image.base64, url = true)
 			encyclopediaDatasource.writeEntryImage(serverDef, imageBytes, image.fileExtension)
 		} else if (oldDef != null && encyclopediaDatasource.hasEntryImage(oldDef, "jpg")) {
@@ -177,5 +191,11 @@ class ClientEncyclopediaSynchronizer(
 			// sync-marking) since we're applying server state, not making a local edit.
 			encyclopediaDatasource.removeEntryImage(oldDef)
 		}
+	}
+
+	companion object {
+		val ALLOWED_IMAGE_EXTENSIONS = setOf(
+			"jpg", "jpeg", "png", "gif", "webp", "bmp", "heic", "heif",
+		)
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientSceneDraftSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientSceneDraftSynchronizer.kt
@@ -8,15 +8,18 @@ import com.darkrockstudios.apps.hammer.base.http.synchronizer.EntityHasher
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectInject
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogI
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogW
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.sync_draft_deleted
+import com.darkrockstudios.apps.hammer.sync_draft_rejected_invalid_name
 import io.github.aakira.napier.Napier
 
 class ClientSceneDraftSynchronizer(
@@ -90,6 +93,17 @@ class ClientSceneDraftSynchronizer(
 		syncId: String,
 		onLog: OnSyncLog
 	): Boolean {
+		if (!SceneDraftsDatasource.validDraftName(serverEntity.name)) {
+			Napier.w("Rejected synced draft ${serverEntity.id}: invalid draft name")
+			onLog(
+				syncLogW(
+					strRes.get(Res.string.sync_draft_rejected_invalid_name, serverEntity.id),
+					projectDef
+				)
+			)
+			return false
+		}
+
 		sceneDraftRepository.insertSyncDraft(serverEntity)
 		return true
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/PathContainment.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/fileio/okio/PathContainment.kt
@@ -1,0 +1,23 @@
+package com.darkrockstudios.apps.hammer.common.fileio.okio
+
+import okio.Path
+
+/**
+ * Containment backstop against path traversal. Returns true only when this path,
+ * once `..`/`.` segments are collapsed, equals [root] or sits nested beneath it.
+ * A non-descendant (sibling escape, absolute reach-out, `..` climb) returns false.
+ */
+fun Path.isWithin(root: Path): Boolean {
+	val normalizedRoot = root.normalized()
+	val normalizedCandidate = normalized()
+
+	if (normalizedCandidate.isAbsolute != normalizedRoot.isAbsolute) return false
+
+	if (normalizedCandidate == normalizedRoot) return true
+
+	val rootSegments = normalizedRoot.segments
+	val candidateSegments = normalizedCandidate.segments
+	if (candidateSegments.size <= rootSegments.size) return false
+
+	return candidateSegments.subList(0, rootSegments.size) == rootSegments
+}

--- a/common/src/desktopTest/kotlin/fileio/PathContainmentTest.kt
+++ b/common/src/desktopTest/kotlin/fileio/PathContainmentTest.kt
@@ -1,0 +1,58 @@
+package fileio
+
+import com.darkrockstudios.apps.hammer.common.fileio.okio.isWithin
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PathContainmentTest {
+
+	private val root = "/projects/Test/.drafts/1".toPath()
+
+	@Test
+	fun `a genuine descendant is within the root`() {
+		assertTrue(("/projects/Test/.drafts/1/1-5-draft-100.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `the root itself is within the root`() {
+		assertTrue(root.isWithin(root))
+	}
+
+	@Test
+	fun `a parent-climbing traversal escapes the root`() {
+		val escape = ("/projects/Test/.drafts/1" / "../../../../evil").toPath()
+		assertFalse(escape.isWithin(root))
+	}
+
+	@Test
+	fun `an embedded dot-dot segment that escapes the root is rejected`() {
+		assertFalse(("/projects/Test/.drafts/1/../../evil.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `a sibling directory is not within the root`() {
+		assertFalse(("/projects/Test/.drafts/2/file.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `a prefix-sharing sibling is not within the root`() {
+		// "/projects/Test/.drafts/10" shares the textual prefix "/projects/Test/.drafts/1"
+		// but is a different directory.
+		assertFalse(("/projects/Test/.drafts/10/file.md".toPath()).isWithin(root))
+	}
+
+	@Test
+	fun `an absolute reach-out is not within a relative root`() {
+		val relativeRoot = ".drafts/1".toPath()
+		assertFalse(("/etc/passwd".toPath()).isWithin(relativeRoot))
+	}
+
+	@Test
+	fun `an unrelated absolute path is not within the root`() {
+		assertFalse(("/etc/passwd".toPath()).isWithin(root))
+	}
+
+	private operator fun String.div(other: String) = "$this/$other"
+}

--- a/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientEncyclopediaSynchronizerTest.kt
@@ -254,6 +254,67 @@ class ClientEncyclopediaSynchronizerTest : BaseTest() {
 	}
 
 	@Test
+	fun `storeEntity rejects a traversal file extension and writes no image but still stores the entry`() = runTest {
+		val imageBytes = byteArrayOf(4, 5, 6)
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			text = "Stored anyway",
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(imageBytes, url = true),
+				fileExtension = "jpg/../../../../evil",
+			),
+		)
+
+		val before = allRegularFiles()
+
+		val stored = sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		assertTrue(stored)
+		assertEquals("Stored anyway", repository.loadEntry(entry1().id).entry.text)
+		assertEquals(before, allRegularFiles())
+	}
+
+	@Test
+	fun `storeEntity rejects an unknown image extension`() = runTest {
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(byteArrayOf(1), url = true),
+				fileExtension = "exe",
+			),
+		)
+
+		val before = allRegularFiles()
+		sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		assertEquals(before, allRegularFiles())
+	}
+
+	@Test
+	fun `storeEntity writes a png image with an allowed extension`() = runTest {
+		val imageBytes = byteArrayOf(7, 7, 7)
+		val sync = newSynchronizer()
+		val serverEntity = sync.createEntityForId(entry1().id).copy(
+			image = com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity.EncyclopediaEntryEntity.Image(
+				base64 = Base64.encode(imageBytes, url = true),
+				fileExtension = "png",
+			),
+		)
+
+		sync.storeEntity(serverEntity, syncId = "sync", onLog = {})
+
+		val def = entry1().toDef(projectDef)
+		assertTrue(datasource.hasEntryImage(def, "png"))
+		assertContentEquals(imageBytes, datasource.loadEntryImage(def, "png"))
+	}
+
+	private fun allRegularFiles(): Set<String> =
+		fileSystem.allPaths
+			.filter { fileSystem.metadataOrNull(it)?.isRegularFile == true }
+			.map { it.toString() }
+			.toSet()
+
+	@Test
 	fun `storeEntity drops a local image when the server has none`() = runTest {
 		val def = entry1().toDef(projectDef)
 		datasource.writeEntryImage(def, byteArrayOf(1, 2, 3), "jpg")

--- a/common/src/desktopTest/kotlin/synchronizer/ClientSceneDraftSynchronizerSecurityTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientSceneDraftSynchronizerSecurityTest.kt
@@ -1,0 +1,149 @@
+package synchronizer
+
+import PROJECT_2_NAME
+import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
+import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
+import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogLevel
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogMessage
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.synchronizers.ClientSceneDraftSynchronizer
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
+import com.darkrockstudios.apps.hammer.common.util.StrRes
+import createProject
+import getProjectDef
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.dsl.module
+import utils.BaseTest
+import utils.TestStrRes
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * Classical-style: drives a real [SceneDraftRepository] / [SceneDraftsDatasource] over a
+ * [FakeFileSystem] seeded from the "Test Project 2" fixture. Only the network boundary is
+ * mocked. Asserts observable filesystem outcomes (no file escapes the drafts directory).
+ */
+class ClientSceneDraftSynchronizerSecurityTest : BaseTest() {
+
+	private val projectDef = getProjectDef(PROJECT_2_NAME)
+	private val strRes: StrRes = TestStrRes()
+
+	@MockK(relaxed = true)
+	private lateinit var serverProjectApi: ServerProjectApi
+
+	@MockK(relaxed = true)
+	private lateinit var projectMetadataDatasource: ProjectMetadataDatasource
+
+	@MockK(relaxed = true)
+	private lateinit var idAllocator: IdAllocator
+
+	@MockK(relaxed = true)
+	private lateinit var sceneContentRepository: SceneContentRepository
+
+	@MockK(relaxed = true)
+	private lateinit var clock: Clock
+
+	private lateinit var ffs: FakeFileSystem
+	private lateinit var repository: SceneDraftRepository
+	private lateinit var datasource: SceneDraftsDatasource
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		MockKAnnotations.init(this, relaxUnitFun = true)
+
+		ffs = FakeFileSystem()
+		createProject(ffs, PROJECT_2_NAME)
+
+		val sceneDatasource = SceneDatasource(projectDef, ffs)
+		datasource = SceneDraftsDatasource(ffs, sceneDatasource)
+
+		setupKoin(module {
+			single { idAllocator }
+			single { clock }
+			scope<ProjectDefScope> {
+				scoped { projectDef }
+				scoped { repository }
+			}
+		})
+
+		repository = SceneDraftRepository(projectDef, sceneContentRepository, datasource, clock)
+	}
+
+	private fun newSynchronizer() = ClientSceneDraftSynchronizer(
+		projectDef = projectDef,
+		serverProjectApi = serverProjectApi,
+		projectMetadataDatasource = projectMetadataDatasource,
+		strRes = strRes,
+	)
+
+	private fun draftEntity(name: String) = ApiProjectEntity.SceneDraftEntity(
+		id = 500,
+		sceneId = 1,
+		created = Instant.fromEpochSeconds(1000),
+		name = name,
+		content = "PWNED",
+	)
+
+	private fun allFiles(): Set<String> =
+		ffs.allPaths
+			.filter { ffs.metadataOrNull(it)?.isRegularFile == true }
+			.map { it.toString() }
+			.toSet()
+
+	@Test
+	fun `a traversal draft name escaping with dot-dot is rejected and writes no file`() = runTest {
+		val before = allFiles()
+		val logs = mutableListOf<SyncLogMessage>()
+
+		val stored = newSynchronizer().storeEntity(
+			draftEntity("../../../../evil"),
+			syncId = "sync",
+			onLog = { logs.add(it) },
+		)
+
+		assertFalse(stored, "Malicious draft must be skipped")
+		assertEquals(before, allFiles(), "No file may be created anywhere on the filesystem")
+		assertTrue(logs.any { it.level == SyncLogLevel.WARN })
+	}
+
+	@Test
+	fun `a draft name with an embedded slash is rejected and writes no file`() = runTest {
+		val before = allFiles()
+
+		val stored = newSynchronizer().storeEntity(
+			draftEntity("a/b"),
+			syncId = "sync",
+			onLog = {},
+		)
+
+		assertFalse(stored)
+		assertEquals(before, allFiles())
+	}
+
+	@Test
+	fun `a normal draft name is stored and loads back`() = runTest {
+		val entity = draftEntity("Clean Name")
+
+		val stored = newSynchronizer().storeEntity(entity, syncId = "sync", onLog = {})
+
+		assertTrue(stored)
+		val def = repository.getDraftDef(500)
+		assertEquals("Clean Name", def?.draftName)
+		assertEquals("PWNED", repository.loadDraftContent(def!!))
+	}
+}


### PR DESCRIPTION
A malicious or compromised sync server could supply crafted entity
fields that were used verbatim as filename components when writing
downloaded entities to disk, with no validation on the sync path
(unlike the local-create paths). Embedded `/` or `..` escaped the
intended directory and, since file contents are attacker-controlled,
gave a write-anywhere primitive on the unsandboxed Desktop target.

Two sinks were affected:
- SceneDraftEntity.name flows into the draft filename in
  SceneDraftsDatasource.insertSyncDraft.
- EncyclopediaEntryEntity.Image.fileExtension flows into the entry
  image filename in EncyclopediaDatasource.writeEntryImage.

Defense in depth, two layers:

Layer 1 (synchronizer boundary, graceful per-entity skip):
- ClientSceneDraftSynchronizer.storeEntity rejects any draft whose
  name fails the existing validDraftName check, logs a warning, and
  returns false so only that entity is skipped (no synced hash is
  recorded, so sync state is not poisoned and the run is not aborted).
- ClientEncyclopediaSynchronizer.handleImage validates the image
  file extension against a known-image allowlist (ALLOWED_IMAGE_
  EXTENSIONS); a disallowed extension skips just the image write while
  the entry itself is still stored.

Layer 2 (containment backstop): a new Path.isWithin(root) helper
(okio normalized()) is asserted right before the write in both
datasource sinks, hard-failing any path that escapes its intended
directory. With Layer 1 in place this should never fire for the known
sinks; it fail-closes any future sink that forgets validation.

Tests (TDD, confirmed failing before the fix): traversal draft names
and image extensions are blocked with no file written outside the
target directory; isWithin rejects `..`, absolute, and sibling-escape
paths; happy-path drafts and jpg/png images still round-trip.

---
Continues the security-audit stack (replaces #650, which auto-closed when its base branch `sec/04` was deleted on merge).
