### PR TITLE
Encrypt iOS auth tokens at rest via Keychain; run iOS tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,10 +127,11 @@ jobs:
             android/build/reports/androidTests/connected/
             android/build/outputs/androidTest-results/connected/
 
-  # Compile gate for Kotlin/Native — the ubuntu `build` job never compiles the
-  # iOS targets, so Native-only breakage in commonMain slips through otherwise.
+  # The ubuntu `build` job never touches the iOS targets, so Native-only breakage
+  # in commonMain slips through otherwise. This job both compiles the iOS targets
+  # and runs the Kotlin/Native unit tests on the simulator.
   ios-compile:
-    name: iOS compile check
+    name: iOS compile & test
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -144,6 +145,17 @@ jobs:
         run: chmod +x gradlew
       - name: Compile iOS Kotlin targets
         run: ./gradlew :composeUi:compileKotlinIosArm64 :composeUi:compileKotlinIosSimulatorArm64
+      - name: Run iOS unit tests
+        id: ios-tests
+        run: ./gradlew :common:iosSimulatorArm64Test
+      - name: Upload iOS test report on failure
+        if: failure() && steps.ios-tests.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-tests-report
+          path: |
+            common/build/reports/tests/iosSimulatorArm64Test/
+            common/build/test-results/iosSimulatorArm64Test/
 
 #  ios:
 #    runs-on: macos-latest

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -95,7 +95,6 @@ kotlin {
 			dependencies {
 				implementation(kotlin("test"))
 				implementation(libs.koin.test)
-				implementation(libs.okio.fakefilesystem)
 				implementation(libs.kotlin.reflect)
 			}
 		}
@@ -104,6 +103,12 @@ kotlin {
 		}
 		val jvmTest by creating {
 			dependsOn(commonTest)
+			dependencies {
+				// okio-fakefilesystem references the deprecated kotlinx.datetime.Clock typealias,
+				// which double-binds during Kotlin/Native klib caching and breaks the iOS test
+				// link. Keep it off the native test classpath - only JVM tests use FakeFileSystem.
+				implementation(libs.okio.fakefilesystem)
+			}
 		}
 		val androidMain by getting {
 			dependsOn(jvmMain)
@@ -124,7 +129,11 @@ kotlin {
 				api(libs.ktor.client.darwin)
 			}
 		}
