### PR TITLE
Fix crash when deleting a scene while its metadata panel is open

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneEditorService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneEditorService.kt
@@ -141,8 +141,10 @@ class SceneEditorService(
 	 * changed. The repo handles only the pure persist + flow emission.
 	 */
 	suspend fun storeMetadata(metadata: SceneMetadata, sceneId: Int) {
+		// A flush can arrive after the scene was deleted (e.g. the metadata panel's save on
+		// destroy). Nothing to persist for a scene that no longer exists.
 		val scene = sceneEditorRepository.getSceneItemFromIdIncludingArchived(sceneId)
-			?: error("storeMetadata: Failed to load scene for id: $sceneId ")
+			?: return
 
 		val previous = sceneMetadataRepository.loadRawMetadata(sceneId)
 

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneEditorServiceTest.kt
@@ -417,6 +417,24 @@ class SceneEditorServiceTest : BaseTest() {
 			}
 		}
 
+	// A metadata flush can land after the scene was deleted (e.g. the metadata panel's
+	// fire-and-forget save on destroy). The scene is gone, so there is nothing to persist
+	// and the call must not crash.
+	@Test
+	fun `Store metadata for a deleted scene is a no-op and does not throw`() =
+		runTest(mainTestDispatcher) {
+			val service = initializedService()
+			val scene = service.getSceneItemFromId(1)!!
+			val metadata = service.loadSceneMetadata(1).copy(notes = "late write")
+
+			assertTrue(service.deleteScene(scene))
+			assertNull(service.getSceneItemFromIdIncludingArchived(1))
+
+			service.storeMetadata(metadata, 1)
+
+			coVerify(exactly = 0) { referenceIndexRepository.applySceneDelta(any(), any(), any()) }
+		}
+
 	@Test
 	fun `Store metadata emits on the metadata update flow`() = runTest(mainTestDispatcher) {
 		val service = initializedService()


### PR DESCRIPTION
## Problem

On a phone, deleting the currently-open scene from the scene editor's options menu crashes the app:

```
java.lang.IllegalStateException: storeMetadata: Failed to load scene for id: 1
    at SceneEditorService.storeMetadata(SceneEditorService.kt:145)
    at SceneMetadataPanelComponent$onDestroy$1.invokeSuspend(SceneMetadataPanelComponent.kt:334)
```

Deleting a scene destroys its `SceneMetadataPanelComponent`. The component's `onDestroy()` fires a fire-and-forget metadata save on the app-wide scope:

```kotlin
appScope.launch { editor.storeMetadata(scrubbed, originalSceneItem.id) }
```

By the time that coroutine runs, the scene is already gone, so `storeMetadata` looked it up, got `null`, and called `error(...)`. Because the exception was thrown on an uncaught `appScope` coroutine, it took down the whole process.

## Fix

`SceneEditorService.storeMetadata` now returns early when the scene no longer exists — a missing scene is an expected race after deletion, not an exceptional condition. A normal save of a live scene is unchanged.

## Test

Added a regression test (`Store metadata for a deleted scene is a no-op and does not throw`) that deletes a scene then calls `storeMetadata`. It reproduced the `IllegalStateException` before the fix and passes after.
