### PR TITLE
Run data migrations on iOS startup

### DIFF
--- a/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/HammerAppInit.kt
+++ b/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/HammerAppInit.kt
@@ -1,7 +1,10 @@
 package com.darkrockstudios.apps.hammer.common
 
+import com.darkrockstudios.apps.hammer.common.data.migrator.DataMigrator
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.aboutLibrariesModule
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.imageLoadingModule
+import kotlinx.coroutines.runBlocking
+import org.koin.mp.KoinPlatform.getKoin
 
 fun initializeHammerApp() {
 	initializeKoin(
@@ -10,4 +13,8 @@ fun initializeHammerApp() {
 			aboutLibrariesModule,
 		)
 	)
+
+	// Run data migrations before the UI starts, matching Android (HammerApplication) and
+	// desktop (Main). Without this iOS would never run global or per-project migrations.
+	runBlocking { getKoin().get<DataMigrator>().handleDataMigration() }
 }


### PR DESCRIPTION
## Summary

iOS started Koin but never invoked `DataMigrator`, so **no** migrations ran on iOS — not the global ones (`installId` relocation, inline auth-token relocation) nor per-project data-version migrations.

This calls `handleDataMigration()` from `initializeHammerApp()` right after Koin is up, mirroring Android (`HammerApplication.onCreate`) and desktop (`Main`), so every platform runs the same startup migrations.

## Notes

- Independent of #683 and safe in either merge order. iOS shipped in v3.5.0 writing tokens tokenless from day one, so it has no legacy inline-token `server.json` — running `DataMigrator` there won't hit the bootstrap cycle even before #683 lands. Once both merge, iOS picks up the inline-token migration too.
- **Needs a green CI iOS build before merge** — the change couldn't be compiled locally (Kotlin/Native Apple targets require macOS). It uses only multiplatform APIs already present in commonMain (`runBlocking`, `KoinPlatform.getKoin`, `DataMigrator`). Desktop still compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbY3HswstDTfuuyiqNKBwY