### PR TITLE
Unify and localize the story exporters' shared handling

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values/strings_project_home.xml
@@ -111,6 +111,9 @@
 	<string name="project_home_export_help_format_rtf">A broadly compatible rich-text format; a safe choice when you are unsure which word processor the recipient uses.</string>
 	<string name="project_home_export_help_dismiss">Got it</string>
 
+	<string name="project_home_export_contents_title">Contents</string>
+	<string name="project_home_export_byline">by %1$s</string>
+
 	<string name="project_home_action_import">Import Story</string>
 	<string name="project_home_action_import_toast_success">Story Imported</string>
 	<string name="project_home_action_import_toast_failure">Import failed</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
@@ -19,8 +19,6 @@ import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
 import org.intellij.markdown.parser.MarkdownParser
 import no.synth.kmpzip.okio.ZipOutputStream as OkioZipOutputStream
 
-private const val TOC_TITLE = "Contents"
-
 private const val W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 private const val R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 private const val CONTENT_TYPES_NS = "http://schemas.openxmlformats.org/package/2006/content-types"
@@ -44,8 +42,6 @@ private const val REL_TYPE_NUMBERING =
 private const val REL_TYPE_HYPERLINK =
 	"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
 
-private const val BODY_FONT = "Georgia"
-private const val MONOSPACE_FONT = "Consolas"
 private const val DEFAULT_LINK_COLOR = "0563C1"
 
 private const val BULLET_NUM_ID = 1
@@ -54,8 +50,6 @@ private const val DECIMAL_ABSTRACT_ID = 1
 
 /** Relationship ids rId1/rId2 in document.xml.rels are styles and numbering; hyperlinks follow. */
 private const val FIRST_HYPERLINK_REL_ID = 3
