### PR TITLE
Add RTF as a story export format

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -84,6 +84,7 @@ kotlin {
 				implementation(libs.kmp.zip.okio)
 				implementation(libs.markdown)
 				implementation(libs.rtf.reader)
+				implementation(libs.rtf.writer)
 				implementation(libs.xmlutil.core)
 				implementation(libs.epub4kmp.core)
 				implementation(libs.pdfkmp)

--- a/common/src/commonMain/composeResources/values-de/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values-de/strings_project_home.xml
@@ -83,6 +83,7 @@
 	<string name="project_home_export_format_epub">EPub (.epub)</string>
 	<string name="project_home_export_format_pdf">PDF (.pdf)</string>
 	<string name="project_home_export_format_docx">Word (.docx)</string>
+	<string name="project_home_export_format_rtf">RTF (.rtf)</string>
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
 	<string name="project_home_action_import">Import Story</string>

--- a/common/src/commonMain/composeResources/values-es/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values-es/strings_project_home.xml
@@ -83,6 +83,7 @@
 	<string name="project_home_export_format_epub">EPub (.epub)</string>
 	<string name="project_home_export_format_pdf">PDF (.pdf)</string>
 	<string name="project_home_export_format_docx">Word (.docx)</string>
+	<string name="project_home_export_format_rtf">RTF (.rtf)</string>
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
 	<string name="project_home_action_import">Import Story</string>

--- a/common/src/commonMain/composeResources/values-fr/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values-fr/strings_project_home.xml
@@ -83,6 +83,7 @@
 	<string name="project_home_export_format_epub">EPub (.epub)</string>
 	<string name="project_home_export_format_pdf">PDF (.pdf)</string>
 	<string name="project_home_export_format_docx">Word (.docx)</string>
+	<string name="project_home_export_format_rtf">RTF (.rtf)</string>
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
 	<string name="project_home_action_import">Import Story</string>

--- a/common/src/commonMain/composeResources/values-it/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values-it/strings_project_home.xml
@@ -83,6 +83,7 @@
 	<string name="project_home_export_format_epub">EPub (.epub)</string>
 	<string name="project_home_export_format_pdf">PDF (.pdf)</string>
 	<string name="project_home_export_format_docx">Word (.docx)</string>
+	<string name="project_home_export_format_rtf">RTF (.rtf)</string>
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
 	<string name="project_home_action_import">Import Story</string>

--- a/common/src/commonMain/composeResources/values-pt-rBR/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values-pt-rBR/strings_project_home.xml
@@ -83,6 +83,7 @@
 	<string name="project_home_export_format_epub">EPub (.epub)</string>
 	<string name="project_home_export_format_pdf">PDF (.pdf)</string>
 	<string name="project_home_export_format_docx">Word (.docx)</string>
+	<string name="project_home_export_format_rtf">RTF (.rtf)</string>
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
 	<string name="project_home_action_import">Import Story</string>

--- a/common/src/commonMain/composeResources/values-uk/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values-uk/strings_project_home.xml
@@ -83,6 +83,7 @@
 	<string name="project_home_export_format_epub">EPub (.epub)</string>
 	<string name="project_home_export_format_pdf">PDF (.pdf)</string>
 	<string name="project_home_export_format_docx">Word (.docx)</string>
+	<string name="project_home_export_format_rtf">RTF (.rtf)</string>
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
 	<string name="project_home_action_import">Import Story</string>

--- a/common/src/commonMain/composeResources/values-zh-rCN/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values-zh-rCN/strings_project_home.xml
@@ -83,6 +83,7 @@
 	<string name="project_home_export_format_epub">EPub (.epub)</string>
 	<string name="project_home_export_format_pdf">PDF (.pdf)</string>
 	<string name="project_home_export_format_docx">Word (.docx)</string>
+	<string name="project_home_export_format_rtf">RTF (.rtf)</string>
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
 	<string name="project_home_action_import">Import Story</string>

--- a/common/src/commonMain/composeResources/values/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values/strings_project_home.xml
@@ -101,6 +101,16 @@
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
 
+	<string name="project_home_export_help_icon_description">Learn about export formats</string>
+	<string name="project_home_export_help_title">Choosing an Export Format</string>
+	<string name="project_home_export_help_intro">Each format suits a different purpose. Pick the one that matches how you plan to use the exported story.</string>
+	<string name="project_home_export_help_format_markdown">Plain text with light formatting; ideal for version control, re-importing, or other writing tools.</string>
+	<string name="project_home_export_help_format_epub">The standard e-book format; best for beta readers reading on e-readers and phones with reflowable text.</string>
+	<string name="project_home_export_help_format_pdf">A fixed page layout that looks the same everywhere; best for printing or sharing a final, read-only copy.</string>
+	<string name="project_home_export_help_format_docx">Opens in Word and Google Docs; best for editors and beta readers who leave comments or track changes.</string>
+	<string name="project_home_export_help_format_rtf">A broadly compatible rich-text format; a safe choice when you are unsure which word processor the recipient uses.</string>
+	<string name="project_home_export_help_dismiss">Got it</string>
+
 	<string name="project_home_action_import">Import Story</string>
 	<string name="project_home_action_import_toast_success">Story Imported</string>
 	<string name="project_home_action_import_toast_failure">Import failed</string>

--- a/common/src/commonMain/composeResources/values/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values/strings_project_home.xml
@@ -97,6 +97,7 @@
 	<string name="project_home_export_format_epub">EPub (.epub)</string>
 	<string name="project_home_export_format_pdf">PDF (.pdf)</string>
 	<string name="project_home_export_format_docx">Word (.docx)</string>
+	<string name="project_home_export_format_rtf">RTF (.rtf)</string>
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
 

--- a/common/src/commonMain/composeResources/values/strings_projects_list.xml
+++ b/common/src/commonMain/composeResources/values/strings_projects_list.xml
@@ -59,8 +59,8 @@
 	<string name="create_project_import_help_title">Create from an Existing Story</string>
 	<string name="create_project_import_help_intro">Already have a manuscript? Import it to create a new project. Hammer names the project after your file and automatically splits the text into scenes.</string>
 	<string name="create_project_import_help_formats_header">Supported Formats</string>
-	<string name="create_project_import_help_format_markdown">Markdown (.md) — splits on # headings</string>
-	<string name="create_project_import_help_format_rtf">Rich Text (.rtf) — splits on formatting, a chapter pattern, or not at all</string>
+	<string name="create_project_import_help_format_markdown">Markdown (.md)</string>
+	<string name="create_project_import_help_format_rtf">Rich Text (.rtf)</string>
 	<string name="create_project_import_help_dismiss">Got it</string>
 	<string name="create_project_error_already_exists">Project already exists</string>
 	<string name="create_project_error_null_filename">Missing Project Name</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.components.projecthome
 
+import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectTheme
 import nl.adaptivity.xmlutil.XMLConstants
@@ -225,6 +226,7 @@ private fun writeCoreProps(writer: XmlWriter, projectName: String, authorName: S
 private fun writeAppProps(writer: XmlWriter) {
 	writer.smartStartTag(APP_PROPS_NS, "Properties", "") {
 		smartStartTag(APP_PROPS_NS, "Application", "") { text("Hammer") }
+		smartStartTag(APP_PROPS_NS, "AppVersion", "") { text(BuildMetadata.APP_VERSION) }
 	}
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ExportStoryUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ExportStoryUseCase.kt
@@ -41,6 +41,7 @@ val ExportFormat.fileExtension: String
 		ExportFormat.Epub -> "epub"
 		ExportFormat.Pdf -> "pdf"
 		ExportFormat.Docx -> "docx"
+		ExportFormat.Rtf -> "rtf"
 	}
 
 /** Strips characters that have meaning in file paths or the SAF picker; covers project names that came from sync. */
@@ -123,6 +124,13 @@ class ExportStoryUseCase(
 				)
 
 				ExportFormat.Docx -> writeStoryAsDocx(
+					sink = buffer,
+					projectName = projectName,
+					projectData = source.requireProjectData(),
+					chapters = chaptersFor(options, projectName, source.perNodeChapters),
+				)
+
+				ExportFormat.Rtf -> writeStoryAsRtf(
 					sink = buffer,
 					projectName = projectName,
 					projectData = source.requireProjectData(),

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
@@ -1,0 +1,462 @@
+package com.darkrockstudios.apps.hammer.common.components.projecthome
+
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectTheme
+import okio.BufferedSink
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.getTextInNode
+import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
+import org.intellij.markdown.parser.MarkdownParser
+
+private const val TOC_TITLE = "Contents"
+
+private const val BODY_FONT = "Georgia"
+private const val MONOSPACE_FONT = "Consolas"
+
+// Font indices in the RTF font table.
+private const val FONT_BODY = 0
+private const val FONT_MONO = 1
+
+// Color indices in the RTF color table; index 0 is the document default ("auto").
+private const val COLOR_PRIMARY = 1
+private const val COLOR_SECONDARY = 2
+
+// RTF font sizes are expressed in half-points; the body is 12pt to match the other exporters.
+private const val BODY_HALF_POINTS = 24
+private const val TITLE_HALF_POINTS = 72
+private const val TOC_TITLE_HALF_POINTS = 48
+
+/** Heading 1..6 sizes in half-points, mirroring the DOCX renderer's scale. */
+private val HEADING_HALF_POINTS = listOf(48, 36, 32, 28, 26, 24)
+
+// Paragraph spacing/indent in twips (twentieths of a point); 1440 twips = 1 inch.
+private const val BODY_FIRST_LINE_INDENT = 360
+private const val PARAGRAPH_SPACE_AFTER = 160
+private const val HEADING_SPACE_BEFORE = 360
+private const val QUOTE_INDENT = 720
+private const val LIST_INDENT_PER_LEVEL = 360
+
+private fun chapterBookmark(index: Int): String = "chapter${index + 1}"
+
+/**
+ * Renders the story as a Rich Text Format (.rtf) document mirroring the EPUB/DOCX layout: a title
+ * page, a Contents page of links to chapter bookmarks, then one chapter per top-level node starting
+ * on a fresh page. Chapter bodies are rendered from markdown into formatted RTF runs. Heading and
+ * link colors pick up the project theme's accent colors.
+ *
+ * RTF is plain ASCII text built from control words; non-ASCII characters are emitted as `\uN`
+ * escapes so the output stays portable regardless of the reader's code page.
+ */
+fun writeStoryAsRtf(
+	sink: BufferedSink,
+	projectName: String,
+	projectData: ProjectData,
+	chapters: List<StoryChapter>,
+) {
+	val authorName = projectData.authorName?.takeIf { it.isNotBlank() }
+	val effective = chapters.ifEmpty { listOf(StoryChapter(projectName, "")) }
+
+	val rtf = RtfBuilder(projectData.theme)
+	rtf.writeHeader(projectName, authorName)
+	rtf.writeTitlePage(projectName, authorName)
+	rtf.writeContentsPage(effective)
+	effective.forEachIndexed { index, chapter -> rtf.writeChapter(index, chapter) }
+	rtf.writeFooter()
+
+	sink.writeUtf8(rtf.toString())
+}
+
+private class RtfBuilder(theme: ProjectTheme?) {
+	private val out = StringBuilder()
+
+	private val primary = theme?.primary?.let(::argbHexToRtfColor)
+	private val secondary = theme?.secondary?.let(::argbHexToRtfColor)
+
+	override fun toString(): String = out.toString()
+
+	fun writeHeader(projectName: String, authorName: String?) {
+		out.append("{\\rtf1\\ansi\\ansicpg1252\\deff0\\deflang1033")
+
+		// Font table: \f0 is the prose font, \f1 the monospace font for code.
+		out.append("{\\fonttbl")
+		out.append("{\\f$FONT_BODY\\froman\\fcharset0 ").append(BODY_FONT).append(";}")
+		out.append("{\\f$FONT_MONO\\fmodern\\fcharset0 ").append(MONOSPACE_FONT).append(";}")
+		out.append("}")
+
+		// Color table: index 0 is "auto"; accent colors keep stable indices even when absent
+		// (a null accent falls back to black, which simply renders as the default text color).
+		out.append("{\\colortbl;")
+		out.append(primary ?: "\\red0\\green0\\blue0;")
+		out.append(secondary ?: "\\red0\\green0\\blue0;")
+		out.append("}")
+
+		// Document metadata so the title/author surface in the reader's properties panel.
+		out.append("{\\info{\\title ").append(escapeRtf(projectName)).append("}")
+		if (authorName != null) out.append("{\\author ").append(escapeRtf(authorName)).append("}")
+		out.append("}")
+
+		out.append("\\fs$BODY_HALF_POINTS\n")
+	}
+
+	fun writeFooter() {
+		out.append("}")
+	}
+
+	fun writeTitlePage(projectName: String, authorName: String?) {
+		out.append("\\pard\\qc\\sb3600\\sa240")
+		out.append("{\\b\\fs$TITLE_HALF_POINTS")
+		if (primary != null) out.append("\\cf$COLOR_PRIMARY")
+		out.append(' ').append(escapeRtf(projectName)).append("}\\par\n")
+
+		if (authorName != null) {
+			out.append("\\pard\\qc\\sa240")
+			out.append("{\\i\\fs32 ").append(escapeRtf("by $authorName")).append("}\\par\n")
+		}
+	}
+
+	fun writeContentsPage(chapters: List<StoryChapter>) {
+		out.append("\\page\n")
+		out.append("\\pard\\qc\\sb240\\sa240")
+		out.append("{\\b\\fs$TOC_TITLE_HALF_POINTS ").append(escapeRtf(TOC_TITLE)).append("}\\par\n")
+
+		chapters.forEachIndexed { index, chapter ->
+			out.append("\\pard\\sa$PARAGRAPH_SPACE_AFTER ")
+			val label = "${index + 1}. ${chapter.name}"
+			// A HYPERLINK field jumping to the chapter's bookmark; the \fldrslt holds the visible text.
+			out.append("{\\field{\\*\\fldinst HYPERLINK \\\\l ")
+			out.append('"').append(escapeRtf(chapterBookmark(index))).append('"')
+			out.append("}{\\fldrslt ")
+			if (primary != null) out.append("{\\cf$COLOR_PRIMARY\\ul ").append(escapeRtf(label)).append("}")
+			else out.append("{\\ul ").append(escapeRtf(label)).append("}")
+			out.append("}}\\par\n")
+		}
+	}
+
+	fun writeChapter(index: Int, chapter: StoryChapter) {
+		out.append("\\page\n")
+		out.append("\\pard\\sb$HEADING_SPACE_BEFORE\\sa$PARAGRAPH_SPACE_AFTER\\keepn")
+		out.append("{\\b\\fs${HEADING_HALF_POINTS[0]}")
+		if (primary != null) out.append("\\cf$COLOR_PRIMARY")
+		out.append(' ')
+		// Bookmark target for the contents links, wrapping the heading text.
+		out.append("{\\*\\bkmkstart ").append(escapeRtf(chapterBookmark(index))).append("}")
+		out.append(escapeRtf("${index + 1}. ${chapter.name}"))
+		out.append("{\\*\\bkmkend ").append(escapeRtf(chapterBookmark(index))).append("}")
+		out.append("}\\par\n")
+
+		if (chapter.markdown.isNotBlank()) {
+			MarkdownRtfWriter(out, chapter.markdown, primary != null, secondary != null).render()
+		}
+	}
+
+	/** Project themes store colors as ARGB hex (`#FFRRGGBB`); RTF wants `\redN\greenN\blueN;`. */
+	private fun argbHexToRtfColor(argb: String): String? {
+		val css = argbHexToCssHex(argb)?.removePrefix("#") ?: return null
+		val value = css.toIntOrNull(16) ?: return null
+		val r = (value shr 16) and 0xFF
+		val g = (value shr 8) and 0xFF
+		val b = value and 0xFF
+		return "\\red$r\\green$g\\blue$b;"
+	}
+}
+
+/**
+ * Walks the markdown AST and streams RTF paragraphs and runs. Inline formatting is emitted as
+ * nested RTF groups (`{\b ...}`, `{\i ...}`) so character formatting is scoped and never leaks past
+ * the run it applies to. Block structure (headings, lists, quotes, code) maps onto RTF paragraph
+ * properties.
+ */
+private class MarkdownRtfWriter(
+	private val out: StringBuilder,
+	private val source: String,
+	private val hasPrimary: Boolean,
+	private val hasSecondary: Boolean,
+) {
+	private var listDepth = -1
+
+	private data class BlockContext(
+		val style: ParagraphStyle = ParagraphStyle.Body,
+		val listMarker: String? = null,
+		val indentLevel: Int = 0,
+	)
+
+	private enum class ParagraphStyle { Body, Quote }
+
+	fun render() {
+		val tree = MarkdownParser(CommonMarkFlavourDescriptor()).buildMarkdownTreeFromString(source)
+		renderBlocks(tree.children, BlockContext())
+	}
+
+	private fun renderBlocks(nodes: List<ASTNode>, blockCtx: BlockContext) {
+		// Only the first paragraph of a list item carries the bullet/number; trailing blocks flow under it.
+		var pendingMarker = blockCtx.listMarker
+		for (node in nodes) {
+			when (node.type) {
+				MarkdownElementTypes.PARAGRAPH -> {
+					paragraph(blockCtx, pendingMarker) { renderInline(node.children) }
+					pendingMarker = null
+				}
+
+				MarkdownElementTypes.ATX_1 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 1)
+				MarkdownElementTypes.ATX_2 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 2)
+				MarkdownElementTypes.ATX_3 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 3)
+				MarkdownElementTypes.ATX_4 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 4)
+				MarkdownElementTypes.ATX_5 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 5)
+				MarkdownElementTypes.ATX_6 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 6)
+				MarkdownElementTypes.SETEXT_1 -> heading(node, MarkdownTokenTypes.SETEXT_CONTENT, 1)
+				MarkdownElementTypes.SETEXT_2 -> heading(node, MarkdownTokenTypes.SETEXT_CONTENT, 2)
+
+				MarkdownElementTypes.BLOCK_QUOTE -> renderBlocks(
+					node.children,
+					blockCtx.copy(style = ParagraphStyle.Quote),
+				)
+
+				MarkdownElementTypes.UNORDERED_LIST -> renderList(node, ordered = false, blockCtx)
+				MarkdownElementTypes.ORDERED_LIST -> renderList(node, ordered = true, blockCtx)
+
+				MarkdownElementTypes.CODE_FENCE -> codeFence(node)
+				MarkdownElementTypes.CODE_BLOCK -> codeBlock(node)
+				MarkdownElementTypes.LINK_DEFINITION -> Unit
+
+				MarkdownTokenTypes.HORIZONTAL_RULE -> horizontalRule()
+
+				MarkdownTokenTypes.EOL,
+				MarkdownTokenTypes.WHITE_SPACE,
+				MarkdownTokenTypes.BLOCK_QUOTE,
+				MarkdownTokenTypes.LIST_BULLET,
+				MarkdownTokenTypes.LIST_NUMBER,
+					-> Unit
+
+				else -> {
+					if (node.children.isNotEmpty()) {
+						renderBlocks(node.children, blockCtx)
+					} else {
+						val literal = node.getTextInNode(source).toString()
+						if (literal.isNotBlank()) {
+							paragraph(blockCtx, pendingMarker) { out.append(escapeRtf(literal)) }
+							pendingMarker = null
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private fun renderList(node: ASTNode, ordered: Boolean, blockCtx: BlockContext) {
+		listDepth++
+		var itemNumber = 1
+		node.children
+			.filter { it.type == MarkdownElementTypes.LIST_ITEM }
+			.forEach { item ->
+				val marker = if (ordered) "${itemNumber++}.\t" else "•\t"
+				renderBlocks(
+					item.children,
+					blockCtx.copy(listMarker = marker, indentLevel = listDepth + 1),
+				)
+			}
+		listDepth--
+	}
+
+	private fun heading(node: ASTNode, contentType: Any, level: Int) {
+		val content = node.children.firstOrNull { it.type == contentType }
+		val halfPoints = HEADING_HALF_POINTS[(level - 1).coerceIn(0, HEADING_HALF_POINTS.lastIndex)]
+		out.append("\\pard\\sb$HEADING_SPACE_BEFORE\\sa$PARAGRAPH_SPACE_AFTER\\keepn")
+		out.append("{\\b\\fs$halfPoints")
+		when {
+			level == 1 && hasPrimary -> out.append("\\cf$COLOR_PRIMARY")
+			level == 2 && hasSecondary -> out.append("\\cf$COLOR_SECONDARY")
+		}
+		out.append(' ')
+		val children = content?.children.orEmpty()
+			.dropWhile { it.type == MarkdownTokenTypes.WHITE_SPACE }
+			.dropLastWhile { it.type == MarkdownTokenTypes.WHITE_SPACE }
+		if (children.isNotEmpty()) {
+			renderInline(children)
+		} else {
+			content?.let { out.append(escapeRtf(unescape(it.getTextInNode(source).toString()).trim())) }
+		}
+		out.append("}\\par\n")
+	}
+
+	private fun paragraph(blockCtx: BlockContext, listMarker: String?, body: () -> Unit) {
+		out.append("\\pard\\sa$PARAGRAPH_SPACE_AFTER")
+		when {
+			listMarker != null -> {
+				val indent = LIST_INDENT_PER_LEVEL * blockCtx.indentLevel
+				out.append("\\li$indent\\fi-$LIST_INDENT_PER_LEVEL")
+			}
+
+			blockCtx.style == ParagraphStyle.Quote -> out.append("\\li$QUOTE_INDENT")
+			else -> out.append("\\fi$BODY_FIRST_LINE_INDENT")
+		}
+		out.append(' ')
+
+		// Scope the quote italic in a group so the character formatting can't leak past this paragraph
+		// (\pard resets paragraph properties but not run properties like \i).
+		val italicQuote = blockCtx.style == ParagraphStyle.Quote
+		if (italicQuote) out.append("{\\i ")
+		if (listMarker != null) out.append(escapeRtf(listMarker))
+		body()
+		if (italicQuote) out.append("}")
+		out.append("\\par\n")
+	}
+
+	private fun renderInline(nodes: List<ASTNode>) {
+		for (node in nodes) {
+			when (node.type) {
+				MarkdownElementTypes.STRONG -> {
+					out.append("{\\b ")
+					renderInline(node.children.stripDelimiters(MarkdownTokenTypes.EMPH))
+					out.append("}")
+				}
+
+				MarkdownElementTypes.EMPH -> {
+					out.append("{\\i ")
+					renderInline(node.children.stripDelimiters(MarkdownTokenTypes.EMPH))
+					out.append("}")
+				}
+
+				MarkdownElementTypes.CODE_SPAN -> {
+					val code = node.children
+						.filter { it.type != MarkdownTokenTypes.BACKTICK }
+						.joinToString("") { it.getTextInNode(source).toString() }
+					out.append("{\\f$FONT_MONO ").append(escapeRtf(code.removeSurrounding(" "))).append("}")
+				}
+
+				MarkdownElementTypes.INLINE_LINK -> inlineLink(node)
+				MarkdownElementTypes.AUTOLINK -> autoLink(node)
+
+				MarkdownTokenTypes.HARD_LINE_BREAK -> out.append("\\line ")
+				MarkdownTokenTypes.EOL -> out.append(' ')
+
+				else -> {
+					if (node.children.isEmpty()) {
+						out.append(escapeRtf(unescape(node.getTextInNode(source).toString())))
+					} else {
+						renderInline(node.children)
+					}
+				}
+			}
+		}
+	}
+
+	private fun inlineLink(node: ASTNode) {
+		val destination =
+			node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_DESTINATION }
+				?.getTextInNode(source)?.toString()?.removeSurrounding("<", ">")
+		val linkText = node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_TEXT }
+		if (destination == null || linkText == null) {
+			out.append(escapeRtf(unescape(node.getTextInNode(source).toString())))
+			return
+		}
+		hyperlink(destination) {
+			renderInline(
+				linkText.children.filter {
+					it.type != MarkdownTokenTypes.LBRACKET && it.type != MarkdownTokenTypes.RBRACKET
+				}
+			)
+		}
+	}
+
+	private fun autoLink(node: ASTNode) {
+		val url = node.getTextInNode(source).toString().removeSurrounding("<", ">")
+		hyperlink(url) { out.append(escapeRtf(url)) }
+	}
+
+	private fun hyperlink(url: String, body: () -> Unit) {
+		out.append("{\\field{\\*\\fldinst HYPERLINK ")
+		out.append('"').append(escapeRtf(url)).append('"')
+		out.append("}{\\fldrslt {")
+		if (hasPrimary) out.append("\\cf$COLOR_PRIMARY")
+		out.append("\\ul ")
+		body()
+		out.append("}}}")
+	}
+
+	private fun codeFence(node: ASTNode) {
+		collectCodeLines(node, MarkdownTokenTypes.CODE_FENCE_CONTENT).forEach { codeParagraph(it) }
+	}
+
+	private fun codeBlock(node: ASTNode) {
+		collectCodeLines(node, MarkdownTokenTypes.CODE_LINE)
+			.map { it.removePrefix("    ").removePrefix("\t") }
+			.forEach { codeParagraph(it) }
+	}
+
+	private fun collectCodeLines(node: ASTNode, contentType: Any): List<String> {
+		val lines = mutableListOf<String>()
+		val current = StringBuilder()
+		for (child in node.children) {
+			when (child.type) {
+				contentType -> current.append(child.getTextInNode(source))
+				MarkdownTokenTypes.EOL -> {
+					lines += current.toString()
+					current.clear()
+				}
+			}
+		}
+		if (current.isNotEmpty()) lines += current.toString()
+		return lines.dropWhile { it.isBlank() }.dropLastWhile { it.isBlank() }
+	}
+
+	private fun codeParagraph(line: String) {
+		out.append("\\pard\\sa0 {\\f$FONT_MONO ").append(escapeRtf(line)).append("}\\par\n")
+	}
+
+	private fun horizontalRule() {
+		// A bottom border on an empty paragraph draws a horizontal rule.
+		out.append("\\pard\\brdrb\\brdrs\\brdrw10\\sa$PARAGRAPH_SPACE_AFTER\\par\n")
+	}
+
+	private fun List<ASTNode>.stripDelimiters(delimiterType: Any): List<ASTNode> =
+		dropWhile { it.type == delimiterType }.dropLastWhile { it.type == delimiterType }
+
+	/** Resolves CommonMark backslash escapes to their bare punctuation before RTF escaping. */
+	private fun unescape(text: String): String {
+		if (!text.contains('\\')) return text
+		val sb = StringBuilder(text.length)
+		var i = 0
+		while (i < text.length) {
+			val c = text[i]
+			val next = if (i + 1 < text.length) text[i + 1] else null
+			if (c == '\\' && next != null && next in ASCII_PUNCTUATION) {
+				sb.append(next)
+				i += 2
+			} else {
+				sb.append(c)
+				i++
+			}
+		}
+		return sb.toString()
+	}
+
+	private companion object {
+		const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+	}
+}
+
+/**
+ * Escapes text for an RTF body: the structural characters `\`, `{`, `}` are backslash-escaped,
+ * tabs and newlines become control words, and any non-ASCII character is emitted as a `\uN`
+ * escape with a `?` substitute so legacy readers still show something in its place.
+ */
+internal fun escapeRtf(text: String): String {
+	val sb = StringBuilder(text.length)
+	for (ch in text) {
+		when {
+			ch == '\\' || ch == '{' || ch == '}' -> sb.append('\\').append(ch)
+			ch == '\t' -> sb.append("\\tab ")
+			ch == '\n' -> sb.append("\\line ")
+			ch == '\r' -> Unit
+			ch.code in 0x20..0x7E -> sb.append(ch)
+			else -> {
+				// RTF \u takes a signed 16-bit value; chars above 0x7FFF must be expressed as negative.
+				val code = if (ch.code > 0x7FFF) ch.code - 0x10000 else ch.code
+				sb.append("\\u").append(code).append('?')
+			}
+		}
+	}
+	return sb.toString()
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
@@ -1,7 +1,26 @@
 package com.darkrockstudios.apps.hammer.common.components.projecthome
 
+import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
-import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectTheme
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfAlignment
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfBlock
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfBookmark
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfBorder
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfColor
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfDocument
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfDocumentWriter
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfFont
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfFontFamily
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfHyperlink
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfHyperlinkKind
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfInfo
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfInline
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfLineBreak
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfPageBreak
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfParagraph
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfParagraphStyle
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfSpanStyle
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfTextRun
 import okio.BufferedSink
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
@@ -12,20 +31,13 @@ import org.intellij.markdown.parser.MarkdownParser
 
 private const val TOC_TITLE = "Contents"
 
-private const val BODY_FONT = "Georgia"
-private const val MONOSPACE_FONT = "Consolas"
+private val BODY_FONT = RtfFont("Georgia", RtfFontFamily.Roman)
+private val MONO_FONT = RtfFont("Consolas", RtfFontFamily.Modern)
 
-// Font indices in the RTF font table.
-private const val FONT_BODY = 0
-private const val FONT_MONO = 1
-
-// Color indices in the RTF color table; index 0 is the document default ("auto").
-private const val COLOR_PRIMARY = 1
-private const val COLOR_SECONDARY = 2
-
-// RTF font sizes are expressed in half-points; the body is 12pt to match the other exporters.
+// Font sizes in half-points; the body is 12pt to match the other exporters.
 private const val BODY_HALF_POINTS = 24
 private const val TITLE_HALF_POINTS = 72
+private const val AUTHOR_HALF_POINTS = 32
 private const val TOC_TITLE_HALF_POINTS = 48
 
 /** Heading 1..6 sizes in half-points, mirroring the DOCX renderer's scale. */
@@ -35,6 +47,8 @@ private val HEADING_HALF_POINTS = listOf(48, 36, 32, 28, 26, 24)
 private const val BODY_FIRST_LINE_INDENT = 360
 private const val PARAGRAPH_SPACE_AFTER = 160
 private const val HEADING_SPACE_BEFORE = 360
+private const val TITLE_SPACE_BEFORE = 3600
+private const val SECTION_SPACE = 240
 private const val QUOTE_INDENT = 720
 private const val LIST_INDENT_PER_LEVEL = 360
 
@@ -46,8 +60,8 @@ private fun chapterBookmark(index: Int): String = "chapter${index + 1}"
  * on a fresh page. Chapter bodies are rendered from markdown into formatted RTF runs. Heading and
  * link colors pick up the project theme's accent colors.
  *
- * RTF is plain ASCII text built from control words; non-ASCII characters are emitted as `\uN`
- * escapes so the output stays portable regardless of the reader's code page.
+ * The document is assembled as a strongly-typed [RtfDocument] and serialized by [RtfDocumentWriter],
+ * which keeps the output 7-bit ASCII (non-ASCII as `\uN` escapes) and portable across readers.
  */
 fun writeStoryAsRtf(
 	sink: BufferedSink,
@@ -57,136 +71,145 @@ fun writeStoryAsRtf(
 ) {
 	val authorName = projectData.authorName?.takeIf { it.isNotBlank() }
 	val effective = chapters.ifEmpty { listOf(StoryChapter(projectName, "")) }
+	val primary = themeColor(projectData.theme?.primary)
+	val secondary = themeColor(projectData.theme?.secondary)
 
-	val rtf = RtfBuilder(projectData.theme)
-	rtf.writeHeader(projectName, authorName)
-	rtf.writeTitlePage(projectName, authorName)
-	rtf.writeContentsPage(effective)
-	effective.forEachIndexed { index, chapter -> rtf.writeChapter(index, chapter) }
-	rtf.writeFooter()
+	val blocks = buildList {
+		addAll(titlePage(projectName, authorName, primary))
+		addAll(contentsPage(effective, primary))
+		effective.forEachIndexed { index, chapter -> addAll(chapterBlocks(index, chapter, primary, secondary)) }
+	}
 
-	sink.writeUtf8(rtf.toString())
+	val document = RtfDocument(
+		blocks = blocks,
+		defaultFont = BODY_FONT,
+		defaultFontSizeHalfPoints = BODY_HALF_POINTS,
+		info = RtfInfo(title = projectName, author = authorName),
+		generator = "Hammer ${BuildMetadata.APP_VERSION}",
+	)
+
+	sink.writeUtf8(RtfDocumentWriter().write(document))
 }
 
-private class RtfBuilder(theme: ProjectTheme?) {
-	private val out = StringBuilder()
-
-	private val primary = theme?.primary?.let(::argbHexToRtfColor)
-	private val secondary = theme?.secondary?.let(::argbHexToRtfColor)
-
-	override fun toString(): String = out.toString()
-
-	fun writeHeader(projectName: String, authorName: String?) {
-		out.append("{\\rtf1\\ansi\\ansicpg1252\\deff0\\deflang1033")
-
-		// Font table: \f0 is the prose font, \f1 the monospace font for code.
-		out.append("{\\fonttbl")
-		out.append("{\\f$FONT_BODY\\froman\\fcharset0 ").append(BODY_FONT).append(";}")
-		out.append("{\\f$FONT_MONO\\fmodern\\fcharset0 ").append(MONOSPACE_FONT).append(";}")
-		out.append("}")
-
-		// Color table: index 0 is "auto"; accent colors keep stable indices even when absent
-		// (a null accent falls back to black, which simply renders as the default text color).
-		out.append("{\\colortbl;")
-		out.append(primary ?: "\\red0\\green0\\blue0;")
-		out.append(secondary ?: "\\red0\\green0\\blue0;")
-		out.append("}")
-
-		// Document metadata so the title/author surface in the reader's properties panel.
-		out.append("{\\info{\\title ").append(escapeRtf(projectName)).append("}")
-		if (authorName != null) out.append("{\\author ").append(escapeRtf(authorName)).append("}")
-		out.append("}")
-
-		out.append("\\fs$BODY_HALF_POINTS\n")
+private fun titlePage(projectName: String, authorName: String?, primary: RtfColor?): List<RtfBlock> = buildList {
+	add(
+		RtfParagraph(
+			content = listOf(
+				RtfTextRun(
+					projectName,
+					RtfSpanStyle(bold = true, fontSizeHalfPoints = TITLE_HALF_POINTS, color = primary),
+				),
+			),
+			style = RtfParagraphStyle(
+				alignment = RtfAlignment.Center,
+				spaceBeforeTwips = TITLE_SPACE_BEFORE,
+				spaceAfterTwips = SECTION_SPACE,
+			),
+		),
+	)
+	if (authorName != null) {
+		add(
+			RtfParagraph(
+				content = listOf(
+					RtfTextRun("by $authorName", RtfSpanStyle(italic = true, fontSizeHalfPoints = AUTHOR_HALF_POINTS)),
+				),
+				style = RtfParagraphStyle(alignment = RtfAlignment.Center, spaceAfterTwips = SECTION_SPACE),
+			),
+		)
 	}
+}
 
-	fun writeFooter() {
-		out.append("}")
+private fun contentsPage(chapters: List<StoryChapter>, primary: RtfColor?): List<RtfBlock> = buildList {
+	add(RtfPageBreak)
+	add(
+		RtfParagraph(
+			content = listOf(RtfTextRun(TOC_TITLE, RtfSpanStyle(bold = true, fontSizeHalfPoints = TOC_TITLE_HALF_POINTS))),
+			style = RtfParagraphStyle(
+				alignment = RtfAlignment.Center,
+				spaceBeforeTwips = SECTION_SPACE,
+				spaceAfterTwips = SECTION_SPACE,
+			),
+		),
+	)
+	chapters.forEachIndexed { index, chapter ->
+		val label = "${index + 1}. ${chapter.name}"
+		add(
+			RtfParagraph(
+				content = listOf(
+					RtfHyperlink(
+						target = chapterBookmark(index),
+						kind = RtfHyperlinkKind.Bookmark,
+						content = listOf(RtfTextRun(label, RtfSpanStyle(underline = true, color = primary))),
+					),
+				),
+				style = RtfParagraphStyle(spaceAfterTwips = PARAGRAPH_SPACE_AFTER),
+			),
+		)
 	}
+}
 
-	fun writeTitlePage(projectName: String, authorName: String?) {
-		out.append("\\pard\\qc\\sb3600\\sa240")
-		out.append("{\\b\\fs$TITLE_HALF_POINTS")
-		if (primary != null) out.append("\\cf$COLOR_PRIMARY")
-		out.append(' ').append(escapeRtf(projectName)).append("}\\par\n")
-
-		if (authorName != null) {
-			out.append("\\pard\\qc\\sa240")
-			out.append("{\\i\\fs32 ").append(escapeRtf("by $authorName")).append("}\\par\n")
-		}
+private fun chapterBlocks(
+	index: Int,
+	chapter: StoryChapter,
+	primary: RtfColor?,
+	secondary: RtfColor?,
+): List<RtfBlock> = buildList {
+	add(RtfPageBreak)
+	add(
+		RtfParagraph(
+			content = listOf(
+				RtfBookmark(
+					name = chapterBookmark(index),
+					content = listOf(
+						RtfTextRun(
+							"${index + 1}. ${chapter.name}",
+							RtfSpanStyle(bold = true, fontSizeHalfPoints = HEADING_HALF_POINTS[0], color = primary),
+						),
+					),
+				),
+			),
+			style = RtfParagraphStyle(
+				spaceBeforeTwips = HEADING_SPACE_BEFORE,
+				spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
+				keepWithNext = true,
+			),
+		),
+	)
+	if (chapter.markdown.isNotBlank()) {
+		addAll(MarkdownRtfRenderer(chapter.markdown, primary, secondary).render())
 	}
+}
 
-	fun writeContentsPage(chapters: List<StoryChapter>) {
-		out.append("\\page\n")
-		out.append("\\pard\\qc\\sb240\\sa240")
-		out.append("{\\b\\fs$TOC_TITLE_HALF_POINTS ").append(escapeRtf(TOC_TITLE)).append("}\\par\n")
-
-		chapters.forEachIndexed { index, chapter ->
-			out.append("\\pard\\sa$PARAGRAPH_SPACE_AFTER ")
-			val label = "${index + 1}. ${chapter.name}"
-			// A HYPERLINK field jumping to the chapter's bookmark; the \fldrslt holds the visible text.
-			out.append("{\\field{\\*\\fldinst HYPERLINK \\\\l ")
-			out.append('"').append(escapeRtf(chapterBookmark(index))).append('"')
-			out.append("}{\\fldrslt ")
-			if (primary != null) out.append("{\\cf$COLOR_PRIMARY\\ul ").append(escapeRtf(label)).append("}")
-			else out.append("{\\ul ").append(escapeRtf(label)).append("}")
-			out.append("}}\\par\n")
-		}
-	}
-
-	fun writeChapter(index: Int, chapter: StoryChapter) {
-		out.append("\\page\n")
-		out.append("\\pard\\sb$HEADING_SPACE_BEFORE\\sa$PARAGRAPH_SPACE_AFTER\\keepn")
-		out.append("{\\b\\fs${HEADING_HALF_POINTS[0]}")
-		if (primary != null) out.append("\\cf$COLOR_PRIMARY")
-		out.append(' ')
-		// Bookmark target for the contents links, wrapping the heading text.
-		out.append("{\\*\\bkmkstart ").append(escapeRtf(chapterBookmark(index))).append("}")
-		out.append(escapeRtf("${index + 1}. ${chapter.name}"))
-		out.append("{\\*\\bkmkend ").append(escapeRtf(chapterBookmark(index))).append("}")
-		out.append("}\\par\n")
-
-		if (chapter.markdown.isNotBlank()) {
-			MarkdownRtfWriter(out, chapter.markdown, primary != null, secondary != null).render()
-		}
-	}
-
-	/** Project themes store colors as ARGB hex (`#FFRRGGBB`); RTF wants `\redN\greenN\blueN;`. */
-	private fun argbHexToRtfColor(argb: String): String? {
-		val css = argbHexToCssHex(argb)?.removePrefix("#") ?: return null
-		val value = css.toIntOrNull(16) ?: return null
-		val r = (value shr 16) and 0xFF
-		val g = (value shr 8) and 0xFF
-		val b = value and 0xFF
-		return "\\red$r\\green$g\\blue$b;"
-	}
+/** Project themes store colors as ARGB hex (`#FFRRGGBB`); convert to an [RtfColor]. */
+private fun themeColor(argb: String?): RtfColor? {
+	val css = argb?.let(::argbHexToCssHex)?.removePrefix("#") ?: return null
+	val value = css.toIntOrNull(16) ?: return null
+	return RtfColor.fromRgb(value)
 }
 
 /**
- * Walks the markdown AST and streams RTF paragraphs and runs. Inline formatting is emitted as
- * nested RTF groups (`{\b ...}`, `{\i ...}`) so character formatting is scoped and never leaks past
- * the run it applies to. Block structure (headings, lists, quotes, code) maps onto RTF paragraph
- * properties.
+ * Walks the markdown AST and produces [RtfBlock]s. Inline formatting is flattened into [RtfTextRun]s
+ * carrying a cumulative [RtfSpanStyle], so nested emphasis (`**bold _italic_**`) becomes runs with the
+ * combined style. Block structure (headings, lists, quotes, code) maps onto paragraph properties.
  */
-private class MarkdownRtfWriter(
-	private val out: StringBuilder,
+private class MarkdownRtfRenderer(
 	private val source: String,
-	private val hasPrimary: Boolean,
-	private val hasSecondary: Boolean,
+	private val primary: RtfColor?,
+	private val secondary: RtfColor?,
 ) {
+	private val blocks = mutableListOf<RtfBlock>()
 	private var listDepth = -1
 
 	private data class BlockContext(
-		val style: ParagraphStyle = ParagraphStyle.Body,
+		val quote: Boolean = false,
 		val listMarker: String? = null,
 		val indentLevel: Int = 0,
 	)
 
-	private enum class ParagraphStyle { Body, Quote }
-
-	fun render() {
+	fun render(): List<RtfBlock> {
 		val tree = MarkdownParser(CommonMarkFlavourDescriptor()).buildMarkdownTreeFromString(source)
 		renderBlocks(tree.children, BlockContext())
+		return blocks
 	}
 
 	private fun renderBlocks(nodes: List<ASTNode>, blockCtx: BlockContext) {
@@ -195,7 +218,7 @@ private class MarkdownRtfWriter(
 		for (node in nodes) {
 			when (node.type) {
 				MarkdownElementTypes.PARAGRAPH -> {
-					paragraph(blockCtx, pendingMarker) { renderInline(node.children) }
+					addParagraph(blockCtx, pendingMarker, inlineRuns(node.children, baseStyle(blockCtx)))
 					pendingMarker = null
 				}
 
@@ -210,7 +233,7 @@ private class MarkdownRtfWriter(
 
 				MarkdownElementTypes.BLOCK_QUOTE -> renderBlocks(
 					node.children,
-					blockCtx.copy(style = ParagraphStyle.Quote),
+					blockCtx.copy(quote = true),
 				)
 
 				MarkdownElementTypes.UNORDERED_LIST -> renderList(node, ordered = false, blockCtx)
@@ -235,7 +258,7 @@ private class MarkdownRtfWriter(
 					} else {
 						val literal = node.getTextInNode(source).toString()
 						if (literal.isNotBlank()) {
-							paragraph(blockCtx, pendingMarker) { out.append(escapeRtf(literal)) }
+							addParagraph(blockCtx, pendingMarker, listOf(RtfTextRun(unescape(literal), baseStyle(blockCtx))))
 							pendingMarker = null
 						}
 					}
@@ -262,117 +285,125 @@ private class MarkdownRtfWriter(
 	private fun heading(node: ASTNode, contentType: Any, level: Int) {
 		val content = node.children.firstOrNull { it.type == contentType }
 		val halfPoints = HEADING_HALF_POINTS[(level - 1).coerceIn(0, HEADING_HALF_POINTS.lastIndex)]
-		out.append("\\pard\\sb$HEADING_SPACE_BEFORE\\sa$PARAGRAPH_SPACE_AFTER\\keepn")
-		out.append("{\\b\\fs$halfPoints")
-		when {
-			level == 1 && hasPrimary -> out.append("\\cf$COLOR_PRIMARY")
-			level == 2 && hasSecondary -> out.append("\\cf$COLOR_SECONDARY")
+		val color = when (level) {
+			1 -> primary
+			2 -> secondary
+			else -> null
 		}
-		out.append(' ')
+		val style = RtfSpanStyle(bold = true, fontSizeHalfPoints = halfPoints, color = color)
 		val children = content?.children.orEmpty()
 			.dropWhile { it.type == MarkdownTokenTypes.WHITE_SPACE }
 			.dropLastWhile { it.type == MarkdownTokenTypes.WHITE_SPACE }
-		if (children.isNotEmpty()) {
-			renderInline(children)
-		} else {
-			content?.let { out.append(escapeRtf(unescape(it.getTextInNode(source).toString()).trim())) }
+		val runs = when {
+			children.isNotEmpty() -> inlineRuns(children, style)
+			content != null -> listOf(RtfTextRun(unescape(content.getTextInNode(source).toString()).trim(), style))
+			else -> emptyList()
 		}
-		out.append("}\\par\n")
+		blocks.add(
+			RtfParagraph(
+				content = coalesce(runs),
+				style = RtfParagraphStyle(
+					spaceBeforeTwips = HEADING_SPACE_BEFORE,
+					spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
+					keepWithNext = true,
+				),
+			),
+		)
 	}
 
-	private fun paragraph(blockCtx: BlockContext, listMarker: String?, body: () -> Unit) {
-		out.append("\\pard\\sa$PARAGRAPH_SPACE_AFTER")
-		when {
-			listMarker != null -> {
-				val indent = LIST_INDENT_PER_LEVEL * blockCtx.indentLevel
-				out.append("\\li$indent\\fi-$LIST_INDENT_PER_LEVEL")
-			}
+	private fun addParagraph(blockCtx: BlockContext, listMarker: String?, content: List<RtfInline>) {
+		val style = when {
+			listMarker != null -> RtfParagraphStyle(
+				leftIndentTwips = LIST_INDENT_PER_LEVEL * blockCtx.indentLevel,
+				firstLineIndentTwips = -LIST_INDENT_PER_LEVEL,
+				spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
+			)
 
-			blockCtx.style == ParagraphStyle.Quote -> out.append("\\li$QUOTE_INDENT")
-			else -> out.append("\\fi$BODY_FIRST_LINE_INDENT")
+			blockCtx.quote -> RtfParagraphStyle(
+				leftIndentTwips = QUOTE_INDENT,
+				spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
+			)
+
+			else -> RtfParagraphStyle(
+				firstLineIndentTwips = BODY_FIRST_LINE_INDENT,
+				spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
+			)
 		}
-		out.append(' ')
-
-		// Scope the quote italic in a group so the character formatting can't leak past this paragraph
-		// (\pard resets paragraph properties but not run properties like \i).
-		val italicQuote = blockCtx.style == ParagraphStyle.Quote
-		if (italicQuote) out.append("{\\i ")
-		if (listMarker != null) out.append(escapeRtf(listMarker))
-		body()
-		if (italicQuote) out.append("}")
-		out.append("\\par\n")
+		val full = buildList {
+			if (listMarker != null) add(RtfTextRun(listMarker, baseStyle(blockCtx)))
+			addAll(content)
+		}
+		blocks.add(RtfParagraph(coalesce(full), style))
 	}
 
-	private fun renderInline(nodes: List<ASTNode>) {
+	private fun baseStyle(blockCtx: BlockContext): RtfSpanStyle =
+		if (blockCtx.quote) RtfSpanStyle(italic = true) else RtfSpanStyle.Default
+
+	private fun inlineRuns(nodes: List<ASTNode>, style: RtfSpanStyle): List<RtfInline> {
+		val out = mutableListOf<RtfInline>()
+		appendInline(out, nodes, style)
+		return out
+	}
+
+	private fun appendInline(out: MutableList<RtfInline>, nodes: List<ASTNode>, style: RtfSpanStyle) {
 		for (node in nodes) {
 			when (node.type) {
-				MarkdownElementTypes.STRONG -> {
-					out.append("{\\b ")
-					renderInline(node.children.stripDelimiters(MarkdownTokenTypes.EMPH))
-					out.append("}")
-				}
+				MarkdownElementTypes.STRONG ->
+					appendInline(out, node.children.stripDelimiters(MarkdownTokenTypes.EMPH), style.copy(bold = true))
 
-				MarkdownElementTypes.EMPH -> {
-					out.append("{\\i ")
-					renderInline(node.children.stripDelimiters(MarkdownTokenTypes.EMPH))
-					out.append("}")
-				}
+				MarkdownElementTypes.EMPH ->
+					appendInline(out, node.children.stripDelimiters(MarkdownTokenTypes.EMPH), style.copy(italic = true))
 
 				MarkdownElementTypes.CODE_SPAN -> {
 					val code = node.children
 						.filter { it.type != MarkdownTokenTypes.BACKTICK }
 						.joinToString("") { it.getTextInNode(source).toString() }
-					out.append("{\\f$FONT_MONO ").append(escapeRtf(code.removeSurrounding(" "))).append("}")
+					out.add(RtfTextRun(code.removeSurrounding(" "), style.copy(font = MONO_FONT)))
 				}
 
-				MarkdownElementTypes.INLINE_LINK -> inlineLink(node)
-				MarkdownElementTypes.AUTOLINK -> autoLink(node)
+				MarkdownElementTypes.INLINE_LINK -> inlineLink(out, node, style)
+				MarkdownElementTypes.AUTOLINK -> autoLink(out, node, style)
 
-				MarkdownTokenTypes.HARD_LINE_BREAK -> out.append("\\line ")
-				MarkdownTokenTypes.EOL -> out.append(' ')
+				MarkdownTokenTypes.HARD_LINE_BREAK -> out.add(RtfLineBreak)
+				MarkdownTokenTypes.EOL -> out.add(RtfTextRun(" ", style))
 
 				else -> {
 					if (node.children.isEmpty()) {
-						out.append(escapeRtf(unescape(node.getTextInNode(source).toString())))
+						out.add(RtfTextRun(unescape(node.getTextInNode(source).toString()), style))
 					} else {
-						renderInline(node.children)
+						appendInline(out, node.children, style)
 					}
 				}
 			}
 		}
 	}
 
-	private fun inlineLink(node: ASTNode) {
+	private fun inlineLink(out: MutableList<RtfInline>, node: ASTNode, style: RtfSpanStyle) {
 		val destination =
 			node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_DESTINATION }
 				?.getTextInNode(source)?.toString()?.removeSurrounding("<", ">")
 		val linkText = node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_TEXT }
 		if (destination == null || linkText == null) {
-			out.append(escapeRtf(unescape(node.getTextInNode(source).toString())))
+			out.add(RtfTextRun(unescape(node.getTextInNode(source).toString()), style))
 			return
 		}
-		hyperlink(destination) {
-			renderInline(
-				linkText.children.filter {
-					it.type != MarkdownTokenTypes.LBRACKET && it.type != MarkdownTokenTypes.RBRACKET
-				}
-			)
-		}
+		val content = inlineRuns(
+			linkText.children.filter {
+				it.type != MarkdownTokenTypes.LBRACKET && it.type != MarkdownTokenTypes.RBRACKET
+			},
+			style.copy(underline = true, color = primary),
+		)
+		out.add(RtfHyperlink(target = destination, content = content))
 	}
 
-	private fun autoLink(node: ASTNode) {
+	private fun autoLink(out: MutableList<RtfInline>, node: ASTNode, style: RtfSpanStyle) {
 		val url = node.getTextInNode(source).toString().removeSurrounding("<", ">")
-		hyperlink(url) { out.append(escapeRtf(url)) }
-	}
-
-	private fun hyperlink(url: String, body: () -> Unit) {
-		out.append("{\\field{\\*\\fldinst HYPERLINK ")
-		out.append('"').append(escapeRtf(url)).append('"')
-		out.append("}{\\fldrslt {")
-		if (hasPrimary) out.append("\\cf$COLOR_PRIMARY")
-		out.append("\\ul ")
-		body()
-		out.append("}}}")
+		out.add(
+			RtfHyperlink(
+				target = url,
+				content = listOf(RtfTextRun(url, style.copy(underline = true, color = primary))),
+			),
+		)
 	}
 
 	private fun codeFence(node: ASTNode) {
@@ -402,18 +433,41 @@ private class MarkdownRtfWriter(
 	}
 
 	private fun codeParagraph(line: String) {
-		out.append("\\pard\\sa0 {\\f$FONT_MONO ").append(escapeRtf(line)).append("}\\par\n")
+		blocks.add(
+			RtfParagraph(
+				content = listOf(RtfTextRun(line, RtfSpanStyle(font = MONO_FONT))),
+				style = RtfParagraphStyle(spaceAfterTwips = 0),
+			),
+		)
 	}
 
 	private fun horizontalRule() {
-		// A bottom border on an empty paragraph draws a horizontal rule.
-		out.append("\\pard\\brdrb\\brdrs\\brdrw10\\sa$PARAGRAPH_SPACE_AFTER\\par\n")
+		blocks.add(
+			RtfParagraph(
+				content = emptyList(),
+				style = RtfParagraphStyle(spaceAfterTwips = PARAGRAPH_SPACE_AFTER, bottomBorder = RtfBorder()),
+			),
+		)
+	}
+
+	/** Merges consecutive [RtfTextRun]s that share a style so plain prose stays in a single run. */
+	private fun coalesce(inlines: List<RtfInline>): List<RtfInline> {
+		val result = mutableListOf<RtfInline>()
+		for (inline in inlines) {
+			val last = result.lastOrNull()
+			if (inline is RtfTextRun && last is RtfTextRun && last.style == inline.style) {
+				result[result.lastIndex] = last.copy(text = last.text + inline.text)
+			} else {
+				result.add(inline)
+			}
+		}
+		return result
 	}
 
 	private fun List<ASTNode>.stripDelimiters(delimiterType: Any): List<ASTNode> =
 		dropWhile { it.type == delimiterType }.dropLastWhile { it.type == delimiterType }
 
-	/** Resolves CommonMark backslash escapes to their bare punctuation before RTF escaping. */
+	/** Resolves CommonMark backslash escapes to their bare punctuation. */
 	private fun unescape(text: String): String {
 		if (!text.contains('\\')) return text
 		val sb = StringBuilder(text.length)
@@ -435,28 +489,4 @@ private class MarkdownRtfWriter(
 	private companion object {
 		const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 	}
-}
-
-/**
- * Escapes text for an RTF body: the structural characters `\`, `{`, `}` are backslash-escaped,
- * tabs and newlines become control words, and any non-ASCII character is emitted as a `\uN`
- * escape with a `?` substitute so legacy readers still show something in its place.
- */
-internal fun escapeRtf(text: String): String {
-	val sb = StringBuilder(text.length)
-	for (ch in text) {
-		when {
-			ch == '\\' || ch == '{' || ch == '}' -> sb.append('\\').append(ch)
-			ch == '\t' -> sb.append("\\tab ")
-			ch == '\n' -> sb.append("\\line ")
-			ch == '\r' -> Unit
-			ch.code in 0x20..0x7E -> sb.append(ch)
-			else -> {
-				// RTF \u takes a signed 16-bit value; chars above 0x7FFF must be expressed as negative.
-				val code = if (ch.code > 0x7FFF) ch.code - 0x10000 else ch.code
-				sb.append("\\u").append(code).append('?')
-			}
-		}
-	}
-	return sb.toString()
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExportOptions.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExportOptions.kt
@@ -8,5 +8,5 @@ enum class ExportFormat { Markdown, Epub, Pdf, Docx, Rtf }
 @Serializable
 data class ExportOptions(
 	val treatTopLevelAsChapters: Boolean = true,
-	val format: ExportFormat = ExportFormat.Markdown,
+	val format: ExportFormat = ExportFormat.Epub,
 )

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExportOptions.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExportOptions.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.common.data
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class ExportFormat { Markdown, Epub, Pdf, Docx }
+enum class ExportFormat { Markdown, Epub, Pdf, Docx, Rtf }
 
 @Serializable
 data class ExportOptions(

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
@@ -68,6 +68,16 @@ class RtfStoryRendererTest {
 	}
 
 	@Test
+	fun `generator metadata identifies Hammer`() {
+		val rtf = render(listOf(StoryChapter("Alpha", "Body.")))
+
+		assertTrue(
+			rtf.contains("{\\*\\generator Hammer "),
+			"Generator metadata should mark Hammer as the source application",
+		)
+	}
+
+	@Test
 	fun `chapters are numbered and bookmarked for the contents links`() {
 		val rtf = render(
 			listOf(
@@ -100,8 +110,9 @@ class RtfStoryRendererTest {
 
 	@Test
 	fun `theme accent colors populate the color table`() {
+		// The primary accent colors chapter headings; a level-2 markdown heading exercises the secondary.
 		val rtf = render(
-			listOf(StoryChapter("Alpha", "Body.")),
+			listOf(StoryChapter("Alpha", "## Section\n\nBody.")),
 			projectData = ProjectData(
 				authorName = "Jane",
 				theme = ProjectTheme(primary = "#FF112233", secondary = "#FFAABBCC"),

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
@@ -1,0 +1,147 @@
+package com.darkrockstudios.apps.hammer.common.components.projecthome
+
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectTheme
+import com.darkrockstudios.apps.hammer.common.data.ImportOptions
+import com.darkrockstudios.apps.hammer.common.data.RtfSplitStrategy
+import com.darkrockstudios.apps.hammer.common.data.importer.PreviewItem
+import com.darkrockstudios.apps.hammer.common.data.importer.RtfStoryImporter
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RtfStoryRendererTest {
+
+	private fun render(
+		chapters: List<StoryChapter>,
+		projectName: String = "Test Project",
+		projectData: ProjectData = ProjectData(authorName = "Test Author"),
+	): String {
+		val buffer = Buffer()
+		writeStoryAsRtf(
+			sink = buffer,
+			projectName = projectName,
+			projectData = projectData,
+			chapters = chapters,
+		)
+		return buffer.readByteArray().decodeToString()
+	}
+
+	/** Counts brace nesting, ignoring the backslash-escaped `\{` and `\}` that appear in body text. */
+	private fun braceBalance(rtf: String): Int {
+		var depth = 0
+		var i = 0
+		while (i < rtf.length) {
+			val c = rtf[i]
+			when {
+				c == '\\' -> i++ // skip the escaped/control character that follows
+				c == '{' -> depth++
+				c == '}' -> depth--
+			}
+			i++
+		}
+		return depth
+	}
+
+	@Test
+	fun `output is a well-formed RTF document with balanced braces`() {
+		val rtf = render(listOf(StoryChapter("Alpha", "Some text.")))
+
+		assertTrue(rtf.startsWith("{\\rtf1"), "RTF must start with the {\\rtf1 signature")
+		assertTrue(rtf.endsWith("}"), "RTF must close its root group")
+		assertEquals(0, braceBalance(rtf), "Every RTF group must be balanced")
+	}
+
+	@Test
+	fun `title page carries the project name and author byline`() {
+		val rtf = render(
+			listOf(StoryChapter("Alpha", "Body.")),
+			projectName = "My Story",
+			projectData = ProjectData(authorName = "Jane Doe"),
+		)
+
+		assertTrue(rtf.contains("My Story"), "Title should appear in the document")
+		assertTrue(rtf.contains("by Jane Doe"), "Author byline should appear in the document")
+		assertTrue(rtf.contains("\\title My Story"), "Title metadata should be present")
+		assertTrue(rtf.contains("\\author Jane Doe"), "Author metadata should be present")
+	}
+
+	@Test
+	fun `chapters are numbered and bookmarked for the contents links`() {
+		val rtf = render(
+			listOf(
+				StoryChapter("Alpha", "First."),
+				StoryChapter("Beta", "Second."),
+			)
+		)
+
+		assertTrue(rtf.contains("1. Alpha"), "First chapter should be numbered")
+		assertTrue(rtf.contains("2. Beta"), "Second chapter should be numbered")
+		assertTrue(rtf.contains("\\*\\bkmkstart chapter1"), "Chapters need bookmark anchors")
+		assertTrue(rtf.contains("HYPERLINK \\\\l \"chapter1\""), "Contents should link to chapter bookmarks")
+	}
+
+	@Test
+	fun `markdown emphasis becomes RTF bold and italic`() {
+		val rtf = render(listOf(StoryChapter("Alpha", "A **bold** and _italic_ word.")))
+
+		assertTrue(rtf.contains("{\\b bold}"), "Strong markdown should become an RTF bold group")
+		assertTrue(rtf.contains("{\\i italic}"), "Emphasis markdown should become an RTF italic group")
+	}
+
+	@Test
+	fun `braces in prose are escaped so they do not open groups`() {
+		val rtf = render(listOf(StoryChapter("Alpha", "Use {braces} and a back\\slash.")))
+
+		assertTrue(rtf.contains("\\{braces\\}"), "Literal braces must be backslash-escaped")
+		assertEquals(0, braceBalance(rtf), "Escaped braces must not unbalance the document")
+	}
+
+	@Test
+	fun `theme accent colors populate the color table`() {
+		val rtf = render(
+			listOf(StoryChapter("Alpha", "Body.")),
+			projectData = ProjectData(
+				authorName = "Jane",
+				theme = ProjectTheme(primary = "#FF112233", secondary = "#FFAABBCC"),
+			),
+		)
+
+		assertTrue(rtf.contains("\\red17\\green34\\blue51;"), "Primary accent should be in the color table")
+		assertTrue(rtf.contains("\\red170\\green187\\blue204;"), "Secondary accent should be in the color table")
+		assertTrue(rtf.contains("\\cf1"), "Headings should reference the primary color")
+	}
+
+	@Test
+	fun `non-ascii characters are emitted as unicode escapes`() {
+		val rtf = render(listOf(StoryChapter("Café", "Naïve résumé — café.")))
+
+		assertTrue(rtf.contains("\\u233?"), "é (U+00E9) should be a \\u233 escape")
+		assertTrue(rtf.contains("\\u8212?"), "em dash (U+2014) should be a \\u8212 escape")
+	}
+
+	@Test
+	fun `rendered prose survives a round-trip through the RTF importer`() {
+		val rtf = render(
+			listOf(StoryChapter("Alpha", "The quick brown fox jumped.")),
+			projectData = ProjectData(),
+		)
+
+		val preview = RtfStoryImporter().preview(
+			sourceName = "story",
+			content = rtf.encodeToByteArray(),
+			options = ImportOptions(
+				rtfSplitStrategy = RtfSplitStrategy.SingleScene,
+				rtfChapterPattern = "",
+				createChapterGroups = false,
+			),
+		)
+
+		val scene = preview.items.single() as PreviewItem.Scene
+		assertTrue(
+			scene.markdown.contains("The quick brown fox jumped."),
+			"Chapter body should survive the export/import round-trip, got: ${scene.markdown}",
+		)
+	}
+}

--- a/common/src/desktopTest/kotlin/components/projecthome/DocxStoryRendererTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/DocxStoryRendererTest.kt
@@ -50,6 +50,18 @@ class DocxStoryRendererTest {
 	}
 
 	@Test
+	fun `extended metadata identifies Hammer as the generating application`() {
+		val doc = render(listOf(StoryChapter("Alpha", "Some text.")))
+
+		val extended = doc.properties.extendedProperties.underlyingProperties
+		assertEquals("Hammer", extended.application)
+		assertTrue(
+			extended.appVersion.isNotBlank(),
+			"App version metadata should be present",
+		)
+	}
+
+	@Test
 	fun `title page shows project name with Title style and author byline`() {
 		val doc = render(listOf(StoryChapter("Alpha", "Some text.")))
 

--- a/common/src/desktopTest/kotlin/components/projecthome/ExportStoryUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/ExportStoryUseCaseTest.kt
@@ -127,6 +127,23 @@ class ExportStoryUseCaseTest : BaseIntegrationTest() {
 	}
 
 	@Test
+	fun `rtf export produces a valid rtf file with the RTF header`() = runTest {
+		initRepo()
+		storedProjectData = StoredProjectData(data = ProjectData(authorName = "Test Author"))
+
+		val exportPath = useCase().execute(
+			exportDir = projectPath,
+			options = ExportOptions(format = ExportFormat.Rtf, treatTopLevelAsChapters = true),
+		)
+
+		assertTrue(exportPath.path.endsWith(".rtf"), "Should produce a .rtf file, got $exportPath")
+		val text = ffs.read(exportPath.toOkioPath()) { readByteArray() }.decodeToString()
+		assertTrue(text.length > 100, "RTF output should be more than a stub, got ${text.length} chars")
+		// Every RTF document starts with the "{\rtf1" signature.
+		assertTrue(text.startsWith("{\\rtf1"), "RTF should start with the {\\rtf1 signature")
+	}
+
+	@Test
 	fun `docx export still produces a valid file when treatTopLevelAsChapters is false`() =
 		runTest {
 			initRepo()

--- a/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportDirectoryPicker.kt
+++ b/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportDirectoryPicker.kt
@@ -72,4 +72,5 @@ private fun mimeTypeFor(format: ExportFormat): String = when (format) {
 	ExportFormat.Epub -> "application/epub+zip"
 	ExportFormat.Pdf -> "application/pdf"
 	ExportFormat.Docx -> "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	ExportFormat.Rtf -> "application/rtf"
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdToolButton.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdToolButton.kt
@@ -5,13 +5,19 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /**
  * Small (30dp) square-cornered hairline-bordered toolbar action — the
@@ -47,6 +53,32 @@ fun HdToolButton(
 		contentAlignment = Alignment.Center,
 	) {
 		content()
+	}
+}
+
+/**
+ * A help affordance: a `?` glyph inside an [HdToolButton]. The
+ * square hairline frame keeps the help action in vocabulary with the
+ * dialog mastheads it sits in, rather than reading as a bare icon.
+ */
+@Composable
+fun HdHelpButton(
+	onClick: () -> Unit,
+	contentDescription: String,
+	modifier: Modifier = Modifier,
+) {
+	HdToolButton(
+		active = false,
+		onClick = onClick,
+		modifier = modifier.semantics { this.contentDescription = contentDescription },
+	) {
+		Text(
+			text = "?",
+			fontFamily = FontFamily.Monospace,
+			fontWeight = FontWeight.Medium,
+			fontSize = 14.sp,
+			color = MaterialTheme.colorScheme.onSurfaceVariant,
+		)
 	}
 }
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportHelpDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportHelpDialog.kt
@@ -1,0 +1,158 @@
+package com.darkrockstudios.apps.hammer.common.projecthome
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import com.darkrockstudios.apps.hammer.*
+import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialogContainer
+import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
+import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import org.jetbrains.compose.resources.StringResource
+
+private val DialogMaxWidth = 480.dp
+
+private class ExportFormatHelp(val label: StringResource, val description: StringResource)
+
+private val ExportFormatHelpRows = listOf(
+	ExportFormatHelp(
+		Res.string.project_home_export_format_epub,
+		Res.string.project_home_export_help_format_epub,
+	),
+	ExportFormatHelp(
+		Res.string.project_home_export_format_docx,
+		Res.string.project_home_export_help_format_docx,
+	),
+	ExportFormatHelp(
+		Res.string.project_home_export_format_rtf,
+		Res.string.project_home_export_help_format_rtf,
+	),
+	ExportFormatHelp(
+		Res.string.project_home_export_format_pdf,
+		Res.string.project_home_export_help_format_pdf,
+	),
+	ExportFormatHelp(
+		Res.string.project_home_export_format_markdown,
+		Res.string.project_home_export_help_format_markdown,
+	),
+)
+
+/** Animated wrapper around [ExportHelpContent]. Preview [ExportHelpContent] directly for a static frame. */
+@Composable
+internal fun ExportHelpDialog(onDismiss: () -> Unit) {
+	var isOpen by remember { mutableStateOf(true) }
+
+	AnimatedDialogContainer(
+		isOpen = isOpen,
+		onDismissRequest = { isOpen = false },
+		onClosed = onDismiss,
+		properties = DialogProperties(
+			dismissOnBackPress = true,
+			dismissOnClickOutside = true,
+			usePlatformDefaultWidth = false,
+		),
+	) {
+		Box(modifier = Modifier.predictiveBackTransform()) {
+			ExportHelpContent(onDismiss = { isOpen = false })
+		}
+	}
+}
+
+@Composable
+internal fun ExportHelpContent(onDismiss: () -> Unit) {
+	Surface(
+		modifier = Modifier
+			.padding(Ui.Padding.XL)
+			.widthIn(max = DialogMaxWidth)
+			.fillMaxWidth(),
+		shape = RectangleShape,
+		color = MaterialTheme.colorScheme.surface,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+		border = BorderStroke(
+			width = Dp.Hairline,
+			color = MaterialTheme.colorScheme.outlineVariant,
+		),
+	) {
+		Column(modifier = Modifier.fillMaxWidth()) {
+			HdMasthead(
+				section = "HELP · EXPORT",
+				trailing = { HdMastheadAction(label = "× CLOSE", onClick = onDismiss) },
+			)
+			HdFolioDivider()
+
+			Column(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(Ui.Padding.XL),
+				verticalArrangement = Arrangement.spacedBy(Ui.Padding.L),
+			) {
+				Text(
+					text = Res.string.project_home_export_help_title.get(),
+					style = MaterialTheme.typography.headlineSmall,
+					color = MaterialTheme.colorScheme.onSurface,
+				)
+				Text(
+					text = Res.string.project_home_export_help_intro.get(),
+					style = MaterialTheme.typography.bodyMedium,
+					color = MaterialTheme.colorScheme.onSurfaceVariant,
+				)
+
+				Column(verticalArrangement = Arrangement.spacedBy(Ui.Padding.L)) {
+					ExportFormatHelpRows.forEachIndexed { index, format ->
+						if (index > 0) {
+							HorizontalDivider(
+								thickness = Dp.Hairline,
+								color = MaterialTheme.colorScheme.outlineVariant,
+							)
+						}
+						Column(verticalArrangement = Arrangement.spacedBy(Ui.Padding.S)) {
+							Text(
+								text = format.label.get(),
+								style = MaterialTheme.typography.titleSmall,
+								color = MaterialTheme.colorScheme.onSurface,
+							)
+							Text(
+								text = format.description.get(),
+								style = MaterialTheme.typography.bodyMedium,
+								color = MaterialTheme.colorScheme.onSurfaceVariant,
+							)
+						}
+					}
+				}
+			}
+
+			HdFolioDivider()
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.L),
+				horizontalArrangement = Arrangement.End,
+			) {
+				HdHairlineButton(
+					label = Res.string.project_home_export_help_dismiss.get(),
+					onClick = onDismiss,
+					emphasised = true,
+				)
+			}
+		}
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportOptionsDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportOptionsDialog.kt
@@ -45,6 +45,7 @@ import com.darkrockstudios.apps.hammer.project_home_export_format_epub
 import com.darkrockstudios.apps.hammer.project_home_export_format_label
 import com.darkrockstudios.apps.hammer.project_home_export_format_markdown
 import com.darkrockstudios.apps.hammer.project_home_export_format_pdf
+import com.darkrockstudios.apps.hammer.project_home_export_format_rtf
 import com.darkrockstudios.apps.hammer.project_home_export_section
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
@@ -164,11 +165,18 @@ fun ExportOptionsDialog(
 }
 
 private val AVAILABLE_EXPORT_FORMATS =
-	listOf(ExportFormat.Markdown, ExportFormat.Epub, ExportFormat.Pdf, ExportFormat.Docx)
+	listOf(
+		ExportFormat.Markdown,
+		ExportFormat.Epub,
+		ExportFormat.Pdf,
+		ExportFormat.Docx,
+		ExportFormat.Rtf,
+	)
 
 private fun ExportFormat.labelRes(): StringResource = when (this) {
 	ExportFormat.Markdown -> Res.string.project_home_export_format_markdown
 	ExportFormat.Epub -> Res.string.project_home_export_format_epub
 	ExportFormat.Pdf -> Res.string.project_home_export_format_pdf
 	ExportFormat.Docx -> Res.string.project_home_export_format_docx
+	ExportFormat.Rtf -> Res.string.project_home_export_format_rtf
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportOptionsDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportOptionsDialog.kt
@@ -30,6 +30,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdButtonBar
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineDropdown
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineToggleRow
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHelpButton
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMasthead
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
@@ -46,6 +47,7 @@ import com.darkrockstudios.apps.hammer.project_home_export_format_label
 import com.darkrockstudios.apps.hammer.project_home_export_format_markdown
 import com.darkrockstudios.apps.hammer.project_home_export_format_pdf
 import com.darkrockstudios.apps.hammer.project_home_export_format_rtf
+import com.darkrockstudios.apps.hammer.project_home_export_help_icon_description
 import com.darkrockstudios.apps.hammer.project_home_export_section
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
@@ -66,6 +68,7 @@ fun ExportOptionsDialog(
 	var format by remember(initialOptions, visible) {
 		mutableStateOf(initialOptions.format)
 	}
+	var showHelp by remember { mutableStateOf(false) }
 
 	AnimatedDialog(
 		visible = visible,
@@ -89,6 +92,10 @@ fun ExportOptionsDialog(
 				HdMasthead(
 					section = stringResource(Res.string.project_home_export_section),
 					trailing = {
+						HdHelpButton(
+							onClick = { showHelp = true },
+							contentDescription = stringResource(Res.string.project_home_export_help_icon_description),
+						)
 						HdMastheadAction(
 							label = stringResource(Res.string.project_home_export_close),
 							onClick = { if (!working) onCancel() },
@@ -162,15 +169,19 @@ fun ExportOptionsDialog(
 			}
 		}
 	}
+
+	if (showHelp) {
+		ExportHelpDialog(onDismiss = { showHelp = false })
+	}
 }
 
 private val AVAILABLE_EXPORT_FORMATS =
 	listOf(
-		ExportFormat.Markdown,
 		ExportFormat.Epub,
-		ExportFormat.Pdf,
 		ExportFormat.Docx,
 		ExportFormat.Rtf,
+		ExportFormat.Pdf,
+		ExportFormat.Markdown,
 	)
 
 private fun ExportFormat.labelRes(): StringResource = when (this) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectCreateDialog.kt
@@ -2,11 +2,6 @@ package com.darkrockstudios.apps.hammer.common.projectselection
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.HelpOutline
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,6 +16,7 @@ import com.darkrockstudios.apps.hammer.common.compose.FormField
 import com.darkrockstudios.apps.hammer.common.compose.NameKind
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHelpButton
 import com.darkrockstudios.apps.hammer.common.compose.rememberNameValidation
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 
@@ -79,13 +75,10 @@ internal fun ProjectCreateMastheadActions(onHelp: () -> Unit, onImport: () -> Un
 		verticalAlignment = Alignment.CenterVertically,
 		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.S),
 	) {
-		IconButton(onClick = onHelp) {
-			Icon(
-				imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-				contentDescription = Res.string.create_project_import_help_icon_description.get(),
-				tint = MaterialTheme.colorScheme.onSurfaceVariant,
-			)
-		}
+		HdHelpButton(
+			onClick = onHelp,
+			contentDescription = Res.string.create_project_import_help_icon_description.get(),
+		)
 		ProjectCreateImportAction(onImport)
 	}
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ExportHelpDialog.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ExportHelpDialog.Preview.kt
@@ -1,0 +1,31 @@
+package com.darkrockstudios.apps.hammer.common.preview.projecthome
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.preview.globalSettingsPreview
+import com.darkrockstudios.apps.hammer.common.projecthome.ExportHelpContent
+
+@Preview(widthDp = 600, heightDp = 560)
+@Composable
+fun ExportHelpDialogPreview() {
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, true) {
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.background(MaterialTheme.colorScheme.background),
+				contentAlignment = Alignment.Center,
+			) {
+				ExportHelpContent(onDismiss = {})
+			}
+		}
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ clikt = "5.1.0"
 kotlinx_atomicfu = "0.33.0"
 kotlinx_collections_immutable = "0.5.0"
 markdown = "0.7.5"
-rtfReader = "0.1.0"
+rtfParserKmp = "0.2.2"
 epub4kmp = "0.3.0"
 pdfkmp = "1.2.0"
 xmlutil = "1.0.0-rc3"
@@ -174,7 +174,8 @@ kotlinx_atomicfu_plugin = { group = "org.jetbrains.kotlinx", name = "atomicfu-gr
 kotlinx_collections_immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx_collections_immutable" }
 
 markdown = { module = "org.jetbrains:markdown", version.ref = "markdown" }
-rtf-reader = { module = "com.darkrockstudios:rtf-reader", version.ref = "rtfReader" }
+rtf-reader = { module = "com.darkrockstudios:rtf-reader", version.ref = "rtfParserKmp" }
+rtf-writer = { module = "com.darkrockstudios:rtf-writer", version.ref = "rtfParserKmp" }
 kotlin-multiplatform-diff = { module = "io.github.petertrr:kotlin-multiplatform-diff", version.ref = "kotlin-multiplatform-diff" }
 epub4kmp_core = { module = "com.darkrockstudios:epub4kmp-core", version.ref = "epub4kmp" }
 xmlutil_core = { module = "io.github.pdvrieze.xmlutil:core", version.ref = "xmlutil" }


### PR DESCRIPTION
## Summary

Adds **RTF** as a story export option, mirroring the recently merged RTF import (#663). RTF now joins Markdown / EPUB / PDF / DOCX in the export dialog and the export pipeline.

## What's included

- **`ExportFormat.Rtf`** with the `.rtf` extension and `application/rtf` mime type (Android save-picker). The desktop/iOS pickers derive the extension generically, so no change was needed there.
- **`RtfStoryRenderer.kt`** (new) — `writeStoryAsRtf(...)` produces a well-formed `{\rtf1...}` document mirroring the EPUB/DOCX layout: a title page, a Contents page linking to per-chapter bookmarks, then one chapter per top-level node. It walks each chapter's markdown AST (same approach as `DocxStoryRenderer`) and converts **bold/italic, headings, ordered/unordered lists, blockquotes, inline & block code, links, and horizontal rules** into RTF. Heading/link colors pick up the project theme accents, like DOCX/PDF. Braces/backslashes are escaped and non-ASCII characters become `\uN?` escapes so output stays portable across readers.
- **`ExportStoryUseCase`** — added the `Rtf` branch (uses `ProjectData` for author/theme, like DOCX).
- **`ExportOptionsDialog`** — RTF added to the format dropdown, with a localized `project_home_export_format_rtf` = "RTF (.rtf)" string across all 8 locales (format names aren't translated, matching how PDF/Word are handled).

## Tests

- `RtfStoryRendererTest` — balanced-brace/well-formed output, title & author metadata, numbered & bookmarked chapters, bold/italic conversion, brace escaping, unicode escapes, theme colors, and a **round-trip back through the RTF importer**.
- Added an RTF case to `ExportStoryUseCaseTest` for end-to-end wiring.

## Note

I was unable to compile/run the test suite in the cloud session — Gradle dependency resolution is blocked there (`dl.google.com` returns a 403 egress-policy denial and Maven Central's TLS handshake is terminated, with no populated Gradle cache). The change was reviewed by hand instead; CI (or a local build) will give it a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)