### PR TITLE
Add Find and Replace to the format bar overflow menu

### DIFF
--- a/common/src/commonMain/composeResources/values/strings.xml
+++ b/common/src/commonMain/composeResources/values/strings.xml
@@ -40,6 +40,7 @@
 	<string name="markdown_format_bar_decrease_text_size">Decrease text size</string>
 	<string name="markdown_format_bar_increase_text_size">Increase text size</string>
 	<string name="markdown_format_bar_reset_text_size">Reset text size</string>
+	<string name="markdown_format_bar_find_replace">Find and replace</string>
 
 	<string name="markdown_format_bar_bold">Bold</string>
 	<string name="markdown_format_bar_italic">Italic</string>

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownFormatBar.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownFormatBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.FormatListNumbered
 import androidx.compose.material.icons.filled.FormatQuote
 import androidx.compose.material.icons.filled.HorizontalRule
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -53,6 +54,7 @@ import com.darkrockstudios.apps.hammer.markdown_format_bar_blockquote
 import com.darkrockstudios.apps.hammer.markdown_format_bar_bold
 import com.darkrockstudios.apps.hammer.markdown_format_bar_bullet_list
 import com.darkrockstudios.apps.hammer.markdown_format_bar_decrease_text_size
+import com.darkrockstudios.apps.hammer.markdown_format_bar_find_replace
 import com.darkrockstudios.apps.hammer.markdown_format_bar_heading
 import com.darkrockstudios.apps.hammer.markdown_format_bar_horizontal_rule
 import com.darkrockstudios.apps.hammer.markdown_format_bar_increase_text_size
@@ -77,6 +79,7 @@ fun MarkdownFormatBar(
 	decreaseTextSize: (() -> Unit)? = null,
 	increaseTextSize: (() -> Unit)? = null,
 	resetTextSize: (() -> Unit)? = null,
+	onFindReplace: (() -> Unit)? = null,
 ) {
 	var isBoldActive by remember { mutableStateOf(false) }
 	var isItalicActive by remember { mutableStateOf(false) }
@@ -115,7 +118,8 @@ fun MarkdownFormatBar(
 		state.editOperations.collect { reconcileHorizontalRules(state) }
 	}
 
-	val showOverflow = decreaseTextSize != null || increaseTextSize != null || resetTextSize != null
+	val showOverflow = decreaseTextSize != null || increaseTextSize != null ||
+		resetTextSize != null || onFindReplace != null
 
 	BoxWithConstraints(modifier = modifier.background(MaterialTheme.colorScheme.surfaceContainerLow)) {
 		val compact = maxWidth < TOOLBAR_COMPACT_THRESHOLD
@@ -147,6 +151,7 @@ fun MarkdownFormatBar(
 				decreaseTextSize = decreaseTextSize,
 				increaseTextSize = increaseTextSize,
 				resetTextSize = resetTextSize,
+				onFindReplace = onFindReplace,
 				showOverflow = showOverflow,
 			)
 		}
@@ -260,6 +265,7 @@ private fun HistoryAndOverflow(
 	decreaseTextSize: (() -> Unit)?,
 	increaseTextSize: (() -> Unit)?,
 	resetTextSize: (() -> Unit)?,
+	onFindReplace: (() -> Unit)?,
 	showOverflow: Boolean,
 ) {
 	EditorTooltip(Res.string.markdown_format_bar_undo.get()) {
@@ -295,6 +301,21 @@ private fun HistoryAndOverflow(
 			expanded = menuExpanded,
 			onDismissRequest = { menuExpanded = false },
 		) {
+			if (onFindReplace != null) {
+				DropdownMenuItem(
+					text = { Text(Res.string.markdown_format_bar_find_replace.get()) },
+					leadingIcon = {
+						Icon(
+							imageVector = Icons.Default.Search,
+							contentDescription = null,
+						)
+					},
+					onClick = {
+						onFindReplace()
+						menuExpanded = false
+					},
+				)
+			}
 			if (decreaseTextSize != null) {
 				DropdownMenuItem(
 					text = { Text(Res.string.markdown_format_bar_decrease_text_size.get()) },

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
@@ -120,6 +120,7 @@ fun FocusModeUi(component: FocusMode) {
 					markdownState = markdownExtension,
 					decreaseTextSize = component::decreaseTextSize,
 					increaseTextSize = component::increaseTextSize,
+					onFindReplace = { showFindBar = true },
 					modifier = Modifier.weight(1f),
 				)
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -175,6 +175,7 @@ fun SceneEditorUi(
 					decreaseTextSize = component::decreaseTextSize,
 					increaseTextSize = component::increaseTextSize,
 					resetTextSize = component::resetTextSize,
+					onFindReplace = { showFindBar = true },
 				)
 
 				AnimatedVisibility(


### PR DESCRIPTION
@
## Summary

Adds a **Find and replace** item to the markdown format bars overflow (⋮) menu, giving mouse/touch users a discoverable way to reach find/replace (previously only available via the `Ctrl+F` shortcut).

The item reuses the editors existing `FindBar` (which already supports replace) — it simply toggles the same `showFindBar` state the keyboard shortcut drives. Wired in both the scene editor and focus mode.

## Changes

- `MarkdownFormatBar`: new optional `onFindReplace` callback; when supplied, a `Find and replace` entry appears as the first item in the overflow dropdown (Search icon). Folded into the `showOverflow` condition.
- `SceneEditorUi` / `FocusModeUi`: pass `onFindReplace = { showFindBar = true }`.
- `values/strings.xml`: new `markdown_format_bar_find_replace` string (base locale only; translations handled externally).

`MarkdownEditField` (notes/encyclopedia) has no find feature and omits the callback, so its menu is unchanged.

## Testing

- `./gradlew :composeUi:compileKotlinDesktop` passes.
@