### PR TITLE
Fix editor undo/redo broken by decoration spans

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/drafts/DraftCompareUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/drafts/DraftCompareUi.kt
@@ -26,8 +26,10 @@ import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
 import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.getInitialEditorContent
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.TextEditor
+import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.markdown.withMarkdown
 import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpan
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.rememberTextEditorState
 import kotlinx.coroutines.delay
@@ -359,23 +361,32 @@ private fun applyDiffHighlights(
 	style: HighlightSpanStyle,
 	previousStyle: HighlightSpanStyle?,
 ) {
-	editorState.richSpanManager.getAllRichSpans()
+	val toRemove = editorState.richSpanManager.getAllRichSpans()
 		.filter { it.style === style || it.style === previousStyle }
-		.forEach { editorState.removeRichSpan(it) }
 
 	val text = editorState.getAllText().text
 	val length = text.length
-	if (length == 0) return
-	for (span in spans) {
-		val start = span.range.start.coerceIn(0, length)
-		val end = span.range.endExclusive.coerceIn(start, length)
-		if (end <= start) continue
-		editorState.addRichSpan(
-			start = offsetToCharLine(text, start),
-			end = offsetToCharLine(text, end),
-			style = style,
-		)
+	val toAdd = if (length == 0) {
+		emptyList()
+	} else {
+		spans.mapNotNull { span ->
+			val start = span.range.start.coerceIn(0, length)
+			val end = span.range.endExclusive.coerceIn(start, length)
+			if (end <= start) return@mapNotNull null
+			RichSpan(
+				range = TextEditorRange(
+					start = offsetToCharLine(text, start),
+					end = offsetToCharLine(text, end),
+				),
+				style = style,
+			)
+		}
 	}
+
+	// Diff highlights are ephemeral overlays: route them through the batch
+	// overlay API so they stay out of undo history and the edit stream and
+	// relayout once instead of per span.
+	editorState.updateRichSpans(remove = toRemove, add = toAdd)
 }
 
 private fun offsetToCharLine(text: String, offset: Int): CharLineOffset {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
@@ -46,7 +46,6 @@ import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownFor
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
 import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.getInitialEditorContent
-import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.isDecorationOnly
 import com.darkrockstudios.apps.hammer.common.utils.toEditorSpellChecker
 import com.darkrockstudios.apps.hammer.scene_editor_menu_item_close
 import com.darkrockstudios.texteditor.find.FindBar
@@ -55,7 +54,6 @@ import com.darkrockstudios.texteditor.rememberTextEditorStyle
 import com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor
 import com.darkrockstudios.texteditor.spellcheck.markdown.withMarkdown
 import com.darkrockstudios.texteditor.spellcheck.rememberSpellCheckState
-import kotlinx.coroutines.flow.filterNot
 
 @Composable
 fun FocusModeUi(component: FocusMode) {
@@ -95,7 +93,6 @@ fun FocusModeUi(component: FocusMode) {
 		// to prevent empty content from being sent to the buffer before it's populated
 		if (hasReceivedInitialBuffer) {
 			textEditorState.textState.editOperations
-				.filterNot { it.isDecorationOnly() }
 				.collect { _ ->
 					component.onContentChanged(ComposeRichText(markdownExtension))
 				}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
@@ -61,8 +61,13 @@ fun FocusModeUi(component: FocusMode) {
 	val lastForceUpdate by component.lastForceUpdate.subscribeAsState()
 	val markdownConfig = LocalMarkdownConfig.current
 
+	// Stable per dictionary: a fresh instance each recomposition would re-key
+	// rememberSpellCheckState's full-rescan effect, wiping spans on every edit.
+	val editorSpellChecker = remember(state.spellChecker) {
+		state.spellChecker.toEditorSpellChecker()
+	}
 	val textEditorState = rememberSpellCheckState(
-		spellChecker = state.spellChecker.toEditorSpellChecker(),
+		spellChecker = editorSpellChecker,
 		initialText = getInitialEditorContent(state.sceneBuffer?.content, markdownConfig),
 		enableSpellChecking = state.spellCheckingEnabled,
 	)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
@@ -61,8 +61,6 @@ fun FocusModeUi(component: FocusMode) {
 	val lastForceUpdate by component.lastForceUpdate.subscribeAsState()
 	val markdownConfig = LocalMarkdownConfig.current
 
-	// Stable per dictionary: a fresh instance each recomposition would re-key
-	// rememberSpellCheckState's full-rescan effect, wiping spans on every edit.
 	val editorSpellChecker = remember(state.spellChecker) {
 		state.spellChecker.toEditorSpellChecker()
 	}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneContentUtils.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneContentUtils.kt
@@ -3,13 +3,8 @@ package com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor
 import androidx.compose.ui.text.AnnotatedString
 import com.darkrockstudios.apps.hammer.common.compose.ComposeRichText
 import com.darkrockstudios.apps.hammer.common.data.SceneContent
-import com.darkrockstudios.texteditor.find.FindCurrentMatchStyle
-import com.darkrockstudios.texteditor.find.FindMatchStyle
 import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import com.darkrockstudios.texteditor.markdown.toAnnotatedStringFromMarkdown
-import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
-import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
-import com.darkrockstudios.texteditor.state.TextEditOperation
 
 fun getInitialEditorContent(
 	sceneContent: SceneContent?,
@@ -27,23 +22,5 @@ fun getInitialEditorContent(
 		}
 	} else {
 		AnnotatedString("")
-	}
-}
-
-/**
- * The editor emits every mutation on `editOperations`, including ephemeral decoration
- * spans (spell-check underlines, find highlights) that never serialize to markdown.
- * These must not mark the scene buffer dirty, or an async spell-check pass re-dirties
- * a freshly-saved scene.
- */
-fun TextEditOperation.isDecorationOnly(): Boolean {
-	if (this !is TextEditOperation.RichSpan) return false
-	return when (style) {
-		is SpellCheckStyle,
-		is HighlightSpanStyle,
-		is FindMatchStyle,
-		is FindCurrentMatchStyle -> true
-
-		else -> false
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -87,8 +87,13 @@ fun SceneEditorUi(
 	val markdownConfig = LocalMarkdownConfig.current
 	val scope = rememberCoroutineScope()
 
+	// Stable per dictionary: a fresh instance each recomposition would re-key
+	// rememberSpellCheckState's full-rescan effect, wiping spans on every edit.
+	val editorSpellChecker = remember(state.spellChecker) {
+		state.spellChecker.toEditorSpellChecker()
+	}
 	val textEditorState = rememberSpellCheckState(
-		spellChecker = state.spellChecker.toEditorSpellChecker(),
+		spellChecker = editorSpellChecker,
 		initialText = getInitialEditorContent(state.sceneBuffer?.content, markdownConfig),
 		enableSpellChecking = state.spellCheckingEnabled,
 		spellCheckMode = SpellCheckMode.Word,

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -69,7 +69,6 @@ import com.darkrockstudios.texteditor.spellcheck.SpellCheckMode
 import com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor
 import com.darkrockstudios.texteditor.spellcheck.markdown.withMarkdown
 import com.darkrockstudios.texteditor.spellcheck.rememberSpellCheckState
-import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.launch
 
 const val SCENE_EDITOR_TEXT_TAG = "scene-editor-text"
@@ -122,7 +121,6 @@ fun SceneEditorUi(
 		// to prevent empty content from being sent to the buffer before it's populated
 		if (hasReceivedInitialBuffer) {
 			textEditorState.textState.editOperations
-				.filterNot { it.isDecorationOnly() }
 				.collect { _ ->
 					component.onContentChanged(ComposeRichText(markdownExtension))
 				}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -87,8 +87,6 @@ fun SceneEditorUi(
 	val markdownConfig = LocalMarkdownConfig.current
 	val scope = rememberCoroutineScope()
 
-	// Stable per dictionary: a fresh instance each recomposition would re-key
-	// rememberSpellCheckState's full-rescan effect, wiping spans on every edit.
 	val editorSpellChecker = remember(state.spellChecker) {
 		state.spellChecker.toEditorSpellChecker()
 	}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,7 +99,7 @@ korge-core = "6.0.0"
 bouncycastle = "1.84"
 kotlinx-io-okio = "0.9.0"
 
-compose-texteditor = "2.2.5"
+compose-texteditor = "2.2.6"
 kotlin-multiplatform-diff = "1.3.0"
 platform-spellcheckerkt = "1.3.1"
 nucleus = "1.15.7"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,7 +99,7 @@ korge-core = "6.0.0"
 bouncycastle = "1.84"
 kotlinx-io-okio = "0.9.0"
 
-compose-texteditor = "2.2.3"
+compose-texteditor = "2.2.5"
 kotlin-multiplatform-diff = "1.3.0"
 platform-spellcheckerkt = "1.3.1"
 nucleus = "1.15.7"


### PR DESCRIPTION
## Problem

Undo/redo in the scene/focus editors was effectively dead — shortcut keys and toolbar buttons did nothing.

**Root cause:** ComposeTextEditor PR #26 ("Make standalone rich spans undoable") routed `addRichSpan`/`removeRichSpan` through the undo history. Spell-check underlines are applied through those same calls, so every spell-check pass pushed invisible span ops onto the undo stack and cleared the redo queue. Undo popped a no-op decoration; redo was permanently dead.

## Fixes (library, consumed here)

Fixed upstream in `composetexteditor`, bumped to **2.2.6**:

- **`2.2.4`/`2.2.5`** — new `RichSpanStyle.isDecoration` flag: decoration spans (spell-check, find) are kept out of **both** the undo history and the `editOperations` stream. `HighlightSpanStyle` stays structural (it's the user highlighter).
- **`2.2.6`** — spell-check passes made **cancellation-safe**: they now compute misspellings under suspension, then swap spans in one non-suspending step, so an interrupted rescan can't wipe spans document-wide.

## Hammer changes here

- Bump `composetexteditor` to `2.2.6`.
- Delete `isDecorationOnly()` and the two `.filterNot { it.isDecorationOnly() }` edit-stream filters — decorations no longer emit, so the filter is dead.
- Route DraftCompare diff highlights through `updateRichSpans` (the batch overlay API), since they are overlays too.
- **Stabilize the spell-checker instance** with `remember(state.spellChecker)` in both editors. `toEditorSpellChecker()` built a new instance every recomposition, which re-keyed `rememberSpellCheckState`'s full-rescan effect — so once undo actually mutated text, a recomposition cancelled the rescan mid-flight and wiped every squiggle (whole document, no recovery). This also removes a real perf bug: a full-document spell scan was running on every keystroke.

## Testing

- Library: regression tests for undo skipping a decoration, redo surviving a decoration pass, decorations staying off the edit stream, and a cancelled rescan not wiping spans. All suites pass.
- Hammer: `composeUi:desktopTest` passes against the published `2.2.6` artifacts (pre-commit hook).
- Manual: undo/redo works and spell-check spans survive undo.