### PR TITLE
Fix getProjects crash when a project dir is deleted mid-listing

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectsrepository/ProjectsRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectsrepository/ProjectsRepository.kt
@@ -107,7 +107,7 @@ class ProjectsRepository(
 	fun getProjects(projectsDir: HPath = getProjectsDirectory()): List<ProjectDef> {
 		val projPath = projectsDir.toOkioPath()
 		return fileSystem.list(projPath)
-			.filter { fileSystem.metadata(it).isDirectory }
+			.filter { fileSystem.metadataOrNull(it)?.isDirectory == true }
 			.filter { it.name.startsWith('.').not() }
 			.map { path -> ProjectDef(decodeFromFilename(path.name), path.toHPath()) }
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
@@ -100,7 +100,7 @@ class SceneDatasource(
 	fun getSceneTempBufferContents(): List<SceneContent> {
 		val bufferDirectory = getSceneBufferDirectory().toOkioPath()
 		return fileSystem.list(bufferDirectory)
-			.filter { fileSystem.metadata(it).isRegularFile }
+			.filter { fileSystem.metadataOrNull(it)?.isRegularFile == true }
 			.mapNotNull { path ->
 				val sceneId = getSceneIdFromBufferFilename(path.name)
 				resolveScenePathFromFilesystem(sceneId)?.let { scenePath ->

--- a/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryConcurrencyTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryConcurrencyTest.kt
@@ -1,0 +1,37 @@
+package repositories.projectsrepository
+
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
+import createProjectDirectories
+import getProjectsDirectory
+import kotlinx.coroutines.test.runTest
+import okio.ForwardingFileSystem
+import okio.Path
+import org.junit.jupiter.api.Test
+import projectNames
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProjectsRepositoryConcurrencyTest : ProjectsRepositoryBaseTest() {
+
+	/**
+	 * Reproduces the listing-then-stat race: a project directory is deleted between
+	 * `list()` and the per-entry `metadata()` call. getProjects must skip the vanished
+	 * entry rather than throwing FileNotFoundException.
+	 */
+	@Test
+	fun `Get Projects skips entries deleted during listing`() = scope.runTest {
+		createProjectDirectories(ffs)
+
+		val phantom = getProjectsDirectory().div("Vanished Project")
+		val racingFs = object : ForwardingFileSystem(ffs) {
+			override fun list(dir: Path): List<Path> =
+				if (dir == getProjectsDirectory()) super.list(dir) + phantom else super.list(dir)
+		}
+
+		val repo = ProjectsRepository(racingFs, settingsRepo, projectsMetaDatasource)
+		val projects = repo.getProjects()
+
+		assertEquals(projectNames.size, projects.size)
+		projects.forEach { project -> assertTrue(projectNames.contains(project.name)) }
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneDatasourceBufferRaceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneDatasourceBufferRaceTest.kt
@@ -1,0 +1,69 @@
+package repositories.sceneeditor
+
+import PROJECT_1_NAME
+import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.UpdateSource
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import createProject
+import getProjectDef
+import kotlinx.coroutines.test.runTest
+import okio.ForwardingFileSystem
+import okio.Path
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import utils.BaseTest
+import kotlin.test.assertEquals
+
+/**
+ * Reproduces the listing-then-stat race for scene temp buffers: a file is deleted between
+ * `list()` and the per-entry `metadata()` call. getSceneTempBufferContents must skip the
+ * vanished entry rather than throwing FileNotFoundException.
+ */
+class SceneDatasourceBufferRaceTest : BaseTest() {
+
+	private lateinit var ffs: FakeFileSystem
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		ffs = FakeFileSystem()
+		createProject(ffs, PROJECT_1_NAME)
+	}
+
+	@AfterEach
+	override fun tearDown() {
+		super.tearDown()
+		ffs.checkNoOpenFiles()
+	}
+
+	@Test
+	fun `Get temp buffer contents skips entries deleted during listing`() = runTest {
+		val projectDef = getProjectDef(PROJECT_1_NAME)
+		val datasource = SceneDatasource(projectDef, ffs)
+
+		val bufferDir = datasource.getSceneBufferDirectory().toOkioPath()
+
+		val scenePath = datasource.resolveScenePathFromFilesystem(3)!!
+		val scene = datasource.getSceneFromPath(scenePath)
+		datasource.storeTempSceneBuffer(
+			SceneBuffer(SceneContent(scene, "buffered text"), source = UpdateSource.Editor)
+		)
+
+		val phantom = bufferDir.div("99999.md")
+		val racingFs = object : ForwardingFileSystem(ffs) {
+			override fun list(dir: Path): List<Path> =
+				if (dir == bufferDir) super.list(dir) + phantom else super.list(dir)
+		}
+
+		val racingDatasource = SceneDatasource(projectDef, racingFs)
+		val contents = racingDatasource.getSceneTempBufferContents()
+
+		assertEquals(1, contents.size)
+		assertEquals(3, contents.first().scene.id)
+		assertEquals("buffered text", contents.first().markdown)
+	}
+}


### PR DESCRIPTION
## Problem

`ProjectsRepository.getProjects` lists the projects directory, then stats each entry via `metadata()`:

```kotlin
fileSystem.list(projPath)
    .filter { fileSystem.metadata(it).isDirectory }
```

`list()` snapshots the directory entries, but `metadata()` is called per-entry afterward. If a project directory is removed **between** the snapshot and the stat — a concurrent delete, a sync removing a project, or simply a racing list refresh — Okio throws `FileNotFoundException` and crashes the caller's coroutine.

This surfaced as a CI failure in the Android e2e `ProjectLifecycleTest`: a background `loadProjectList` refresh raced the project teardown and crashed with:

```
java.io.FileNotFoundException: no such file: .../HammerProjects/E2E Smoke ...
  at okio…commonMetadata
  at ProjectsRepository.getProjects(ProjectsRepository.kt:110)
  at ProjectsListComponent.loadProjectList
```

## Fix

Use `metadataOrNull` so a vanished entry is filtered out instead of throwing:

```kotlin
.filter { fileSystem.metadataOrNull(it)?.isDirectory == true }
```

The same `list()`-then-`metadata()` pattern existed in `SceneDatasource.getSceneTempBufferContents`, fixed the same way. `ProjectBackupRepository.getBackups` already guards the race with a try/catch, so it's left as-is.

## Test

`ProjectsRepositoryConcurrencyTest` uses a `ForwardingFileSystem` whose `list()` returns a phantom (already-deleted) entry, deterministically reproducing the race. Confirmed it fails with `FileNotFoundException` without the fix and passes with it.

Independent of the editor undo/redo work — the failing e2e test is from #516 and just rode along on another branch's CI.