### PR TITLE
docs: list desktop log locations per OS and Linux package format

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -71,3 +71,14 @@ Notes:
   If you've set `$XDG_CONFIG_HOME`, substitute it for `~/.config` above.
 - Snap and Flatpak run sandboxed, so they relocate the config directory
   into their per-app sandbox.
+
+### Mobile
+
+**Android:** Logs aren't browsed directly from a folder. Instead, open the
+About screen and use the **Export Logs** button at the bottom — it bundles
+the logs into a zip and lets you share them out (e.g. via email or a chat
+app) so you can attach them to a bug report.
+
+**iOS:** Hammer doesn't write logs to disk on iOS, so there's nothing to
+export or share. If you're hitting a bug on iOS, please describe what
+happened and your app version when you reach out.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -39,8 +39,35 @@ the About screen, and scrolling to the bottom.
 
 ### Where are the logs stored?
 
-On desktop, Logs are written to:
+On desktop, logs are written to a `logs` folder inside the app's config
+directory. The exact location depends on your OS and, on Linux, on how you
+installed Hammer (sandboxed packages such as Snap and Flatpak redirect the
+config directory).
 
 **Windows:**
 
 `C:\Users\<username>\AppData\Local\DarkrockStudios\hammer\0\logs\`
+
+**macOS:**
+
+`~/Library/Application Support/hammer/0/logs/`
+
+**Linux:**
+
+The path depends on the package format you installed:
+
+| Package format        | Logs directory                                                  |
+|-----------------------|-----------------------------------------------------------------|
+| `.deb`                | `~/.config/hammer/0/logs/`                                       |
+| `.rpm`                | `~/.config/hammer/0/logs/`                                       |
+| AppImage              | `~/.config/hammer/0/logs/`                                       |
+| Snap                  | `~/snap/hammer-editor/current/.config/hammer/0/logs/`           |
+| Flatpak               | `~/.var/app/studio.darkrock.hammer/config/hammer/0/logs/`       |
+
+Notes:
+
+- The native packages (`.deb`, `.rpm`, AppImage) follow the
+  [XDG Base Directory spec](https://specifications.freedesktop.org/basedir-spec/latest/).
+  If you've set `$XDG_CONFIG_HOME`, substitute it for `~/.config` above.
+- Snap and Flatpak run sandboxed, so they relocate the config directory
+  into their per-app sandbox.


### PR DESCRIPTION
Documents where Hammer's logs live and how to retrieve them, filling out the "Where are the logs stored?" section in `SUPPORT.md` (previously Windows-only).

## Desktop
- Added **macOS** path.
- Added a per-package-format table for **Linux** (`.deb` / `.rpm` / AppImage, Snap, Flatpak), since sandboxed packages (Snap, Flatpak) relocate the config directory while the native packages follow the XDG Base Directory spec.

## Mobile
- **Android:** documented the **Export Logs** button on the About screen, which zips the logs and shares them out for bug reports.
- **iOS:** noted that logs aren't written to disk on iOS (its About section is a no-op and `getLogDirectory()` returns `null`), so there's nothing to export — rather than implying a share button that doesn't exist.

Docs-only change; no code modified.