### PR TITLE
feat: detect moved paragraphs in prose diff (blue highlight)

### DIFF
--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/diff/DiffTypes.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/diff/DiffTypes.kt
@@ -10,12 +10,13 @@ data class SourceRange(val start: Int, val endExclusive: Int) {
 	}
 }
 
-enum class DiffKind { DELETED, INSERTED }
+enum class DiffKind { DELETED, INSERTED, MOVED }
 
 /** One change span to highlight in either the left (old) or right (new) text. */
 data class DiffSpan(
 	val kind: DiffKind,
 	val range: SourceRange,
+	val moveId: Int? = null,
 )
 
 /**

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiff.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiff.kt
@@ -102,29 +102,93 @@ object ProseDiff {
 		}
 
 		val merged = mergeSmallGaps(rawHunks, SMALL_GAP_THRESHOLD)
+		val movePlan = detectMovedParagraphs(merged, left.plain.plain, right.plain.plain)
 
 		val leftSpans = ArrayList<DiffSpan>(merged.size)
 		val rightSpans = ArrayList<DiffSpan>(merged.size)
 		val anchors = ArrayList<DiffAnchor>(merged.size * 2 + 2)
+		val emittedLeftMoves = HashSet<Int>()
+		val emittedRightMoves = HashSet<Int>()
 		anchors += DiffAnchor(0, 0)
 
-		for (h in merged) {
-			anchors += DiffAnchor(
-				leftSource = left.plain.plainOffsetToSource(h.leftPlainStart),
-				rightSource = right.plain.plainOffsetToSource(h.rightPlainStart),
-			)
+		for ((index, h) in merged.withIndex()) {
+			val hunkMoveId = movePlan.hunkMoveIds[index]
+			val skipAnchors = hunkMoveId != null || movePlan.isParagraphMoveArtifact(h)
+			if (!skipAnchors) {
+				anchors += DiffAnchor(
+					leftSource = left.plain.plainOffsetToSource(h.leftPlainStart),
+					rightSource = right.plain.plainOffsetToSource(h.rightPlainStart),
+				)
+			}
 			if (h.leftPlainEnd > h.leftPlainStart) {
-				val range = left.plain.plainRangeToSource(h.leftPlainStart, h.leftPlainEnd)
-				if (!range.isEmpty) leftSpans += DiffSpan(DiffKind.DELETED, range)
+				val moved = movePlan.leftMovedParagraph(h.leftPlainStart, h.leftPlainEnd)
+				when {
+					hunkMoveId != null -> {
+						val range = left.plain.plainRangeToSource(h.leftPlainStart, h.leftPlainEnd)
+						if (!range.isEmpty) {
+							leftSpans += DiffSpan(DiffKind.MOVED, range, moveId = hunkMoveId)
+						}
+					}
+
+					moved != null -> {
+						if (emittedLeftMoves.add(moved.moveId)) {
+							val range = left.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
+							if (!range.isEmpty) {
+								leftSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
+							}
+						}
+					}
+
+					!movePlan.isStableLeftParagraph(h.leftPlainStart, h.leftPlainEnd) -> {
+						val range = left.plain.plainRangeToSource(h.leftPlainStart, h.leftPlainEnd)
+						if (!range.isEmpty) leftSpans += DiffSpan(DiffKind.DELETED, range)
+					}
+				}
 			}
 			if (h.rightPlainEnd > h.rightPlainStart) {
-				val range = right.plain.plainRangeToSource(h.rightPlainStart, h.rightPlainEnd)
-				if (!range.isEmpty) rightSpans += DiffSpan(DiffKind.INSERTED, range)
+				val moved = movePlan.rightMovedParagraph(h.rightPlainStart, h.rightPlainEnd)
+				when {
+					hunkMoveId != null -> {
+						val range = right.plain.plainRangeToSource(h.rightPlainStart, h.rightPlainEnd)
+						if (!range.isEmpty) {
+							rightSpans += DiffSpan(DiffKind.MOVED, range, moveId = hunkMoveId)
+						}
+					}
+
+					moved != null -> {
+						if (emittedRightMoves.add(moved.moveId)) {
+							val range = right.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
+							if (!range.isEmpty) {
+								rightSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
+							}
+						}
+					}
+
+					!movePlan.isStableRightParagraph(h.rightPlainStart, h.rightPlainEnd) -> {
+						val range = right.plain.plainRangeToSource(h.rightPlainStart, h.rightPlainEnd)
+						if (!range.isEmpty) rightSpans += DiffSpan(DiffKind.INSERTED, range)
+					}
+				}
 			}
-			anchors += DiffAnchor(
-				leftSource = left.plain.plainOffsetToSource(h.leftPlainEnd, preferEnd = true),
-				rightSource = right.plain.plainOffsetToSource(h.rightPlainEnd, preferEnd = true),
-			)
+			if (!skipAnchors) {
+				anchors += DiffAnchor(
+					leftSource = left.plain.plainOffsetToSource(h.leftPlainEnd, preferEnd = true),
+					rightSource = right.plain.plainOffsetToSource(h.rightPlainEnd, preferEnd = true),
+				)
+			}
+		}
+
+		for (moved in movePlan.leftMovedParagraphs) {
+			if (emittedLeftMoves.add(moved.moveId)) {
+				val range = left.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
+				if (!range.isEmpty) leftSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
+			}
+		}
+		for (moved in movePlan.rightMovedParagraphs) {
+			if (emittedRightMoves.add(moved.moveId)) {
+				val range = right.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
+				if (!range.isEmpty) rightSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
+			}
 		}
 
 		anchors += DiffAnchor(left.sourceLength, right.sourceLength)
@@ -143,6 +207,214 @@ private data class Hunk(
 	val rightPlainStart: Int,
 	val rightPlainEnd: Int,
 )
+
+private data class MoveCandidate(
+	val hunkIndex: Int,
+	val key: String,
+)
+
+private data class Paragraph(
+	val range: SourceRange,
+	val key: String,
+	val index: Int,
+)
+
+private data class ParagraphMatch(
+	val left: Paragraph,
+	val right: Paragraph,
+)
+
+private data class MovedParagraph(
+	val range: SourceRange,
+	val moveId: Int,
+)
+
+private data class MovePlan(
+	val hunkMoveIds: Map<Int, Int> = emptyMap(),
+	val leftMovedParagraphs: List<MovedParagraph> = emptyList(),
+	val rightMovedParagraphs: List<MovedParagraph> = emptyList(),
+	val leftStableParagraphs: List<SourceRange> = emptyList(),
+	val rightStableParagraphs: List<SourceRange> = emptyList(),
+) {
+	private val hasParagraphMoves: Boolean get() = leftMovedParagraphs.isNotEmpty() || rightMovedParagraphs.isNotEmpty()
+
+	fun leftMovedParagraph(start: Int, end: Int): MovedParagraph? =
+		leftMovedParagraphs.firstOrNull { rangesOverlap(start, end, it.range) }
+
+	fun rightMovedParagraph(start: Int, end: Int): MovedParagraph? =
+		rightMovedParagraphs.firstOrNull { rangesOverlap(start, end, it.range) }
+
+	fun isStableLeftParagraph(start: Int, end: Int): Boolean =
+		hasParagraphMoves && leftStableParagraphs.any { rangesOverlap(start, end, it) }
+
+	fun isStableRightParagraph(start: Int, end: Int): Boolean =
+		hasParagraphMoves && rightStableParagraphs.any { rangesOverlap(start, end, it) }
+
+	fun isParagraphMoveArtifact(h: Hunk): Boolean =
+		hasParagraphMoves &&
+			(
+				leftMovedParagraph(h.leftPlainStart, h.leftPlainEnd) != null ||
+					rightMovedParagraph(h.rightPlainStart, h.rightPlainEnd) != null ||
+					isStableLeftParagraph(h.leftPlainStart, h.leftPlainEnd) ||
+					isStableRightParagraph(h.rightPlainStart, h.rightPlainEnd)
+				)
+}
+
+private fun detectMovedParagraphs(
+	hunks: List<Hunk>,
+	leftPlain: String,
+	rightPlain: String,
+): MovePlan {
+	val hunkMoveIds = detectPureMovedParagraphHunks(hunks, leftPlain, rightPlain)
+	if (hunkMoveIds.isNotEmpty()) return MovePlan(hunkMoveIds = hunkMoveIds)
+
+	return detectMovedParagraphsBySequence(leftPlain, rightPlain)
+}
+
+private fun detectPureMovedParagraphHunks(
+	hunks: List<Hunk>,
+	leftPlain: String,
+	rightPlain: String,
+): Map<Int, Int> {
+	val deletes = ArrayList<MoveCandidate>()
+	val inserts = ArrayList<MoveCandidate>()
+
+	for ((index, h) in hunks.withIndex()) {
+		if (isPureDeleteParagraphHunk(h, leftPlain)) {
+			val key = normalizeParagraph(leftPlain.substring(h.leftPlainStart, h.leftPlainEnd))
+			if (key.isNotEmpty()) deletes += MoveCandidate(index, key)
+		}
+		if (isPureInsertParagraphHunk(h, rightPlain)) {
+			val key = normalizeParagraph(rightPlain.substring(h.rightPlainStart, h.rightPlainEnd))
+			if (key.isNotEmpty()) inserts += MoveCandidate(index, key)
+		}
+	}
+
+	val deleteCounts = deletes.groupingBy { it.key }.eachCount()
+	val insertCounts = inserts.groupingBy { it.key }.eachCount()
+	val insertsByKey = inserts.associateBy { it.key }
+	val movedHunks = LinkedHashMap<Int, Int>()
+	var nextMoveId = 0
+
+	for (delete in deletes) {
+		if (deleteCounts[delete.key] == 1 && insertCounts[delete.key] == 1) {
+			val insert = insertsByKey.getValue(delete.key)
+			movedHunks[delete.hunkIndex] = nextMoveId
+			movedHunks[insert.hunkIndex] = nextMoveId
+			nextMoveId++
+		}
+	}
+
+	return movedHunks
+}
+
+private fun detectMovedParagraphsBySequence(leftPlain: String, rightPlain: String): MovePlan {
+	val leftParagraphs = paragraphs(leftPlain)
+	val rightParagraphs = paragraphs(rightPlain)
+	if (leftParagraphs.isEmpty() || rightParagraphs.isEmpty()) return MovePlan()
+
+	val leftCounts = leftParagraphs.groupingBy { it.key }.eachCount()
+	val rightCounts = rightParagraphs.groupingBy { it.key }.eachCount()
+	val rightByKey = rightParagraphs.associateBy { it.key }
+	val matches = leftParagraphs.mapNotNull { left ->
+		if (leftCounts[left.key] == 1 && rightCounts[left.key] == 1) {
+			ParagraphMatch(left, rightByKey.getValue(left.key))
+		} else {
+			null
+		}
+	}
+	if (matches.isEmpty()) return MovePlan()
+
+	val stableKeys = longestIncreasingParagraphKeys(matches)
+	val movedMatches = matches.filter { it.left.key !in stableKeys }
+	if (movedMatches.isEmpty()) return MovePlan()
+
+	val leftMoved = ArrayList<MovedParagraph>(movedMatches.size)
+	val rightMoved = ArrayList<MovedParagraph>(movedMatches.size)
+	for ((moveId, match) in movedMatches.withIndex()) {
+		leftMoved += MovedParagraph(match.left.range, moveId)
+		rightMoved += MovedParagraph(match.right.range, moveId)
+	}
+
+	return MovePlan(
+		leftMovedParagraphs = leftMoved,
+		rightMovedParagraphs = rightMoved,
+		leftStableParagraphs = matches.filter { it.left.key in stableKeys }.map { it.left.range },
+		rightStableParagraphs = matches.filter { it.left.key in stableKeys }.map { it.right.range },
+	)
+}
+
+private fun paragraphs(plain: String): List<Paragraph> {
+	val paragraphs = ArrayList<Paragraph>()
+	var start = 0
+	while (start <= plain.length) {
+		val newline = plain.indexOf('\n', start)
+		val end = if (newline == -1) plain.length else newline
+		val key = normalizeParagraph(plain.substring(start, end))
+		if (key.isNotEmpty()) {
+			paragraphs += Paragraph(SourceRange(start, end), key, paragraphs.size)
+		}
+		if (newline == -1) break
+		start = newline + 1
+	}
+	return paragraphs
+}
+
+private fun longestIncreasingParagraphKeys(matches: List<ParagraphMatch>): Set<String> {
+	if (matches.isEmpty()) return emptySet()
+
+	val tails = IntArray(matches.size)
+	val previous = IntArray(matches.size) { -1 }
+	var size = 0
+
+	for (i in matches.indices) {
+		val rightIndex = matches[i].right.index
+		var lo = 0
+		var hi = size
+		while (lo < hi) {
+			val mid = (lo + hi) ushr 1
+			if (matches[tails[mid]].right.index < rightIndex) {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+		if (lo > 0) previous[i] = tails[lo - 1]
+		tails[lo] = i
+		if (lo == size) size++
+	}
+
+	val stableKeys = HashSet<String>()
+	var cursor = tails[size - 1]
+	while (cursor != -1) {
+		stableKeys += matches[cursor].left.key
+		cursor = previous[cursor]
+	}
+	return stableKeys
+}
+
+private fun isPureDeleteParagraphHunk(h: Hunk, leftPlain: String): Boolean =
+	h.leftPlainEnd > h.leftPlainStart &&
+		h.rightPlainEnd == h.rightPlainStart &&
+		isCompleteParagraph(leftPlain, h.leftPlainStart, h.leftPlainEnd)
+
+private fun isPureInsertParagraphHunk(h: Hunk, rightPlain: String): Boolean =
+	h.rightPlainEnd > h.rightPlainStart &&
+		h.leftPlainEnd == h.leftPlainStart &&
+		isCompleteParagraph(rightPlain, h.rightPlainStart, h.rightPlainEnd)
+
+private fun isCompleteParagraph(plain: String, start: Int, end: Int): Boolean {
+	if (start < 0 || end < start || end > plain.length) return false
+	val startsAtBoundary = start == 0 || plain[start - 1] == '\n'
+	val endsAtBoundary = end == plain.length || plain[end] == '\n'
+	return startsAtBoundary && endsAtBoundary
+}
+
+private fun normalizeParagraph(text: String): String =
+	text.replace(Regex("\\s+"), " ").trim()
+
+private fun rangesOverlap(start: Int, end: Int, range: SourceRange): Boolean =
+	start < range.endExclusive && end > range.start
 
 /**
  * Slide a pure insertion or deletion along its run of equivalent positions so the changed block

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiff.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiff.kt
@@ -113,7 +113,12 @@ object ProseDiff {
 
 		for ((index, h) in merged.withIndex()) {
 			val hunkMoveId = movePlan.hunkMoveIds[index]
-			val skipAnchors = hunkMoveId != null || movePlan.isParagraphMoveArtifact(h)
+			val leftMoved = movePlan.leftMovedParagraph(h.leftPlainStart, h.leftPlainEnd)
+			val rightMoved = movePlan.rightMovedParagraph(h.rightPlainStart, h.rightPlainEnd)
+			val leftStable = movePlan.isStableLeftParagraph(h.leftPlainStart, h.leftPlainEnd)
+			val rightStable = movePlan.isStableRightParagraph(h.rightPlainStart, h.rightPlainEnd)
+			val skipAnchors = hunkMoveId != null ||
+				(movePlan.hasParagraphMoves && (leftMoved != null || rightMoved != null || leftStable || rightStable))
 			if (!skipAnchors) {
 				anchors += DiffAnchor(
 					leftSource = left.plain.plainOffsetToSource(h.leftPlainStart),
@@ -121,7 +126,6 @@ object ProseDiff {
 				)
 			}
 			if (h.leftPlainEnd > h.leftPlainStart) {
-				val moved = movePlan.leftMovedParagraph(h.leftPlainStart, h.leftPlainEnd)
 				when {
 					hunkMoveId != null -> {
 						val range = left.plain.plainRangeToSource(h.leftPlainStart, h.leftPlainEnd)
@@ -130,23 +134,22 @@ object ProseDiff {
 						}
 					}
 
-					moved != null -> {
-						if (emittedLeftMoves.add(moved.moveId)) {
-							val range = left.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
+					leftMoved != null -> {
+						if (emittedLeftMoves.add(leftMoved.moveId)) {
+							val range = left.plain.plainRangeToSource(leftMoved.range.start, leftMoved.range.endExclusive)
 							if (!range.isEmpty) {
-								leftSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
+								leftSpans += DiffSpan(DiffKind.MOVED, range, moveId = leftMoved.moveId)
 							}
 						}
 					}
 
-					!movePlan.isStableLeftParagraph(h.leftPlainStart, h.leftPlainEnd) -> {
+					!leftStable -> {
 						val range = left.plain.plainRangeToSource(h.leftPlainStart, h.leftPlainEnd)
 						if (!range.isEmpty) leftSpans += DiffSpan(DiffKind.DELETED, range)
 					}
 				}
 			}
 			if (h.rightPlainEnd > h.rightPlainStart) {
-				val moved = movePlan.rightMovedParagraph(h.rightPlainStart, h.rightPlainEnd)
 				when {
 					hunkMoveId != null -> {
 						val range = right.plain.plainRangeToSource(h.rightPlainStart, h.rightPlainEnd)
@@ -155,16 +158,16 @@ object ProseDiff {
 						}
 					}
 
-					moved != null -> {
-						if (emittedRightMoves.add(moved.moveId)) {
-							val range = right.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
+					rightMoved != null -> {
+						if (emittedRightMoves.add(rightMoved.moveId)) {
+							val range = right.plain.plainRangeToSource(rightMoved.range.start, rightMoved.range.endExclusive)
 							if (!range.isEmpty) {
-								rightSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
+								rightSpans += DiffSpan(DiffKind.MOVED, range, moveId = rightMoved.moveId)
 							}
 						}
 					}
 
-					!movePlan.isStableRightParagraph(h.rightPlainStart, h.rightPlainEnd) -> {
+					!rightStable -> {
 						val range = right.plain.plainRangeToSource(h.rightPlainStart, h.rightPlainEnd)
 						if (!range.isEmpty) rightSpans += DiffSpan(DiffKind.INSERTED, range)
 					}
@@ -236,7 +239,7 @@ private data class MovePlan(
 	val leftStableParagraphs: List<SourceRange> = emptyList(),
 	val rightStableParagraphs: List<SourceRange> = emptyList(),
 ) {
-	private val hasParagraphMoves: Boolean get() = leftMovedParagraphs.isNotEmpty() || rightMovedParagraphs.isNotEmpty()
+	val hasParagraphMoves: Boolean get() = leftMovedParagraphs.isNotEmpty() || rightMovedParagraphs.isNotEmpty()
 
 	fun leftMovedParagraph(start: Int, end: Int): MovedParagraph? =
 		leftMovedParagraphs.firstOrNull { rangesOverlap(start, end, it.range) }
@@ -249,15 +252,6 @@ private data class MovePlan(
 
 	fun isStableRightParagraph(start: Int, end: Int): Boolean =
 		hasParagraphMoves && rightStableParagraphs.any { rangesOverlap(start, end, it) }
-
-	fun isParagraphMoveArtifact(h: Hunk): Boolean =
-		hasParagraphMoves &&
-			(
-				leftMovedParagraph(h.leftPlainStart, h.leftPlainEnd) != null ||
-					rightMovedParagraph(h.rightPlainStart, h.rightPlainEnd) != null ||
-					isStableLeftParagraph(h.leftPlainStart, h.leftPlainEnd) ||
-					isStableRightParagraph(h.rightPlainStart, h.rightPlainEnd)
-				)
 }
 
 private fun detectMovedParagraphs(
@@ -410,8 +404,10 @@ private fun isCompleteParagraph(plain: String, start: Int, end: Int): Boolean {
 	return startsAtBoundary && endsAtBoundary
 }
 
+private val WhitespaceRun = Regex("\\s+")
+
 private fun normalizeParagraph(text: String): String =
-	text.replace(Regex("\\s+"), " ").trim()
+	text.replace(WhitespaceRun, " ").trim()
 
 private fun rangesOverlap(start: Int, end: Int, range: SourceRange): Boolean =
 	start < range.endExclusive && end > range.start

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiff.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiff.kt
@@ -102,78 +102,37 @@ object ProseDiff {
 		}
 
 		val merged = mergeSmallGaps(rawHunks, SMALL_GAP_THRESHOLD)
-		val movePlan = detectMovedParagraphs(merged, left.plain.plain, right.plain.plain)
+		val movePlan = detectMovedParagraphs(left.plain.plain, right.plain.plain)
 
 		val leftSpans = ArrayList<DiffSpan>(merged.size)
 		val rightSpans = ArrayList<DiffSpan>(merged.size)
 		val anchors = ArrayList<DiffAnchor>(merged.size * 2 + 2)
-		val emittedLeftMoves = HashSet<Int>()
-		val emittedRightMoves = HashSet<Int>()
 		anchors += DiffAnchor(0, 0)
 
-		for ((index, h) in merged.withIndex()) {
-			val hunkMoveId = movePlan.hunkMoveIds[index]
-			val leftMoved = movePlan.leftMovedParagraph(h.leftPlainStart, h.leftPlainEnd)
-			val rightMoved = movePlan.rightMovedParagraph(h.rightPlainStart, h.rightPlainEnd)
-			val leftStable = movePlan.isStableLeftParagraph(h.leftPlainStart, h.leftPlainEnd)
-			val rightStable = movePlan.isStableRightParagraph(h.rightPlainStart, h.rightPlainEnd)
-			val skipAnchors = hunkMoveId != null ||
-				(movePlan.hasParagraphMoves && (leftMoved != null || rightMoved != null || leftStable || rightStable))
-			if (!skipAnchors) {
+		for (h in merged) {
+			// A hunk straddling a move can't anchor scroll-sync (its two sides sit in different
+			// paragraphs), so leave moved hunks out of the monotonic offset map.
+			val touchesMove = movePlan.hasMoves &&
+				movePlan.overlapsMove(h.leftPlainStart, h.leftPlainEnd, h.rightPlainStart, h.rightPlainEnd)
+			if (!touchesMove) {
 				anchors += DiffAnchor(
 					leftSource = left.plain.plainOffsetToSource(h.leftPlainStart),
 					rightSource = right.plain.plainOffsetToSource(h.rightPlainStart),
 				)
 			}
-			if (h.leftPlainEnd > h.leftPlainStart) {
-				when {
-					hunkMoveId != null -> {
-						val range = left.plain.plainRangeToSource(h.leftPlainStart, h.leftPlainEnd)
-						if (!range.isEmpty) {
-							leftSpans += DiffSpan(DiffKind.MOVED, range, moveId = hunkMoveId)
-						}
-					}
-
-					leftMoved != null -> {
-						if (emittedLeftMoves.add(leftMoved.moveId)) {
-							val range = left.plain.plainRangeToSource(leftMoved.range.start, leftMoved.range.endExclusive)
-							if (!range.isEmpty) {
-								leftSpans += DiffSpan(DiffKind.MOVED, range, moveId = leftMoved.moveId)
-							}
-						}
-					}
-
-					!leftStable -> {
-						val range = left.plain.plainRangeToSource(h.leftPlainStart, h.leftPlainEnd)
-						if (!range.isEmpty) leftSpans += DiffSpan(DiffKind.DELETED, range)
-					}
-				}
+			// Subtract the moved/stable paragraph ranges so a hunk that merged a move with an
+			// adjacent edit still surfaces the edit, without re-highlighting the moved text.
+			for (sub in subtractBlocked(h.leftPlainStart, h.leftPlainEnd, movePlan.leftBlocked)) {
+				if (left.plain.plain.isBlankRange(sub)) continue
+				val range = left.plain.plainRangeToSource(sub.start, sub.endExclusive)
+				if (!range.isEmpty) leftSpans += DiffSpan(DiffKind.DELETED, range)
 			}
-			if (h.rightPlainEnd > h.rightPlainStart) {
-				when {
-					hunkMoveId != null -> {
-						val range = right.plain.plainRangeToSource(h.rightPlainStart, h.rightPlainEnd)
-						if (!range.isEmpty) {
-							rightSpans += DiffSpan(DiffKind.MOVED, range, moveId = hunkMoveId)
-						}
-					}
-
-					rightMoved != null -> {
-						if (emittedRightMoves.add(rightMoved.moveId)) {
-							val range = right.plain.plainRangeToSource(rightMoved.range.start, rightMoved.range.endExclusive)
-							if (!range.isEmpty) {
-								rightSpans += DiffSpan(DiffKind.MOVED, range, moveId = rightMoved.moveId)
-							}
-						}
-					}
-
-					!rightStable -> {
-						val range = right.plain.plainRangeToSource(h.rightPlainStart, h.rightPlainEnd)
-						if (!range.isEmpty) rightSpans += DiffSpan(DiffKind.INSERTED, range)
-					}
-				}
+			for (sub in subtractBlocked(h.rightPlainStart, h.rightPlainEnd, movePlan.rightBlocked)) {
+				if (right.plain.plain.isBlankRange(sub)) continue
+				val range = right.plain.plainRangeToSource(sub.start, sub.endExclusive)
+				if (!range.isEmpty) rightSpans += DiffSpan(DiffKind.INSERTED, range)
 			}
-			if (!skipAnchors) {
+			if (!touchesMove) {
 				anchors += DiffAnchor(
 					leftSource = left.plain.plainOffsetToSource(h.leftPlainEnd, preferEnd = true),
 					rightSource = right.plain.plainOffsetToSource(h.rightPlainEnd, preferEnd = true),
@@ -181,17 +140,13 @@ object ProseDiff {
 			}
 		}
 
-		for (moved in movePlan.leftMovedParagraphs) {
-			if (emittedLeftMoves.add(moved.moveId)) {
-				val range = left.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
-				if (!range.isEmpty) leftSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
-			}
+		for (moved in movePlan.leftMoves) {
+			val range = left.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
+			if (!range.isEmpty) leftSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
 		}
-		for (moved in movePlan.rightMovedParagraphs) {
-			if (emittedRightMoves.add(moved.moveId)) {
-				val range = right.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
-				if (!range.isEmpty) rightSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
-			}
+		for (moved in movePlan.rightMoves) {
+			val range = right.plain.plainRangeToSource(moved.range.start, moved.range.endExclusive)
+			if (!range.isEmpty) rightSpans += DiffSpan(DiffKind.MOVED, range, moveId = moved.moveId)
 		}
 
 		anchors += DiffAnchor(left.sourceLength, right.sourceLength)
@@ -211,11 +166,6 @@ private data class Hunk(
 	val rightPlainEnd: Int,
 )
 
-private data class MoveCandidate(
-	val hunkIndex: Int,
-	val key: String,
-)
-
 private data class Paragraph(
 	val range: SourceRange,
 	val key: String,
@@ -233,76 +183,21 @@ private data class MovedParagraph(
 )
 
 private data class MovePlan(
-	val hunkMoveIds: Map<Int, Int> = emptyMap(),
-	val leftMovedParagraphs: List<MovedParagraph> = emptyList(),
-	val rightMovedParagraphs: List<MovedParagraph> = emptyList(),
-	val leftStableParagraphs: List<SourceRange> = emptyList(),
-	val rightStableParagraphs: List<SourceRange> = emptyList(),
+	val leftMoves: List<MovedParagraph> = emptyList(),
+	val rightMoves: List<MovedParagraph> = emptyList(),
+	/** Moved + stable paragraph ranges (sorted by start) to carve out of delete spans. */
+	val leftBlocked: List<SourceRange> = emptyList(),
+	/** Moved + stable paragraph ranges (sorted by start) to carve out of insert spans. */
+	val rightBlocked: List<SourceRange> = emptyList(),
 ) {
-	val hasParagraphMoves: Boolean get() = leftMovedParagraphs.isNotEmpty() || rightMovedParagraphs.isNotEmpty()
+	val hasMoves: Boolean get() = leftMoves.isNotEmpty()
 
-	fun leftMovedParagraph(start: Int, end: Int): MovedParagraph? =
-		leftMovedParagraphs.firstOrNull { rangesOverlap(start, end, it.range) }
-
-	fun rightMovedParagraph(start: Int, end: Int): MovedParagraph? =
-		rightMovedParagraphs.firstOrNull { rangesOverlap(start, end, it.range) }
-
-	fun isStableLeftParagraph(start: Int, end: Int): Boolean =
-		hasParagraphMoves && leftStableParagraphs.any { rangesOverlap(start, end, it) }
-
-	fun isStableRightParagraph(start: Int, end: Int): Boolean =
-		hasParagraphMoves && rightStableParagraphs.any { rangesOverlap(start, end, it) }
+	fun overlapsMove(leftStart: Int, leftEnd: Int, rightStart: Int, rightEnd: Int): Boolean =
+		leftMoves.any { rangesOverlap(leftStart, leftEnd, it.range) } ||
+			rightMoves.any { rangesOverlap(rightStart, rightEnd, it.range) }
 }
 
