### PR TITLE
Fix v3.5.0 startup hang migrating legacy inline auth tokens

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/GlobalSettingsFilesystemDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/GlobalSettingsFilesystemDatasource.kt
@@ -34,18 +34,17 @@ class GlobalSettingsFilesystemDatasource(
 			readUtf8()
 		}
 
-		val settings: GlobalSettings = try {
+		// Pure read: a corrupt file is left in place (overwritten on the next store) rather
+		// than deleted here, so loading never mutates the filesystem during app bootstrap.
+		return try {
 			toml.decodeFromString(settingsText)
 		} catch (e: NumberFormatException) {
 			Napier.e("Failed to load Global Settings, Reverting to defaults.", e)
-			fileSystem.delete(CONFIG_PATH)
 			createDefault(languageUtil, platformSpellCheckerFactory)
 		} catch (e: SerializationException) {
 			Napier.e("Failed to load Global Settings, Reverting to defaults.", e)
-			fileSystem.delete(CONFIG_PATH)
 			createDefault(languageUtil, platformSpellCheckerFactory)
 		}
-		return settings
 	}
 
 	override fun storeSettings(settings: GlobalSettings) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/ServerSettingsDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/ServerSettingsDatasource.kt
@@ -8,4 +8,13 @@ interface ServerSettingsDatasource {
 	fun loadServerSettings(projectsDir: HPath): ServerSettings?
 	fun storeServerSettings(settings: ServerSettings, projectsDir: HPath)
 	fun removeServerSettings(projectsDir: HPath)
+
+	/**
+	 * One-shot, idempotent migration of legacy inline `server.json` tokens into the
+	 * [AuthTokenStore], rewriting the file tokenless. A no-op when there are no inline
+	 * tokens. Performs writes, so it must run after app bootstrap, never during it.
+	 *
+	 * Transitional: delete once 4.0 ships.
+	 */
+	fun migrateInlineTokens(projectsDir: HPath)
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/ServerSettingsFilesystemDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/ServerSettingsFilesystemDatasource.kt
@@ -35,13 +35,14 @@ class ServerSettingsFilesystemDatasource(
 		val persisted: PersistedServerSettings = try {
 			json.decodeFromString(settingsText)
 		} catch (e: SerializationException) {
-			Napier.e("Failed to load Server Settings, removing invalid file.", e)
-			fileSystem.delete(path)
+			Napier.e("Failed to load Server Settings.", e)
 			return null
 		}
 
-		val migratedTokens = migrateInlineTokens(settingsText, persisted, projectsDir)
-		val tokens = migratedTokens ?: authTokenStore.get(persisted.url, persisted.userId)
+		// Legacy files may still carry inline tokens until migrateInlineTokens runs; honor
+		// them for this session, otherwise read from the token store. This is a pure read.
+		// Transitional: drop the readInlineTokens fallback once 4.0 ships.
+		val tokens = readInlineTokens(settingsText) ?: authTokenStore.get(persisted.url, persisted.userId)
 
 		return persisted.toServerSettings(tokens)
 	}
@@ -68,31 +69,34 @@ class ServerSettingsFilesystemDatasource(
 	}
 
 	/**
-	 * Moves inline tokens from a legacy `server.json` into the token store and
-	 * rewrites the file tokenless, so the plaintext secrets no longer live in the
-	 * workspace. Returns the extracted tokens, or null when there were none.
+	 * Moves inline tokens from a legacy `server.json` into the token store and rewrites
+	 * the file tokenless, so the plaintext secrets no longer live in the workspace.
+	 * Idempotent and self-gating: a no-op once the file carries no inline tokens.
 	 *
-	 * On a token-store write failure the extracted tokens are still returned so the
-	 * in-memory session is never dropped.
+	 * Transitional: delete this (and [readInlineTokens]) once 4.0 ships and every upgrading
+	 * user has run it.
 	 */
-	private fun migrateInlineTokens(
-		settingsText: String,
-		persisted: PersistedServerSettings,
-		projectsDir: HPath,
-	): AuthTokens? {
-		val inline = readInlineTokens(settingsText) ?: return null
+	override fun migrateInlineTokens(projectsDir: HPath) {
+		val path = getServerSettingsPath(projectsDir).toOkioPath()
+		if (!fileSystem.exists(path)) return
 
-		val migrated = runCatching {
+		val settingsText = fileSystem.read(path) { readUtf8() }
+		val inline = readInlineTokens(settingsText) ?: return
+
+		val persisted: PersistedServerSettings = try {
+			json.decodeFromString(settingsText)
+		} catch (e: SerializationException) {
+			Napier.e("Failed to parse server.json during inline-token migration.", e)
+			return
+		}
+
+		try {
 			authTokenStore.put(persisted.url, persisted.userId, inline)
-			val path = getServerSettingsPath(projectsDir).toOkioPath()
 			fileSystem.writeJson(path, json, persisted)
+			Napier.i("Migrated inline server.json tokens into the token store")
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.e("Failed to migrate inline auth tokens", e)
 		}
-
-		if (migrated.isFailure) {
-			Napier.e("Failed to migrate inline auth tokens; keeping in-memory session.", migrated.exceptionOrNull())
-		}
-
-		return inline
 	}
 
 	private fun readInlineTokens(settingsText: String): AuthTokens? {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/migrator/DataMigrator.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/migrator/DataMigrator.kt
@@ -26,8 +26,11 @@ open class DataMigrator(
 		return migrators
 	}
 
+	// Order matters: MigrateInlineAuthTokens rewrites server.json tokenless and in doing so
+	// drops legacy fields, so MigrateInstallIdToGlobal must read installId out of it first.
 	protected open fun getGlobalMigrations(): List<GlobalMigration> = listOf(
 		getKoin().get<MigrateInstallIdToGlobal>(),
+		getKoin().get<MigrateInlineAuthTokens>(),
 	)
 
 	private fun getProjects(): List<ProjectData> {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/migrator/MigrateInlineAuthTokens.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/migrator/MigrateInlineAuthTokens.kt
@@ -1,0 +1,29 @@
+package com.darkrockstudios.apps.hammer.common.data.migrator
+
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
+import okio.Path.Companion.toPath
+
+/**
+ * One-shot migration that relocates legacy inline auth tokens out of `server.json`
+ * and into the [com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore].
+ *
+ * This intentionally runs as a startup migration rather than inside
+ * [ServerSettingsDatasource.loadServerSettings]: the migration performs guarded
+ * filesystem writes, and doing that while [GlobalSettingsStore] is still constructing
+ * would re-enter the store's own bootstrap and loop forever. Running here, after the
+ * store is built, keeps loads pure. Idempotent — a no-op once tokens are relocated.
+ *
+ * Transitional: delete once 4.0 ships and every upgrading user has run it.
+ */
+class MigrateInlineAuthTokens(
+	private val globalSettingsStore: GlobalSettingsStore,
+	private val serverSettingsDatasource: ServerSettingsDatasource,
+) : GlobalMigration {
+
+	override suspend fun migrate() {
+		val projectsDir = globalSettingsStore.globalSettings.projectsDirectory.toPath().toHPath()
+		serverSettingsDatasource.migrateInlineTokens(projectsDir)
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/MigratorModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/MigratorModule.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.dependencyinjection
 
 import com.darkrockstudios.apps.hammer.common.data.migrator.DataMigrator
+import com.darkrockstudios.apps.hammer.common.data.migrator.MigrateInlineAuthTokens
 import com.darkrockstudios.apps.hammer.common.data.migrator.MigrateInstallIdToGlobal
 import com.darkrockstudios.apps.hammer.common.data.migrator.Migration0_1
 import com.darkrockstudios.apps.hammer.common.data.migrator.Migration1_2
@@ -12,4 +13,5 @@ val migratorModule = module {
 	factoryOf(::Migration0_1)
 	factoryOf(::Migration1_2)
 	factoryOf(::MigrateInstallIdToGlobal)
+	factoryOf(::MigrateInlineAuthTokens)
 }

--- a/common/src/desktopTest/kotlin/datamigrator/DataMigratorTest.kt
+++ b/common/src/desktopTest/kotlin/datamigrator/DataMigratorTest.kt
@@ -118,6 +118,7 @@ class DataMigratorTest : BaseTest() {
 			factory<Migration0_1> { mockMigrator }
 			factory<Migration1_2> { mockk(relaxed = true) }
 			factory<MigrateInstallIdToGlobal> { mockk(relaxed = true) }
+			factory<MigrateInlineAuthTokens> { mockk(relaxed = true) }
 		}
 		setupKoin(testModule)
 
@@ -167,6 +168,7 @@ class DataMigratorTest : BaseTest() {
 			factory<Migration0_1> { mockMigrator }
 			factory<Migration1_2> { mockk(relaxed = true) }
 			factory<MigrateInstallIdToGlobal> { mockk(relaxed = true) }
+			factory<MigrateInlineAuthTokens> { mockk(relaxed = true) }
 		}
 		setupKoin(testModule)
 
@@ -230,6 +232,7 @@ class DataMigratorTest : BaseTest() {
 
 		val testModule = module {
 			factory<MigrateInstallIdToGlobal> { mockk(relaxed = true) }
+			factory<MigrateInlineAuthTokens> { mockk(relaxed = true) }
 		}
 		setupKoin(testModule)
 
@@ -318,6 +321,7 @@ class DataMigratorTest : BaseTest() {
 
 		val testModule = module {
 			factory<MigrateInstallIdToGlobal> { mockk(relaxed = true) }
+			factory<MigrateInlineAuthTokens> { mockk(relaxed = true) }
 		}
 		setupKoin(testModule)
 

--- a/common/src/desktopTest/kotlin/dependencyinjection/GlobalSettingsBootstrapCycleTest.kt
+++ b/common/src/desktopTest/kotlin/dependencyinjection/GlobalSettingsBootstrapCycleTest.kt
@@ -1,0 +1,161 @@
+package dependencyinjection
+
+import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
+import com.darkrockstudios.apps.hammer.base.http.writeJson
+import com.darkrockstudios.apps.hammer.base.http.writeToml
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokenStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.AuthTokens
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.FileAuthTokenStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsFilesystemDatasource
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsFilesystemDatasource
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.managedStorageRoots
+import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.fileio.okio.ContainedFileSystem
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
+import com.darkrockstudios.apps.hammer.common.spellcheck.LanguageUtil
+import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
+import io.mockk.mockk
+import net.peanuuutz.tomlkt.Toml
+import okio.FileSystem
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.Koin
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlinx.serialization.json.Json
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Reproduces the v3.5.0 prod hang: when a legacy `server.json` carries inline auth
+ * tokens, [GlobalSettingsStore]'s construction performs a guarded write during its
+ * own init, whose containment check resolves the projects root by re-entering the
+ * store — an infinite construction loop that ANRs on the main thread.
+ */
+class GlobalSettingsBootstrapCycleTest {
+
+	private lateinit var rawFs: FakeFileSystem
+	private lateinit var json: Json
+	private lateinit var toml: Toml
+	private lateinit var languageUtil: LanguageUtil
+	private lateinit var koin: Koin
+
+	@BeforeEach
+	fun setup() {
+		rawFs = FakeFileSystem()
+		json = createJsonSerializer()
+		toml = createTomlSerializer()
+		languageUtil = mockk(relaxed = true)
+
+		koin = startKoin {
+			modules(
+				module {
+					single { json }
+					single { toml }
+					single { languageUtil }
+					single { PlatformSpellCheckerFactory() }
+					single<FileSystem> { ContainedFileSystem(rawFs) { managedStorageRoots(getKoin()) } }
+					single<AuthTokenStore> { FileAuthTokenStore(get(), get()) }
+					single { GlobalSettingsFilesystemDatasource(get(), get(), get(), get()) }
+					single<GlobalSettingsDatasource> { get<GlobalSettingsFilesystemDatasource>() }
+					single<ServerSettingsDatasource> {
+						CountingServerSettingsDatasource(
+							ServerSettingsFilesystemDatasource(get(), get(), get())
+						)
+					}
+					single { GlobalSettingsStore(get(), get()) }
+				}
+			)
+		}.koin
+	}
+
+	@AfterEach
+	fun tearDown() {
+		stopKoin()
+	}
+
+	@Test
+	fun `Construction is a pure read and the migration relocates tokens without looping`() {
+		val projectsDir = GlobalSettingsStore.defaultProjectDir()
+		// A real legacy device has both files; seeding only server.json would instead trip
+		// the unrelated fresh-install config-write path.
+		rawFs.createDirectories(GlobalSettingsFilesystemDatasource.CONFIG_PATH.parent!!)
+		rawFs.writeToml(
+			GlobalSettingsFilesystemDatasource.CONFIG_PATH,
+			toml,
+			GlobalSettings(projectsDirectory = projectsDir.toString()),
+		)
+
+		val serverJson = projectsDir / ServerSettingsFilesystemDatasource.SERVER_FILE_NAME
+		rawFs.createDirectories(projectsDir)
+		rawFs.writeJson(serverJson, json, legacyServerSettings())
+
+		// Precondition: the seeded file really does carry inline tokens.
+		assertTrue(rawFs.read(serverJson) { readUtf8() }.contains("zxc456"))
+
+		// Constructing the store must not loop, and reads the inline tokens for the session.
+		val store = koin.get<GlobalSettingsStore>()
+		val counter = koin.get<ServerSettingsDatasource>() as CountingServerSettingsDatasource
+
+		assertEquals(1, counter.loadCalls, "Store construction must not re-enter loadServerSettings")
+		assertEquals("zxc456", store.serverSettings?.bearerToken)
+		// Construction is pure: the file is untouched until the migration runs.
+		assertTrue(rawFs.read(serverJson) { readUtf8() }.contains("zxc456"))
+
+		// The migration writes through the guarded filesystem (where the cycle lived) after
+		// the store is built — it must relocate the tokens without re-entering the store.
+		koin.get<ServerSettingsDatasource>().migrateInlineTokens(projectsDir.toHPath())
+
+		val rewritten = rawFs.read(serverJson) { readUtf8() }
+		assertFalse(rewritten.contains("zxc456"))
+		assertFalse(rewritten.contains("bnm789"))
+		assertEquals(AuthTokens("zxc456", "bnm789"), koin.get<AuthTokenStore>().get("hammer.ink", 1L))
+		assertEquals(1, counter.loadCalls, "Migration must not trigger more settings loads")
+	}
+
+	private fun legacyServerSettings() = ServerSettings(
+		ssl = true,
+		url = "hammer.ink",
+		email = "test@example.com",
+		userId = 1,
+		bearerToken = "zxc456",
+		refreshToken = "bnm789",
+	)
+
+	/** Counts load calls and hard-caps recursion so a regression fails fast instead of hanging. */
+	private class CountingServerSettingsDatasource(
+		private val delegate: ServerSettingsDatasource,
+	) : ServerSettingsDatasource {
+		var loadCalls = 0
+			private set
+
+		override fun serverIsSetup(projectsDir: HPath) = delegate.serverIsSetup(projectsDir)
+
+		override fun loadServerSettings(projectsDir: HPath): ServerSettings? {
+			loadCalls++
+			check(loadCalls <= MAX_CALLS) { "loadServerSettings re-entered $loadCalls times — bootstrap cycle regression" }
+			return delegate.loadServerSettings(projectsDir)
+		}
+
+		override fun storeServerSettings(settings: ServerSettings, projectsDir: HPath) =
+			delegate.storeServerSettings(settings, projectsDir)
+
+		override fun removeServerSettings(projectsDir: HPath) = delegate.removeServerSettings(projectsDir)
+
+		override fun migrateInlineTokens(projectsDir: HPath) = delegate.migrateInlineTokens(projectsDir)
+
+		companion object {
+			private const val MAX_CALLS = 25
+		}
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/globalsettings/ServerSettingsDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/globalsettings/ServerSettingsDatasourceTest.kt
@@ -133,7 +133,7 @@ class ServerSettingsDatasourceTest : BaseTest() {
 	}
 
 	@Test
-	fun `Legacy server json with inline tokens is migrated into the store`() = runTest {
+	fun `Loading legacy server json honors inline tokens without rewriting the file`() = runTest {
 		val legacy = createConfig()
 		fileSystem.createDirectories(projectsDir().toOkioPath())
 		fileSystem.writeJson(configPath().toOkioPath(), json, legacy)
@@ -144,7 +144,20 @@ class ServerSettingsDatasourceTest : BaseTest() {
 		val datasource = createDatasource()
 		val loaded = datasource.loadServerSettings(projectsDir())
 
+		// The session gets the tokens, but loading is a pure read: nothing is relocated yet.
 		assertEquals(legacy, loaded)
+		assertNull(authTokenStore.get(legacy.url, legacy.userId))
+		assertTrue(readServerJson().contains("zxc456"))
+	}
+
+	@Test
+	fun `migrateInlineTokens relocates inline tokens into the store and rewrites the file`() = runTest {
+		val legacy = createConfig()
+		fileSystem.createDirectories(projectsDir().toOkioPath())
+		fileSystem.writeJson(configPath().toOkioPath(), json, legacy)
+
+		val datasource = createDatasource()
+		datasource.migrateInlineTokens(projectsDir())
 
 		assertEquals(
 			AuthTokens(legacy.bearerToken, legacy.refreshToken),
@@ -156,6 +169,10 @@ class ServerSettingsDatasourceTest : BaseTest() {
 		assertFalse(rewritten.contains("refreshToken"))
 		assertFalse(rewritten.contains("zxc456"))
 		assertFalse(rewritten.contains("bnm789"))
+
+		// Idempotent: a second run is a no-op and the relocated tokens still resolve.
+		datasource.migrateInlineTokens(projectsDir())
+		assertEquals(legacy, datasource.loadServerSettings(projectsDir()))
 	}
 
 	@Test

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/PreviewSpellCheck.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/PreviewSpellCheck.kt
@@ -23,6 +23,7 @@ private val fakeServerSettingsDatasource = object : ServerSettingsDatasource {
 	override fun loadServerSettings(projectsDir: HPath): ServerSettings? = null
 	override fun storeServerSettings(settings: ServerSettings, projectsDir: HPath) {}
 	override fun removeServerSettings(projectsDir: HPath) {}
+	override fun migrateInlineTokens(projectsDir: HPath) {}
 }
 
 /**

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/InMemorySettingsDatasources.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/InMemorySettingsDatasources.kt
@@ -39,4 +39,6 @@ class InMemoryServerSettingsDatasource : ServerSettingsDatasource {
 	override fun removeServerSettings(projectsDir: HPath) {
 		store.remove(key(projectsDir))
 	}
+
+	override fun migrateInlineTokens(projectsDir: HPath) = Unit
 }


### PR DESCRIPTION
## Summary

Fixes an all-platform startup hang (Android gray-screen → ANR; desktop freeze) that v3.5.0 introduced for **any user upgrading with a sync account configured on ≤ v3.4.x**. Symptom in the logs is an infinite loop alternating `Loading Server Settings` / `Loading Global Settings`.

## Root cause

Only triggers when `server.json` still carries legacy inline auth tokens:

1. `HammerApplication.onCreate` / desktop `Main` run `runBlocking { handleDataMigration() }`, constructing `GlobalSettingsStore`.
2. `GlobalSettingsStore.init` → `loadServerSettings`, which for inline tokens performed a **guarded write** (the token migration) *during construction*.
3. That write routes through `ContainedFileSystem` → `managedStorageRoots` → `koin.get<GlobalSettingsStore>()`.
4. Koin re-invokes the still-constructing single (it only throws circular during *parameter* resolution, not from the init block), so the store re-enters its own construction → infinite recursion.

Both culprits — the inline-token migration (`4572c33a8`) and the `ContainedFileSystem` guard (`1ae79eac2`) — shipped together in v3.5.0, so no earlier release pre-migrated the file. The write never completes, so the file stays poisoned and it hangs on every launch.

## Fix

Make `GlobalSettingsStore` construction perform **only pure reads** — then root resolution can safely prefer the store again.

- `loadServerSettings` / `loadSettings` no longer write during load (the inline-token rewrite **and** the corrupt-file self-delete were removed from the load paths). `loadServerSettings` still *reads* inline tokens so the session isn't dropped before migration runs.
- The inline-token migration moves to a new idempotent `MigrateInlineAuthTokens` global migration, run by `DataMigrator` after the store is built (after `MigrateInstallIdToGlobal`, which must read the legacy `installId` before the tokenless rewrite drops it).
- All transitional inline-token code is annotated for removal once 4.0 ships.

## Testing

- New `GlobalSettingsBootstrapCycleTest`: wires the real `ContainedFileSystem` + store graph over a fake filesystem with legacy inline tokens, proves construction doesn't loop and the migration relocates tokens without re-entering the store.
- Updated `ServerSettingsDatasourceTest` (load is a pure read / migration is separate + idempotent) and the four `DataMigratorTest` cases.
- Full `:common:desktopTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbY3HswstDTfuuyiqNKBwY