### PR TITLE
Pin Xcode 26 for iOS test link in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Select Xcode 26
+        # macos-latest still defaults to Xcode 16.4 (iOS 18.5 SDK), but linking the
+        # iOS test executable pulls in Compose's ui-uikit, which references symbols
+        # (e.g. UIViewLayoutRegion) that only exist in the iOS 26 SDK. Without this
+        # the link fails non-deterministically depending on the runner image. Glob
+        # keeps us off a pinned patch version that could vanish on a future image.
+        run: |
+          XCODE_APP="$(ls -d /Applications/Xcode_26*.app | sort -V | tail -1)"
+          echo "Using $XCODE_APP"
+          sudo xcode-select -s "$XCODE_APP/Contents/Developer"
+          xcodebuild -version
       - name: set up JDK 21
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
## Summary

Fixes the `develop` CI breakage introduced by PR #680.

Running `:common:iosSimulatorArm64Test` is the first thing in CI to actually **link** an iOS executable (the old `ios-compile` job only compiled klibs). The test binary pulls in Compose's `ui-uikit`, which references iOS 26 SDK symbols such as `_OBJC_CLASS_$_UIViewLayoutRegion`. `macos-latest` still defaults to **Xcode 16.4 (iOS 18.5 SDK)**, which lacks those symbols — so the link failed non-deterministically:
- ✅ PR #680 run happened to land on a runner state that linked
- ❌ the develop merge run hit Xcode 16.4 → `Undefined symbols for architecture arm64`

This selects the newest installed `Xcode_26.x` before building, exactly mirroring what `publish-ios-app-store.yml` already does for the same SDK reason.

## Test plan
- CI on this PR must show the `iOS compile & test` job green with `xcodebuild -version` reporting Xcode 26.x.
- `:common:iosSimulatorArm64Test` links and runs (110+ tests across 11 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)