### PR TITLE
Render RTF and DOCX exports through the shared prose model

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
@@ -11,12 +11,7 @@ import nl.adaptivity.xmlutil.smartStartTag
 import no.synth.kmpzip.zip.ZipEntry
 import no.synth.kmpzip.zip.ZipOutputStream
 import okio.BufferedSink
-import org.intellij.markdown.MarkdownElementTypes
-import org.intellij.markdown.MarkdownTokenTypes
-import org.intellij.markdown.ast.ASTNode
-import org.intellij.markdown.ast.getTextInNode
 import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
-import org.intellij.markdown.parser.MarkdownParser
 import no.synth.kmpzip.okio.ZipOutputStream as OkioZipOutputStream
 
 private const val W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -503,7 +498,7 @@ private fun XmlWriter.writeChapter(ctx: DocxRenderContext, index: Int, chapter: 
 		w("bookmarkEnd") { wAttr("id", index.toString()) }
 	}
 	if (chapter.markdown.isNotBlank()) {
-		MarkdownDocxWriter(this, ctx, chapter.markdown).render()
+		MarkdownDocxWriter(this, ctx).render(chapter.markdown)
 	}
 }
 
@@ -513,204 +508,95 @@ private fun XmlWriter.writeChapter(ctx: DocxRenderContext, index: Int, chapter: 
  * properties reflect the state at its text's position; literal text accumulates in a buffer
  * that flushes as a single run whenever the state changes.
  */
+/**
+ * Renders a chapter's markdown into WordprocessingML by consuming the shared [parseProseMarkdown]
+ * model (CommonMark flavour) and streaming `<w:p>` / `<w:r>` into [writer]. Block kinds map onto
+ * paragraph styles; inline spans become runs, with consecutive same-link spans wrapped in one
+ * `<w:hyperlink>` (its URL registered with [ctx] in document order) and `\n` hard breaks split into
+ * `<w:br/>`.
+ */
 private class MarkdownDocxWriter(
 	private val writer: XmlWriter,
 	private val ctx: DocxRenderContext,
-	private val source: String,
 ) {
-	private var boldDepth = 0
-	private var italicDepth = 0
-	private var inHyperlink = false
-	private var listDepth = -1
-	private val textBuffer = StringBuilder()
-
-	private data class NumPr(val numId: Int, val ilvl: Int)
-	private data class BlockContext(val style: String? = null, val numbering: NumPr? = null)
-
-	fun render() {
-		val tree = MarkdownParser(CommonMarkFlavourDescriptor()).buildMarkdownTreeFromString(source)
-		renderBlocks(tree.children, BlockContext())
-	}
-
-	private fun renderBlocks(nodes: List<ASTNode>, blockCtx: BlockContext) {
-		// Only the first paragraph of a list item carries the number; trailing blocks flow under it.
-		var pendingNumbering = blockCtx.numbering
-		for (node in nodes) {
-			when (node.type) {
-				MarkdownElementTypes.PARAGRAPH -> {
-					paragraph(blockCtx.style, pendingNumbering) { renderInline(node.children) }
-					pendingNumbering = null
+	fun render(markdown: String) {
+		for (block in parseProseMarkdown(markdown, CommonMarkFlavourDescriptor())) {
+			when (block) {
+				is ProseBlock.Paragraph -> paragraph(style = null, numId = null) { runs(block.spans) }
+				is ProseBlock.Heading -> paragraph(style = "Heading${block.level}", numId = null) { runs(block.spans) }
+				is ProseBlock.Listing -> {
+					val numbering = DocxListNumbering(ctx)
+					block.items.forEach { item ->
+						val (numId, ilvl) = numbering.numbering(item)
+						paragraph(style = null, numId = numId, ilvl = ilvl) { runs(item.spans) }
+					}
 				}
 
-				MarkdownElementTypes.ATX_1 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 1)
-				MarkdownElementTypes.ATX_2 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 2)
-				MarkdownElementTypes.ATX_3 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 3)
-				MarkdownElementTypes.ATX_4 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 4)
-				MarkdownElementTypes.ATX_5 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 5)
-				MarkdownElementTypes.ATX_6 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 6)
-				MarkdownElementTypes.SETEXT_1 -> heading(node, MarkdownTokenTypes.SETEXT_CONTENT, 1)
-				MarkdownElementTypes.SETEXT_2 -> heading(node, MarkdownTokenTypes.SETEXT_CONTENT, 2)
+				is ProseBlock.Quote -> block.paragraphs.forEach { paragraph(style = "Quote", numId = null) { runs(it) } }
+				is ProseBlock.CodeBlock -> codeBlockLines(block.code).forEach { codeParagraph(it) }
+				ProseBlock.Rule -> horizontalRule()
+				is ProseBlock.Table -> tableFallback(block)
+			}
+		}
+	}
 
-				MarkdownElementTypes.BLOCK_QUOTE -> renderBlocks(
-					node.children,
-					blockCtx.copy(style = "Quote")
-				)
+	/** Emits runs for [spans], wrapping consecutive same-link spans in one `<w:hyperlink>`. */
+	private fun runs(spans: List<ProseSpan>) {
+		var i = 0
+		while (i < spans.size) {
+			val link = spans[i].link
+			if (link != null) {
+				val relId = ctx.addHyperlink(link)
+				writer.w("hyperlink") {
+					attribute(R_NS, "id", "r", relId)
+					while (i < spans.size && spans[i].link == link) {
+						emitSpan(spans[i], hyperlink = true)
+						i++
+					}
+				}
+			} else {
+				emitSpan(spans[i], hyperlink = false)
+				i++
+			}
+		}
+	}
 
-				MarkdownElementTypes.UNORDERED_LIST -> renderList(node, ordered = false, blockCtx)
-				MarkdownElementTypes.ORDERED_LIST -> renderList(node, ordered = true, blockCtx)
+	private fun emitSpan(span: ProseSpan, hyperlink: Boolean) {
+		// A hard break rides in span text as '\n'; emit a <w:br/> between the surrounding fragments.
+		span.text.split("\n").forEachIndexed { index, part ->
+			if (index > 0) writer.w("r") { w("br") }
+			if (part.isNotEmpty()) emitRun(part, span, hyperlink)
+		}
+	}
 
