### PR TITLE
Pin the GitHub version-check endpoint to HTTPS

### DIFF
--- a/android/src/main/res/xml/network_security_config.xml
+++ b/android/src/main/res/xml/network_security_config.xml
@@ -2,7 +2,13 @@
 	Self-hosted sync servers are configured by the user at runtime and may be plain HTTP
 	(ServerSettings.ssl = false), so cleartext must stay permitted. From Android 17 (API 37)
 	the usesCleartextTraffic manifest flag is ignored without this config.
+
+	First-party endpoints (the GitHub version check) are pinned to HTTPS so they can never be
+	downgraded; only the user's own server is allowed to fall back to cleartext.
 -->
 <network-security-config>
 	<base-config cleartextTrafficPermitted="true" />
+	<domain-config cleartextTrafficPermitted="false">
+		<domain includeSubdomains="false">api.github.com</domain>
+	</domain-config>
 </network-security-config>


### PR DESCRIPTION
Self-hosted sync servers are user-configured at runtime and may be plain HTTP, so `network_security_config.xml` permits cleartext globally. That also leaves the one first-party endpoint — the GitHub version check (`api.github.com`) — downgradable to cleartext.

Pin `api.github.com` to HTTPS via a `domain-config cleartextTrafficPermitted="false"`, while keeping `base-config` permissive so the user's own server can still fall back to HTTP. Both app flavors share this single config (the F-Droid manifest references the same `@xml/network_security_config`).

Part of the F-3 hardening follow-ups (opt-in cleartext stays supported for low-security self-hosters; this just ensures first-party traffic can't be downgraded).
