### PR TITLE
Restore hover values on dashboard chapter chart and encyclopedia donut

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values/strings_project_home.xml
@@ -61,6 +61,7 @@
 
 	<string name="project_home_stat_chapter_words_summary">σ %1$d · min %2$d · max %3$d</string>
 	<string name="project_home_stat_donut_entries">entries</string>
+	<string name="project_home_stat_donut_tooltip">%1$s · %2$s entries</string>
 
 	<string name="project_home_stat_themes_title">Themes</string>
 	<string name="project_home_stat_themes_summary">%1$d tags · %2$d uses</string>

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdBarChart.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdBarChart.kt
@@ -1,12 +1,12 @@
 package com.darkrockstudios.apps.hammer.common.compose.designsystem
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -18,6 +18,8 @@ import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -25,6 +27,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 
 private val BarShape = RoundedCornerShape(2.dp)
 
@@ -38,9 +41,10 @@ data class HdBarChartItem(
  * dashboard. Bars share a single [color] (defaults to theme primary) and
  * scale relative to the largest value.
  *
- * When [tooltipText] is provided, each column becomes a hover/long-press
- * target that surfaces the underlying value. Otherwise it stays a pure
- * "manuscript" visual — no axes, no grid, no animation.
+ * When [tooltipText] is provided, each bar surfaces the underlying value:
+ * hover on desktop, tap on touch. A tapped tooltip persists until the user
+ * taps elsewhere. Otherwise it stays a pure "manuscript" visual — no axes,
+ * no grid, no animation.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,25 +69,26 @@ fun HdBarChart(
 			verticalAlignment = Alignment.Bottom,
 		) {
 			items.forEach { item ->
-				val fraction = (item.value.toFloat() / maxValue).coerceAtLeast(0.02f)
+				val fraction = (item.value.toFloat() / maxValue).coerceIn(0.02f, 1f)
+				val barHeight = height * fraction
 				if (tooltipText != null) {
-					TooltipBox(
-						positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
-						tooltip = { PlainTooltip { Text(tooltipText(item)) } },
-						state = rememberTooltipState(),
-						modifier = Modifier
-							.weight(1f)
-							.fillMaxHeight(),
-					) {
-						Box(
-							modifier = Modifier.fillMaxSize(),
-							contentAlignment = Alignment.BottomCenter,
-						) {
-							Bar(fraction = fraction, color = color, modifier = Modifier.fillMaxWidth())
-						}
+					// TooltipBox wraps its anchor in an unmodified Box, so the
+					// column weight has to live on a wrapper, not on TooltipBox.
+					Box(modifier = Modifier.weight(1f)) {
+						BarWithTooltip(
+							barHeight = barHeight,
+							color = color,
+							text = tooltipText(item),
+						)
 					}
 				} else {
-					Bar(fraction = fraction, color = color, modifier = Modifier.weight(1f))
+					Box(
+						modifier = Modifier
+							.weight(1f)
+							.height(barHeight)
+							.clip(BarShape)
+							.background(color),
+					)
 				}
 			}
 		}
@@ -106,12 +111,30 @@ fun HdBarChart(
 	}
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun Bar(fraction: Float, color: Color, modifier: Modifier) {
-	Box(
-		modifier = modifier
-			.fillMaxHeight(fraction)
-			.clip(BarShape)
-			.background(color),
-	)
+private fun BarWithTooltip(
+	barHeight: Dp,
+	color: Color,
+	text: String,
+) {
+	val state = rememberTooltipState(isPersistent = true)
+	val scope = rememberCoroutineScope()
+	TooltipBox(
+		positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+		tooltip = { PlainTooltip { Text(text) } },
+		state = state,
+	) {
+		Box(
+			modifier = Modifier
+				.fillMaxWidth()
+				.height(barHeight)
+				.clip(BarShape)
+				.background(color)
+				.clickable(
+					interactionSource = remember { MutableInteractionSource() },
+					indication = null,
+				) { scope.launch { state.show() } },
+		)
+	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdBarChart.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdBarChart.kt
@@ -6,11 +6,17 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,10 +38,11 @@ data class HdBarChartItem(
  * dashboard. Bars share a single [color] (defaults to theme primary) and
  * scale relative to the largest value.
  *
- * Designed to match the dashboard mock — no axes, no grid, no animation.
- * For richer interactive charts (tooltips, multi-series) use KoalaPlot
- * directly; this is the "manuscript" treatment.
+ * When [tooltipText] is provided, each column becomes a hover/long-press
+ * target that surfaces the underlying value. Otherwise it stays a pure
+ * "manuscript" visual — no axes, no grid, no animation.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HdBarChart(
 	items: List<HdBarChartItem>,
@@ -44,6 +51,7 @@ fun HdBarChart(
 	color: Color = MaterialTheme.colorScheme.primary,
 	barSpacing: Dp = 4.dp,
 	showLabels: Boolean = true,
+	tooltipText: ((HdBarChartItem) -> String)? = null,
 ) {
 	if (items.isEmpty()) return
 	val maxValue = items.maxOf { it.value }.coerceAtLeast(1)
@@ -57,14 +65,26 @@ fun HdBarChart(
 			verticalAlignment = Alignment.Bottom,
 		) {
 			items.forEach { item ->
-				val fraction = item.value.toFloat() / maxValue
-				Box(
-					modifier = Modifier
-						.weight(1f)
-						.fillMaxHeight(fraction.coerceAtLeast(0.02f))
-						.clip(BarShape)
-						.background(color),
-				)
+				val fraction = (item.value.toFloat() / maxValue).coerceAtLeast(0.02f)
+				if (tooltipText != null) {
+					TooltipBox(
+						positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+						tooltip = { PlainTooltip { Text(tooltipText(item)) } },
+						state = rememberTooltipState(),
+						modifier = Modifier
+							.weight(1f)
+							.fillMaxHeight(),
+					) {
+						Box(
+							modifier = Modifier.fillMaxSize(),
+							contentAlignment = Alignment.BottomCenter,
+						) {
+							Bar(fraction = fraction, color = color, modifier = Modifier.fillMaxWidth())
+						}
+					}
+				} else {
+					Bar(fraction = fraction, color = color, modifier = Modifier.weight(1f))
+				}
 			}
 		}
 		if (showLabels) {
@@ -84,4 +104,14 @@ fun HdBarChart(
 			}
 		}
 	}
+}
+
+@Composable
+private fun Bar(fraction: Float, color: Color, modifier: Modifier) {
+	Box(
+		modifier = modifier
+			.fillMaxHeight(fraction)
+			.clip(BarShape)
+			.background(color),
+	)
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
@@ -45,6 +46,7 @@ import com.darkrockstudios.apps.hammer.common.data.projectstatistics.estimateRea
 import com.darkrockstudios.apps.hammer.common.data.tagindex.TaggedEntityType
 import com.darkrockstudios.apps.hammer.common.util.formatDecimalSeparator
 import io.github.koalaplot.core.pie.BezierLabelConnector
+import io.github.koalaplot.core.pie.DefaultSlice
 import io.github.koalaplot.core.pie.PieChart
 import io.github.koalaplot.core.style.KoalaPlotTheme
 import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
@@ -528,10 +530,19 @@ private fun StructureSection(
 						)
 					},
 				)
+				val chapterAxis = stringResource(Res.string.project_home_stat_chapter_words_x_axis)
+				val chapterTooltips = state.wordsByChapter.values.mapIndexed { index, words ->
+					stringResource(
+						Res.string.project_home_stat_chapter_words_tooltip,
+						"$chapterAxis ${index + 1}",
+						words.formatDecimalSeparator(),
+					)
+				}
 				HdBarChart(
 					items = chapterStats.items,
 					modifier = Modifier.fillMaxWidth(),
 					height = 140.dp,
+					tooltipText = { item -> chapterTooltips[item.label.toInt() - 1] },
 				)
 			}
 		}
@@ -1175,6 +1186,7 @@ private fun EncyclopediaDonut(
 	// KoalaPlot crashes on zero values, so add 0.01f.
 	val values = remember(typeCounts) { typeCounts.map { it.value.toFloat() + .01f } }
 	val keys = remember(typeCounts) { typeCounts.keys.toList() }
+	val counts = remember(typeCounts) { typeCounts.values.toList() }
 	if (values.isEmpty() || values.sum() <= 0f) {
 		Spacer(modifier = modifier.height(180.dp))
 		return
@@ -1200,6 +1212,19 @@ private fun EncyclopediaDonut(
 				modifier = Modifier.fillMaxSize().focusable(false),
 				values = values,
 				holeSize = 0.55f,
+				slice = { index ->
+					DefaultSlice(
+						color = hammerColors.colorFor(keys[index]),
+						hoverExpandFactor = 1.05f,
+						hoverElement = {
+							EncyclopediaSliceTooltip(
+								type = keys[index],
+								count = counts[index],
+								color = hammerColors.colorFor(keys[index]),
+							)
+						},
+					)
+				},
 				holeContent = {
 					Column(
 						modifier = Modifier.fillMaxSize(),
@@ -1234,6 +1259,36 @@ private fun EncyclopediaDonut(
 	}
 
 	LaunchedEffect(Unit) { hasAnimated = true }
+}
+
+@Composable
+private fun EncyclopediaSliceTooltip(
+	type: EntryType,
+	count: Int,
+	color: Color,
+) {
+	Surface(
+		color = MaterialTheme.colorScheme.inverseSurface,
+		contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+		shape = RoundedCornerShape(4.dp),
+		shadowElevation = 4.dp,
+	) {
+		Row(
+			modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+			verticalAlignment = Alignment.CenterVertically,
+			horizontalArrangement = Arrangement.spacedBy(8.dp),
+		) {
+			Box(modifier = Modifier.size(8.dp).background(color))
+			HdMonoLabel(
+				text = stringResource(
+					Res.string.project_home_stat_donut_tooltip,
+					stringResource(type.toStringResource()),
+					count.formatDecimalSeparator(),
+				),
+				color = MaterialTheme.colorScheme.inverseOnSurface,
+			)
+		}
+	}
 }
 
 @Composable

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
@@ -4,7 +4,9 @@ import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -1196,6 +1198,10 @@ private fun EncyclopediaDonut(
 	val animationDelay = remember { Random.nextInt(300, 1000) }
 	val hammerColors = LocalHammerColors.current
 
+	// Touch has no hover, so a tap selects a slice and reveals its count in
+	// the donut hole; tapping the slice again or empty space clears it.
+	var selectedIndex by remember(keys) { mutableStateOf<Int?>(null) }
+
 	KoalaPlotTheme(
 		animationSpec = if (!hasAnimated) {
 			tween(
@@ -1208,6 +1214,16 @@ private fun EncyclopediaDonut(
 		},
 	) {
 		Box(modifier = modifier) {
+			if (selectedIndex != null) {
+				Box(
+					modifier = Modifier
+						.matchParentSize()
+						.clickable(
+							interactionSource = remember { MutableInteractionSource() },
+							indication = null,
+						) { selectedIndex = null },
+				)
+			}
 			PieChart(
 				modifier = Modifier.fillMaxSize().focusable(false),
 				values = values,
@@ -1216,6 +1232,8 @@ private fun EncyclopediaDonut(
 					DefaultSlice(
 						color = hammerColors.colorFor(keys[index]),
 						hoverExpandFactor = 1.05f,
+						clickable = true,
+						onClick = { selectedIndex = if (selectedIndex == index) null else index },
 						hoverElement = {
 							EncyclopediaSliceTooltip(
 								type = keys[index],
@@ -1226,20 +1244,33 @@ private fun EncyclopediaDonut(
 					)
 				},
 				holeContent = {
+					val selected = selectedIndex
 					Column(
 						modifier = Modifier.fillMaxSize(),
 						verticalArrangement = Arrangement.Center,
 						horizontalAlignment = Alignment.CenterHorizontally,
 					) {
-						Text(
-							totalEntries.formatDecimalSeparator(),
-							style = MaterialTheme.typography.headlineMedium,
-							color = MaterialTheme.colorScheme.onSurface,
-						)
-						HdMonoLabel(
-							text = stringResource(Res.string.project_home_stat_donut_entries),
-							color = MaterialTheme.colorScheme.onSurfaceVariant,
-						)
+						if (selected != null) {
+							Text(
+								counts[selected].formatDecimalSeparator(),
+								style = MaterialTheme.typography.headlineMedium,
+								color = hammerColors.colorFor(keys[selected]),
+							)
+							HdMonoLabel(
+								text = stringResource(keys[selected].toStringResource()),
+								color = MaterialTheme.colorScheme.onSurfaceVariant,
+							)
+						} else {
+							Text(
+								totalEntries.formatDecimalSeparator(),
+								style = MaterialTheme.typography.headlineMedium,
+								color = MaterialTheme.colorScheme.onSurface,
+							)
+							HdMonoLabel(
+								text = stringResource(Res.string.project_home_stat_donut_entries),
+								color = MaterialTheme.colorScheme.onSurfaceVariant,
+							)
+						}
 					}
 				},
 				label = { index ->

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/designsystem/DesignSystem.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/designsystem/DesignSystem.Preview.kt
@@ -508,6 +508,7 @@ fun BarChartPreview() {
 					HdBarChartItem("Ch 6", 860),
 				),
 				modifier = Modifier.fillMaxWidth(),
+				tooltipText = { "Chapter ${it.label}: ${it.value} words" },
 			)
 		}
 	}


### PR DESCRIPTION
Fixes the dashboard regression reported in #690, where the **Words in Chapters** bar chart and the **Encyclopedia Entries** donut no longer surfaced the underlying numbers.

## Changes

### Words in Chapters
- `HdBarChart` gains an optional `tooltipText` parameter. When provided, each **column** (full height, so the hover target is larger than the visible bar) is wrapped in a Material3 `TooltipBox` — shows on **mouse hover (desktop)** and **long-press (touch)**.
- The chapter chart wires this up, reusing the existing `project_home_stat_chapter_words_tooltip` string, e.g. *"Chapter 5: 2,609 words"*.
- The chart's visuals are unchanged (verified by re-rendering `BarChartPreview`).

### Encyclopedia Entries
- The donut now supplies a custom `slice` to KoalaPlot's `PieChart` using `DefaultSlice(hoverElement = …)`, so hovering a segment shows a small tooltip with a color swatch + the category and count, e.g. *"Person · 3 entries"*. The hovered slice expands slightly for feedback.
- Slice fills now use the app's semantic entry colors (`hammerColors.colorFor`) instead of KoalaPlot's generic hue palette, so slices, label connectors, and the tooltip swatch are all consistent.
- The center total count is preserved.

## Notes
- Bar tooltips work on both desktop hover and mobile long-press.
- The donut tooltip relies on KoalaPlot's `HoverableElementArea`, which is **pointer-hover only**. On touch the donut still shows the category labels and total but not per-slice counts on tap — this matches the pre-redesign behavior. A tap-to-reveal interaction for the donut on mobile could be a follow-up.
- One new string added to the default `values/` locale only, per the project's externally-handled-translations convention.

Closes #690