-private fun detectMovedParagraphs(
-	hunks: List<Hunk>,
-	leftPlain: String,
-	rightPlain: String,
-): MovePlan {
-	val hunkMoveIds = detectPureMovedParagraphHunks(hunks, leftPlain, rightPlain)
-	if (hunkMoveIds.isNotEmpty()) return MovePlan(hunkMoveIds = hunkMoveIds)
-
-	return detectMovedParagraphsBySequence(leftPlain, rightPlain)
-}
-
-private fun detectPureMovedParagraphHunks(
-	hunks: List<Hunk>,
-	leftPlain: String,
-	rightPlain: String,
-): Map<Int, Int> {
-	val deletes = ArrayList<MoveCandidate>()
-	val inserts = ArrayList<MoveCandidate>()
-
-	for ((index, h) in hunks.withIndex()) {
-		if (isPureDeleteParagraphHunk(h, leftPlain)) {
-			val key = normalizeParagraph(leftPlain.substring(h.leftPlainStart, h.leftPlainEnd))
-			if (key.isNotEmpty()) deletes += MoveCandidate(index, key)
-		}
-		if (isPureInsertParagraphHunk(h, rightPlain)) {
-			val key = normalizeParagraph(rightPlain.substring(h.rightPlainStart, h.rightPlainEnd))
-			if (key.isNotEmpty()) inserts += MoveCandidate(index, key)
-		}
-	}
-
-	val deleteCounts = deletes.groupingBy { it.key }.eachCount()
-	val insertCounts = inserts.groupingBy { it.key }.eachCount()
-	val insertsByKey = inserts.associateBy { it.key }
-	val movedHunks = LinkedHashMap<Int, Int>()
-	var nextMoveId = 0
-
-	for (delete in deletes) {
-		if (deleteCounts[delete.key] == 1 && insertCounts[delete.key] == 1) {
-			val insert = insertsByKey.getValue(delete.key)
-			movedHunks[delete.hunkIndex] = nextMoveId
-			movedHunks[insert.hunkIndex] = nextMoveId
-			nextMoveId++
-		}
-	}
-
-	return movedHunks
-}
-
-private fun detectMovedParagraphsBySequence(leftPlain: String, rightPlain: String): MovePlan {
+private fun detectMovedParagraphs(leftPlain: String, rightPlain: String): MovePlan {
 	val leftParagraphs = paragraphs(leftPlain)
 	val rightParagraphs = paragraphs(rightPlain)
 	if (leftParagraphs.isEmpty() || rightParagraphs.isEmpty()) return MovePlan()
@@ -319,23 +214,52 @@ private fun detectMovedParagraphsBySequence(leftPlain: String, rightPlain: Strin
 	}
 	if (matches.isEmpty()) return MovePlan()
 
-	val stableKeys = longestIncreasingParagraphKeys(matches)
+	// The stable backbone is the longest run of matches whose relative order is preserved. A
+	// backbone of a single paragraph is no backbone at all (one paragraph is trivially "in order"
+	// even after teleporting), so a fully reordered set is treated as all-moved.
+	val backbone = longestIncreasingParagraphKeys(matches)
+	val stableKeys = if (backbone.size >= 2) backbone else emptySet()
 	val movedMatches = matches.filter { it.left.key !in stableKeys }
 	if (movedMatches.isEmpty()) return MovePlan()
 
-	val leftMoved = ArrayList<MovedParagraph>(movedMatches.size)
-	val rightMoved = ArrayList<MovedParagraph>(movedMatches.size)
+	val leftMoves = ArrayList<MovedParagraph>(movedMatches.size)
+	val rightMoves = ArrayList<MovedParagraph>(movedMatches.size)
 	for ((moveId, match) in movedMatches.withIndex()) {
-		leftMoved += MovedParagraph(match.left.range, moveId)
-		rightMoved += MovedParagraph(match.right.range, moveId)
+		leftMoves += MovedParagraph(match.left.range, moveId)
+		rightMoves += MovedParagraph(match.right.range, moveId)
 	}
+	val stableMatches = matches.filter { it.left.key in stableKeys }
 
 	return MovePlan(
-		leftMovedParagraphs = leftMoved,
-		rightMovedParagraphs = rightMoved,
-		leftStableParagraphs = matches.filter { it.left.key in stableKeys }.map { it.left.range },
-		rightStableParagraphs = matches.filter { it.left.key in stableKeys }.map { it.right.range },
+		leftMoves = leftMoves,
+		rightMoves = rightMoves,
+		leftBlocked = (leftMoves.map { it.range } + stableMatches.map { it.left.range }).sortedBy { it.start },
+		rightBlocked = (rightMoves.map { it.range } + stableMatches.map { it.right.range }).sortedBy { it.start },
 	)
+}
+
+/** Remove the [blockers] (sorted by start, possibly overlapping) from `[start, end)`. */
+private fun subtractBlocked(start: Int, end: Int, blockers: List<SourceRange>): List<SourceRange> {
+	if (end <= start) return emptyList()
+	if (blockers.isEmpty()) return listOf(SourceRange(start, end))
+	val out = ArrayList<SourceRange>()
+	var cursor = start
+	for (b in blockers) {
+		if (b.endExclusive <= cursor) continue
+		if (b.start >= end) break
+		if (b.start > cursor) out += SourceRange(cursor, minOf(b.start, end))
+		cursor = maxOf(cursor, b.endExclusive)
+		if (cursor >= end) break
+	}
+	if (cursor < end) out += SourceRange(cursor, end)
+	return out
+}
+
+private fun String.isBlankRange(range: SourceRange): Boolean {
+	for (i in range.start until range.endExclusive) {
+		if (!this[i].isWhitespace()) return false
+	}
+	return true
 }
 
 private fun paragraphs(plain: String): List<Paragraph> {
@@ -385,23 +309,6 @@ private fun longestIncreasingParagraphKeys(matches: List<ParagraphMatch>): Set<S
 		cursor = previous[cursor]
 	}
 	return stableKeys
-}
-
-private fun isPureDeleteParagraphHunk(h: Hunk, leftPlain: String): Boolean =
-	h.leftPlainEnd > h.leftPlainStart &&
-		h.rightPlainEnd == h.rightPlainStart &&
-		isCompleteParagraph(leftPlain, h.leftPlainStart, h.leftPlainEnd)
-
-private fun isPureInsertParagraphHunk(h: Hunk, rightPlain: String): Boolean =
-	h.rightPlainEnd > h.rightPlainStart &&
-		h.leftPlainEnd == h.leftPlainStart &&
-		isCompleteParagraph(rightPlain, h.rightPlainStart, h.rightPlainEnd)
-
-private fun isCompleteParagraph(plain: String, start: Int, end: Int): Boolean {
-	if (start < 0 || end < start || end > plain.length) return false
-	val startsAtBoundary = start == 0 || plain[start - 1] == '\n'
-	val endsAtBoundary = end == plain.length || plain[end] == '\n'
-	return startsAtBoundary && endsAtBoundary
 }
 
 private val WhitespaceRun = Regex("\\s+")