-
-private fun chapterBookmark(index: Int): String = "chapter${index + 1}"
 
 /**
  * Renders the story as an OOXML WordprocessingML (.docx) package mirroring the EPUB layout:
@@ -68,6 +62,7 @@ fun writeStoryAsDocx(
 	projectName: String,
 	projectData: ProjectData,
 	chapters: List<StoryChapter>,
+	strings: ExportStrings,
 ) {
 	val authorName = projectData.authorName?.takeIf { it.isNotBlank() }
 	val effective = chapters.ifEmpty { listOf(StoryChapter(projectName, "")) }
@@ -75,7 +70,7 @@ fun writeStoryAsDocx(
 	// The body walk collects hyperlink targets and ordered-list instances that
 	// document.xml.rels and numbering.xml must declare, so it runs first.
 	val ctx = DocxRenderContext()
-	val documentXml = buildXmlPart { writeDocument(it, ctx, projectName, authorName, effective) }
+	val documentXml = buildXmlPart { writeDocument(it, ctx, projectName, strings, effective) }
 
 	val zip = OkioZipOutputStream(sink)
 	zip.putEntry("[Content_Types].xml", buildXmlPart(::writeContentTypes))
@@ -264,7 +259,7 @@ private fun writeStyles(writer: XmlWriter, theme: ProjectTheme?) {
 		w("docDefaults") {
 			w("rPrDefault") {
 				w("rPr") {
-					rFonts(BODY_FONT)
+					rFonts(EXPORT_BODY_FONT)
 					size(24)
 				}
 			}
@@ -312,8 +307,7 @@ private fun writeStyles(writer: XmlWriter, theme: ProjectTheme?) {
 			}
 		}
 
-		val headingSizes = listOf(48, 36, 32, 28, 26, 24)
-		headingSizes.forEachIndexed { index, halfPoints ->
+		HEADING_HALF_POINTS.forEachIndexed { index, halfPoints ->
 			val level = index + 1
 			style("Heading$level", "heading $level") {
 				wVal("next", "Normal")
@@ -404,14 +398,14 @@ private fun writeDocument(
 	writer: XmlWriter,
 	ctx: DocxRenderContext,
 	projectName: String,
-	authorName: String?,
+	strings: ExportStrings,
 	chapters: List<StoryChapter>,
 ) {
 	writer.smartStartTag(W_NS, "document", "w") {
 		namespaceAttr("r", R_NS)
 		w("body") {
-			writeTitlePage(projectName, authorName)
-			writeContentsPage(chapters)
+			writeTitlePage(projectName, strings.authorByline)
+			writeContentsPage(chapters, strings.contentsTitle)
 			chapters.forEachIndexed { index, chapter ->
 				writeChapter(ctx, index, chapter)
 			}
@@ -434,7 +428,7 @@ private fun writeDocument(
 	}
 }
 
-private fun XmlWriter.writeTitlePage(projectName: String, authorName: String?) {
+private fun XmlWriter.writeTitlePage(projectName: String, authorByline: String?) {
 	w("p") {
 		w("pPr") { wVal("pStyle", "Title") }
 		w("r") {
@@ -444,7 +438,7 @@ private fun XmlWriter.writeTitlePage(projectName: String, authorName: String?) {
 			}
 		}
 	}
-	authorName?.let {
+	authorByline?.let {
 		w("p") {
 			w("pPr") { wVal("jc", "center") }
 			w("r") {
@@ -454,14 +448,14 @@ private fun XmlWriter.writeTitlePage(projectName: String, authorName: String?) {
 				}
 				w("t") {
 					preserveSpace()
-					text("by $it")
+					text(it)
 				}
 			}
 		}
 	}
 }
 
-private fun XmlWriter.writeContentsPage(chapters: List<StoryChapter>) {
+private fun XmlWriter.writeContentsPage(chapters: List<StoryChapter>, contentsTitle: String) {
 	w("p") {
 		w("pPr") {
 			wVal("pStyle", "TocTitle")
@@ -470,7 +464,7 @@ private fun XmlWriter.writeContentsPage(chapters: List<StoryChapter>) {
 		w("r") {
 			w("t") {
 				preserveSpace()
-				text(TOC_TITLE)
+				text(contentsTitle)
 			}
 		}
 	}
@@ -613,7 +607,7 @@ private class MarkdownDocxWriter(
 			if (children.isNotEmpty()) {
 				renderInline(children)
 			} else {
-				content?.let { appendText(unescape(it.getTextInNode(source)).trim()) }
+				content?.let { appendText(unescapeMarkdown(it.getTextInNode(source)).trim()) }
 			}
 		}
 	}
@@ -649,7 +643,7 @@ private class MarkdownDocxWriter(
 
 				else -> {
 					if (node.children.isEmpty()) {
-						appendText(unescape(node.getTextInNode(source)))
+						appendText(unescapeMarkdown(node.getTextInNode(source)))
 					} else {
 						renderInline(node.children)
 					}
@@ -704,30 +698,14 @@ private class MarkdownDocxWriter(
 	}
 
 	private fun codeFence(node: ASTNode) {
-		val lines = collectCodeLines(node, MarkdownTokenTypes.CODE_FENCE_CONTENT)
+		val lines = collectCodeLines(node, source, MarkdownTokenTypes.CODE_FENCE_CONTENT)
 		lines.forEach { codeParagraph(it) }
 	}
 
 	private fun codeBlock(node: ASTNode) {
-		val lines = collectCodeLines(node, MarkdownTokenTypes.CODE_LINE)
+		val lines = collectCodeLines(node, source, MarkdownTokenTypes.CODE_LINE)
 			.map { it.removePrefix("    ").removePrefix("\t") }
 		lines.forEach { codeParagraph(it) }
-	}
-
-	private fun collectCodeLines(node: ASTNode, contentType: Any): List<String> {
-		val lines = mutableListOf<String>()
-		val current = StringBuilder()
-		for (child in node.children) {
-			when (child.type) {
-				contentType -> current.append(child.getTextInNode(source))
-				MarkdownTokenTypes.EOL -> {
-					lines += current.toString()
-					current.clear()
-				}
-			}
-		}
-		if (current.isNotEmpty()) lines += current.toString()
-		return lines.dropWhile { it.isBlank() }.dropLastWhile { it.isBlank() }
 	}
 
 	private fun codeParagraph(line: String) {
@@ -790,9 +768,9 @@ private class MarkdownDocxWriter(
 					if (inHyperlink) wVal("rStyle", "Hyperlink")
 					if (code) {
 						w("rFonts") {
-							wAttr("ascii", MONOSPACE_FONT)
-							wAttr("hAnsi", MONOSPACE_FONT)
-							wAttr("cs", MONOSPACE_FONT)
+							wAttr("ascii", EXPORT_MONO_FONT)
+							wAttr("hAnsi", EXPORT_MONO_FONT)
+							wAttr("cs", EXPORT_MONO_FONT)
 						}
 					}
 					if (boldDepth > 0) w("b")
@@ -806,32 +784,4 @@ private class MarkdownDocxWriter(
 		}
 	}
 
-	private fun List<ASTNode>.stripDelimiters(delimiterType: Any): List<ASTNode> =
-		dropWhile { it.type == delimiterType }.dropLastWhile { it.type == delimiterType }
-
-	/**
-	 * Resolves CommonMark backslash escapes to their bare punctuation. Unlike the PDF renderer's
-	 * variant, markdown delimiters are included: this text is final output, never re-parsed.
-	 */
-	private fun unescape(text: CharSequence): String {
-		if (!text.contains('\\')) return text.toString()
-		val out = StringBuilder(text.length)
-		var i = 0
-		while (i < text.length) {
-			val c = text[i]
-			val next = if (i + 1 < text.length) text[i + 1] else null
-			if (c == '\\' && next != null && next in ASCII_PUNCTUATION) {
-				out.append(next)
-				i += 2
-			} else {
-				out.append(c)
-				i++
-			}
-		}
-		return out.toString()
-	}
-
-	private companion object {
-		const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
-	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/EpubStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/EpubStoryRenderer.kt
@@ -11,8 +11,6 @@ import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
 
-private const val TOC_TITLE = "Contents"
-
 private data class TocEntry(val title: String, val href: String)
 
 fun writeStoryAsEpub(
@@ -21,6 +19,7 @@ fun writeStoryAsEpub(
 	projectData: ProjectData,
 	chapters: List<StoryChapter>,
 	language: String,
+	strings: ExportStrings,
 ) {
 	val authorName = projectData.authorName?.takeIf { it.isNotBlank() }
 
@@ -48,12 +47,12 @@ fun writeStoryAsEpub(
 		)
 
 		addSection(
-			TOC_TITLE,
+			strings.contentsTitle,
 			buildXhtmlResource(
 				id = "toc",
 				href = "toc.xhtml",
-				title = TOC_TITLE,
-				bodyBuilder = { tocPageBody(tocEntries) },
+				title = strings.contentsTitle,
+				bodyBuilder = { tocPageBody(strings.contentsTitle, tocEntries) },
 			),
 		)
 
@@ -144,9 +143,9 @@ private fun buildXhtmlResource(
 		.apply { mediaType = MediaTypes.XHTML }
 }
 
-private fun BODY.tocPageBody(entries: List<TocEntry>) {
+private fun BODY.tocPageBody(contentsTitle: String, entries: List<TocEntry>) {
 	classes = setOf("toc-page")
-	h1(classes = "toc-title") { +TOC_TITLE }
+	h1(classes = "toc-title") { +contentsTitle }
 	nav(classes = "toc") {
 		ol(classes = "toc-list") {
 			entries.forEach { entry ->

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ExportStoryUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ExportStoryUseCase.kt
@@ -11,8 +11,12 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectDefaultD
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispatcher
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
+import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
+import com.darkrockstudios.apps.hammer.common.util.StrRes
+import com.darkrockstudios.apps.hammer.project_home_export_byline
+import com.darkrockstudios.apps.hammer.project_home_export_contents_title
 import kotlinx.coroutines.withContext
 import okio.Buffer
 import okio.FileSystem
@@ -54,6 +58,7 @@ class ExportStoryUseCase(
 	private val projectDataDatasource: ProjectDataDatasource,
 	private val fileSystem: FileSystem,
 	private val localeResolver: DeviceLocaleResolver,
+	private val strRes: StrRes,
 ) : KoinComponent {
 
 	private val ioDispatcher by injectIoDispatcher()
@@ -98,6 +103,8 @@ class ExportStoryUseCase(
 			ExportSource(perNodeChapters, projectData, language)
 		}
 
+		val exportStrings = resolveExportStrings(source.projectData)
+
 		return withContext(defaultDispatcher) {
 			val buffer = Buffer()
 			when (options.format) {
@@ -114,6 +121,7 @@ class ExportStoryUseCase(
 					projectData = source.requireProjectData(),
 					chapters = chaptersFor(options, projectName, source.perNodeChapters),
 					language = source.language,
+					strings = exportStrings,
 				)
 
 				ExportFormat.Pdf -> writeStoryAsPdf(
@@ -121,6 +129,7 @@ class ExportStoryUseCase(
 					projectName = projectName,
 					projectData = source.requireProjectData(),
 					chapters = chaptersFor(options, projectName, source.perNodeChapters),
+					strings = exportStrings,
 				)
 
 				ExportFormat.Docx -> writeStoryAsDocx(
@@ -128,6 +137,7 @@ class ExportStoryUseCase(
 					projectName = projectName,
 					projectData = source.requireProjectData(),
 					chapters = chaptersFor(options, projectName, source.perNodeChapters),
+					strings = exportStrings,
 				)
 
 				ExportFormat.Rtf -> writeStoryAsRtf(
@@ -135,10 +145,20 @@ class ExportStoryUseCase(
 					projectName = projectName,
 					projectData = source.requireProjectData(),
 					chapters = chaptersFor(options, projectName, source.perNodeChapters),
+					strings = exportStrings,
 				)
 			}
 			buffer
 		}
+	}
+
+	/** Resolves the user-facing strings that appear inside the exported document for the active locale. */
+	private suspend fun resolveExportStrings(projectData: ProjectData?): ExportStrings {
+		val authorName = projectData?.authorName?.takeIf { it.isNotBlank() }
+		return ExportStrings(
+			contentsTitle = strRes.get(Res.string.project_home_export_contents_title),
+			authorByline = authorName?.let { strRes.get(Res.string.project_home_export_byline, it) },
+		)
 	}
 
 	/** Per-node chapters when treating top-level scenes as chapters; otherwise a single chapter named after the project. */

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfProseMarkdown.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfProseMarkdown.kt
@@ -112,12 +112,6 @@ private val HEADING_LEVELS: Map<IElementType, Int> = mapOf(
 	MarkdownElementTypes.SETEXT_2 to 2,
 )
 
-/** CommonMark backslash escapes: `\X` for ASCII punctuation X resolves to bare X. */
-private val ESCAPE_REGEX = Regex("""\\([!-/:-@\[-`{-~])""")
-
-private fun String.resolveEscapes(): String =
-	if ('\\' in this) ESCAPE_REGEX.replace(this) { it.groupValues[1] } else this
-
 private class ProseWalker(private val source: String) {
 
 	fun blocks(root: ASTNode): List<ProseBlock> = root.children.mapNotNull { block(it) }
@@ -323,7 +317,7 @@ private class ProseWalker(private val source: String) {
 			-> out += span(" ", flags)
 
 			else -> if (node.children.isEmpty()) {
-				out += span(node.getTextInNode(source).toString().resolveEscapes(), flags)
+				out += span(unescapeMarkdown(node.getTextInNode(source)), flags)
 			} else {
 				node.children.forEach { collect(it, flags, out) }
 			}
@@ -345,7 +339,7 @@ private class ProseWalker(private val source: String) {
 		node.findChildOfType(MarkdownElementTypes.LINK_DESTINATION)
 			?.getTextInNode(source)?.toString()
 			?.removeSurrounding("<", ">")
-			?.resolveEscapes()
+			?.let { unescapeMarkdown(it) }
 			?.takeIf { it.isNotBlank() }
 
 	private fun trimEqualDelimiters(children: List<ASTNode>, delimiter: IElementType): List<ASTNode> {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfStoryRenderer.kt
@@ -9,8 +9,6 @@ import com.conamobile.pdfkmp.unit.sp
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import okio.BufferedSink
 
-private const val TOC_TITLE = "Contents"
-
 private fun chapterAnchorId(index: Int): String = "chapter-$index"
 
 /**
@@ -25,6 +23,7 @@ fun writeStoryAsPdf(
 	projectName: String,
 	projectData: ProjectData,
 	chapters: List<StoryChapter>,
+	strings: ExportStrings,
 ) {
 	val authorName = projectData.authorName?.takeIf { it.isNotBlank() }
 	val effective = chapters.ifEmpty { listOf(StoryChapter(projectName, "")) }
@@ -54,15 +53,15 @@ fun writeStoryAsPdf(
 			box(width = 200.dp) {
 				divider(thickness = 2.dp, color = primary ?: PdfColor.Gray)
 			}
-			authorName?.let {
+			strings.authorByline?.let {
 				spacer(height = 10.dp)
-				text("by $it") { fontSize = 16.sp; italic = true }
+				text(it) { fontSize = 16.sp; italic = true }
 			}
 		}
 
 		// Contents page — each row links to the matching chapter's anchor below.
 		page {
-			text(TOC_TITLE) {
+			text(strings.contentsTitle) {
 				fontSize = 26.sp
 				bold = true
 				primary?.let { color = it }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
@@ -29,19 +29,14 @@ import org.intellij.markdown.ast.getTextInNode
 import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
 import org.intellij.markdown.parser.MarkdownParser
 
-private const val TOC_TITLE = "Contents"
-
-private val BODY_FONT = RtfFont("Georgia", RtfFontFamily.Roman)
-private val MONO_FONT = RtfFont("Consolas", RtfFontFamily.Modern)
+private val BODY_FONT = RtfFont(EXPORT_BODY_FONT, RtfFontFamily.Roman)
+private val MONO_FONT = RtfFont(EXPORT_MONO_FONT, RtfFontFamily.Modern)
 
 // Font sizes in half-points; the body is 12pt to match the other exporters.
 private const val BODY_HALF_POINTS = 24
 private const val TITLE_HALF_POINTS = 72
 private const val AUTHOR_HALF_POINTS = 32
 private const val TOC_TITLE_HALF_POINTS = 48
-
-/** Heading 1..6 sizes in half-points, mirroring the DOCX renderer's scale. */
-private val HEADING_HALF_POINTS = listOf(48, 36, 32, 28, 26, 24)
 
 // Paragraph spacing/indent in twips (twentieths of a point); 1440 twips = 1 inch.
 private const val BODY_FIRST_LINE_INDENT = 360
@@ -51,8 +46,6 @@ private const val TITLE_SPACE_BEFORE = 3600
 private const val SECTION_SPACE = 240
 private const val QUOTE_INDENT = 720
 private const val LIST_INDENT_PER_LEVEL = 360
-
-private fun chapterBookmark(index: Int): String = "chapter${index + 1}"
 
 /**
  * Renders the story as a Rich Text Format (.rtf) document mirroring the EPUB/DOCX layout: a title
@@ -68,6 +61,7 @@ fun writeStoryAsRtf(
 	projectName: String,
 	projectData: ProjectData,
 	chapters: List<StoryChapter>,
+	strings: ExportStrings,
 ) {
 	val authorName = projectData.authorName?.takeIf { it.isNotBlank() }
 	val effective = chapters.ifEmpty { listOf(StoryChapter(projectName, "")) }
@@ -75,8 +69,8 @@ fun writeStoryAsRtf(
 	val secondary = themeColor(projectData.theme?.secondary)
 
 	val blocks = buildList {
-		addAll(titlePage(projectName, authorName, primary))
-		addAll(contentsPage(effective, primary))
+		addAll(titlePage(projectName, strings.authorByline, primary))
+		addAll(contentsPage(effective, strings.contentsTitle, primary))
 		effective.forEachIndexed { index, chapter -> addAll(chapterBlocks(index, chapter, primary, secondary)) }
 	}
 
@@ -91,7 +85,7 @@ fun writeStoryAsRtf(
 	sink.writeUtf8(RtfDocumentWriter().write(document))
 }
 
-private fun titlePage(projectName: String, authorName: String?, primary: RtfColor?): List<RtfBlock> = buildList {
+private fun titlePage(projectName: String, authorByline: String?, primary: RtfColor?): List<RtfBlock> = buildList {
 	add(
 		RtfParagraph(
 			content = listOf(
@@ -107,11 +101,11 @@ private fun titlePage(projectName: String, authorName: String?, primary: RtfColo
 			),
 		),
 	)
-	if (authorName != null) {
+	if (authorByline != null) {
 		add(
 			RtfParagraph(
 				content = listOf(
-					RtfTextRun("by $authorName", RtfSpanStyle(italic = true, fontSizeHalfPoints = AUTHOR_HALF_POINTS)),
+					RtfTextRun(authorByline, RtfSpanStyle(italic = true, fontSizeHalfPoints = AUTHOR_HALF_POINTS)),
 				),
 				style = RtfParagraphStyle(alignment = RtfAlignment.Center, spaceAfterTwips = SECTION_SPACE),
 			),
@@ -119,11 +113,11 @@ private fun titlePage(projectName: String, authorName: String?, primary: RtfColo
 	}
 }
 
-private fun contentsPage(chapters: List<StoryChapter>, primary: RtfColor?): List<RtfBlock> = buildList {
+private fun contentsPage(chapters: List<StoryChapter>, contentsTitle: String, primary: RtfColor?): List<RtfBlock> = buildList {
 	add(RtfPageBreak)
 	add(
 		RtfParagraph(
-			content = listOf(RtfTextRun(TOC_TITLE, RtfSpanStyle(bold = true, fontSizeHalfPoints = TOC_TITLE_HALF_POINTS))),
+			content = listOf(RtfTextRun(contentsTitle, RtfSpanStyle(bold = true, fontSizeHalfPoints = TOC_TITLE_HALF_POINTS))),
 			style = RtfParagraphStyle(
 				alignment = RtfAlignment.Center,
 				spaceBeforeTwips = SECTION_SPACE,
@@ -258,7 +252,7 @@ private class MarkdownRtfRenderer(
 					} else {
 						val literal = node.getTextInNode(source).toString()
 						if (literal.isNotBlank()) {
-							addParagraph(blockCtx, pendingMarker, listOf(RtfTextRun(unescape(literal), baseStyle(blockCtx))))
+							addParagraph(blockCtx, pendingMarker, listOf(RtfTextRun(unescapeMarkdown(literal), baseStyle(blockCtx))))
 							pendingMarker = null
 						}
 					}
@@ -296,7 +290,7 @@ private class MarkdownRtfRenderer(
 			.dropLastWhile { it.type == MarkdownTokenTypes.WHITE_SPACE }
 		val runs = when {
 			children.isNotEmpty() -> inlineRuns(children, style)
-			content != null -> listOf(RtfTextRun(unescape(content.getTextInNode(source).toString()).trim(), style))
+			content != null -> listOf(RtfTextRun(unescapeMarkdown(content.getTextInNode(source).toString()).trim(), style))
 			else -> emptyList()
 		}
 		blocks.add(
@@ -369,7 +363,7 @@ private class MarkdownRtfRenderer(
 
 				else -> {
 					if (node.children.isEmpty()) {
-						out.add(RtfTextRun(unescape(node.getTextInNode(source).toString()), style))
+						out.add(RtfTextRun(unescapeMarkdown(node.getTextInNode(source).toString()), style))
 					} else {
 						appendInline(out, node.children, style)
 					}
@@ -384,7 +378,7 @@ private class MarkdownRtfRenderer(
 				?.getTextInNode(source)?.toString()?.removeSurrounding("<", ">")
 		val linkText = node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_TEXT }
 		if (destination == null || linkText == null) {
-			out.add(RtfTextRun(unescape(node.getTextInNode(source).toString()), style))
+			out.add(RtfTextRun(unescapeMarkdown(node.getTextInNode(source).toString()), style))
 			return
 		}
 		val content = inlineRuns(
@@ -407,29 +401,13 @@ private class MarkdownRtfRenderer(
 	}
 
 	private fun codeFence(node: ASTNode) {
-		collectCodeLines(node, MarkdownTokenTypes.CODE_FENCE_CONTENT).forEach { codeParagraph(it) }
+		collectCodeLines(node, source, MarkdownTokenTypes.CODE_FENCE_CONTENT).forEach { codeParagraph(it) }
 	}
 
 	private fun codeBlock(node: ASTNode) {
-		collectCodeLines(node, MarkdownTokenTypes.CODE_LINE)
+		collectCodeLines(node, source, MarkdownTokenTypes.CODE_LINE)
 			.map { it.removePrefix("    ").removePrefix("\t") }
 			.forEach { codeParagraph(it) }
-	}
-
-	private fun collectCodeLines(node: ASTNode, contentType: Any): List<String> {
-		val lines = mutableListOf<String>()
-		val current = StringBuilder()
-		for (child in node.children) {
-			when (child.type) {
-				contentType -> current.append(child.getTextInNode(source))
-				MarkdownTokenTypes.EOL -> {
-					lines += current.toString()
-					current.clear()
-				}
-			}
-		}
-		if (current.isNotEmpty()) lines += current.toString()
-		return lines.dropWhile { it.isBlank() }.dropLastWhile { it.isBlank() }
 	}
 
 	private fun codeParagraph(line: String) {
@@ -464,29 +442,4 @@ private class MarkdownRtfRenderer(
 		return result
 	}
 
-	private fun List<ASTNode>.stripDelimiters(delimiterType: Any): List<ASTNode> =
-		dropWhile { it.type == delimiterType }.dropLastWhile { it.type == delimiterType }
-
-	/** Resolves CommonMark backslash escapes to their bare punctuation. */
-	private fun unescape(text: String): String {
-		if (!text.contains('\\')) return text
-		val sb = StringBuilder(text.length)
-		var i = 0
-		while (i < text.length) {
-			val c = text[i]
-			val next = if (i + 1 < text.length) text[i + 1] else null
-			if (c == '\\' && next != null && next in ASCII_PUNCTUATION) {
-				sb.append(next)
-				i += 2
-			} else {
-				sb.append(c)
-				i++
-			}
-		}
-		return sb.toString()
-	}
-
-	private companion object {
-		const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
-	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/StoryExportCommon.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/StoryExportCommon.kt
@@ -1,0 +1,76 @@
+package com.darkrockstudios.apps.hammer.common.components.projecthome
+
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.getTextInNode
+
+/**
+ * Localized strings that appear in the exported document body. Resolved once by the export use case
+ * (which has the suspending [com.darkrockstudios.apps.hammer.common.util.StrRes] context) and passed
+ * into each renderer, since the renderers themselves are not localization-aware.
+ *
+ * @param contentsTitle the heading of the table-of-contents page.
+ * @param authorByline the title-page byline (e.g. "by Jane Doe"), or null when there is no author.
+ */
+data class ExportStrings(
+	val contentsTitle: String,
+	val authorByline: String?,
+)
+
+// Shared layout vocabulary mirrored across the EPUB / DOCX / RTF / PDF exporters. Keeping these in one
+// place is what lets the "mirrored" exports actually stay in step when the layout is tuned.
+
+/** Prose and monospace font faces shared by the DOCX and RTF exporters. */
+internal const val EXPORT_BODY_FONT = "Georgia"
+internal const val EXPORT_MONO_FONT = "Consolas"
+
+/** Heading 1..6 sizes in half-points, shared by the DOCX and RTF exporters. */
+internal val HEADING_HALF_POINTS = listOf(48, 36, 32, 28, 26, 24)
+
+/** Bookmark / anchor name for the chapter at [index], the target of its Contents link. */
+internal fun chapterBookmark(index: Int): String = "chapter${index + 1}"
+
+// Shared markdown-AST helpers used by the renderers that walk intellij-markdown directly.
+
+private const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+
+/** Resolves CommonMark backslash escapes (`\*` → `*`) to their bare ASCII punctuation. */
+internal fun unescapeMarkdown(text: CharSequence): String {
+	if (!text.contains('\\')) return text.toString()
+	val sb = StringBuilder(text.length)
+	var i = 0
+	while (i < text.length) {
+		val c = text[i]
+		val next = if (i + 1 < text.length) text[i + 1] else null
+		if (c == '\\' && next != null && next in ASCII_PUNCTUATION) {
+			sb.append(next)
+			i += 2
+		} else {
+			sb.append(c)
+			i++
+		}
+	}
+	return sb.toString()
+}
+
+/** Drops the leading and trailing delimiter tokens (e.g. the `**` / `_` around a STRONG / EMPH span). */
+internal fun List<ASTNode>.stripDelimiters(delimiterType: IElementType): List<ASTNode> =
+	dropWhile { it.type == delimiterType }.dropLastWhile { it.type == delimiterType }
+
+/** Collects the lines of a fenced or indented code block, trimming leading and trailing blank lines. */
+internal fun collectCodeLines(node: ASTNode, source: String, contentType: IElementType): List<String> {
+	val lines = mutableListOf<String>()
+	val current = StringBuilder()
+	for (child in node.children) {
+		when (child.type) {
+			contentType -> current.append(child.getTextInNode(source))
+			MarkdownTokenTypes.EOL -> {
+				lines += current.toString()
+				current.clear()
+			}
+		}
+	}
+	if (current.isNotEmpty()) lines += current.toString()
+	return lines.dropWhile { it.isBlank() }.dropLastWhile { it.isBlank() }
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -172,6 +172,7 @@ val mainModule = module {
 				projectDataDatasource = get(),
 				fileSystem = get(named(RAW_FILESYSTEM)),
 				localeResolver = get(),
+				strRes = get(),
 			)
 		}
 		scopedOf(::SceneDraftsDatasource)

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
@@ -19,11 +19,13 @@ class RtfStoryRendererTest {
 		projectData: ProjectData = ProjectData(authorName = "Test Author"),
 	): String {
 		val buffer = Buffer()
+		val author = projectData.authorName?.takeIf { it.isNotBlank() }
 		writeStoryAsRtf(
 			sink = buffer,
 			projectName = projectName,
 			projectData = projectData,
 			chapters = chapters,
+			strings = ExportStrings(contentsTitle = "Contents", authorByline = author?.let { "by $it" }),
 		)
 		return buffer.readByteArray().decodeToString()
 	}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/StoryExportCommonTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/StoryExportCommonTest.kt
@@ -1,0 +1,39 @@
+package com.darkrockstudios.apps.hammer.common.components.projecthome
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StoryExportCommonTest {
+
+	@Test
+	fun `text without a backslash is returned unchanged`() {
+		val input = "Plain prose, no escapes."
+		assertEquals(input, unescapeMarkdown(input))
+	}
+
+	@Test
+	fun `backslash before ASCII punctuation resolves to the bare character`() {
+		assertEquals("*", unescapeMarkdown("\\*"))
+		assertEquals("_", unescapeMarkdown("\\_"))
+		assertEquals("#", unescapeMarkdown("\\#"))
+		assertEquals("\\", unescapeMarkdown("\\\\"))
+		assertEquals("[link]", unescapeMarkdown("\\[link\\]"))
+	}
+
+	@Test
+	fun `emphasis markers are unescaped inside a sentence`() {
+		assertEquals("use *stars* and _unders_", unescapeMarkdown("use \\*stars\\* and \\_unders\\_"))
+	}
+
+	@Test
+	fun `a backslash before a non-punctuation character is preserved`() {
+		// Only ASCII punctuation is a valid CommonMark escape; everything else keeps the backslash.
+		assertEquals("\\a", unescapeMarkdown("\\a"))
+		assertEquals("C:\\temp", unescapeMarkdown("C:\\temp"))
+	}
+
+	@Test
+	fun `a trailing backslash is preserved`() {
+		assertEquals("end\\", unescapeMarkdown("end\\"))
+	}
+}

--- a/common/src/desktopTest/kotlin/components/projecthome/DocxStoryRendererTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/DocxStoryRendererTest.kt
@@ -3,6 +3,7 @@ package components.projecthome
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectTheme
 import com.darkrockstudios.apps.hammer.common.components.projecthome.StoryChapter
+import com.darkrockstudios.apps.hammer.common.components.projecthome.ExportStrings
 import com.darkrockstudios.apps.hammer.common.components.projecthome.writeStoryAsDocx
 import okio.Buffer
 import org.apache.poi.xwpf.usermodel.XWPFDocument
@@ -23,11 +24,13 @@ class DocxStoryRendererTest {
 		projectData: ProjectData = ProjectData(authorName = "Test Author"),
 	): XWPFDocument {
 		val buffer = Buffer()
+		val author = projectData.authorName?.takeIf { it.isNotBlank() }
 		writeStoryAsDocx(
 			sink = buffer,
 			projectName = projectName,
 			projectData = projectData,
 			chapters = chapters,
+			strings = ExportStrings(contentsTitle = "Contents", authorByline = author?.let { "by $it" }),
 		)
 		return XWPFDocument(ByteArrayInputStream(buffer.readByteArray()))
 	}

--- a/common/src/desktopTest/kotlin/components/projecthome/EpubStoryRendererTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/EpubStoryRendererTest.kt
@@ -1,0 +1,88 @@
+package components.projecthome
+
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectTheme
+import com.darkrockstudios.apps.hammer.common.components.projecthome.ExportStrings
+import com.darkrockstudios.apps.hammer.common.components.projecthome.StoryChapter
+import com.darkrockstudios.apps.hammer.common.components.projecthome.writeStoryAsEpub
+import okio.Buffer
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class EpubStoryRendererTest {
+
+	/** Renders the EPUB and concatenates every text part (xhtml / opf / ncx / css) for content assertions. */
+	private fun render(
+		chapters: List<StoryChapter>,
+		projectName: String = "Test Project",
+		projectData: ProjectData = ProjectData(authorName = "Jane Doe"),
+	): String {
+		val buffer = Buffer()
+		val author = projectData.authorName?.takeIf { it.isNotBlank() }
+		writeStoryAsEpub(
+			sink = buffer,
+			projectName = projectName,
+			projectData = projectData,
+			chapters = chapters,
+			language = "en",
+			strings = ExportStrings(contentsTitle = "Contents", authorByline = author?.let { "by $it" }),
+		)
+
+		val sb = StringBuilder()
+		ZipInputStream(ByteArrayInputStream(buffer.readByteArray())).use { zis ->
+			var entry = zis.nextEntry
+			while (entry != null) {
+				if (!entry.isDirectory) sb.append(zis.readBytes().decodeToString()).append('\n')
+				entry = zis.nextEntry
+			}
+		}
+		return sb.toString()
+	}
+
+	@Test
+	fun `contents page carries the localized title`() {
+		val content = render(listOf(StoryChapter("Alpha", "Body.")))
+		assertTrue("Contents" in content, "The TOC title should appear in the EPUB")
+	}
+
+	@Test
+	fun `chapters appear with their names and body text`() {
+		val content = render(
+			listOf(
+				StoryChapter("Alpha", "First chapter body."),
+				StoryChapter("Beta", "Second chapter body."),
+			)
+		)
+		assertTrue("Alpha" in content, "First chapter name should appear")
+		assertTrue("Beta" in content, "Second chapter name should appear")
+		assertTrue("First chapter body." in content, "First chapter body should appear")
+		assertTrue("Second chapter body." in content, "Second chapter body should appear")
+	}
+
+	@Test
+	fun `author appears in the document`() {
+		val content = render(listOf(StoryChapter("Alpha", "Body.")))
+		assertTrue("Jane Doe" in content, "The author should appear in the EPUB")
+	}
+
+	@Test
+	fun `markdown emphasis becomes HTML strong and em`() {
+		val content = render(listOf(StoryChapter("Alpha", "A **bold** and _italic_ word.")))
+		assertTrue("<strong>bold</strong>" in content, "Strong markdown should become <strong>")
+		assertTrue("<em>italic</em>" in content, "Emphasis markdown should become <em>")
+	}
+
+	@Test
+	fun `theme accent color reaches the stylesheet`() {
+		val content = render(
+			listOf(StoryChapter("Alpha", "Body.")),
+			projectData = ProjectData(
+				authorName = "Jane",
+				theme = ProjectTheme(primary = "#FF112233", secondary = "#FFAABBCC"),
+			),
+		)
+		assertTrue("112233" in content, "The theme primary color should reach the stylesheet")
+	}
+}

--- a/common/src/desktopTest/kotlin/components/projecthome/ExportStoryUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/ExportStoryUseCaseTest.kt
@@ -10,11 +10,13 @@ import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
 import com.darkrockstudios.apps.hammer.common.util.Locale
+import com.darkrockstudios.apps.hammer.common.util.StrRes
 import integration.BaseIntegrationTest
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import org.jetbrains.compose.resources.StringResource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -25,6 +27,7 @@ class ExportStoryUseCaseTest : BaseIntegrationTest() {
 	private lateinit var projectDataDatasource: ProjectDataDatasource
 	private lateinit var storedProjectData: StoredProjectData
 	private lateinit var localeResolver: DeviceLocaleResolver
+	private lateinit var strRes: StrRes
 
 	@BeforeEach
 	override fun setup() {
@@ -37,6 +40,7 @@ class ExportStoryUseCaseTest : BaseIntegrationTest() {
 		localeResolver = mockk {
 			every { getCurrentLocale() } returns Locale.forLanguageTag("en-US")
 		}
+		strRes = mockk(relaxed = true)
 	}
 
 	private suspend fun initRepo() {
@@ -48,6 +52,7 @@ class ExportStoryUseCaseTest : BaseIntegrationTest() {
 		projectDataDatasource = projectDataDatasource,
 		fileSystem = ffs,
 		localeResolver = localeResolver,
+		strRes = strRes,
 	)
 
 	@Test
@@ -141,6 +146,29 @@ class ExportStoryUseCaseTest : BaseIntegrationTest() {
 		assertTrue(text.length > 100, "RTF output should be more than a stub, got ${text.length} chars")
 		// Every RTF document starts with the "{\rtf1" signature.
 		assertTrue(text.startsWith("{\\rtf1"), "RTF should start with the {\\rtf1 signature")
+	}
+
+	@Test
+	fun `exported document text comes from the localization system`() = runTest {
+		initRepo()
+		storedProjectData = StoredProjectData(data = ProjectData(authorName = "Ada"))
+		strRes = object : StrRes {
+			override suspend fun get(str: StringResource): String = "TOC_SENTINEL"
+			override suspend fun get(str: StringResource, vararg args: Any): String =
+				"BYLINE_SENTINEL ${args.joinToString()}"
+		}
+
+		val exportPath = useCase().execute(
+			exportDir = projectPath,
+			options = ExportOptions(format = ExportFormat.Rtf, treatTopLevelAsChapters = true),
+		)
+
+		val text = ffs.read(exportPath.toOkioPath()) { readByteArray() }.decodeToString()
+		assertTrue("TOC_SENTINEL" in text, "Contents title should be resolved via StrRes, got: $text")
+		assertTrue(
+			"BYLINE_SENTINEL Ada" in text,
+			"Author byline should be resolved via StrRes with the author name, got: $text",
+		)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/components/projecthome/PdfProseVisualCheck.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/PdfProseVisualCheck.kt
@@ -2,6 +2,7 @@ package components.projecthome
 
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectTheme
+import com.darkrockstudios.apps.hammer.common.components.projecthome.ExportStrings
 import com.darkrockstudios.apps.hammer.common.components.projecthome.StoryChapter
 import com.darkrockstudios.apps.hammer.common.components.projecthome.writeStoryAsPdf
 import okio.FileSystem
@@ -40,7 +41,13 @@ class PdfProseVisualCheck {
 			theme = ProjectTheme(primary = "#FF6750A4", secondary = "#FF7D5260"),
 		)
 		FileSystem.SYSTEM.write(out) {
-			writeStoryAsPdf(this, "Indent Check", projectData, chapters)
+			writeStoryAsPdf(
+				this,
+				"Indent Check",
+				projectData,
+				chapters,
+				ExportStrings(contentsTitle = "Contents", authorByline = "by Test Author"),
+			)
 		}
 		println("Wrote $out")
 	}


### PR DESCRIPTION
## What

Two related cleanups to the story-export renderers (RTF / DOCX / PDF / EPUB), surfaced by a code review of the RTF-export PR (#667).

### 1. Unify the duplicated markdown/layout handling

The exporters had grown three near-identical copies of the markdown helpers and several copies of the layout constants. Extracted into a shared `StoryExportCommon`:

- **Helpers:** `unescapeMarkdown` (CommonMark backslash escapes), `stripDelimiters`, `collectCodeLines` — were duplicated verbatim across RTF/DOCX and a third regex variant in PDF.
- **Layout vocabulary:** the Contents title, heading-size scale, body/mono font names, and `chapterBookmark` — were copy-pasted between the renderers that are documented as mirroring each other's layout.

The renderers shrank notably (DocxStoryRenderer −88, RtfStoryRenderer −79 net).

**Deliberately out of scope:** migrating RTF/DOCX onto the PDF path's `parseProseMarkdown`/`ProseBlock` model. That model flattens nested lists (losing the indent level RTF/DOCX track) and uses GFM vs the renderers' CommonMark, so adopting it would be a behavior regression. Left as a possible future change.

### 2. Localize the exported document strings

The two user-facing strings that land *in the exported file* — the "Contents" heading and the "by &lt;author&gt;" byline — were hardcoded English. They now come from the localization system: `ExportStoryUseCase` resolves them via the injected `StrRes` and passes an `ExportStrings` into each renderer, so they follow the device locale. (EPUB shows the raw author name with no "by" prefix, so it only takes the contents title.)

New string resources: `project_home_export_contents_title`, `project_home_export_byline`.

## Tests

- `StoryExportCommonTest` — direct coverage for the shared escape helper.
- `EpubStoryRendererTest` — **new** content-level coverage (unzips the EPUB and asserts the contents title, chapter names/bodies, author, `<strong>`/`<em>`, theme color). EPUB previously had only a magic-bytes check.
- An end-to-end use-case test that the exported strings are resolved through `StrRes`.
- Existing RTF/DOCX renderer and export-use-case tests updated for the new parameter; full `:common:desktopTest` is green.