### PR TITLE
Fix fresh-install startup crash from bootstrap recursion

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/GlobalSettingsFilesystemDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/GlobalSettingsFilesystemDatasource.kt
@@ -20,15 +20,12 @@ class GlobalSettingsFilesystemDatasource(
 	private val platformSpellCheckerFactory: PlatformSpellCheckerFactory,
 ) : GlobalSettingsDatasource {
 
-	init {
-		if (!fileSystem.exists(CONFIG_PATH)) {
-			val default = createDefault(languageUtil, platformSpellCheckerFactory)
-			storeSettings(default)
-		}
-	}
-
 	override fun loadSettings(): GlobalSettings {
 		Napier.i { "Loading Global Settings from: $CONFIG_PATH" }
+
+		if (!fileSystem.exists(CONFIG_PATH)) {
+			return createDefault(languageUtil, platformSpellCheckerFactory)
+		}
 
 		val settingsText: String = fileSystem.read(CONFIG_PATH) {
 			readUtf8()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -253,9 +253,15 @@ val mainModule = module {
 
 /**
  * Managed storage roots checked by [ContainedFileSystem]: cache, config, and the
- * (user-relocatable, resolved per call) projects directory. Projects resolution is
- * cycle-safe — store, then persisted settings, then default — so config-root writes
- * during the store's own construction aren't blocked.
+ * (user-relocatable, resolved per call) projects directory. Projects resolution
+ * degrades gracefully — store, then persisted settings, then default — so a guarded
+ * write can resolve the root before settings are loaded.
+ *
+ * This chain does NOT make construction-time writes safe: Koin re-enters a still-
+ * constructing singleton instead of throwing, so a guarded write fired from
+ * [GlobalSettingsStore]'s own construction recurses here forever (the fallbacks never
+ * run). The real guarantee is upstream — the store performs no guarded writes during
+ * construction (see GlobalSettingsFilesystemDatasource). Keep it that way.
  */
 internal fun managedStorageRoots(koin: org.koin.core.Koin): List<Path> {
 	val cacheRoot = getCacheDirectory().toPath()

--- a/common/src/desktopTest/kotlin/dependencyinjection/GlobalSettingsBootstrapCycleTest.kt
+++ b/common/src/desktopTest/kotlin/dependencyinjection/GlobalSettingsBootstrapCycleTest.kt
@@ -123,6 +123,29 @@ class GlobalSettingsBootstrapCycleTest {
 		assertEquals(1, counter.loadCalls, "Migration must not trigger more settings loads")
 	}
 
+	@Test
+	fun `Fresh install with no config constructs the store without looping`() {
+		// The original crash: a fresh install (no config file) had the datasource write
+		// defaults from its init block, which re-entered the still-constructing store
+		// through the guarded filesystem and recursed until the stack overflowed. Seed
+		// nothing and assert construction is a pure read that completes.
+		assertFalse(rawFs.exists(GlobalSettingsFilesystemDatasource.CONFIG_PATH))
+
+		val store = koin.get<GlobalSettingsStore>()
+		val counter = koin.get<ServerSettingsDatasource>() as CountingServerSettingsDatasource
+
+		// Construction wrote nothing — defaults live in memory until a real store happens.
+		assertFalse(
+			rawFs.exists(GlobalSettingsFilesystemDatasource.CONFIG_PATH),
+			"Store construction must not write the config on a fresh install",
+		)
+		assertEquals(1, counter.loadCalls, "Store construction must not re-enter loadServerSettings")
+		assertEquals(
+			GlobalSettingsStore.defaultProjectDir().toString(),
+			store.globalSettings.projectsDirectory,
+		)
+	}
+
 	private fun legacyServerSettings() = ServerSettings(
 		ssl = true,
 		url = "hammer.ink",

--- a/common/src/desktopTest/kotlin/repositories/globalsettings/GlobalSettingsDatasourceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/globalsettings/GlobalSettingsDatasourceTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import utils.BaseTest
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class GlobalSettingsDatasourceTest : BaseTest() {
 
@@ -47,6 +48,19 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 	}
 
 	@Test
+	fun `Construction does not write to the filesystem`() = runTest {
+		createDatasource()
+
+		// Writing during construction re-enters the still-constructing GlobalSettingsStore
+		// through the guarded ContainedFileSystem (managedStorageRoots -> get<GlobalSettingsStore>),
+		// recursing forever and crashing on launch (stack overflow / SIGSEGV) on a fresh install.
+		assertFalse(
+			fileSystem.exists(GlobalSettingsFilesystemDatasource.CONFIG_PATH),
+			"Constructing the datasource must not write during bootstrap"
+		)
+	}
+
+	@Test
 	fun `Load Global Settings when non exists`() = runTest {
 		val datasource = createDatasource()
 		val default = GlobalSettingsStore.createDefault(languageUtil, platformSpellCheckerFactory)
@@ -54,6 +68,12 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 		val loaded: GlobalSettings = datasource.loadSettings()
 
 		assertEquals(default, loaded)
+		// loadSettings on a fresh install is a pure read: it returns defaults in memory and
+		// must not persist them (persistence happens on the next real store).
+		assertFalse(
+			fileSystem.exists(GlobalSettingsFilesystemDatasource.CONFIG_PATH),
+			"loadSettings on a fresh install must not write"
+		)
 	}
 
 	@Test
@@ -64,6 +84,7 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 			automaticBackups = false,
 			automaticSyncing = false,
 		)
+		fileSystem.createDirectories(GlobalSettingsFilesystemDatasource.CONFIG_PATH.parent!!)
 		fileSystem.writeToml(
 			GlobalSettingsFilesystemDatasource.CONFIG_PATH,
 			toml,
@@ -78,6 +99,7 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 	@Test
 	fun `Load when invalid one exists, default is returned`() = runTest {
 		val datasource = createDatasource()
+		fileSystem.createDirectories(GlobalSettingsFilesystemDatasource.CONFIG_PATH.parent!!)
 		fileSystem.write(GlobalSettingsFilesystemDatasource.CONFIG_PATH) {
 			writeUtf8(".invalid-!@#$%toml")
 		}
@@ -90,6 +112,7 @@ class GlobalSettingsDatasourceTest : BaseTest() {
 	@Test
 	fun `Load Global Settings missing initialProjectScreen defaults to Home`() = runTest {
 		val datasource = createDatasource()
+		fileSystem.createDirectories(GlobalSettingsFilesystemDatasource.CONFIG_PATH.parent!!)
 		fileSystem.write(GlobalSettingsFilesystemDatasource.CONFIG_PATH) {
 			writeUtf8(
 				"""


### PR DESCRIPTION
GlobalSettingsFilesystemDatasource wrote default settings from its init block when no config file existed. That write runs during GlobalSettingsStore construction and routes through the guarded ContainedFileSystem, whose containment check resolves the projects root by re-entering the still-constructing store (managedStorageRoots -> get<GlobalSettingsStore>). Koin re-enters construction instead of throwing, so the write recurses forever and overflows the stack (EXC_BAD_ACCESS / SIGSEGV) on launch. This hit every fresh install and any re-UUID'd simulator/device container with no persisted config -- the remaining construction-time write after the load-time paths were fixed in 3.5.1 / commit 78474390.

Make construction a pure read: loadSettings returns defaults in memory when the config is absent and no longer persists during bootstrap. The defaults are written on the next real store. Add coverage asserting construction performs no filesystem write, and fix sibling tests that relied on the old init write to create the config directory.