--- a/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiffTest.kt
+++ b/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiffTest.kt
@@ -266,6 +266,59 @@ class ProseDiffTest {
 	}
 
 	@Test
+	fun `swapped paragraphs around an edited paragraph are both moved and the edit is shown`() {
+		val left = "Alpha para.\n\nMiddle cat.\n\nGamma para."
+		val right = "Gamma para.\n\nMiddle dog.\n\nAlpha para."
+		val result = ProseDiff.diff(left, right)
+
+		fun List<DiffSpan>.movedContaining(text: String, source: String) = singleOrNull {
+			it.kind == DiffKind.MOVED && text in source.substring(it.range.start, it.range.endExclusive)
+		}
+
+		val leftAlpha = result.leftSpans.movedContaining("Alpha", left)
+		val leftGamma = result.leftSpans.movedContaining("Gamma", left)
+		val rightAlpha = result.rightSpans.movedContaining("Alpha", right)
+		val rightGamma = result.rightSpans.movedContaining("Gamma", right)
+
+		assertTrue(leftAlpha != null, "expected moved Alpha on left, got: ${result.leftSpans}")
+		assertTrue(leftGamma != null, "expected moved Gamma on left, got: ${result.leftSpans}")
+		assertTrue(rightAlpha != null, "expected moved Alpha on right, got: ${result.rightSpans}")
+		assertTrue(rightGamma != null, "expected moved Gamma on right, got: ${result.rightSpans}")
+		assertEquals(leftAlpha.moveId, rightAlpha.moveId, "Alpha move ids should match")
+		assertEquals(leftGamma.moveId, rightGamma.moveId, "Gamma move ids should match")
+		assertTrue(leftAlpha.moveId != leftGamma.moveId, "Alpha and Gamma should have distinct move ids")
+
+		val deletedCat = result.leftSpans.any {
+			it.kind == DiffKind.DELETED && "cat" in left.substring(it.range.start, it.range.endExclusive)
+		}
+		val insertedDog = result.rightSpans.any {
+			it.kind == DiffKind.INSERTED && "dog" in right.substring(it.range.start, it.range.endExclusive)
+		}
+		assertTrue(deletedCat, "expected the cat->dog edit deleted on left, got: ${result.leftSpans}")
+		assertTrue(insertedDog, "expected the cat->dog edit inserted on right, got: ${result.rightSpans}")
+	}
+
+	@Test
+	fun `an edit adjacent to a moved paragraph is not swallowed by the move span`() {
+		val left = "Intro stays.\n\nAlpha para.\n\nThe quick fox."
+		val right = "Alpha para.\n\nIntro stays.\n\nThe slow fox."
+		val result = ProseDiff.diff(left, right)
+
+		assertTrue(
+			result.leftSpans.any { it.kind == DiffKind.DELETED && "quick" in left.substring(it.range.start, it.range.endExclusive) },
+			"expected 'quick' deleted on left, got: ${result.leftSpans}",
+		)
+		assertTrue(
+			result.rightSpans.any { it.kind == DiffKind.INSERTED && "slow" in right.substring(it.range.start, it.range.endExclusive) },
+			"expected 'slow' inserted on right, got: ${result.rightSpans}",
+		)
+		assertTrue(
+			result.leftSpans.any { it.kind == DiffKind.MOVED && "Alpha" in left.substring(it.range.start, it.range.endExclusive) },
+			"expected Alpha moved on left, got: ${result.leftSpans}",
+		)
+	}
+
+	@Test
 	fun `moved hunk emits no scroll sync anchor inside moved paragraph`() {
 		val left = "Alpha para.\n\nBeta para.\n\nGamma para."
 		val right = "Beta para.\n\nGamma para.\n\nAlpha para."

--- a/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiffTest.kt
+++ b/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/diff/ProseDiffTest.kt
@@ -189,4 +189,105 @@ class ProseDiffTest {
 		val highlighted = right.substring(r.start, r.endExclusive)
 		assertTrue("Para two" in highlighted, "expected 'Para two' in inserted highlight, got: '$highlighted'")
 	}
+
+	@Test
+	fun `paragraph moved verbatim is marked moved on both sides`() {
+		val left = "Alpha para.\n\nBeta para.\n\nGamma para."
+		val right = "Beta para.\n\nGamma para.\n\nAlpha para."
+		val result = ProseDiff.diff(left, right)
+
+		val leftMove = result.leftSpans.singleOrNull {
+			it.kind == DiffKind.MOVED && "Alpha" in left.substring(it.range.start, it.range.endExclusive)
+		}
+		val rightMove = result.rightSpans.singleOrNull {
+			it.kind == DiffKind.MOVED && "Alpha" in right.substring(it.range.start, it.range.endExclusive)
+		}
+
+		assertTrue(leftMove != null, "expected moved Alpha span on left, got: ${result.leftSpans}")
+		assertTrue(rightMove != null, "expected moved Alpha span on right, got: ${result.rightSpans}")
+		assertEquals(leftMove.moveId, rightMove.moveId)
+		assertTrue(result.leftSpans.none { it.kind == DiffKind.DELETED }, "expected no deleted spans, got: ${result.leftSpans}")
+		assertTrue(result.rightSpans.none { it.kind == DiffKind.INSERTED }, "expected no inserted spans, got: ${result.rightSpans}")
+	}
+
+	@Test
+	fun `paragraph moved with whitespace-only change is still marked moved`() {
+		val left = "Alpha  para.\n\nBeta para.\n\nGamma para."
+		val right = "Beta para.\n\nGamma para.\n\nAlpha para."
+		val result = ProseDiff.diff(left, right)
+
+		val leftMove = result.leftSpans.singleOrNull {
+			it.kind == DiffKind.MOVED && "Alpha" in left.substring(it.range.start, it.range.endExclusive)
+		}
+		val rightMove = result.rightSpans.singleOrNull {
+			it.kind == DiffKind.MOVED && "Alpha" in right.substring(it.range.start, it.range.endExclusive)
+		}
+
+		assertTrue(leftMove != null, "expected moved Alpha span on left, got: ${result.leftSpans}")
+		assertTrue(rightMove != null, "expected moved Alpha span on right, got: ${result.rightSpans}")
+		assertEquals(leftMove.moveId, rightMove.moveId)
+	}
+
+	@Test
+	fun `paragraph moved with edited word is not marked moved`() {
+		val left = "Alpha para.\n\nBeta para.\n\nGamma para."
+		val right = "Beta para.\n\nGamma para.\n\nAlpha changed."
+		val result = ProseDiff.diff(left, right)
+
+		assertTrue(result.leftSpans.none { it.kind == DiffKind.MOVED }, "expected no moved left spans, got: ${result.leftSpans}")
+		assertTrue(result.rightSpans.none { it.kind == DiffKind.MOVED }, "expected no moved right spans, got: ${result.rightSpans}")
+		assertTrue(result.leftSpans.any { it.kind == DiffKind.DELETED }, "expected deleted span, got: ${result.leftSpans}")
+		assertTrue(result.rightSpans.any { it.kind == DiffKind.INSERTED }, "expected inserted span, got: ${result.rightSpans}")
+	}
+
+	@Test
+	fun `duplicate paragraph text is ambiguous and not marked moved`() {
+		val left = "Dup para.\n\nKeep one.\n\nDup para.\n\nKeep two."
+		val right = "Keep one.\n\nKeep two.\n\nDup para."
+		val result = ProseDiff.diff(left, right)
+
+		assertTrue(result.leftSpans.none { it.kind == DiffKind.MOVED }, "expected no moved left spans, got: ${result.leftSpans}")
+		assertTrue(result.rightSpans.none { it.kind == DiffKind.MOVED }, "expected no moved right spans, got: ${result.rightSpans}")
+		assertTrue(result.leftSpans.any { it.kind == DiffKind.DELETED }, "expected deleted span, got: ${result.leftSpans}")
+		assertTrue(result.rightSpans.any { it.kind == DiffKind.INSERTED }, "expected inserted span, got: ${result.rightSpans}")
+	}
+
+	@Test
+	fun `two different moved paragraphs get distinct move ids`() {
+		val left = "Alpha para.\n\nStable one.\n\nBeta para.\n\nStable two.\n\nStable three."
+		val right = "Stable one.\n\nAlpha para.\n\nStable two.\n\nBeta para.\n\nStable three."
+		val result = ProseDiff.diff(left, right)
+
+		val movedSpans = result.leftSpans.plus(result.rightSpans).filter { it.kind == DiffKind.MOVED }
+		val movedIds = movedSpans.mapNotNull { it.moveId }.toSet()
+
+		assertEquals(4, movedSpans.size, "expected two moved pairs, got: $movedSpans")
+		assertEquals(2, movedIds.size, "expected two distinct move ids, got: $movedIds")
+	}
+
+	@Test
+	fun `moved hunk emits no scroll sync anchor inside moved paragraph`() {
+		val left = "Alpha para.\n\nBeta para.\n\nGamma para."
+		val right = "Beta para.\n\nGamma para.\n\nAlpha para."
+		val result = ProseDiff.diff(left, right)
+		val movedLeft = result.leftSpans.single {
+			it.kind == DiffKind.MOVED && "Alpha" in left.substring(it.range.start, it.range.endExclusive)
+		}
+
+		assertEquals(DiffAnchor(0, 0), result.anchors.first())
+		assertEquals(DiffAnchor(left.length, right.length), result.anchors.last())
+
+		var prev = result.anchors.first()
+		for (a in result.anchors.drop(1)) {
+			assertTrue(a.leftSource >= prev.leftSource, "left anchors must be non-decreasing: $prev -> $a")
+			assertTrue(a.rightSource >= prev.rightSource, "right anchors must be non-decreasing: $prev -> $a")
+			prev = a
+		}
+
+		val movedRange = movedLeft.range
+		assertTrue(
+			result.anchors.none { it.leftSource > movedRange.start && it.leftSource < movedRange.endExclusive },
+			"expected no left anchor inside moved range $movedRange, got: ${result.anchors}",
+		)
+	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/theme/HammerExtendedColors.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/theme/HammerExtendedColors.kt
@@ -15,6 +15,7 @@ data class HammerExtendedColors(
 	val success: Color,
 	val warning: Color,
 	val danger: Color,
+	val moved: Color,
 	val characterPalette: List<Color>,
 	val tagPalette: List<Color>,
 ) {
@@ -101,6 +102,7 @@ val LightHammerColors = HammerExtendedColors(
 	success = Color(0xFF2E7D32),
 	warning = Color(0xFFB58940),
 	danger = Color(0xFFC62828),
+	moved = Color(0xFF3A5FA0),
 	characterPalette = LightCharacterPalette,
 	tagPalette = LightTagPalette,
 )
@@ -114,6 +116,7 @@ val DarkHammerColors = HammerExtendedColors(
 	success = Color(0xFF7BC97D),
 	warning = Color(0xFFE0B36B),
 	danger = Color(0xFFE57373),
+	moved = Color(0xFF7B9FD4),
 	characterPalette = DarkCharacterPalette,
 	tagPalette = DarkTagPalette,
 )

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ConflictDiff.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ConflictDiff.kt
@@ -1,7 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.projectsync
 
 import androidx.compose.runtime.*
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -74,9 +73,10 @@ internal fun diffInsertedStyle(): SpanStyle {
 	}
 }
 
+/** Blue background for relocated text, shown on both sides of a move. */
 @Composable
 internal fun diffMovedStyle(): SpanStyle {
-	val moved = Color(0xFF3A5FA0)
+	val moved = LocalHammerColors.current.moved
 	return remember(moved) {
 		SpanStyle(background = moved.copy(alpha = CONFLICT_DIFF_HIGHLIGHT_ALPHA))
 	}
@@ -93,7 +93,7 @@ internal fun diffHighlightedString(
 	text: String,
 	spans: List<DiffSpan>,
 	style: SpanStyle,
-	movedStyle: SpanStyle = style,
+	movedStyle: SpanStyle,
 ): AnnotatedString {
 	if (spans.isEmpty()) return AnnotatedString(text)
 	return buildAnnotatedString {
@@ -109,7 +109,7 @@ internal fun diffHighlightedString(
 internal class DiffHighlightTransformation(
 	private val spans: List<DiffSpan>,
 	private val style: SpanStyle,
-	private val movedStyle: SpanStyle = style,
+	private val movedStyle: SpanStyle,
 ) : VisualTransformation {
 	override fun filter(text: AnnotatedString): TransformedText {
 		if (spans.isEmpty()) return TransformedText(text, OffsetMapping.Identity)
@@ -133,7 +133,7 @@ internal class DiffHighlightTransformation(
 private fun AnnotatedString.Builder.applyDiffSpans(
 	spans: List<DiffSpan>,
 	style: SpanStyle,
-	movedStyle: SpanStyle = style,
+	movedStyle: SpanStyle,
 	length: Int,
 ) {
 	for (span in spans) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ConflictDiff.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ConflictDiff.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.projectsync
 
 import androidx.compose.runtime.*
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -8,6 +9,7 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextDecoration
+import com.darkrockstudios.apps.hammer.base.diff.DiffKind
 import com.darkrockstudios.apps.hammer.base.diff.DiffResult
 import com.darkrockstudios.apps.hammer.base.diff.DiffSpan
 import com.darkrockstudios.apps.hammer.base.diff.PreparedText
@@ -72,6 +74,14 @@ internal fun diffInsertedStyle(): SpanStyle {
 	}
 }
 
+@Composable
+internal fun diffMovedStyle(): SpanStyle {
+	val moved = Color(0xFF3A5FA0)
+	return remember(moved) {
+		SpanStyle(background = moved.copy(alpha = CONFLICT_DIFF_HIGHLIGHT_ALPHA))
+	}
+}
+
 /**
  * Overlay [style] onto [text] across the given diff [spans], leaving the text itself unchanged.
  *
@@ -83,11 +93,12 @@ internal fun diffHighlightedString(
 	text: String,
 	spans: List<DiffSpan>,
 	style: SpanStyle,
+	movedStyle: SpanStyle = style,
 ): AnnotatedString {
 	if (spans.isEmpty()) return AnnotatedString(text)
 	return buildAnnotatedString {
 		append(text)
-		applyDiffSpans(spans, style, text.length)
+		applyDiffSpans(spans, style, movedStyle, text.length)
 	}
 }
 
@@ -98,32 +109,39 @@ internal fun diffHighlightedString(
 internal class DiffHighlightTransformation(
 	private val spans: List<DiffSpan>,
 	private val style: SpanStyle,
+	private val movedStyle: SpanStyle = style,
 ) : VisualTransformation {
 	override fun filter(text: AnnotatedString): TransformedText {
 		if (spans.isEmpty()) return TransformedText(text, OffsetMapping.Identity)
 		val annotated = buildAnnotatedString {
 			append(text)
-			applyDiffSpans(spans, style, text.length)
+			applyDiffSpans(spans, style, movedStyle, text.length)
 		}
 		return TransformedText(annotated, OffsetMapping.Identity)
 	}
 
 	override fun equals(other: Any?): Boolean =
-		other is DiffHighlightTransformation && other.spans == spans && other.style == style
+		other is DiffHighlightTransformation &&
+			other.spans == spans &&
+			other.style == style &&
+			other.movedStyle == movedStyle
 
-	override fun hashCode(): Int = 31 * spans.hashCode() + style.hashCode()
+	override fun hashCode(): Int =
+		31 * (31 * spans.hashCode() + style.hashCode()) + movedStyle.hashCode()
 }
 
 private fun AnnotatedString.Builder.applyDiffSpans(
 	spans: List<DiffSpan>,
 	style: SpanStyle,
+	movedStyle: SpanStyle = style,
 	length: Int,
 ) {
 	for (span in spans) {
 		val start = span.range.start
 		val end = span.range.endExclusive
 		if (start in 0..length && end in start..length) {
-			addStyle(style, start, end)
+			val s = if (span.kind == DiffKind.MOVED) movedStyle else style
+			addStyle(s, start, end)
 		}
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/SceneConflict.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/SceneConflict.kt
@@ -50,6 +50,7 @@ internal fun SceneConflict(
 	val contentDiff = rememberContentDiff(server.content, contentTextValue)
 	val deletedStyle = diffDeletedStyle()
 	val insertedStyle = diffInsertedStyle()
+	val movedStyle = diffMovedStyle()
 
 	val useLocal = {
 		val error = component.resolveConflict(
@@ -89,6 +90,7 @@ internal fun SceneConflict(
 				nameError = nameError,
 				contentInsertedSpans = contentDiff?.rightSpans.orEmpty(),
 				insertedStyle = insertedStyle,
+				movedStyle = movedStyle,
 				component = component,
 			)
 		},
@@ -100,6 +102,7 @@ internal fun SceneConflict(
 				tab = selectedTab,
 				contentDeletedSpans = contentDiff?.leftSpans.orEmpty(),
 				deletedStyle = deletedStyle,
+				movedStyle = movedStyle,
 				component = component,
 			)
 		},
@@ -151,6 +154,7 @@ private fun LocalSceneBody(
 	nameError: String?,
 	contentInsertedSpans: List<DiffSpan>,
 	insertedStyle: SpanStyle,
+	movedStyle: SpanStyle,
 	component: ProjectSynchronization,
 ) {
 	Column(
@@ -161,8 +165,8 @@ private fun LocalSceneBody(
 	) {
 		when (tab) {
 			SceneConflictTab.CONTENT -> {
-				val contentTransformation = remember(contentInsertedSpans, insertedStyle) {
-					DiffHighlightTransformation(contentInsertedSpans, insertedStyle)
+				val contentTransformation = remember(contentInsertedSpans, insertedStyle, movedStyle) {
+					DiffHighlightTransformation(contentInsertedSpans, insertedStyle, movedStyle)
 				}
 				HdConflictField(
 					label = Res.string.sync_conflict_title_scene_field_content.get(),
@@ -241,6 +245,7 @@ private fun RemoteSceneBody(
 	tab: SceneConflictTab,
 	contentDeletedSpans: List<DiffSpan>,
 	deletedStyle: SpanStyle,
+	movedStyle: SpanStyle,
 	component: ProjectSynchronization,
 ) {
 	Column(
@@ -251,8 +256,8 @@ private fun RemoteSceneBody(
 	) {
 		when (tab) {
 			SceneConflictTab.CONTENT -> {
-				val highlighted = remember(server.content, contentDeletedSpans, deletedStyle) {
-					diffHighlightedString(server.content, contentDeletedSpans, deletedStyle)
+				val highlighted = remember(server.content, contentDeletedSpans, deletedStyle, movedStyle) {
+					diffHighlightedString(server.content, contentDeletedSpans, deletedStyle, movedStyle)
 				}
 				HdConflictField(
 					label = Res.string.sync_conflict_title_scene_field_content.get(),

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/SceneDraftConflict.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/SceneDraftConflict.kt
@@ -44,6 +44,7 @@ internal fun SceneDraftConflict(
 	val contentDiff = rememberContentDiff(server.content, contentTextValue)
 	val deletedStyle = diffDeletedStyle()
 	val insertedStyle = diffInsertedStyle()
+	val movedStyle = diffMovedStyle()
 
 	val useLocal = {
 		val error = component.resolveConflict(
@@ -81,8 +82,8 @@ internal fun SceneDraftConflict(
 						modifier = Modifier.fillMaxWidth(),
 					)
 				}
-				val contentTransformation = remember(contentDiff, insertedStyle) {
-					DiffHighlightTransformation(contentDiff?.rightSpans.orEmpty(), insertedStyle)
+				val contentTransformation = remember(contentDiff, insertedStyle, movedStyle) {
+					DiffHighlightTransformation(contentDiff?.rightSpans.orEmpty(), insertedStyle, movedStyle)
 				}
 				HdConflictField(
 					label = Res.string.sync_conflict_title_scene_draft_field_content.get(),
@@ -113,8 +114,8 @@ internal fun SceneDraftConflict(
 				) {
 					ReadOnlyLine(c.serverEntity.name)
 				}
-				val highlighted = remember(c.serverEntity.content, contentDiff, deletedStyle) {
-					diffHighlightedString(c.serverEntity.content, contentDiff?.leftSpans.orEmpty(), deletedStyle)
+				val highlighted = remember(c.serverEntity.content, contentDiff, deletedStyle, movedStyle) {
+					diffHighlightedString(c.serverEntity.content, contentDiff?.leftSpans.orEmpty(), deletedStyle, movedStyle)
 				}
 				HdConflictField(
 					label = Res.string.sync_conflict_title_scene_draft_field_content.get(),

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/drafts/DraftCompareUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/drafts/DraftCompareUi.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.Dp
@@ -179,31 +178,13 @@ private fun DraftPane(
 	val strRes = rememberStrRes()
 	val state by component.state.subscribeAsState()
 	val deletedHighlight = rememberDeletedHighlight()
-	val movedHighlight = rememberMovedHighlight()
-	var appliedStyle by remember(textEditorState) { mutableStateOf<HighlightSpanStyle?>(null) }
-	var appliedMovedStyle by remember(textEditorState) { mutableStateOf<HighlightSpanStyle?>(null) }
 
 	// The draft is read-only, so its rendered text never changes — submit it once for the diff.
 	LaunchedEffect(textEditorState) {
 		component.submitDraftText(textEditorState.getAllText().text)
 	}
-	LaunchedEffect(state.diffResult, state.showDiff, textEditorState, deletedHighlight, movedHighlight) {
-		val spans = if (state.showDiff) state.diffResult?.leftSpans.orEmpty() else emptyList()
-		applyDiffHighlights(
-			editorState = textEditorState,
-			spans = spans.filter { it.kind != DiffKind.MOVED },
-			style = deletedHighlight,
-			previousStyle = appliedStyle,
-		)
-		applyDiffHighlights(
-			editorState = textEditorState,
-			spans = spans.filter { it.kind == DiffKind.MOVED },
-			style = movedHighlight,
-			previousStyle = appliedMovedStyle,
-		)
-		appliedStyle = deletedHighlight
-		appliedMovedStyle = movedHighlight
-	}
+	val spans = if (state.showDiff) state.diffResult?.leftSpans.orEmpty() else emptyList()
+	DiffHighlightEffect(textEditorState, spans, deletedHighlight)
 
 	var title by remember { mutableStateOf("") }
 	LaunchedEffect(component.draftDef.draftName) {
@@ -263,9 +244,6 @@ private fun CurrentPane(
 	val state by component.state.subscribeAsState()
 	val markdownConfig = LocalMarkdownConfig.current
 	val insertedHighlight = rememberInsertedHighlight()
-	val movedHighlight = rememberMovedHighlight()
-	var appliedStyle by remember(textEditorState) { mutableStateOf<HighlightSpanStyle?>(null) }
-	var appliedMovedStyle by remember(textEditorState) { mutableStateOf<HighlightSpanStyle?>(null) }
 
 	val markdownExtension = remember(textEditorState) { textEditorState.withMarkdown(markdownConfig) }
 
@@ -288,23 +266,8 @@ private fun CurrentPane(
 		}
 	}
 
-	LaunchedEffect(state.diffResult, state.showDiff, textEditorState, insertedHighlight, movedHighlight) {
-		val spans = if (state.showDiff) state.diffResult?.rightSpans.orEmpty() else emptyList()
-		applyDiffHighlights(
-			editorState = textEditorState,
-			spans = spans.filter { it.kind != DiffKind.MOVED },
-			style = insertedHighlight,
-			previousStyle = appliedStyle,
-		)
-		applyDiffHighlights(
-			editorState = textEditorState,
-			spans = spans.filter { it.kind == DiffKind.MOVED },
-			style = movedHighlight,
-			previousStyle = appliedMovedStyle,
-		)
-		appliedStyle = insertedHighlight
-		appliedMovedStyle = movedHighlight
-	}
+	val spans = if (state.showDiff) state.diffResult?.rightSpans.orEmpty() else emptyList()
+	DiffHighlightEffect(textEditorState, spans, insertedHighlight)
 
 	Column(
 		modifier = modifier.padding(
@@ -361,8 +324,42 @@ private fun rememberInsertedHighlight(): HighlightSpanStyle {
 }
 
 @Composable
-private fun rememberMovedHighlight(): HighlightSpanStyle =
-	remember { HighlightSpanStyle(Color(0xFF3A5FA0).copy(alpha = DIFF_HIGHLIGHT_ALPHA)) }
+private fun rememberMovedHighlight(): HighlightSpanStyle {
+	val moved = LocalHammerColors.current.moved
+	return remember(moved) { HighlightSpanStyle(moved.copy(alpha = DIFF_HIGHLIGHT_ALPHA)) }
+}
+
+/**
+ * Paint one pane's diff [spans] onto its editor: plain deletions/insertions in [baseStyle] and
+ * relocated paragraphs in the shared moved style. Each kind is tracked independently so a theme
+ * change re-applies cleanly without orphaning the prior pass's spans.
+ */
+@Composable
+private fun DiffHighlightEffect(
+	editorState: TextEditorState,
+	spans: List<DiffSpan>,
+	baseStyle: HighlightSpanStyle,
+) {
+	val movedStyle = rememberMovedHighlight()
+	var appliedBase by remember(editorState) { mutableStateOf<HighlightSpanStyle?>(null) }
+	var appliedMoved by remember(editorState) { mutableStateOf<HighlightSpanStyle?>(null) }
+	LaunchedEffect(spans, editorState, baseStyle, movedStyle) {
+		applyDiffHighlights(
+			editorState = editorState,
+			spans = spans.filter { it.kind != DiffKind.MOVED },
+			style = baseStyle,
+			previousStyle = appliedBase,
+		)
+		applyDiffHighlights(
+			editorState = editorState,
+			spans = spans.filter { it.kind == DiffKind.MOVED },
+			style = movedStyle,
+			previousStyle = appliedMoved,
+		)
+		appliedBase = baseStyle
+		appliedMoved = movedStyle
+	}
+}
 
 /**
  * Replace the diff highlights drawn with [style] on this editor.

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/drafts/DraftCompareUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/drafts/DraftCompareUi.kt
@@ -9,11 +9,13 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.Dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
+import com.darkrockstudios.apps.hammer.base.diff.DiffKind
 import com.darkrockstudios.apps.hammer.base.diff.DiffResult
 import com.darkrockstudios.apps.hammer.base.diff.DiffSpan
 import com.darkrockstudios.apps.hammer.base.diff.OffsetMap
@@ -177,20 +179,30 @@ private fun DraftPane(
 	val strRes = rememberStrRes()
 	val state by component.state.subscribeAsState()
 	val deletedHighlight = rememberDeletedHighlight()
+	val movedHighlight = rememberMovedHighlight()
 	var appliedStyle by remember(textEditorState) { mutableStateOf<HighlightSpanStyle?>(null) }
+	var appliedMovedStyle by remember(textEditorState) { mutableStateOf<HighlightSpanStyle?>(null) }
 
 	// The draft is read-only, so its rendered text never changes — submit it once for the diff.
 	LaunchedEffect(textEditorState) {
 		component.submitDraftText(textEditorState.getAllText().text)
 	}
-	LaunchedEffect(state.diffResult, state.showDiff, textEditorState, deletedHighlight) {
+	LaunchedEffect(state.diffResult, state.showDiff, textEditorState, deletedHighlight, movedHighlight) {
+		val spans = if (state.showDiff) state.diffResult?.leftSpans.orEmpty() else emptyList()
 		applyDiffHighlights(
 			editorState = textEditorState,
-			spans = if (state.showDiff) state.diffResult?.leftSpans.orEmpty() else emptyList(),
+			spans = spans.filter { it.kind != DiffKind.MOVED },
 			style = deletedHighlight,
 			previousStyle = appliedStyle,
 		)
+		applyDiffHighlights(
+			editorState = textEditorState,
+			spans = spans.filter { it.kind == DiffKind.MOVED },
+			style = movedHighlight,
+			previousStyle = appliedMovedStyle,
+		)
 		appliedStyle = deletedHighlight
+		appliedMovedStyle = movedHighlight
 	}
 
 	var title by remember { mutableStateOf("") }
@@ -251,7 +263,9 @@ private fun CurrentPane(
 	val state by component.state.subscribeAsState()
 	val markdownConfig = LocalMarkdownConfig.current
 	val insertedHighlight = rememberInsertedHighlight()
+	val movedHighlight = rememberMovedHighlight()
 	var appliedStyle by remember(textEditorState) { mutableStateOf<HighlightSpanStyle?>(null) }
+	var appliedMovedStyle by remember(textEditorState) { mutableStateOf<HighlightSpanStyle?>(null) }
 
 	val markdownExtension = remember(textEditorState) { textEditorState.withMarkdown(markdownConfig) }
 
@@ -274,14 +288,22 @@ private fun CurrentPane(
 		}
 	}
 
-	LaunchedEffect(state.diffResult, state.showDiff, textEditorState, insertedHighlight) {
+	LaunchedEffect(state.diffResult, state.showDiff, textEditorState, insertedHighlight, movedHighlight) {
+		val spans = if (state.showDiff) state.diffResult?.rightSpans.orEmpty() else emptyList()
 		applyDiffHighlights(
 			editorState = textEditorState,
-			spans = if (state.showDiff) state.diffResult?.rightSpans.orEmpty() else emptyList(),
+			spans = spans.filter { it.kind != DiffKind.MOVED },
 			style = insertedHighlight,
 			previousStyle = appliedStyle,
 		)
+		applyDiffHighlights(
+			editorState = textEditorState,
+			spans = spans.filter { it.kind == DiffKind.MOVED },
+			style = movedHighlight,
+			previousStyle = appliedMovedStyle,
+		)
 		appliedStyle = insertedHighlight
+		appliedMovedStyle = movedHighlight
 	}
 
 	Column(
@@ -337,6 +359,10 @@ private fun rememberInsertedHighlight(): HighlightSpanStyle {
 	val success = LocalHammerColors.current.success
 	return remember(success) { HighlightSpanStyle(success.copy(alpha = DIFF_HIGHLIGHT_ALPHA)) }
 }
+
+@Composable
+private fun rememberMovedHighlight(): HighlightSpanStyle =
+	remember { HighlightSpanStyle(Color(0xFF3A5FA0).copy(alpha = DIFF_HIGHLIGHT_ALPHA)) }
 
 /**
  * Replace the diff highlights drawn with [style] on this editor.


### PR DESCRIPTION
## Summary

Supersedes #665. Carries the moved-paragraph detection work (original commit by @mvanhorn) plus the conflict-UI wiring, and fixes the three move-detection edge cases raised in review on #665 — which the original author did not follow up on.

A paragraph that is relocated is shown as a single blue "moved" highlight on both sides, instead of a red deletion at its old spot plus a green insertion at its new one. See #527.

## The three edge cases fixed

These all lived in the sequence-based detector + emit loop (not the Myers engine) and interacted, so they're fixed as one focused rework rather than three patches.

**Repro (now passing as a test):**

```kotlin
ProseDiff.diff(
    "Alpha para.\n\nMiddle cat.\n\nGamma para.",
    "Gamma para.\n\nMiddle dog.\n\nAlpha para.",
)
// Now: Alpha & Gamma MOVED (blue, distinct ids); "cat"->"dog" shown as DELETED/INSERTED.
// Before: only Alpha MOVED; Gamma's move swallowed; cat->dog produced no right-side highlight.
```

1. **Edits adjacent to a move were swallowed.** The old emit loop gated whole delete/insert spans on `rangesOverlap` against "stable"/"moved" paragraphs, so a hunk that merely *touched* one had its entire span dropped — the reviewer saw no highlight where text actually changed. Replaced with proper **range subtraction**: a delete/insert span is the hunk minus the moved/stable ranges, so a hunk that `mergeSmallGaps` bridged across a move + an adjacent edit now surfaces the edit, without re-highlighting the moved text.

2. **A hunk overlapping a moved paragraph dropped its own change.** Same root cause; the range-subtraction emit splits a hunk into its moved sub-range (rendered blue once, from the move plan) vs. its genuinely-changed sub-range (red/green).

3. **Degenerate LIS marked a clearly-moved paragraph as stable.** For a full reorder/swap the "longest increasing subsequence = stable backbone" heuristic elects a single moved paragraph as the anchor (LIS over `[2, 0]` has length 1). A backbone of one paragraph is no backbone — a lone paragraph is trivially "in order" even after teleporting — so a fully reordered set is now treated as all-moved.

This also unifies the two detection paths (the pure-hunk detector is dropped in favor of the single paragraph-level detector) and keeps the existing behavior that moved hunks emit no scroll-sync anchor, preserving the monotonic offset map.

## Changes

- `ProseDiff.kt`: single `detectMovedParagraphs` pass; range-subtraction emit (`subtractBlocked`); LIS-backbone-of-one guard. Net ~166 lines removed.
- Tests: 2 new scenarios (swap-around-an-edit; edit adjacent to a move) on top of the existing 23.

## Testing

- `./gradlew :base:desktopTest --tests "*ProseDiffTest*"` — 25 pass.
- `./gradlew :composeUi:compileKotlinDesktop` — clean (public diff API unchanged).

Fixes #527