-				MarkdownElementTypes.CODE_FENCE -> codeFence(node)
-				MarkdownElementTypes.CODE_BLOCK -> codeBlock(node)
-				MarkdownElementTypes.LINK_DEFINITION -> Unit
-
-				MarkdownTokenTypes.HORIZONTAL_RULE -> horizontalRule()
-
-				MarkdownTokenTypes.EOL,
-				MarkdownTokenTypes.WHITE_SPACE,
-				MarkdownTokenTypes.BLOCK_QUOTE,
-				MarkdownTokenTypes.LIST_BULLET,
-				MarkdownTokenTypes.LIST_NUMBER,
-					-> Unit
-
-				else -> {
-					if (node.children.isNotEmpty()) {
-						renderBlocks(node.children, blockCtx)
-					} else {
-						val literal = node.getTextInNode(source).toString()
-						if (literal.isNotBlank()) {
-							paragraph(blockCtx.style, pendingNumbering) { appendText(literal) }
-							pendingNumbering = null
+	private fun emitRun(text: String, span: ProseSpan, hyperlink: Boolean) {
+		writer.w("r") {
+			val needsProps = span.code || hyperlink || span.bold || span.italic || span.strikethrough
+			if (needsProps) {
+				w("rPr") {
+					if (hyperlink) wVal("rStyle", "Hyperlink")
+					if (span.code) {
+						w("rFonts") {
+							wAttr("ascii", EXPORT_MONO_FONT)
+							wAttr("hAnsi", EXPORT_MONO_FONT)
+							wAttr("cs", EXPORT_MONO_FONT)
 						}
 					}
+					if (span.bold) w("b")
+					if (span.italic) w("i")
+					if (span.strikethrough) w("strike")
 				}
 			}
-		}
-	}
-
-	private fun renderList(node: ASTNode, ordered: Boolean, blockCtx: BlockContext) {
-		listDepth++
-		val numId = if (ordered) ctx.newOrderedList(listDepth) else BULLET_NUM_ID
-		node.children
-			.filter { it.type == MarkdownElementTypes.LIST_ITEM }
-			.forEach { item ->
-				renderBlocks(item.children, blockCtx.copy(numbering = NumPr(numId, listDepth)))
-			}
-		listDepth--
-	}
-
-	private fun heading(node: ASTNode, contentType: Any, level: Int) {
-		val content = node.children.firstOrNull { it.type == contentType }
-		paragraph(style = "Heading$level", numPr = null) {
-			val children = content?.children.orEmpty()
-				.dropWhile { it.type == MarkdownTokenTypes.WHITE_SPACE }
-				.dropLastWhile { it.type == MarkdownTokenTypes.WHITE_SPACE }
-			if (children.isNotEmpty()) {
-				renderInline(children)
-			} else {
-				content?.let { appendText(unescapeMarkdown(it.getTextInNode(source)).trim()) }
+			w("t") {
+				preserveSpace()
+				text(text)
 			}
 		}
-	}
-
-	private fun renderInline(nodes: List<ASTNode>) {
-		for (node in nodes) {
-			when (node.type) {
-				MarkdownElementTypes.STRONG -> formatted(bold = true) {
-					renderInline(node.children.stripDelimiters(MarkdownTokenTypes.EMPH))
-				}
-
-				MarkdownElementTypes.EMPH -> formatted(italic = true) {
-					renderInline(node.children.stripDelimiters(MarkdownTokenTypes.EMPH))
-				}
-
-				MarkdownElementTypes.CODE_SPAN -> {
-					flushRun()
-					val code = node.children
-						.filter { it.type != MarkdownTokenTypes.BACKTICK }
-						.joinToString("") { it.getTextInNode(source) }
-					emitRun(code.removeSurrounding(" "), code = true)
-				}
-
-				MarkdownElementTypes.INLINE_LINK -> inlineLink(node)
-				MarkdownElementTypes.AUTOLINK -> autoLink(node)
-
-				MarkdownTokenTypes.HARD_LINE_BREAK -> {
-					flushRun()
-					writer.w("r") { w("br") }
-				}
-
-				MarkdownTokenTypes.EOL -> appendText(" ")
-
-				else -> {
-					if (node.children.isEmpty()) {
-						appendText(unescapeMarkdown(node.getTextInNode(source)))
-					} else {
-						renderInline(node.children)
-					}
-				}
-			}
-		}
-	}
-
-	private fun formatted(bold: Boolean = false, italic: Boolean = false, body: () -> Unit) {
-		flushRun()
-		if (bold) boldDepth++
-		if (italic) italicDepth++
-		body()
-		flushRun()
-		if (bold) boldDepth--
-		if (italic) italicDepth--
-	}
-
-	private fun inlineLink(node: ASTNode) {
-		val destination =
-			node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_DESTINATION }
-				?.getTextInNode(source)?.toString()?.removeSurrounding("<", ">")
-		val linkText = node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_TEXT }
-		if (destination == null || linkText == null) {
-			appendText(node.getTextInNode(source))
-			return
-		}
-		hyperlink(destination) {
-			renderInline(
-				linkText.children.filter {
-					it.type != MarkdownTokenTypes.LBRACKET && it.type != MarkdownTokenTypes.RBRACKET
-				}
-			)
-		}
-	}
-
-	private fun autoLink(node: ASTNode) {
-		val url = node.getTextInNode(source).toString().removeSurrounding("<", ">")
-		hyperlink(url) { appendText(url) }
-	}
-
-	private fun hyperlink(url: String, body: () -> Unit) {
-		flushRun()
-		val relId = ctx.addHyperlink(url)
-		writer.w("hyperlink") {
-			attribute(R_NS, "id", "r", relId)
-			inHyperlink = true
-			body()
-			flushRun()
-			inHyperlink = false
-		}
-	}
-
-	private fun codeFence(node: ASTNode) {
-		val lines = collectCodeLines(node, source, MarkdownTokenTypes.CODE_FENCE_CONTENT)
-		lines.forEach { codeParagraph(it) }
-	}
-
-	private fun codeBlock(node: ASTNode) {
-		val lines = collectCodeLines(node, source, MarkdownTokenTypes.CODE_LINE)
-			.map { it.removePrefix("    ").removePrefix("\t") }
-		lines.forEach { codeParagraph(it) }
 	}
 
 	private fun codeParagraph(line: String) {
 		writer.w("p") {
-			this@MarkdownDocxWriter.emitRun(line, code = true)
+			this@MarkdownDocxWriter.emitRun(line, ProseSpan(text = line, code = true), hyperlink = false)
 		}
 	}
 
@@ -729,59 +615,60 @@ private class MarkdownDocxWriter(
 		}
 	}
 
-	private fun paragraph(style: String?, numPr: NumPr?, body: () -> Unit) {
+	/** Tab-separated text fallback for tables (never produced under CommonMark; defensive). */
+	private fun tableFallback(block: ProseBlock.Table) {
+		(listOf(block.header) + block.rows).forEach { row ->
+			paragraph(style = null, numId = null) {
+				row.forEachIndexed { index, cell ->
+					if (index > 0) writer.w("r") { w("t") { text("\t") } }
+					runs(cell)
+				}
+			}
+		}
+	}
+
+	private fun paragraph(style: String?, numId: Int?, ilvl: Int = 0, body: () -> Unit) {
 		// Plain prose gets the first-line-indented body style; numbered paragraphs control their own indent.
-		val effectiveStyle = style ?: if (numPr == null) "BodyText" else null
+		val effectiveStyle = style ?: if (numId == null) "BodyText" else null
 		writer.w("p") {
-			if (effectiveStyle != null || numPr != null) {
+			if (effectiveStyle != null || numId != null) {
 				w("pPr") {
 					effectiveStyle?.let { wVal("pStyle", it) }
-					numPr?.let {
+					if (numId != null) {
 						w("numPr") {
-							wVal("ilvl", it.ilvl.toString())
-							wVal("numId", it.numId.toString())
+							wVal("ilvl", ilvl.toString())
+							wVal("numId", numId.toString())
 						}
 					}
 				}
 			}
 			body()
-			this@MarkdownDocxWriter.flushRun()
 		}
 	}
+}
 
-	private fun appendText(text: CharSequence) {
-		textBuffer.append(text)
-	}
+/**
+ * Allocates Word numbering for a single [ProseBlock.Listing]. Bullet items share [BULLET_NUM_ID];
+ * each ordered sublist gets its own `numId` (via [DocxRenderContext.newOrderedList]) so its numbering
+ * restarts. Items arrive flattened in reading order, so descending into a level allocates a fresh
+ * ordered instance and ascending drops the deeper ones.
+ */
+private class DocxListNumbering(private val ctx: DocxRenderContext) {
+	private val orderedNumIdByLevel = mutableMapOf<Int, Int>()
+	private var lastLevel = -1
 
-	private fun flushRun() {
-		if (textBuffer.isEmpty()) return
-		val text = textBuffer.toString()
-		textBuffer.clear()
-		emitRun(text)
-	}
-
-	private fun emitRun(text: String, code: Boolean = false) {
-		writer.w("r") {
-			val needsProps = code || inHyperlink || boldDepth > 0 || italicDepth > 0
-			if (needsProps) {
-				w("rPr") {
-					if (inHyperlink) wVal("rStyle", "Hyperlink")
-					if (code) {
-						w("rFonts") {
-							wAttr("ascii", EXPORT_MONO_FONT)
-							wAttr("hAnsi", EXPORT_MONO_FONT)
-							wAttr("cs", EXPORT_MONO_FONT)
-						}
-					}
-					if (boldDepth > 0) w("b")
-					if (italicDepth > 0) w("i")
-				}
-			}
-			w("t") {
-				preserveSpace()
-				text(text)
-			}
+	/** Returns the `(numId, ilvl)` for [item]. */
+	fun numbering(item: ProseListItem): Pair<Int, Int> {
+		val level = item.level
+		if (level < lastLevel) {
+			orderedNumIdByLevel.keys.filter { it > level }.toList().forEach(orderedNumIdByLevel::remove)
 		}
+		val numId = if (item.ordered) {
+			orderedNumIdByLevel.getOrPut(level) { ctx.newOrderedList(level) }
+		} else {
+			BULLET_NUM_ID
+		}
+		lastLevel = level
+		return numId to level
 	}
-
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
@@ -11,7 +11,6 @@ import nl.adaptivity.xmlutil.smartStartTag
 import no.synth.kmpzip.zip.ZipEntry
 import no.synth.kmpzip.zip.ZipOutputStream
 import okio.BufferedSink
-import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
 import no.synth.kmpzip.okio.ZipOutputStream as OkioZipOutputStream
 
 private const val W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -503,24 +502,17 @@ private fun XmlWriter.writeChapter(ctx: DocxRenderContext, index: Int, chapter: 
 }
 
 /**
- * Walks the markdown AST and streams WordprocessingML paragraphs and runs. Inline formatting
- * is carried as nesting state (bold/italic depth, hyperlink scope) so each emitted run's
- * properties reflect the state at its text's position; literal text accumulates in a buffer
- * that flushes as a single run whenever the state changes.
- */
-/**
  * Renders a chapter's markdown into WordprocessingML by consuming the shared [parseProseMarkdown]
- * model (CommonMark flavour) and streaming `<w:p>` / `<w:r>` into [writer]. Block kinds map onto
- * paragraph styles; inline spans become runs, with consecutive same-link spans wrapped in one
- * `<w:hyperlink>` (its URL registered with [ctx] in document order) and `\n` hard breaks split into
- * `<w:br/>`.
+ * model and streaming `<w:p>` / `<w:r>` into [writer]. Block kinds map onto paragraph styles; inline
+ * spans become runs, with consecutive same-link spans wrapped in one `<w:hyperlink>` (its URL
+ * registered with [ctx] in document order) and `\n` hard breaks split into `<w:br/>`.
  */
 private class MarkdownDocxWriter(
 	private val writer: XmlWriter,
 	private val ctx: DocxRenderContext,
 ) {
 	fun render(markdown: String) {
-		for (block in parseProseMarkdown(markdown, CommonMarkFlavourDescriptor())) {
+		for (block in parseProseMarkdown(markdown)) {
 			when (block) {
 				is ProseBlock.Paragraph -> paragraph(style = null, numId = null) { runs(block.spans) }
 				is ProseBlock.Heading -> paragraph(style = "Heading${block.level}", numId = null) { runs(block.spans) }
@@ -615,7 +607,7 @@ private class MarkdownDocxWriter(
 		}
 	}
 
-	/** Tab-separated text fallback for tables (never produced under CommonMark; defensive). */
+	/** Tab-separated text fallback for GFM pipe tables, which the export has no real table layout for yet. */
 	private fun tableFallback(block: ProseBlock.Table) {
 		(listOf(block.header) + block.rows).forEach { row ->
 			paragraph(style = null, numId = null) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/EpubStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/EpubStoryRenderer.kt
@@ -7,7 +7,7 @@ import io.documentnode.epub4kmp.epub.EpubWriter
 import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
 import okio.BufferedSink
-import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
 
@@ -94,6 +94,7 @@ private fun buildStylesheet(theme: ProjectTheme?): Stylesheet = stylesheet {
 		nav.toc ol.toc-list { list-style: none; padding: 0; margin: 0; }
 		nav.toc li.toc-item { margin: 0.6em 0; text-indent: 0; }
 		nav.toc li.toc-item a { text-decoration: none; }
+		.user-del { text-decoration: line-through; }
 		""".trimIndent(),
 	)
 
@@ -170,7 +171,7 @@ private fun BODY.titlePageBody(projectName: String, authorName: String?) {
 
 private fun BODY.chapterBody(chapterTitle: String, markdown: String) {
 	h1(classes = "chapter-title") { +chapterTitle }
-	val flavour = CommonMarkFlavourDescriptor()
+	val flavour = GFMFlavourDescriptor()
 	val parsed = MarkdownParser(flavour).buildMarkdownTreeFromString(markdown)
 	val htmlBody = HtmlGenerator(markdown, parsed, flavour).generateHtml()
 	val xhtmlBody = htmlBody.selfCloseHtmlVoidTags()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfProseMarkdown.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfProseMarkdown.kt
@@ -20,7 +20,6 @@ import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.ast.getTextInNode
-import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
@@ -104,15 +103,11 @@ internal sealed interface ProseBlock {
 }
 
 /**
- * Parses [markdown] into renderable blocks. Defaults to GFM (so `~~strike~~` and pipe tables work);
- * pass [CommonMarkFlavourDescriptor][org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor]
- * to match the CommonMark renderers. Unknown syntax degrades to paragraph text.
+ * Parses [markdown] into renderable blocks using the GFM flavour, so `~~strike~~`, pipe tables, and
+ * autolinks are recognized. Unknown syntax degrades to paragraph text.
  */
-internal fun parseProseMarkdown(
-	markdown: String,
-	flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
-): List<ProseBlock> {
-	val root = MarkdownParser(flavour).buildMarkdownTreeFromString(markdown)
+internal fun parseProseMarkdown(markdown: String): List<ProseBlock> {
+	val root = MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(markdown)
 	return ProseWalker(markdown).blocks(root)
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfProseMarkdown.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfProseMarkdown.kt
@@ -20,6 +20,7 @@ import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.ast.getTextInNode
+import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
@@ -80,20 +81,38 @@ internal data class ProseSpan(
 	val link: String? = null,
 )
 
-/** A block-level markdown element, reduced to what the PDF prose layout renders. */
+/**
+ * One item of a [ProseBlock.Listing]. Nested lists are flattened into the parent's [items] in reading
+ * order, but each item keeps its own [level] (0-based nesting depth) and [ordered] flag so consumers
+ * can reconstruct indentation and markers.
+ */
+internal data class ProseListItem(
+	val spans: List<ProseSpan>,
+	val level: Int,
+	val ordered: Boolean,
+)
+
+/** A block-level markdown element, reduced to what the prose layout renders. */
 internal sealed interface ProseBlock {
 	data class Paragraph(val spans: List<ProseSpan>) : ProseBlock
 	data class Heading(val level: Int, val spans: List<ProseSpan>) : ProseBlock
-	data class Listing(val ordered: Boolean, val items: List<List<ProseSpan>>) : ProseBlock
+	data class Listing(val ordered: Boolean, val items: List<ProseListItem>) : ProseBlock
 	data class Quote(val paragraphs: List<List<ProseSpan>>) : ProseBlock
 	data class CodeBlock(val code: String) : ProseBlock
 	data object Rule : ProseBlock
 	data class Table(val header: List<List<ProseSpan>>, val rows: List<List<List<ProseSpan>>>) : ProseBlock
 }
 
-/** Parses [markdown] (GFM flavour) into renderable blocks. Unknown syntax degrades to paragraph text. */
-internal fun parseProseMarkdown(markdown: String): List<ProseBlock> {
-	val root = MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(markdown)
+/**
+ * Parses [markdown] into renderable blocks. Defaults to GFM (so `~~strike~~` and pipe tables work);
+ * pass [CommonMarkFlavourDescriptor][org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor]
+ * to match the CommonMark renderers. Unknown syntax degrades to paragraph text.
+ */
+internal fun parseProseMarkdown(
+	markdown: String,
+	flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
+): List<ProseBlock> {
+	val root = MarkdownParser(flavour).buildMarkdownTreeFromString(markdown)
 	return ProseWalker(markdown).blocks(root)
 }
 
@@ -122,8 +141,11 @@ private class ProseWalker(private val source: String) {
 
 		in HEADING_LEVELS -> heading(node)
 
-		MarkdownElementTypes.UNORDERED_LIST -> ProseBlock.Listing(ordered = false, items = listItems(node))
-		MarkdownElementTypes.ORDERED_LIST -> ProseBlock.Listing(ordered = true, items = listItems(node))
+		MarkdownElementTypes.UNORDERED_LIST ->
+			ProseBlock.Listing(ordered = false, items = listItems(node, level = 0, ordered = false))
+
+		MarkdownElementTypes.ORDERED_LIST ->
+			ProseBlock.Listing(ordered = true, items = listItems(node, level = 0, ordered = true))
 
 		MarkdownElementTypes.BLOCK_QUOTE ->
 			quoteParagraphs(node).ifEmpty { null }?.let { ProseBlock.Quote(it) }
@@ -152,31 +174,36 @@ private class ProseWalker(private val source: String) {
 		return ProseBlock.Heading(level = HEADING_LEVELS.getValue(node.type), spans = spans)
 	}
 
-	private fun listItems(listNode: ASTNode): List<List<ProseSpan>> {
-		val items = mutableListOf<List<ProseSpan>>()
+	private fun listItems(listNode: ASTNode, level: Int, ordered: Boolean): List<ProseListItem> {
+		val items = mutableListOf<ProseListItem>()
 		for (item in listNode.children) {
 			if (item.type != MarkdownElementTypes.LIST_ITEM) continue
 			val spans = mutableListOf<ProseSpan>()
+			fun flush() {
+				if (spans.isNotEmpty()) {
+					items += ProseListItem(spans.toList(), level = level, ordered = ordered)
+					spans.clear()
+				}
+			}
 			for (child in item.children) {
 				when (child.type) {
 					MarkdownElementTypes.PARAGRAPH -> {
 						if (spans.isNotEmpty()) spans += ProseSpan("\n")
 						spans += inline(child)
 					}
-					// Nested lists are flattened into follow-on items.
-					MarkdownElementTypes.UNORDERED_LIST,
-					MarkdownElementTypes.ORDERED_LIST,
-					-> {
-						if (spans.isNotEmpty()) {
-							items += spans.toList()
-							spans.clear()
-						}
-						items += listItems(child)
+					// Nested lists keep reading order: emit this item's text, then the deeper items.
+					MarkdownElementTypes.UNORDERED_LIST -> {
+						flush()
+						items += listItems(child, level = level + 1, ordered = false)
+					}
+					MarkdownElementTypes.ORDERED_LIST -> {
+						flush()
+						items += listItems(child, level = level + 1, ordered = true)
 					}
 					else -> Unit
 				}
 			}
-			if (spans.isNotEmpty()) items += spans.toList()
+			flush()
 		}
 		return items
 	}
@@ -462,7 +489,7 @@ private fun ContainerScope.renderListing(block: ProseBlock.Listing, base: TextSt
 					richText {
 						defaultSpanStyle = base
 						lineHeight = base.lineHeight
-						for (s in item) span(s.text) { applyFlags(s, colors) }
+						for (s in item.spans) span(s.text) { applyFlags(s, colors) }
 					}
 				}
 			}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
@@ -15,19 +15,14 @@ import com.darkrockstudios.libs.rtfparserkmp.writer.RtfHyperlink
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfHyperlinkKind
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfInfo
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfInline
-import com.darkrockstudios.libs.rtfparserkmp.writer.RtfLineBreak
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfPageBreak
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfParagraph
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfParagraphStyle
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfSpanStyle
+import com.darkrockstudios.libs.rtfparserkmp.writer.RtfTab
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfTextRun
 import okio.BufferedSink
-import org.intellij.markdown.MarkdownElementTypes
-import org.intellij.markdown.MarkdownTokenTypes
-import org.intellij.markdown.ast.ASTNode
-import org.intellij.markdown.ast.getTextInNode
 import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
-import org.intellij.markdown.parser.MarkdownParser
 
 private val BODY_FONT = RtfFont(EXPORT_BODY_FONT, RtfFontFamily.Roman)
 private val MONO_FONT = RtfFont(EXPORT_MONO_FONT, RtfFontFamily.Modern)
@@ -170,7 +165,7 @@ private fun chapterBlocks(
 		),
 	)
 	if (chapter.markdown.isNotBlank()) {
-		addAll(MarkdownRtfRenderer(chapter.markdown, primary, secondary).render())
+		addAll(renderMarkdownRtf(chapter.markdown, primary, secondary))
 	}
 }
 
@@ -182,264 +177,166 @@ private fun themeColor(argb: String?): RtfColor? {
 }
 
 /**
- * Walks the markdown AST and produces [RtfBlock]s. Inline formatting is flattened into [RtfTextRun]s
- * carrying a cumulative [RtfSpanStyle], so nested emphasis (`**bold _italic_**`) becomes runs with the
- * combined style. Block structure (headings, lists, quotes, code) maps onto paragraph properties.
+ * Renders a chapter's markdown into [RtfBlock]s by consuming the shared [parseProseMarkdown] model
+ * (CommonMark flavour). Block kinds map onto paragraph properties; inline spans become styled
+ * [RtfTextRun]s, with consecutive same-link spans grouped into a single [RtfHyperlink]. Hard line
+ * breaks ride along as `\n` in run text — the rtf-writer escaper turns those into `\line`.
  */
-private class MarkdownRtfRenderer(
-	private val source: String,
-	private val primary: RtfColor?,
-	private val secondary: RtfColor?,
-) {
-	private val blocks = mutableListOf<RtfBlock>()
-	private var listDepth = -1
+private fun renderMarkdownRtf(markdown: String, primary: RtfColor?, secondary: RtfColor?): List<RtfBlock> {
+	val blocks = mutableListOf<RtfBlock>()
+	for (block in parseProseMarkdown(markdown, CommonMarkFlavourDescriptor())) {
+		when (block) {
+			is ProseBlock.Paragraph -> blocks += bodyParagraph(block.spans, primary)
+			is ProseBlock.Heading -> blocks += headingParagraph(block, primary, secondary)
+			is ProseBlock.Listing -> {
+				val numbering = RtfListNumbering()
+				block.items.forEach { blocks += listParagraph(it, numbering, primary) }
+			}
 
-	private data class BlockContext(
-		val quote: Boolean = false,
-		val listMarker: String? = null,
-		val indentLevel: Int = 0,
+			is ProseBlock.Quote -> block.paragraphs.forEach { blocks += quoteParagraph(it, primary) }
+			is ProseBlock.CodeBlock -> codeBlockLines(block.code).forEach { blocks += codeParagraph(it) }
+			ProseBlock.Rule -> blocks += ruleParagraph()
+			is ProseBlock.Table -> blocks += tableParagraphs(block, primary)
+		}
+	}
+	return blocks
+}
+
+private fun bodyParagraph(spans: List<ProseSpan>, primary: RtfColor?): RtfParagraph = RtfParagraph(
+	content = coalesceRuns(spansToInlines(spans, RtfSpanStyle.Default, primary)),
+	style = RtfParagraphStyle(firstLineIndentTwips = BODY_FIRST_LINE_INDENT, spaceAfterTwips = PARAGRAPH_SPACE_AFTER),
+)
+
+private fun headingParagraph(block: ProseBlock.Heading, primary: RtfColor?, secondary: RtfColor?): RtfParagraph {
+	val halfPoints = HEADING_HALF_POINTS[(block.level - 1).coerceIn(0, HEADING_HALF_POINTS.lastIndex)]
+	val color = when (block.level) {
+		1 -> primary
+		2 -> secondary
+		else -> null
+	}
+	val style = RtfSpanStyle(bold = true, fontSizeHalfPoints = halfPoints, color = color)
+	return RtfParagraph(
+		content = coalesceRuns(spansToInlines(block.spans, style, primary)),
+		style = RtfParagraphStyle(
+			spaceBeforeTwips = HEADING_SPACE_BEFORE,
+			spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
+			keepWithNext = true,
+		),
 	)
+}
 
-	fun render(): List<RtfBlock> {
-		val tree = MarkdownParser(CommonMarkFlavourDescriptor()).buildMarkdownTreeFromString(source)
-		renderBlocks(tree.children, BlockContext())
-		return blocks
+private fun listParagraph(item: ProseListItem, numbering: RtfListNumbering, primary: RtfColor?): RtfParagraph {
+	val content = buildList {
+		add(RtfTextRun(numbering.marker(item), RtfSpanStyle.Default))
+		addAll(spansToInlines(item.spans, RtfSpanStyle.Default, primary))
 	}
+	return RtfParagraph(
+		content = coalesceRuns(content),
+		style = RtfParagraphStyle(
+			leftIndentTwips = LIST_INDENT_PER_LEVEL * (item.level + 1),
+			firstLineIndentTwips = -LIST_INDENT_PER_LEVEL,
+			spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
+		),
+	)
+}
 
-	private fun renderBlocks(nodes: List<ASTNode>, blockCtx: BlockContext) {
-		// Only the first paragraph of a list item carries the bullet/number; trailing blocks flow under it.
-		var pendingMarker = blockCtx.listMarker
-		for (node in nodes) {
-			when (node.type) {
-				MarkdownElementTypes.PARAGRAPH -> {
-					addParagraph(blockCtx, pendingMarker, inlineRuns(node.children, baseStyle(blockCtx)))
-					pendingMarker = null
-				}
+private fun quoteParagraph(spans: List<ProseSpan>, primary: RtfColor?): RtfParagraph = RtfParagraph(
+	content = coalesceRuns(spansToInlines(spans, RtfSpanStyle(italic = true), primary)),
+	style = RtfParagraphStyle(leftIndentTwips = QUOTE_INDENT, spaceAfterTwips = PARAGRAPH_SPACE_AFTER),
+)
 
-				MarkdownElementTypes.ATX_1 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 1)
-				MarkdownElementTypes.ATX_2 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 2)
-				MarkdownElementTypes.ATX_3 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 3)
-				MarkdownElementTypes.ATX_4 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 4)
-				MarkdownElementTypes.ATX_5 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 5)
-				MarkdownElementTypes.ATX_6 -> heading(node, MarkdownTokenTypes.ATX_CONTENT, 6)
-				MarkdownElementTypes.SETEXT_1 -> heading(node, MarkdownTokenTypes.SETEXT_CONTENT, 1)
-				MarkdownElementTypes.SETEXT_2 -> heading(node, MarkdownTokenTypes.SETEXT_CONTENT, 2)
+private fun codeParagraph(line: String): RtfParagraph = RtfParagraph(
+	content = listOf(RtfTextRun(line, RtfSpanStyle(font = MONO_FONT))),
+	style = RtfParagraphStyle(spaceAfterTwips = 0),
+)
 
-				MarkdownElementTypes.BLOCK_QUOTE -> renderBlocks(
-					node.children,
-					blockCtx.copy(quote = true),
-				)
+private fun ruleParagraph(): RtfParagraph = RtfParagraph(
+	content = emptyList(),
+	style = RtfParagraphStyle(spaceAfterTwips = PARAGRAPH_SPACE_AFTER, bottomBorder = RtfBorder()),
+)
 
-				MarkdownElementTypes.UNORDERED_LIST -> renderList(node, ordered = false, blockCtx)
-				MarkdownElementTypes.ORDERED_LIST -> renderList(node, ordered = true, blockCtx)
-
-				MarkdownElementTypes.CODE_FENCE -> codeFence(node)
-				MarkdownElementTypes.CODE_BLOCK -> codeBlock(node)
-				MarkdownElementTypes.LINK_DEFINITION -> Unit
-
-				MarkdownTokenTypes.HORIZONTAL_RULE -> horizontalRule()
-
-				MarkdownTokenTypes.EOL,
-				MarkdownTokenTypes.WHITE_SPACE,
-				MarkdownTokenTypes.BLOCK_QUOTE,
-				MarkdownTokenTypes.LIST_BULLET,
-				MarkdownTokenTypes.LIST_NUMBER,
-					-> Unit
-
-				else -> {
-					if (node.children.isNotEmpty()) {
-						renderBlocks(node.children, blockCtx)
-					} else {
-						val literal = node.getTextInNode(source).toString()
-						if (literal.isNotBlank()) {
-							addParagraph(blockCtx, pendingMarker, listOf(RtfTextRun(unescapeMarkdown(literal), baseStyle(blockCtx))))
-							pendingMarker = null
-						}
-					}
-				}
+/** Tab-separated text fallback for tables (never produced under CommonMark; defensive). */
+private fun tableParagraphs(block: ProseBlock.Table, primary: RtfColor?): List<RtfBlock> =
+	(listOf(block.header) + block.rows).map { row ->
+		val content = buildList {
+			row.forEachIndexed { index, cell ->
+				if (index > 0) add(RtfTab)
+				addAll(spansToInlines(cell, RtfSpanStyle.Default, primary))
 			}
 		}
+		RtfParagraph(coalesceRuns(content), RtfParagraphStyle(spaceAfterTwips = PARAGRAPH_SPACE_AFTER))
 	}
 
-	private fun renderList(node: ASTNode, ordered: Boolean, blockCtx: BlockContext) {
-		listDepth++
-		var itemNumber = 1
-		node.children
-			.filter { it.type == MarkdownElementTypes.LIST_ITEM }
-			.forEach { item ->
-				val marker = if (ordered) "${itemNumber++}.\t" else "•\t"
-				renderBlocks(
-					item.children,
-					blockCtx.copy(listMarker = marker, indentLevel = listDepth + 1),
-				)
+/** Maps prose spans to RTF inlines, grouping consecutive same-link spans into one [RtfHyperlink]. */
+private fun spansToInlines(spans: List<ProseSpan>, base: RtfSpanStyle, primary: RtfColor?): List<RtfInline> {
+	val out = mutableListOf<RtfInline>()
+	var i = 0
+	while (i < spans.size) {
+		val link = spans[i].link
+		if (link != null) {
+			val linkStyle = base.copy(underline = true, color = primary)
+			val content = mutableListOf<RtfInline>()
+			while (i < spans.size && spans[i].link == link) {
+				content += runFor(spans[i], linkStyle)
+				i++
 			}
-		listDepth--
-	}
-
-	private fun heading(node: ASTNode, contentType: Any, level: Int) {
-		val content = node.children.firstOrNull { it.type == contentType }
-		val halfPoints = HEADING_HALF_POINTS[(level - 1).coerceIn(0, HEADING_HALF_POINTS.lastIndex)]
-		val color = when (level) {
-			1 -> primary
-			2 -> secondary
-			else -> null
+			out += RtfHyperlink(target = link, content = content)
+		} else {
+			out += runFor(spans[i], base)
+			i++
 		}
-		val style = RtfSpanStyle(bold = true, fontSizeHalfPoints = halfPoints, color = color)
-		val children = content?.children.orEmpty()
-			.dropWhile { it.type == MarkdownTokenTypes.WHITE_SPACE }
-			.dropLastWhile { it.type == MarkdownTokenTypes.WHITE_SPACE }
-		val runs = when {
-			children.isNotEmpty() -> inlineRuns(children, style)
-			content != null -> listOf(RtfTextRun(unescapeMarkdown(content.getTextInNode(source).toString()).trim(), style))
-			else -> emptyList()
-		}
-		blocks.add(
-			RtfParagraph(
-				content = coalesce(runs),
-				style = RtfParagraphStyle(
-					spaceBeforeTwips = HEADING_SPACE_BEFORE,
-					spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
-					keepWithNext = true,
-				),
-			),
-		)
 	}
+	return out
+}
 
-	private fun addParagraph(blockCtx: BlockContext, listMarker: String?, content: List<RtfInline>) {
-		val style = when {
-			listMarker != null -> RtfParagraphStyle(
-				leftIndentTwips = LIST_INDENT_PER_LEVEL * blockCtx.indentLevel,
-				firstLineIndentTwips = -LIST_INDENT_PER_LEVEL,
-				spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
-			)
+private fun runFor(span: ProseSpan, base: RtfSpanStyle): RtfTextRun = RtfTextRun(
+	text = span.text,
+	style = base.copy(
+		bold = base.bold || span.bold,
+		italic = base.italic || span.italic,
+		strikethrough = base.strikethrough || span.strikethrough,
+		font = if (span.code) MONO_FONT else base.font,
+	),
+)
 
-			blockCtx.quote -> RtfParagraphStyle(
-				leftIndentTwips = QUOTE_INDENT,
-				spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
-			)
-
-			else -> RtfParagraphStyle(
-				firstLineIndentTwips = BODY_FIRST_LINE_INDENT,
-				spaceAfterTwips = PARAGRAPH_SPACE_AFTER,
-			)
+/** Merges consecutive [RtfTextRun]s that share a style so plain prose stays in a single run. */
+private fun coalesceRuns(inlines: List<RtfInline>): List<RtfInline> {
+	val result = mutableListOf<RtfInline>()
+	for (inline in inlines) {
+		val last = result.lastOrNull()
+		if (inline is RtfTextRun && last is RtfTextRun && last.style == inline.style) {
+			result[result.lastIndex] = last.copy(text = last.text + inline.text)
+		} else {
+			result.add(inline)
 		}
-		val full = buildList {
-			if (listMarker != null) add(RtfTextRun(listMarker, baseStyle(blockCtx)))
-			addAll(content)
-		}
-		blocks.add(RtfParagraph(coalesce(full), style))
 	}
+	return result
+}
 
-	private fun baseStyle(blockCtx: BlockContext): RtfSpanStyle =
-		if (blockCtx.quote) RtfSpanStyle(italic = true) else RtfSpanStyle.Default
+/**
+ * Per-level counters for the literal ordered-list numbers RTF must write itself. Items arrive
+ * flattened in reading order with a [ProseListItem.level]; descending starts a fresh counter,
+ * ascending continues the shallower list and drops the deeper ones.
+ */
+private class RtfListNumbering {
+	private val counters = mutableListOf<Int>()
+	private var lastLevel = -1
 
-	private fun inlineRuns(nodes: List<ASTNode>, style: RtfSpanStyle): List<RtfInline> {
-		val out = mutableListOf<RtfInline>()
-		appendInline(out, nodes, style)
-		return out
-	}
+	fun marker(item: ProseListItem): String {
+		val level = item.level
+		when {
+			level > lastLevel -> {
+				while (counters.size <= level) counters.add(0)
+				counters[level] = 1
+			}
 
-	private fun appendInline(out: MutableList<RtfInline>, nodes: List<ASTNode>, style: RtfSpanStyle) {
-		for (node in nodes) {
-			when (node.type) {
-				MarkdownElementTypes.STRONG ->
-					appendInline(out, node.children.stripDelimiters(MarkdownTokenTypes.EMPH), style.copy(bold = true))
-
-				MarkdownElementTypes.EMPH ->
-					appendInline(out, node.children.stripDelimiters(MarkdownTokenTypes.EMPH), style.copy(italic = true))
-
-				MarkdownElementTypes.CODE_SPAN -> {
-					val code = node.children
-						.filter { it.type != MarkdownTokenTypes.BACKTICK }
-						.joinToString("") { it.getTextInNode(source).toString() }
-					out.add(RtfTextRun(code.removeSurrounding(" "), style.copy(font = MONO_FONT)))
-				}
-
-				MarkdownElementTypes.INLINE_LINK -> inlineLink(out, node, style)
-				MarkdownElementTypes.AUTOLINK -> autoLink(out, node, style)
-
-				MarkdownTokenTypes.HARD_LINE_BREAK -> out.add(RtfLineBreak)
-				MarkdownTokenTypes.EOL -> out.add(RtfTextRun(" ", style))
-
-				else -> {
-					if (node.children.isEmpty()) {
-						out.add(RtfTextRun(unescapeMarkdown(node.getTextInNode(source).toString()), style))
-					} else {
-						appendInline(out, node.children, style)
-					}
-				}
+			level == lastLevel -> counters[level]++
+			else -> {
+				while (counters.size > level + 1) counters.removeAt(counters.lastIndex)
+				counters[level]++
 			}
 		}
+		lastLevel = level
+		return if (item.ordered) "${counters[level]}.\t" else "•\t"
 	}
-
-	private fun inlineLink(out: MutableList<RtfInline>, node: ASTNode, style: RtfSpanStyle) {
-		val destination =
-			node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_DESTINATION }
-				?.getTextInNode(source)?.toString()?.removeSurrounding("<", ">")
-		val linkText = node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_TEXT }
-		if (destination == null || linkText == null) {
-			out.add(RtfTextRun(unescapeMarkdown(node.getTextInNode(source).toString()), style))
-			return
-		}
-		val content = inlineRuns(
-			linkText.children.filter {
-				it.type != MarkdownTokenTypes.LBRACKET && it.type != MarkdownTokenTypes.RBRACKET
-			},
-			style.copy(underline = true, color = primary),
-		)
-		out.add(RtfHyperlink(target = destination, content = content))
-	}
-
-	private fun autoLink(out: MutableList<RtfInline>, node: ASTNode, style: RtfSpanStyle) {
-		val url = node.getTextInNode(source).toString().removeSurrounding("<", ">")
-		out.add(
-			RtfHyperlink(
-				target = url,
-				content = listOf(RtfTextRun(url, style.copy(underline = true, color = primary))),
-			),
-		)
-	}
-
-	private fun codeFence(node: ASTNode) {
-		collectCodeLines(node, source, MarkdownTokenTypes.CODE_FENCE_CONTENT).forEach { codeParagraph(it) }
-	}
-
-	private fun codeBlock(node: ASTNode) {
-		collectCodeLines(node, source, MarkdownTokenTypes.CODE_LINE)
-			.map { it.removePrefix("    ").removePrefix("\t") }
-			.forEach { codeParagraph(it) }
-	}
-
-	private fun codeParagraph(line: String) {
-		blocks.add(
-			RtfParagraph(
-				content = listOf(RtfTextRun(line, RtfSpanStyle(font = MONO_FONT))),
-				style = RtfParagraphStyle(spaceAfterTwips = 0),
-			),
-		)
-	}
-
-	private fun horizontalRule() {
-		blocks.add(
-			RtfParagraph(
-				content = emptyList(),
-				style = RtfParagraphStyle(spaceAfterTwips = PARAGRAPH_SPACE_AFTER, bottomBorder = RtfBorder()),
-			),
-		)
-	}
-
-	/** Merges consecutive [RtfTextRun]s that share a style so plain prose stays in a single run. */
-	private fun coalesce(inlines: List<RtfInline>): List<RtfInline> {
-		val result = mutableListOf<RtfInline>()
-		for (inline in inlines) {
-			val last = result.lastOrNull()
-			if (inline is RtfTextRun && last is RtfTextRun && last.style == inline.style) {
-				result[result.lastIndex] = last.copy(text = last.text + inline.text)
-			} else {
-				result.add(inline)
-			}
-		}
-		return result
-	}
-
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
@@ -22,7 +22,6 @@ import com.darkrockstudios.libs.rtfparserkmp.writer.RtfSpanStyle
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfTab
 import com.darkrockstudios.libs.rtfparserkmp.writer.RtfTextRun
 import okio.BufferedSink
-import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
 
 private val BODY_FONT = RtfFont(EXPORT_BODY_FONT, RtfFontFamily.Roman)
 private val MONO_FONT = RtfFont(EXPORT_MONO_FONT, RtfFontFamily.Modern)
@@ -177,14 +176,14 @@ private fun themeColor(argb: String?): RtfColor? {
 }
 
 /**
- * Renders a chapter's markdown into [RtfBlock]s by consuming the shared [parseProseMarkdown] model
- * (CommonMark flavour). Block kinds map onto paragraph properties; inline spans become styled
- * [RtfTextRun]s, with consecutive same-link spans grouped into a single [RtfHyperlink]. Hard line
- * breaks ride along as `\n` in run text — the rtf-writer escaper turns those into `\line`.
+ * Renders a chapter's markdown into [RtfBlock]s by consuming the shared [parseProseMarkdown] model.
+ * Block kinds map onto paragraph properties; inline spans become styled [RtfTextRun]s, with
+ * consecutive same-link spans grouped into a single [RtfHyperlink]. Hard line breaks ride along as
+ * `\n` in run text — the rtf-writer escaper turns those into `\line`.
  */
 private fun renderMarkdownRtf(markdown: String, primary: RtfColor?, secondary: RtfColor?): List<RtfBlock> {
 	val blocks = mutableListOf<RtfBlock>()
-	for (block in parseProseMarkdown(markdown, CommonMarkFlavourDescriptor())) {
+	for (block in parseProseMarkdown(markdown)) {
 		when (block) {
 			is ProseBlock.Paragraph -> blocks += bodyParagraph(block.spans, primary)
 			is ProseBlock.Heading -> blocks += headingParagraph(block, primary, secondary)
@@ -255,7 +254,7 @@ private fun ruleParagraph(): RtfParagraph = RtfParagraph(
 	style = RtfParagraphStyle(spaceAfterTwips = PARAGRAPH_SPACE_AFTER, bottomBorder = RtfBorder()),
 )
 
-/** Tab-separated text fallback for tables (never produced under CommonMark; defensive). */
+/** Tab-separated text fallback for GFM pipe tables, which RTF has no real table primitive for yet. */
 private fun tableParagraphs(block: ProseBlock.Table, primary: RtfColor?): List<RtfBlock> =
 	(listOf(block.header) + block.rows).map { row ->
 		val content = buildList {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/StoryExportCommon.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/StoryExportCommon.kt
@@ -1,10 +1,5 @@
 package com.darkrockstudios.apps.hammer.common.components.projecthome
 
-import org.intellij.markdown.IElementType
-import org.intellij.markdown.MarkdownTokenTypes
-import org.intellij.markdown.ast.ASTNode
-import org.intellij.markdown.ast.getTextInNode
-
 /**
  * Localized strings that appear in the exported document body. Resolved once by the export use case
  * (which has the suspending [com.darkrockstudios.apps.hammer.common.util.StrRes] context) and passed
@@ -31,7 +26,7 @@ internal val HEADING_HALF_POINTS = listOf(48, 36, 32, 28, 26, 24)
 /** Bookmark / anchor name for the chapter at [index], the target of its Contents link. */
 internal fun chapterBookmark(index: Int): String = "chapter${index + 1}"
 
-// Shared markdown-AST helpers used by the renderers that walk intellij-markdown directly.
+// Shared markdown text helpers used when turning the parsed prose model into export output.
 
 private const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 
@@ -54,23 +49,6 @@ internal fun unescapeMarkdown(text: CharSequence): String {
 	return sb.toString()
 }
 
-/** Drops the leading and trailing delimiter tokens (e.g. the `**` / `_` around a STRONG / EMPH span). */
-internal fun List<ASTNode>.stripDelimiters(delimiterType: IElementType): List<ASTNode> =
-	dropWhile { it.type == delimiterType }.dropLastWhile { it.type == delimiterType }
-
-/** Collects the lines of a fenced or indented code block, trimming leading and trailing blank lines. */
-internal fun collectCodeLines(node: ASTNode, source: String, contentType: IElementType): List<String> {
-	val lines = mutableListOf<String>()
-	val current = StringBuilder()
-	for (child in node.children) {
-		when (child.type) {
-			contentType -> current.append(child.getTextInNode(source))
-			MarkdownTokenTypes.EOL -> {
-				lines += current.toString()
-				current.clear()
-			}
-		}
-	}
-	if (current.isNotEmpty()) lines += current.toString()
-	return lines.dropWhile { it.isBlank() }.dropLastWhile { it.isBlank() }
-}
+/** Splits a code block's text into lines, trimming leading and trailing blank lines. */
+internal fun codeBlockLines(code: String): List<String> =
+	code.split("\n").dropWhile { it.isBlank() }.dropLastWhile { it.isBlank() }

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
@@ -103,6 +103,13 @@ class RtfStoryRendererTest {
 	}
 
 	@Test
+	fun `markdown strikethrough becomes an RTF strike group`() {
+		val rtf = render(listOf(StoryChapter("Alpha", "This is ~~gone~~ now.")))
+
+		assertTrue(rtf.contains("{\\strike gone}"), "GFM strikethrough should become an RTF strike group")
+	}
+
+	@Test
 	fun `braces in prose are escaped so they do not open groups`() {
 		val rtf = render(listOf(StoryChapter("Alpha", "Use {braces} and a back\\slash.")))
 

--- a/common/src/desktopTest/kotlin/components/projecthome/DocxStoryRendererTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/DocxStoryRendererTest.kt
@@ -136,6 +136,18 @@ class DocxStoryRendererTest {
 	}
 
 	@Test
+	fun `markdown strikethrough becomes a struck-through run`() {
+		val doc = render(listOf(StoryChapter("Alpha", "This is ~~gone~~ now.")))
+
+		val runs = doc.bodyParagraphs().flatMap { it.runs }
+		val struck = runs.first { it.text() == "gone" }
+		assertTrue(struck.isStrikeThrough, "GFM strikethrough should set the run's strike property")
+
+		val plain = runs.first { it.text().contains("now") }
+		assertTrue(!plain.isStrikeThrough)
+	}
+
+	@Test
 	fun `markdown headings map to heading styles`() {
 		val doc =
 			render(listOf(StoryChapter("Alpha", "## Section\n\nBody text.\n\n### Subsection")))

--- a/common/src/desktopTest/kotlin/components/projecthome/EpubStoryRendererTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/EpubStoryRendererTest.kt
@@ -75,6 +75,20 @@ class EpubStoryRendererTest {
 	}
 
 	@Test
+	fun `markdown strikethrough renders struck-through text`() {
+		val content = render(listOf(StoryChapter("Alpha", "This is ~~gone~~ now.")))
+
+		assertTrue(
+			"""<span class="user-del">gone</span>""" in content,
+			"GFM strikethrough should become a user-del span",
+		)
+		assertTrue(
+			".user-del { text-decoration: line-through; }" in content,
+			"The stylesheet must strike the user-del span through",
+		)
+	}
+
+	@Test
 	fun `theme accent color reaches the stylesheet`() {
 		val content = render(
 			listOf(StoryChapter("Alpha", "Body.")),

--- a/common/src/desktopTest/kotlin/components/projecthome/PdfProseMarkdownTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/PdfProseMarkdownTest.kt
@@ -99,9 +99,9 @@ class PdfProseMarkdownTest {
 		val list = assertIs<ProseBlock.Listing>(blocks.single())
 		assertTrue(!list.ordered)
 		assertEquals(2, list.items.size)
-		assertEquals("plain item", list.items[0].plain())
-		assertEquals("bold item", list.items[1].plain())
-		assertTrue(list.items[1].first { it.text == "bold" }.bold)
+		assertEquals("plain item", list.items[0].spans.plain())
+		assertEquals("bold item", list.items[1].spans.plain())
+		assertTrue(list.items[1].spans.first { it.text == "bold" }.bold)
 	}
 
 	@Test
@@ -110,7 +110,16 @@ class PdfProseMarkdownTest {
 
 		val list = assertIs<ProseBlock.Listing>(blocks.single())
 		assertTrue(list.ordered)
-		assertEquals(listOf("first", "second"), list.items.map { it.plain() })
+		assertEquals(listOf("first", "second"), list.items.map { it.spans.plain() })
+	}
+
+	@Test
+	fun `nested list items carry their nesting level in reading order`() {
+		val blocks = parseProseMarkdown("- parent\n    - child\n- sibling")
+
+		val list = assertIs<ProseBlock.Listing>(blocks.single())
+		assertEquals(listOf("parent", "child", "sibling"), list.items.map { it.spans.plain() })
+		assertEquals(listOf(0, 1, 0), list.items.map { it.level })
 	}
 
 	@Test


### PR DESCRIPTION
## What

Two related commits:

1. **Consolidate RTF/DOCX onto the shared prose model.** RTF and DOCX each walked the intellij-markdown AST themselves, duplicating the inline emphasis / link / code-span / escape-resolution handling **three** ways (alongside PDF). Continuing #668, RTF and DOCX now consume the shared `parseProseMarkdown` / `ProseBlock` model that PDF already used, so the inline markdown walk lives in exactly one place. **Net −202 lines.**
2. **Render `~~strikethrough~~` across all exports.** All four exporters now parse with the GFM flavour, so `~~text~~` is recognized everywhere (previously only PDF).

## Consolidation details

- **List nesting.** `ProseBlock.Listing` previously flattened nested lists and lost the depth. Items now carry a `ProseListItem(spans, level, ordered)`, so RTF reconstructs its per-level indents and literal ordered numbering, and DOCX reconstructs `numPr` `ilvl` + per-sublist `numId`.
- **Hard breaks.** They ride along as `\n` in run text — RTF's escaper turns those into `\line` for free; DOCX splits them into `<w:br/>`.
- `MarkdownRtfRenderer` and `MarkdownDocxWriter`'s AST walkers became thin model consumers; the duplicated `stripDelimiters` / `collectCodeLines` helpers are deleted.

## Strikethrough details

- RTF and DOCX already emitted strike formatting for struck spans (`\strike`, `<w:strike/>`); they just never received them under CommonMark. Switching to GFM lights them up.
- EPUB's GFM `HtmlGenerator` wraps strikethrough in `<span class="user-del">`, so the exported stylesheet now strikes that class through.
- GFM pipe tables fall back to tab-separated text (RTF/DOCX) or native HTML tables (EPUB) — we don't support authored tables anywhere, so this is incidental.
- The now-unused CommonMark flavour parameter is dropped from `parseProseMarkdown`.

## Tests

- Existing RTF / DOCX / PDF-model / EPUB / export-use-case suites pass unchanged.
- Added strikethrough tests for RTF, DOCX, and EPUB (the EPUB one also asserts the `.user-del` stylesheet rule); added a PDF-model test asserting nested items carry their `level`.
- Full `:common:desktopTest` is green.
