### PR TITLE
Fix bullet list to use real line-block instead of literal glyph

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditorActions.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditorActions.kt
@@ -7,13 +7,6 @@ import com.darkrockstudios.texteditor.richstyle.HR_PLACEHOLDER
 import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
 import com.darkrockstudios.texteditor.state.TextEditorState
 
-internal fun insertLineBullet(state: TextEditorState) {
-	val saved = state.cursorPosition
-	state.cursor.updatePosition(CharLineOffset(saved.line, 0))
-	state.insertStringAtCursor("• ")
-	state.cursor.updatePosition(CharLineOffset(saved.line, saved.char + 2))
-}
-
 internal fun insertHorizontalRule(state: TextEditorState) {
 	state.insertNewlineAtCursor()
 	val hrLine = state.cursorPosition.line
@@ -54,6 +47,16 @@ internal fun reconcileHorizontalRules(state: TextEditorState) {
 		}
 		state.removeRichSpan(span)
 	}
+}
+
+internal fun toggleBulletList(state: TextEditorState, markdown: MarkdownExtension) {
+	val selection = state.selector.selection
+	val lines = if (selection != null) {
+		selection.start.line..selection.end.line
+	} else {
+		state.cursorPosition.line..state.cursorPosition.line
+	}
+	markdown.toggleBulletList(lines)
 }
 
 internal fun toggleOrderedList(state: TextEditorState, markdown: MarkdownExtension) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownFormatBar.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownFormatBar.kt
@@ -66,6 +66,7 @@ import com.darkrockstudios.apps.hammer.markdown_format_bar_strikethrough
 import com.darkrockstudios.apps.hammer.markdown_format_bar_undo
 import com.darkrockstudios.apps.hammer.more_menu_button
 import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedListSpanStyle
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.getRichSpansAtPosition
@@ -85,6 +86,7 @@ fun MarkdownFormatBar(
 	var isItalicActive by remember { mutableStateOf(false) }
 	var isStrikethroughActive by remember { mutableStateOf(false) }
 	var isBlockquoteActive by remember { mutableStateOf(false) }
+	var isBulletListActive by remember { mutableStateOf(false) }
 	var isOrderedListActive by remember { mutableStateOf(false) }
 	var currentHeaderLevel by remember { mutableStateOf(0) }
 
@@ -107,6 +109,7 @@ fun MarkdownFormatBar(
 			isItalicActive = styles.contains(markdownState.markdownStyles.ITALICS)
 			isStrikethroughActive = styles.contains(markdownState.markdownStyles.STRIKETHROUGH)
 			isBlockquoteActive = styles.contains(markdownState.markdownStyles.BLOCKQUOTE)
+			isBulletListActive = richSpans.any { it.style === BulletListSpanStyle }
 			isOrderedListActive = richSpans.any { it.style === OrderedListSpanStyle }
 			currentHeaderLevel = HEADER_CYCLE_LEVELS.firstOrNull { lvl ->
 				styles.contains(markdownState.markdownStyles.header(lvl))
@@ -136,6 +139,7 @@ fun MarkdownFormatBar(
 				isItalicActive = isItalicActive,
 				isStrikethroughActive = isStrikethroughActive,
 				isBlockquoteActive = isBlockquoteActive,
+				isBulletListActive = isBulletListActive,
 				isOrderedListActive = isOrderedListActive,
 				currentHeaderLevel = currentHeaderLevel,
 			)
@@ -168,6 +172,7 @@ private fun RowScope.FormatButtons(
 	isItalicActive: Boolean,
 	isStrikethroughActive: Boolean,
 	isBlockquoteActive: Boolean,
+	isBulletListActive: Boolean,
 	isOrderedListActive: Boolean,
 	currentHeaderLevel: Int,
 ) {
@@ -221,9 +226,9 @@ private fun RowScope.FormatButtons(
 	EditorTooltip(Res.string.markdown_format_bar_bullet_list.get()) {
 		EditorAction(
 			icon = Icons.AutoMirrored.Filled.FormatListBulleted,
-			active = false,
+			active = isBulletListActive,
 		) {
-			insertLineBullet(state)
+			toggleBulletList(state, markdownState)
 		}
 	}
 	EditorTooltip(Res.string.markdown_format_bar_numbered_list.get()) {


### PR DESCRIPTION
## Problem

In the scene editor, pressing **Enter** on a bullet-list item dropped back to a normal (non-list) line instead of continuing the list. The library's editor (`composetexteditor`) supports smart list continuation — it works in the library's own sample app — so this was an integration bug on our side, not a stale dependency.

## Root cause

The bullet-list toolbar button inserted a literal `"• "` Unicode glyph as plain text (`insertLineBullet`) rather than applying the library's real `BulletList` line-block. Consequences:

- **No Enter continuation** — there's no block span for the editor's smart-Enter to extend.
- **No active/toggle state** — the button was hardcoded `active = false`.
- **Broken markdown round-trip** — bullets exported as literal `• item` text instead of `- item`.

The numbered-list button right beside it already used the real line-block (`toggleOrderedList`), so it didn't have these issues.

## Fix

- Replace `insertLineBullet` with `toggleBulletList`, calling the library's `MarkdownExtension.toggleBulletList(lines)`.
- Track `isBulletListActive` off `BulletListSpanStyle` and drive the button's active state from it, mirroring the numbered-list button.

This restores Enter-to-continue, exit-on-empty-item, the active highlight, and correct `- ` markdown export.

## Notes

Existing scenes that already contain the old literal `• ` glyphs are unaffected (they remain plain text); only newly created bullets get the line-block behavior. A migration pass for legacy glyph-bullets could be a follow-up if desired.

## Testing

- `:composeUi:compileKotlinDesktop` passes; pre-commit hook ran the desktop build + tests green.
- Manual: toggle bullet → type → Enter continues the list; Enter on an empty item exits.