### PR TITLE
Fix MonitoringDaoTest flakiness: join monitoring job on shutdown

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/ConfigureMonitoringJob.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/ConfigureMonitoringJob.kt
@@ -4,6 +4,8 @@ import io.ktor.server.application.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
 import org.koin.ktor.ext.inject
 
 /**
@@ -18,7 +20,10 @@ fun Application.configureMonitoringJob() {
 	job.start(scope)
 	log.info("Monitoring maintenance job started")
 
+	// Block until the loop's in-flight tick finishes so a flush or maintenance
+	// pass can't outlive the application and mutate state after shutdown.
 	environment.monitor.subscribe(ApplicationStopped) {
-		job.stop()
+		runBlocking { job.stopAndJoin() }
+		scope.cancel()
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringMaintenanceJob.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringMaintenanceJob.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.apps.hammer.email.EmailService
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -60,8 +61,9 @@ class MonitoringMaintenanceJob(
 		}
 	}
 
-	fun stop() {
-		job?.cancel()
+	/** Cancels the loop and waits for any in-flight tick to finish, so no tick outlives the caller. */
+	suspend fun stopAndJoin() {
+		job?.cancelAndJoin()
 		job = null
 		logger.info("Monitoring maintenance job stopped")
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringMaintenanceJobLifecycleTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringMaintenanceJobLifecycleTest.kt
@@ -1,0 +1,133 @@
+package com.darkrockstudios.apps.hammer.monitoring
+
+import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
+import com.darkrockstudios.apps.hammer.admin.ConfigRepository
+import com.darkrockstudios.apps.hammer.database.ApiMetricDao
+import com.darkrockstudios.apps.hammer.database.ErrorLogDao
+import com.darkrockstudios.apps.hammer.database.LoginAttemptDao
+import com.darkrockstudios.apps.hammer.database.PublishedStoryReaderDao
+import com.darkrockstudios.apps.hammer.database.ServerConfigDao
+import com.darkrockstudios.apps.hammer.database.UserActivityDao
+import com.darkrockstudios.apps.hammer.dependencyinjection.DISPATCHER_DEFAULT
+import com.darkrockstudios.apps.hammer.dependencyinjection.DISPATCHER_IO
+import com.darkrockstudios.apps.hammer.dependencyinjection.DISPATCHER_MAIN
+import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.email.EmailResult
+import com.darkrockstudios.apps.hammer.email.EmailService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.context.GlobalContext
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * The maintenance loop runs on a real dispatcher in production. Because every test
+ * shares one embedded Postgres, a tick that outlives its application would mutate a
+ * later test's data. These tests pin the shutdown contract that prevents that.
+ */
+class MonitoringMaintenanceJobLifecycleTest {
+
+	private lateinit var db: SqliteTestDatabase
+
+	@BeforeEach
+	fun setup() {
+		GlobalContext.stopKoin()
+		GlobalContext.startKoin {
+			modules(
+				module {
+					single<CoroutineContext>(named(DISPATCHER_DEFAULT)) { Dispatchers.Default }
+					single<CoroutineContext>(named(DISPATCHER_IO)) { Dispatchers.IO }
+					single<CoroutineContext>(named(DISPATCHER_MAIN)) { Dispatchers.Default }
+				}
+			)
+		}
+		db = SqliteTestDatabase()
+		db.initialize()
+	}
+
+	@AfterEach
+	fun tearDown() {
+		GlobalContext.stopKoin()
+	}
+
+	@Test
+	fun `stopAndJoin does not return while a tick is in flight`() = runBlocking {
+		val tickEntered = CountDownLatch(1)
+		val release = CountDownLatch(1)
+
+		// Blocks the first tick partway through, mimicking an in-flight maintenance pass.
+		val gatingClock = object : Clock {
+			private val firstCall = AtomicBoolean(true)
+			override fun now(): Instant {
+				if (firstCall.compareAndSet(true, false)) {
+					tickEntered.countDown()
+					release.await()
+				}
+				return Instant.parse("2026-01-15T12:00:00Z")
+			}
+		}
+
+		val job = buildJob(gatingClock)
+		val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+		job.start(scope)
+
+		assertTrue(tickEntered.await(10, TimeUnit.SECONDS), "the maintenance tick never started")
+
+		val stopper = launch(Dispatchers.Default) { job.stopAndJoin() }
+		delay(200)
+		assertTrue(stopper.isActive, "stopAndJoin returned while a tick was still running")
+
+		release.countDown()
+		stopper.join()
+
+		assertFalse(job.isRunning(), "the job is still running after stopAndJoin")
+		scope.cancel()
+	}
+
+	private suspend fun buildJob(clock: Clock): MonitoringMaintenanceJob {
+		val configRepository = ConfigRepository(ServerConfigDao(db))
+		configRepository.set(
+			AdminServerConfig.MONITORING_CONFIG,
+			MonitoringConfig(enabled = true, trackApiMetrics = true, alertEmailEnabled = false),
+		)
+		return MonitoringMaintenanceJob(
+			configRepository = configRepository,
+			metricsRepository = MetricsRepository(ApiMetricDao(db)),
+			errorRepository = ErrorRepository(ErrorLogDao(db), clock),
+			securityRepository = SecurityRepository(LoginAttemptDao(db), clock),
+			collector = MetricsCollector(clock),
+			userActivityCollector = UserActivityCollector(clock),
+			userActivityRepository = UserActivityRepository(UserActivityDao(db)),
+			storyReaderCollector = StoryReaderCollector(clock),
+			storyReaderRepository = StoryReaderRepository(PublishedStoryReaderDao(db)),
+			monitoringState = MonitoringState(),
+			emailService = NoopEmailService,
+			clock = clock,
+			logger = LoggerFactory.getLogger("test"),
+		)
+	}
+
+	private object NoopEmailService : EmailService {
+		override suspend fun sendEmail(to: String, subject: String, bodyHtml: String, bodyText: String?): EmailResult =
+			EmailResult.Success
+
+		override suspend fun isConfigured(): Boolean = false
+	}
+}


### PR DESCRIPTION
## Root cause

`MonitoringDaoTest` intermittently failed at `MonitoringDaoTest.kt:37` with an `AssertionError` (e.g. `assertEquals(1, rows.size)`).

All server DB tests share **one process-wide embedded Postgres**; each test truncates the user tables in `@BeforeEach` (`SqliteTestDatabase.initialize()`), which gives a clean *start* but assumes nothing writes to those tables *during* a test. JUnit/Gradle run these tests serially, so a sibling test cannot interfere — but a real-thread background job can.

Every full-app test (`EndToEndTest` subclasses boot `appMain` on Jetty) calls `configureMonitoringJob()`, which launches `MonitoringMaintenanceJob` on a real `CoroutineScope(SupervisorJob() + Dispatchers.Default)`. On `ApplicationStopped` the job was only `cancel()`-ed, **never joined**. `server.stop()` returns without waiting, so an in-flight `tick()` (which is mid-blocking-JDBC and not promptly cancellable) can keep running into the *next* test. That tick mutates the shared `api_metric_bucket` table:

- `runMaintenance()` rolls up / purges past-dated HOUR/DAY buckets — and `MonitoringDaoTest` inserts buckets at a fixed past `base = 2026-01-15`, well inside those windows, so its HOUR row gets rolled into a DAY row and deleted → `rows.size` becomes `0`.
- `flush()` can persist accumulated `/api/*` requests as HOUR buckets at real wall-clock time (≥ `base`) → an extra row → `rows.size` becomes `2`.

Either way the exact-count assertions break, intermittently and load-dependently — exactly the observed flake.

## Fix

Fully stop the maintenance job on shutdown: `MonitoringMaintenanceJob.stopAndJoin()` does `cancelAndJoin()`, and `configureMonitoringJob` calls it (via `runBlocking`) on `ApplicationStopped` and cancels the scope. After the server stops, no tick can survive to touch the shared database. This is also a genuine correctness improvement — a background job should not outlive its application.

Added `MonitoringMaintenanceJobLifecycleTest` pinning the contract: `stopAndJoin()` does not return while a tick is in flight. It fails against the old fire-and-forget `cancel()` and passes with the join.

## Verification

- `MonitoringDaoTest` + the new lifecycle test: 5 consecutive green `--rerun` runs.
- Full `./gradlew :server:test --rerun`: green, no regressions.