-		val iosTest by getting
+		val iosTest by getting {
+			dependencies {
+				implementation(libs.multiplatform.settings.test)
+			}
+		}
 		val androidHostTest by getting {
 			dependencies {
 				implementation(kotlin("test"))

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -4,7 +4,7 @@ import org.koin.core.module.Module
 
 /**
  * Provides the platform's [AuthTokenStore] binding. Each platform supplies an
- * encrypted implementation where one exists; iOS currently falls back to the
- * plaintext file store pending a Keychain-backed implementation.
+ * encrypted-at-rest implementation: Android uses EncryptedSharedPreferences,
+ * desktop uses an AES-GCM encrypted file, and iOS uses the Keychain.
  */
 expect val authTokenStoreModule: Module

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/KeychainAuthTokenStore.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/KeychainAuthTokenStore.kt
@@ -1,0 +1,62 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore.Companion.accountKey
+import com.russhwolf.settings.ExperimentalSettingsImplementation
+import com.russhwolf.settings.KeychainSettings
+import com.russhwolf.settings.Settings
+import io.github.aakira.napier.Napier
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.serialization.json.Json
+
+/**
+ * iOS [AuthTokenStore] backed by the Keychain. The account-keyed token map is
+ * serialized to JSON and stored as a single `kSecClassGenericPassword` item, so
+ * the tokens are encrypted at rest by the OS (Secure Enclave / device passcode)
+ * rather than sitting in a plaintext file in the app sandbox.
+ */
+@OptIn(ExperimentalSettingsImplementation::class)
+class KeychainAuthTokenStore(
+	private val json: Json,
+	private val keychain: Settings = KeychainSettings(service = KEYCHAIN_SERVICE),
+) : AuthTokenStore {
+
+	private val lock = reentrantLock()
+
+	override fun get(url: String, userId: Long): AuthTokens? = lock.withLock {
+		loadMap()[accountKey(url, userId)]
+	}
+
+	override fun put(url: String, userId: Long, tokens: AuthTokens): Unit = lock.withLock {
+		val updated = loadMap().toMutableMap()
+		updated[accountKey(url, userId)] = tokens
+		storeMap(updated)
+	}
+
+	override fun remove(url: String, userId: Long): Unit = lock.withLock {
+		val updated = loadMap().toMutableMap()
+		if (updated.remove(accountKey(url, userId)) != null) {
+			storeMap(updated)
+		}
+	}
+
+	private fun loadMap(): Map<String, AuthTokens> {
+		val stored = keychain.getStringOrNull(TOKENS_KEY) ?: return emptyMap()
+		return try {
+			json.decodeFromString<Map<String, AuthTokens>>(stored)
+			// Corruption or tampering: treat as no tokens (forces re-login).
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.w("Failed to parse Keychain auth tokens; treating as empty", e)
+			emptyMap()
+		}
+	}
+
+	private fun storeMap(tokens: Map<String, AuthTokens>) {
+		keychain.putString(TOKENS_KEY, json.encodeToString(tokens))
+	}
+
+	companion object {
+		private const val KEYCHAIN_SERVICE = "com.darkrockstudios.apps.hammer.auth_tokens"
+		private const val TOKENS_KEY = "tokens"
+	}
+}

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/authTokenStoreModule.kt
@@ -1,11 +1,8 @@
 package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
 
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-// TODO(F-4): iOS Keychain-backed AuthTokenStore. iOS still uses the plaintext
-//  file store; replace with a Keychain implementation.
 actual val authTokenStoreModule = module {
-	singleOf(::FileAuthTokenStore) bind AuthTokenStore::class
+	single { KeychainAuthTokenStore(json = get()) } bind AuthTokenStore::class
 }

--- a/common/src/iosTest/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/KeychainAuthTokenStoreTest.kt
+++ b/common/src/iosTest/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/KeychainAuthTokenStoreTest.kt
@@ -1,0 +1,74 @@
+package com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource
+
+import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
+import com.russhwolf.settings.MapSettings
+import kotlinx.serialization.json.Json
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class KeychainAuthTokenStoreTest {
+
+	private lateinit var json: Json
+	private lateinit var settings: MapSettings
+
+	private val url = "hammer.ink"
+	private val userId = 1L
+	private val tokens = AuthTokens(bearerToken = "zxc456", refreshToken = "bnm789")
+
+	@BeforeTest
+	fun setup() {
+		json = createJsonSerializer()
+		settings = MapSettings()
+	}
+
+	private fun createStore(keychain: MapSettings = settings) = KeychainAuthTokenStore(
+		json = json,
+		keychain = keychain,
+	)
+
+	@Test
+	fun tokensRoundTripThroughTheStore() {
+		val store = createStore()
+
+		store.put(url, userId, tokens)
+
+		assertEquals(tokens, store.get(url, userId))
+	}
+
+	@Test
+	fun keyingByUrlAndUserIdIsolatesAccounts() {
+		val store = createStore()
+		store.put(url, userId, tokens)
+
+		assertEquals(tokens, store.get(url, userId))
+		assertNull(store.get("other.example.com", userId))
+		assertNull(store.get(url, 999L))
+	}
+
+	@Test
+	fun removeClearsASingleAccount() {
+		val store = createStore()
+		store.put(url, userId, tokens)
+		store.put("other.example.com", 2L, AuthTokens("a", "b"))
+
+		store.remove(url, userId)
+
+		assertNull(store.get(url, userId))
+		assertEquals(AuthTokens("a", "b"), store.get("other.example.com", 2L))
+	}
+
+	@Test
+	fun separateKeychainsAreIsolated() {
+		createStore().put(url, userId, tokens)
+
+		val other = createStore(keychain = MapSettings())
+		assertNull(other.get(url, userId))
+	}
+
+	@Test
+	fun missingEntryYieldsNoTokens() {
+		assertNull(createStore().get(url, userId))
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -308,6 +308,7 @@ jetbrains_kover = { group = "org.jetbrains.kotlinx", name = "kover-gradle-plugin
 logback_classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback_classic" }
 
 multiplatform_settings = { group = "com.russhwolf", name = "multiplatform-settings-no-arg", version.ref = "multiplatform_settings" }
+multiplatform_settings_test = { group = "com.russhwolf", name = "multiplatform-settings-test", version.ref = "multiplatform_settings" }
 korge-core = { group = "com.soywiz.korge", name = "korge-core", version.ref = "korge-core" }
 kotlinx-io-okio = { group = "org.jetbrains.kotlinx", name = "kotlinx-io-okio", version.ref = "kotlinx-io-okio" }
 


### PR DESCRIPTION
## Summary

Completes client-side auth-token-at-rest encryption for iOS — the last platform left on the plaintext file store after Android and desktop were done — and brings the iOS unit test suite online in CI.

### iOS token encryption
- New `KeychainAuthTokenStore` (iosMain) stores the account-keyed token map as a single `kSecClassGenericPassword` Keychain item, encrypted by the OS (Secure Enclave / device passcode) instead of a plaintext file in the app sandbox. Backed by multiplatform-settings' `KeychainSettings`.
- Wired into the iOS Koin module; the `TODO(F-4)` plaintext fallback is gone.
- Matches the other stores' post-refactor shape (#following `Combine token migration steps into 1`): no plaintext-file migration. That `FileAuthTokenStore` (`auth_tokens.json`) was only ever a develop-stage fallback and never shipped, so there's nothing real to migrate. The genuine legacy case — inline tokens in `server.json` — is already handled by `migrateInlineTokens` in the common `ServerSettingsFilesystemDatasource`.

### iOS tests in CI
- `linkDebugTestIosSimulatorArm64` was failing on a clean checkout: `okio-fakefilesystem` references the deprecated `kotlinx.datetime.Clock` typealias, which double-binds during Kotlin/Native klib caching. Because `commonTest` declared `okio-fakefilesystem`, it polluted the Native test classpath even though only JVM tests use `FakeFileSystem`.
- Moved `okio-fakefilesystem` from `commonTest` to `jvmTest` (still reaches `desktopTest` transitively, off the Native classpath).
- The `ios-compile` CI job now also runs `:common:iosSimulatorArm64Test` — **110+ tests across 11 suites that previously never executed**, including the 5 new `KeychainAuthTokenStoreTest` cases.

## Test plan
- `./gradlew :common:iosSimulatorArm64Test` → all suites green (KeychainAuthTokenStore: round-trip, account isolation, removal, keychain isolation, missing-entry).
- `./gradlew :common:compileTestKotlinDesktop` → desktop tests still compile after the dependency move (pre-commit hook also runs the desktop suite).
- `:composeUi:compileKotlinIosArm64` / `compileKotlinIosSimulatorArm64` → both iOS targets compile.

## Note for reviewers
`KeychainSettings` uses the default Keychain accessibility (`kSecAttrAccessibleWhenUnlocked`): not iCloud-synced, but included in encrypted device backups. Re-login is the fallback, so this is reasonable; switching to `...ThisDeviceOnly` would require a direct `platform.Security` implementation instead of `KeychainSettings`.

The `ios-compile` job's display name changed to "iOS compile & test" — if a required status check is pinned to the old name "iOS compile check", it'll need re-pointing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)