### PR TITLE
Fix fresh-sync re-download and project-data conflict; add resync stability matrix

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations
 
-import com.darkrockstudios.apps.hammer.*
+import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.base.http.EntityType
 import com.darkrockstudios.apps.hammer.base.http.ProjectSynchronizationBegan
@@ -8,15 +8,41 @@ import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.isFailure
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ClientProjectSynchronizer.Companion.ENTITY_END
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ClientProjectSynchronizer.Companion.ENTITY_START
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ClientProjectSynchronizer.Companion.ENTITY_TOTAL
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityConflictHandler
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityDeleteOperationState
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityOriginalState
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizers
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityTransferState
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ProjectSynchronizationData
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncLogMessage
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncOperationState
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogE
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogI
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.syncLogW
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.toEntityType
 import com.darkrockstudios.apps.hammer.common.server.EntityNotFoundException
 import com.darkrockstudios.apps.hammer.common.server.EntityNotModifiedException
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.server.StaleServerHashException
 import com.darkrockstudios.apps.hammer.common.util.StrRes
+import com.darkrockstudios.apps.hammer.sync_log_entities_transferred
+import com.darkrockstudios.apps.hammer.sync_log_entity_conflict
+import com.darkrockstudios.apps.hammer.sync_log_entity_delete_failed
+import com.darkrockstudios.apps.hammer.sync_log_entity_delete_success
+import com.darkrockstudios.apps.hammer.sync_log_entity_download_failed_general
+import com.darkrockstudios.apps.hammer.sync_log_entity_download_failed_not_found
+import com.darkrockstudios.apps.hammer.sync_log_entity_download_not_modified
+import com.darkrockstudios.apps.hammer.sync_log_entity_download_rejected_mismatch
+import com.darkrockstudios.apps.hammer.sync_log_entity_download_success
+import com.darkrockstudios.apps.hammer.sync_log_entity_upload_entity_not_owned
+import com.darkrockstudios.apps.hammer.sync_log_stale_hash_detected
+import com.darkrockstudios.apps.hammer.sync_log_stale_hash_heal_failed
+import com.darkrockstudios.apps.hammer.sync_log_stale_hash_healed
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.yield
 
@@ -192,7 +218,7 @@ class EntityTransferOperation(
 								true
 							} else {
 								// TODO what do we do here?
-								Napier.d("Entity ID $entityId missing from server, but it does exist locally, should we upload it? How did we get here?")
+								Napier.w("Entity ID $entityId missing from server, but it does exist locally, should we upload it? How did we get here?")
 								false
 							}
 						} else {
@@ -288,6 +314,7 @@ class EntityTransferOperation(
 				// Lock the downloaded entity's hash in as the conflict baseline: it's exactly
 				// what the server holds, so a later local edit won't forge a phantom conflict.
 				syncJournal.recordSyncedHash(id, serverEntity.hash())
+				healServerIfEnriched(id, serverEntity, syncId, onLog)
 				onLog(
 					syncLogI(
 						strRes.get(Res.string.sync_log_entity_download_success, id),
@@ -376,6 +403,30 @@ class EntityTransferOperation(
 		}
 	}
 
+	/**
+	 * When storing a downloaded entity leaves the local copy hashing differently from the server's
+	 * (e.g. a null field the client backfilled on store), push the enriched copy back so the server
+	 * converges — otherwise it re-sends the same entity on every sync. The hash just recorded as the
+	 * baseline is exactly what the server holds, so a lone client heals without a conflict.
+	 */
+	private suspend fun healServerIfEnriched(
+		id: Int,
+		serverEntity: ApiProjectEntity,
+		syncId: String,
+		onLog: OnSyncLog,
+	) {
+		val localHash = entitySynchronizers.getLocalEntityHash(id) ?: return
+		if (localHash == serverEntity.hash()) return
+
+		Napier.d("Healing server entity $id: local copy is enriched beyond the server's")
+		suspend fun abortOnConflict(entity: ApiProjectEntity): Unit = throw HealConflictException(entity.id)
+		try {
+			uploadEntity(id, syncId, originalHash = serverEntity.hash(), ::abortOnConflict, onLog)
+		} catch (e: HealConflictException) {
+			Napier.w("Heal upload for entity ${e.entityId} hit a conflict; deferring to a later sync")
+		}
+	}
+
 	private suspend fun uploadEntity(
 		id: Int,
 		syncId: String,
@@ -422,6 +473,8 @@ class EntityTransferOperation(
 			false
 		}
 	}
+
+	private class HealConflictException(val entityId: Int) : Exception()
 
 	private data class TransferState(
 		var maxId: Int,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
@@ -26,6 +27,7 @@ class FinalizeSyncOperation(
 	private val globalSettingsStore: GlobalSettingsStore,
 	private val syncDataDatasource: SyncDataDatasource,
 	private val projectDataDatasource: ProjectDataDatasource,
+	private val idAllocator: IdAllocator,
 ) : SyncOperation(projectDef) {
 
 	override suspend fun execute(
@@ -41,6 +43,10 @@ class FinalizeSyncOperation(
 		var allSuccess = state.allSuccess
 
 		finalizeSync()
+
+		// Entity transfer may have pulled down ids above the allocator's snapshot (taken at sync
+		// start). Re-derive it now so a create before the next sync can't reuse a downloaded id.
+		idAllocator.findNextId()
 
 		yield()
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
@@ -49,6 +49,10 @@ class ProjectDataSyncOperation(
 		val stored = repository.load()
 		val localHash = ProjectDataHasher.hash(stored.data)
 		val lastSyncedHash = stored.lastSyncedHash
+		// A never-synced project baselines against the default-data hash, matching what the server
+		// holds for it. Without this, a fresh download (default local data, null lastSyncedHash)
+		// looks like a local edit and gets pushed, colliding with the server's real settings.
+		val baseline = lastSyncedHash ?: ProjectDataHasher.hash(ProjectData())
 
 		when {
 			serverDto == null -> {
@@ -64,7 +68,7 @@ class ProjectDataSyncOperation(
 				onLog(syncLogI("Project data already in sync", projectDef))
 				return CResult.success(state)
 			}
-			lastSyncedHash == localHash -> {
+			baseline == localHash -> {
 				repository.updateFromSync(serverDto.data, serverDto.hash)
 				onLog(syncLogI("Project data updated from server", projectDef))
 				return CResult.success(state)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientSceneSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientSceneSynchronizer.kt
@@ -322,18 +322,20 @@ class ClientSceneSynchronizer(
 		return true
 	}
 
-	// Preserves local `created`/`lastEdited` when the server didn't ship them
-	// (e.g. older client uploaded first).
-	private suspend fun mergeServerMetadata(serverEntity: ApiProjectEntity.SceneEntity): SceneMetadata {
-		val existing = sceneEditorService.loadSceneMetadata(serverEntity.id)
+	// A scene uploaded before scenes tracked timestamps arrives with null `created`/`lastEdited`.
+	// Those fields are hashed, so backfill them with the project's creation time: the resulting
+	// hash divergence from the server drives the heal upload in [EntityTransferOperation] that
+	// enriches the server's copy, converging both sides on a non-null value.
+	private fun mergeServerMetadata(serverEntity: ApiProjectEntity.SceneEntity): SceneMetadata {
+		val projectCreated = projectMetadataDatasource.loadMetadata(projectDef).info.created
 		return SceneMetadata(
 			notes = serverEntity.notes,
 			outline = serverEntity.outline,
 			confirmedReferences = serverEntity.confirmedReferences,
 			dismissedReferences = serverEntity.dismissedReferences,
 			tags = serverEntity.tags,
-			created = serverEntity.created ?: existing.created,
-			lastEdited = serverEntity.lastEdited ?: existing.lastEdited,
+			created = serverEntity.created ?: projectCreated,
+			lastEdited = serverEntity.lastEdited ?: projectCreated,
 		)
 	}
 

--- a/common/src/desktopTest/kotlin/synchronizer/SceneSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/SceneSynchronizerTest.kt
@@ -2,6 +2,8 @@ package synchronizer
 
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.base.http.ApiSceneType
+import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.Info
+import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.SceneItem.Companion.ROOT_ID
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
@@ -33,6 +35,7 @@ import utils.fromApiEntity
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.time.Instant
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -76,8 +79,11 @@ class SceneSynchronizerTest : BaseTest() {
 		every { sceneEditorRepository.getArchivedScenes() } returns emptyList()
 		every { sceneEditorRepository.getArchivedSceneFromId(any()) } returns null
 
-		// Download path reads existing metadata for created/lastEdited fallback.
 		coEvery { sceneEditorService.loadSceneMetadata(any()) } returns SceneMetadata()
+
+		// Backfilling a downloaded scene's null timestamps reads the project's creation time.
+		every { projectMetadataDatasource.loadMetadata(any()) } returns
+			ProjectMetadata(Info(created = Instant.fromEpochSeconds(1_600_000_000)))
 	}
 
 	private fun defaultSceneSynchronizer() = ClientSceneSynchronizer(

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FinalizeSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FinalizeSyncOperationTest.kt
@@ -3,6 +3,7 @@ package synchronizer.operations
 import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
@@ -45,6 +46,9 @@ class FinalizeSyncOperationTest : BaseTest() {
 	@MockK(relaxed = true)
 	private lateinit var projectDataDatasource: ProjectDataDatasource
 
+	@MockK(relaxed = true)
+	private lateinit var idAllocator: IdAllocator
+
 	private lateinit var strRes: TestStrRes
 
 	private lateinit var clock: TestClock
@@ -80,6 +84,7 @@ class FinalizeSyncOperationTest : BaseTest() {
 			globalSettingsStore = globalSettingsStore,
 			syncDataDatasource = syncDataDatasource,
 			projectDataDatasource = projectDataDatasource,
+			idAllocator = idAllocator,
 		)
 	}
 

--- a/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
@@ -186,6 +186,21 @@ class ProjectDataSyncOperationTest : BaseTest() {
 	}
 
 	@Test
+	fun `fresh sync with default local data adopts the server copy without uploading`() = runTest {
+		// Never synced on this device: no project_data.toml, so the repository hands back
+		// default ProjectData() with a null lastSyncedHash. The server already has settings.
+		val server = ProjectData(authorName = "Server Author")
+		coEvery { api.getProjectData(any(), any()) } returns
+			Result.success(ProjectDataDto(server, "server-hash"))
+
+		val result = createOperation().run()
+
+		assertTrue(isSuccess(result))
+		assertEquals(StoredProjectData(server, "server-hash"), repository.state.value)
+		coVerify(exactly = 0) { api.uploadProjectData(any(), any(), any(), any()) }
+	}
+
+	@Test
 	fun `local diverged from server uploads with the last synced hash as baseline`() = runTest {
 		val local = ProjectData(authorName = "Local Edit")
 		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))

--- a/integrationTests/README.md
+++ b/integrationTests/README.md
@@ -1,0 +1,64 @@
+# Sync integration tests
+
+End-to-end sync tests that run the **real client sync engine against a real server**. Each test
+spins up an in-process Jetty server ([`RoundTripTestBase`](src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt))
+and drives one or more fully-wired clients ([`HeadlessClient`](src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/HeadlessClient.kt))
+through it. Unlike the server-side `:server` e2e tests, which drive the HTTP API by hand, these
+exercise the client's store / hash / conflict logic — the layer where divergence bugs actually live.
+
+## The model-free oracle
+
+The hard part of testing sync is knowing the expected end state. We mostly avoid computing it, and
+instead assert two properties that any correct sync must satisfy — both on `RoundTripTestBase`:
+
+- **`assertConverged(projectName, vararg clients)`** — every client holds exactly the entity set the
+  server holds, hash for hash. Doesn't care *what* the entities are, only that the sides agree.
+- **`assertResyncSilent(client)`** — an immediate extra sync moves nothing over the wire. Built on
+  **`tapWire()`**, an `HttpSend` interceptor that records real traffic (`download_entity` 200 vs 304,
+  `upload_entity`). Any client/server hash divergence surfaces here as a re-download or re-upload.
+
+`tapWire()` is the workhorse: assert what actually crossed the wire, not what the client claims it
+did. The null-timestamp re-download bug was a `200` where a `304` belonged.
+
+## The three regimes
+
+Sync output is a function of `(client baseline, client ops, server ops)`. New tests should slot into
+one of these:
+
+| Regime | Setup | Oracle |
+|---|---|---|
+| **First-time** | client empty, server has entities | every entity pulled; client converges to server |
+| **No-change** | nothing changed since last sync | `assertResyncSilent` — zero wire transfer |
+| **Mixed** | creates / edits / deletes on one or both sides | `assertConverged` + `assertResyncSilent`; conflicts only where both sides touched the same entity |
+
+## Coverage map
+
+**First-time**
+- `ServerDownloadsEntityTest` — server-only scene lands on a clean client
+- `TwoDeviceSyncTest` (`a second device downloads…`) — a second device adopts an existing project
+
+**No-change**
+- `ResyncStabilityMatrixTest` — every entity type × edge-case field values, server-originated, resync silent
+- `UploadResyncStabilityMatrixTest` — same matrix for client-created entities
+- `ResyncDownloadsNothingTest` — all types in one project; first sync pulls + heals, second is silent
+- `SyncHashStabilityTest`, `EditResyncNoConflictTest`, `ResyncBaselineScenariosTest`, `EntityTypeResyncMatrixTest`, `SyncedHashBackfillTest` — targeted baseline / hash-agreement cases
+
+**Mixed**
+- `MixedSyncFuzzTest` — seeded property test: random create/edit/delete/rename across all types, converge + silent
+- `TwoDeviceSyncTest` (`independent edits…`) — two devices, disjoint edits, converge
+- `IndependentEditsTest`, `ClientDeletionTest`, `ClientUploadsEntityTest`, `ServerOriginatedEntitiesTest` — specific transitions
+- `ConflictPickClientTest`, `ConflictPickServerTest` — the conflict sub-case (both sides touch one entity)
+- `SyncFuzzTest` — single-entity edit/rename fuzz (legacy; `MixedSyncFuzzTest` is the broader net)
+
+## Adding tests
+
+- **A new scenario**: extend `RoundTripTestBase`, drive `HeadlessClient`s, and finish with
+  `assertConverged` / `assertResyncSilent` rather than hand-rolled state checks.
+- **Two devices on one project**: `secondDeviceFor(primary, localName)`. The primary must have synced
+  once. A second device that creates entities after adopting should re-open its editor
+  (`initializeSceneEditor()`) first, mirroring a real session re-deriving its next id.
+- **More fuzz coverage**: add seeds to `MixedSyncFuzzTest.SEEDS` (a failure prints the seed + iteration
+  to replay).
+- **Scripted "other device" changes**: `seedServerEntity` / `mutateServerEntity` /
+  `seedServerEntityDeletion` (+ bump `last_id`) set server state directly — more faithful than a second
+  real client for server-originated changes, since it sidesteps shared client-side id allocation.

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/HeadlessClient.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/HeadlessClient.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.integration
 
+import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
@@ -66,7 +67,17 @@ class HeadlessClient private constructor(
 	}
 
 	companion object {
-		suspend fun create(projectName: String, serverSettings: ServerSettings): HeadlessClient {
+		/**
+		 * @param serverProjectId when set, the local project is pre-bound to this existing server
+		 * project instead of minting a new one on first sync — i.e. a second device opening a project
+		 * that already lives on the server. The local project name must differ from the first device's
+		 * (they share one on-disk projects root) but both resolve to the same server project.
+		 */
+		suspend fun create(
+			projectName: String,
+			serverSettings: ServerSettings,
+			serverProjectId: ProjectId? = null,
+		): HeadlessClient {
 			val koin = getKoin()
 			val projectsRepository: ProjectsRepository = koin.get<ProjectsRepository>()
 			val globalSettings: GlobalSettingsStore = koin.get<GlobalSettingsStore>()
@@ -74,6 +85,10 @@ class HeadlessClient private constructor(
 			val createResult = projectsRepository.createProject(projectName)
 			check(isSuccess(createResult)) { "Failed to create local project: $createResult" }
 			val projectDef: ProjectDef = createResult.data
+
+			if (serverProjectId != null) {
+				projectsRepository.setProjectId(projectDef, serverProjectId)
+			}
 
 			// Persist server settings BEFORE opening the scope so the sync pipeline
 			// resolves an HttpClient that points at the test server.

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
@@ -17,6 +17,8 @@ import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
 import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
 import com.darkrockstudios.apps.hammer.e2e.util.TestAccount
+import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntitySynchronizers
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.plugin
@@ -41,7 +43,9 @@ import org.koin.test.KoinTest
 import org.koin.test.get
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
 /**
@@ -254,6 +258,19 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 	protected suspend fun newClient(projectName: String): HeadlessClient =
 		HeadlessClient.create(projectName, makeServerSettings()).also { openClients += it }
 
+	/**
+	 * Opens a second device on the same server project as [primary], which must have synced at least
+	 * once so its server project id exists. The second device gets its own local project dir
+	 * ([localName], which must differ from the first device's name) but binds to the same server
+	 * project — the realistic "two devices, one account, one project" setup.
+	 */
+	protected suspend fun secondDeviceFor(primary: HeadlessClient, localName: String): HeadlessClient {
+		val sharedId = get<ProjectMetadataDatasource>().loadProjectId(primary.projectDef)
+			?: error("primary device has no server project id yet — sync it before opening a second device")
+		return HeadlessClient.create(localName, makeServerSettings(), serverProjectId = sharedId)
+			.also { openClients += it }
+	}
+
 	/** The hash the server currently stores for an entity, or null if it holds none. */
 	protected fun serverEntityHash(projectName: String, entityId: Int): String? {
 		val projectId = serverNumericProjectIdFor(projectName) ?: return null
@@ -268,6 +285,51 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 		val ok = sync(resolveConflict = { entity -> conflicted = true; entity })
 		assertFalse(conflicted, "single-client resync raised a phantom conflict")
 		return ok
+	}
+
+	/** The live entity id→hash map the server currently holds for a project. */
+	protected fun serverEntityHashes(projectName: String): Map<Int, String> {
+		val projectId = serverNumericProjectIdFor(projectName) ?: return emptyMap()
+		return database().serverDatabase.storyEntityQueries
+			.getEntityHashes(userId = userId, projectId = projectId)
+			.executeAsList()
+			.associate { it.id.toInt() to it.hash }
+	}
+
+	/** The live entity id→hash map a client computes from its own local state. */
+	protected suspend fun clientEntityHashes(client: HeadlessClient): Map<Int, String> {
+		val synchronizers: EntitySynchronizers = client.scope.get()
+		return synchronizers.synchronizers.values
+			.flatMap { it.hashEntities(emptyList()) }
+			.associate { it.id to it.hash }
+	}
+
+	/**
+	 * Convergence oracle: every client holds exactly the entity set the server holds, hash for hash.
+	 * Model-free — it doesn't care what the entities *should* be, only that client and server agree,
+	 * which is the property every sync must establish.
+	 */
+	protected suspend fun assertConverged(projectName: String, vararg clients: HeadlessClient) {
+		val server = serverEntityHashes(projectName)
+		clients.forEachIndexed { index, client ->
+			assertEquals(
+				server,
+				clientEntityHashes(client),
+				"client #$index did not converge with the server",
+			)
+		}
+	}
+
+	/**
+	 * Stability oracle: an immediate extra sync moves nothing over the wire. Any client/server hash
+	 * divergence shows up here as a re-download or re-upload, so this catches drift even when the two
+	 * sides happen to be equally wrong.
+	 */
+	protected suspend fun assertResyncSilent(client: HeadlessClient) {
+		val wire = tapWire()
+		assertTrue(client.syncNoConflict(), "resync should succeed")
+		assertEquals(emptyList(), wire.entitiesPulled(), "resync re-downloaded an entity")
+		assertEquals(emptyList(), wire.entitiesUploaded(), "resync re-uploaded an entity")
 	}
 
 	/** One HTTP request the client made, captured by [tapWire]. */

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
@@ -18,6 +18,8 @@ import io.github.aakira.napier.Napier
 import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
 import com.darkrockstudios.apps.hammer.e2e.util.TestAccount
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpSend
+import io.ktor.client.plugins.plugin
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -266,5 +268,39 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 		val ok = sync(resolveConflict = { entity -> conflicted = true; entity })
 		assertFalse(conflicted, "single-client resync raised a phantom conflict")
 		return ok
+	}
+
+	/** One HTTP request the client made, captured by [tapWire]. */
+	protected data class WireCall(val method: String, val path: String, val status: Int)
+
+	/** Records the HTTP calls the client makes so a test can assert what actually crossed the wire. */
+	protected class WireTap {
+		private val lock = Any()
+		private val recorded = mutableListOf<WireCall>()
+
+		fun record(call: WireCall) = synchronized(lock) { recorded += call }
+		fun reset() = synchronized(lock) { recorded.clear() }
+		val calls: List<WireCall> get() = synchronized(lock) { recorded.toList() }
+
+		/** IDs whose entity body the server actually sent down (download_entity → 200). */
+		fun entitiesPulled(): List<Int> = calls
+			.filter { it.path.contains("/download_entity/") && it.status == 200 }
+			.mapNotNull { it.path.substringAfterLast('/').toIntOrNull() }
+	}
+
+	/**
+	 * Installs an [HttpSend] interceptor on the client's shared [HttpClient] that records every
+	 * request and its response status. The interceptor runs inline on the send pipeline, so what it
+	 * captures is exactly what went over the wire — a 200 on `download_entity` is a real pull, a 304
+	 * is the server saying "you already have this".
+	 */
+	protected fun tapWire(): WireTap {
+		val tap = WireTap()
+		get<HttpClient>().plugin(HttpSend).intercept { request ->
+			val call = execute(request)
+			tap.record(WireCall(request.method.value, request.url.buildString(), call.response.status.value))
+			call
+		}
+		return tap
 	}
 }

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
@@ -285,7 +285,16 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 		/** IDs whose entity body the server actually sent down (download_entity → 200). */
 		fun entitiesPulled(): List<Int> = calls
 			.filter { it.path.contains("/download_entity/") && it.status == 200 }
-			.mapNotNull { it.path.substringAfterLast('/').toIntOrNull() }
+			.mapNotNull { idFromPath(it.path) }
+
+		/** IDs the client pushed up (upload_entity, any accepted status). */
+		fun entitiesUploaded(): List<Int> = calls
+			.filter { it.path.contains("/upload_entity/") && it.status in 200..299 }
+			.mapNotNull { idFromPath(it.path) }
+
+		// Paths can carry a query string; the id is the last path segment before any '?'.
+		private fun idFromPath(path: String): Int? =
+			path.substringBefore('?').substringAfterLast('/').toIntOrNull()
 	}
 
 	/**

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/MixedSyncFuzzTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/MixedSyncFuzzTest.kt
@@ -1,0 +1,143 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
+import com.darkrockstudios.apps.hammer.common.data.isSuccess
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
+import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
+import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
+import com.darkrockstudios.apps.hammer.integration.HeadlessClient
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.random.Random
+import kotlin.test.assertTrue
+
+/**
+ * Property test for the mixed regime: a single client drives a random interleaving of creates, edits,
+ * deletes, and renames across every entity type, syncing at random points. Because there's no other
+ * device, no sync may ever conflict; and once the dust settles the client must be converged with the
+ * server and an extra sync must be silent.
+ *
+ * This is the broad net the targeted matrices can't cast — it explores orderings no hand-written
+ * scenario enumerates (a delete between two creates, a metadata edit then rename then sync, a rename
+ * of an entity created earlier in the same run). A divergence bug like the null-timestamp re-download
+ * surfaces here as a non-silent final resync. Seeded for replay; add seeds to widen coverage.
+ */
+class MixedSyncFuzzTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 300)
+	fun `random multi-entity client op sequences stay convergent and silent`() = runBlocking {
+		for (seed in SEEDS) {
+			runSequence(seed)
+		}
+	}
+
+	private suspend fun runSequence(seed: Long) {
+		val rng = Random(seed)
+		val client = newClient("mixed fuzz $seed")
+		val notes: NotesRepository = client.scope.get()
+		val timeline: TimeLineRepository = client.scope.get()
+		val encyclopedia: EncyclopediaRepository = client.scope.get()
+		timeline.initialize()
+		encyclopedia.ensureEntriesLoaded()
+
+		val scenes = mutableListOf<Int>()
+		val noteState = mutableMapOf<Int, NoteContent>()
+		val eventState = mutableMapOf<Int, TimeLineEvent>()
+		val entries = mutableListOf<Int>()
+
+		// Seed a baseline so early edit/delete ops have something to act on.
+		newScene(client, scenes, "Opening", "the beginning")
+		notes.createNote("baseline note").let { if (isSuccess(it)) noteState[it.data.id] = it.data }
+		assertTrue(client.syncNoConflict(), "[seed $seed] baseline sync should succeed")
+
+		repeat(ITERATIONS) { i ->
+			val tag = "[seed $seed iter $i]"
+			when (rng.nextInt(15)) {
+				0 -> newScene(client, scenes, "Scene $i", "content $i")
+				1 -> notes.createNote("note $i", tags = randomTags(rng))
+					.let { if (isSuccess(it)) noteState[it.data.id] = it.data }
+				2 -> timeline.createEvent(content = "event $i", date = if (rng.nextBoolean()) "$i" else null)
+					.let { eventState[it.id] = it }
+				3 -> encyclopedia.createEntry("Entry $i", EntryType.PERSON, "about $i", randomTags(rng), null)
+					.instance?.entry?.id?.let { entries.add(it) }
+
+				4 -> scenes.randomOrNull(rng)?.let { id ->
+					client.sceneEditor.getSceneItemFromId(id)?.let { scene ->
+						client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "edited $i"))
+					}
+				}
+				5 -> scenes.randomOrNull(rng)?.let { id ->
+					client.sceneEditor.getSceneItemFromId(id)?.let { scene ->
+						client.sceneEditorService.renameScene(scene, "Renamed $i")
+					}
+				}
+				6 -> scenes.randomOrNull(rng)?.let { id ->
+					client.sceneEditor.getSceneItemFromId(id)?.let { scene ->
+						val meta = client.sceneEditorService.loadSceneMetadata(id)
+						client.sceneEditorService.storeMetadata(meta.copy(notes = "n$i", outline = "o$i"), id)
+					}
+				}
+
+				7 -> noteState.keys.randomOrNull(rng)?.let { id ->
+					val updated = noteState.getValue(id).copy(content = "note edit $i", tags = randomTags(rng))
+					notes.updateNote(updated)
+					noteState[id] = updated
+				}
+				8 -> eventState.keys.randomOrNull(rng)?.let { id ->
+					val updated = eventState.getValue(id).copy(content = "event edit $i")
+					timeline.updateEvent(updated)
+					eventState[id] = updated
+				}
+				9 -> entries.randomOrNull(rng)?.let { id ->
+					encyclopedia.updateEntry(encyclopedia.getEntryDef(id), "Entry $i", "about edit $i", randomTags(rng))
+				}
+
+				10 -> scenes.randomOrNull(rng)?.let { id ->
+					client.sceneEditor.getSceneItemFromId(id)?.let { scene ->
+						if (client.sceneEditorService.deleteScene(scene)) scenes.remove(id)
+					}
+				}
+				11 -> noteState.keys.randomOrNull(rng)?.let { id ->
+					notes.deleteNote(id)
+					noteState.remove(id)
+				}
+				12 -> eventState.keys.randomOrNull(rng)?.let { id ->
+					if (timeline.deleteEvent(eventState.getValue(id))) eventState.remove(id)
+				}
+				13 -> entries.randomOrNull(rng)?.let { id ->
+					if (encyclopedia.deleteEntry(encyclopedia.getEntryDef(id))) entries.remove(id)
+				}
+
+				14 -> assertTrue(client.syncNoConflict(), "$tag sync should not conflict")
+			}
+		}
+
+		assertTrue(client.syncNoConflict(), "[seed $seed] final sync should succeed")
+		assertConverged(client.projectDef.name, client)
+		assertResyncSilent(client)
+	}
+
+	private suspend fun newScene(client: HeadlessClient, scenes: MutableList<Int>, name: String, content: String) {
+		val scene = client.sceneEditor.createScene(parent = null, sceneName = name) ?: return
+		client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, content))
+		scenes.add(scene.id)
+	}
+
+	private fun randomTags(rng: Random): Set<String> =
+		(0 until rng.nextInt(3)).map { "tag${rng.nextInt(4)}" }.toSet()
+
+	private fun <T> List<T>.randomOrNull(rng: Random): T? = if (isEmpty()) null else this[rng.nextInt(size)]
+	private fun <T> Set<T>.randomOrNull(rng: Random): T? =
+		if (isEmpty()) null else elementAt(rng.nextInt(size))
+
+	companion object {
+		private const val ITERATIONS = 30
+		private val SEEDS = listOf(1L, 777L, 20260630L)
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/ResyncDownloadsNothingTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/ResyncDownloadsNothingTest.kt
@@ -1,0 +1,91 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.e2e.util.E2eTestData
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+/**
+ * A clean client should download server entities once, then leave them alone. After the first sync
+ * pulls everything down, a second sync over an unchanged project must not pull a single entity body
+ * back over the wire — every entity is already current, so the server should answer `304 Not
+ * Modified` for each. A `200` on the second pass means the client's recomputed hash diverged from
+ * what the server stored, so it re-downloads the same entity forever.
+ *
+ * Watches the actual HTTP traffic (via [tapWire]) rather than client logs, so the assertion is about
+ * what crossed the wire, not what we think the client decided.
+ */
+class ResyncDownloadsNothingTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 120)
+	fun `second sync of unchanged server entities pulls nothing over the wire`() = runBlocking {
+		val project = "resync downloads nothing"
+		val client = newClient(project)
+
+		// First sync just registers the project on the server (no entities yet).
+		assertTrue(client.sync(), "registration sync should succeed")
+		val pid = serverNumericProjectIdFor(project)
+		assertNotNull(pid, "server should have created the project")
+
+		// Seed one entity of every type, as if another device had uploaded them.
+		val seeded: List<ApiProjectEntity> = listOf(
+			E2eTestData.createTestScene(id = 1),
+			E2eTestData.createTestNote(id = 2),
+			ApiProjectEntity.TimelineEventEntity(
+				id = 3,
+				order = 0,
+				date = "1920",
+				content = "a battle",
+			),
+			E2eTestData.createTestEncyclopediaEntry(id = 4),
+			ApiProjectEntity.SceneDraftEntity(
+				id = 5,
+				sceneId = 1,
+				created = Instant.fromEpochSeconds(1_700_000_000),
+				name = "Draft One",
+				content = "draft body",
+			),
+		)
+		seeded.forEach { seedServerEntity(pid, it) }
+		database().execute("UPDATE project SET last_id = 5 WHERE id = $pid;")
+
+		// The scene was seeded with null timestamps; remember its hash so we can prove the heal.
+		val seededSceneHash = (seeded.first() as ApiProjectEntity.SceneEntity).hash()
+
+		val wire = tapWire()
+
+		// First real sync: every seeded entity should come down.
+		assertTrue(client.syncNoConflict(), "download sync should succeed")
+		assertEquals(
+			setOf(1, 2, 3, 4, 5),
+			wire.entitiesPulled().toSet(),
+			"first sync should have downloaded every server entity",
+		)
+
+		// The client backfilled the scene's null timestamps, so it should have healed the server's
+		// copy in the same sync rather than just adopting the impoverished version.
+		assertNotEquals(
+			seededSceneHash,
+			serverEntityHash(project, 1),
+			"server's scene should have been healed with the backfilled timestamps",
+		)
+
+		wire.reset()
+
+		// Second sync: nothing changed, so nothing should be pulled back down.
+		assertTrue(client.syncNoConflict(), "second sync should succeed")
+		assertEquals(
+			emptyList(),
+			wire.entitiesPulled(),
+			"second sync re-downloaded entities that were already current locally",
+		)
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/ResyncStabilityMatrixTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/ResyncStabilityMatrixTest.kt
@@ -1,0 +1,163 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.ApiSceneType
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+/**
+ * The invariant that the null-timestamp re-download bug violated: once a client has synced a set of
+ * server-originated entities, syncing again with nothing changed must be **silent** — no entity body
+ * pulled, nothing pushed back. A `200 download` or an `upload` on the second pass means the client's
+ * stored copy hashes differently from the server's, so the entity ping-pongs forever.
+ *
+ * This sweeps every entity type across the field combinations most likely to round-trip lossily —
+ * null/empty optional fields, populated optional fields, images, archive state — because those are
+ * exactly the corners where a hashed field silently diverges. Watches the wire (via [tapWire]) so
+ * the assertion is about real traffic, not what the client claims it did.
+ */
+class ResyncStabilityMatrixTest : RoundTripTestBase() {
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("cases")
+	@Timeout(value = 120)
+	fun `re-syncing unchanged server entities is silent`(case: Case) = runBlocking {
+		val project = "resync matrix ${case.label}"
+		val client = newClient(project)
+
+		// First sync registers the project on the server.
+		assertTrue(client.sync(), "registration sync should succeed")
+		val pid = serverNumericProjectIdFor(project)
+		assertNotNull(pid, "server should have created the project")
+
+		// Seed the case's entities as if another device had uploaded them.
+		case.entities.forEach { seedServerEntity(pid, it) }
+		val maxId = case.entities.maxOf { it.id }
+		database().execute("UPDATE project SET last_id = $maxId WHERE id = $pid;")
+
+		val wire = tapWire()
+
+		// First real sync pulls everything down (and may heal impoverished server copies).
+		assertTrue(client.syncNoConflict(), "download sync should succeed")
+		assertEquals(
+			case.entities.map { it.id }.toSet(),
+			wire.entitiesPulled().toSet(),
+			"first sync should have downloaded every seeded entity",
+		)
+
+		wire.reset()
+
+		// Second sync must be completely silent: nothing changed, so nothing should move.
+		assertTrue(client.syncNoConflict(), "second sync should succeed")
+		assertEquals(emptyList(), wire.entitiesPulled(), "resync re-downloaded an unchanged entity")
+		assertEquals(emptyList(), wire.entitiesUploaded(), "resync re-uploaded an unchanged entity")
+	}
+
+	data class Case(val label: String, val entities: List<ApiProjectEntity>) {
+		override fun toString() = label
+	}
+
+	companion object {
+		private val instant = Instant.fromEpochSeconds(1_700_000_000)
+
+		private fun scene(
+			id: Int,
+			path: List<Int> = listOf(0),
+			content: String = "body $id",
+			sceneType: ApiSceneType = ApiSceneType.Scene,
+			archived: Boolean = false,
+			outline: String = "",
+			notes: String = "",
+			tags: Set<String> = emptySet(),
+			confirmed: Set<Int> = emptySet(),
+			dismissed: Set<Int> = emptySet(),
+			created: Instant? = null,
+			lastEdited: Instant? = null,
+		) = ApiProjectEntity.SceneEntity(
+			id = id,
+			sceneType = sceneType,
+			order = id - 1,
+			name = "scene $id",
+			path = path,
+			content = content,
+			outline = outline,
+			notes = notes,
+			archived = archived,
+			confirmedReferences = confirmed,
+			dismissedReferences = dismissed,
+			tags = tags,
+			created = created,
+			lastEdited = lastEdited,
+		)
+
+		private fun one(label: String, entity: ApiProjectEntity) = Case(label, listOf(entity))
+
+		@JvmStatic
+		fun cases(): List<Arguments> = listOf(
+			one("scene, null timestamps", scene(id = 1)),
+			one("scene, populated timestamps", scene(id = 1, created = instant, lastEdited = instant)),
+			one(
+				"scene, optional text fields populated",
+				scene(id = 1, outline = "an outline", notes = "some notes", tags = setOf("a", "b")),
+			),
+			one("scene, empty content", scene(id = 1, content = "")),
+			one("scene group", scene(id = 1, sceneType = ApiSceneType.Group, content = "")),
+			one("archived scene", scene(id = 1, path = emptyList(), archived = true)),
+			one("note, no tags", ApiProjectEntity.NoteEntity(id = 1, content = "note body", created = instant)),
+			one(
+				"note, with tags",
+				ApiProjectEntity.NoteEntity(id = 1, content = "note body", created = instant, tags = setOf("x", "y")),
+			),
+			one(
+				"timeline event, null date",
+				ApiProjectEntity.TimelineEventEntity(id = 1, order = 0, date = null, content = "event"),
+			),
+			one(
+				"timeline event, with date and tags",
+				ApiProjectEntity.TimelineEventEntity(
+					id = 1, order = 0, date = "1920", content = "event", tags = setOf("war"),
+				),
+			),
+			one(
+				"encyclopedia entry, minimal",
+				ApiProjectEntity.EncyclopediaEntryEntity(
+					id = 1, name = "Hero", entryType = "person", text = "brave", tags = emptySet(),
+					image = null, aliases = emptyList(),
+				),
+			),
+			one(
+				"encyclopedia entry, tags and aliases",
+				ApiProjectEntity.EncyclopediaEntryEntity(
+					id = 1, name = "Hero", entryType = "person", text = "brave",
+					tags = setOf("legend"), image = null, aliases = listOf("The Brave", "Champion"),
+				),
+			),
+			one(
+				"encyclopedia entry, with image",
+				ApiProjectEntity.EncyclopediaEntryEntity(
+					id = 1, name = "Hero", entryType = "person", text = "brave", tags = emptySet(),
+					// Canonical url-safe base64 of "img" so the client's re-encode matches.
+					image = ApiProjectEntity.EncyclopediaEntryEntity.Image(base64 = "aW1n", fileExtension = "png"),
+					aliases = emptyList(),
+				),
+			),
+			Case(
+				"scene draft references its scene",
+				listOf(
+					scene(id = 1, content = "draft target"),
+					ApiProjectEntity.SceneDraftEntity(
+						id = 2, sceneId = 1, created = instant, name = "Draft One", content = "draft body",
+					),
+				),
+			),
+		).map { Arguments.of(it) }
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/StaleAllocatorAfterSyncTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/StaleAllocatorAfterSyncTest.kt
@@ -1,0 +1,47 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.isSuccess
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression: a sync that pulls down new entities must leave the id allocator fresh. The allocator
+ * only re-derived its next id at project-open and sync-start, so a device that adopted a project
+ * (downloading entities) and then created something before the next sync minted an id that collided
+ * with a just-downloaded entity.
+ */
+class StaleAllocatorAfterSyncTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 120)
+	fun `creating an entity right after a download sync does not reuse a downloaded id`() = runBlocking {
+		val a = newClient("stale alloc A")
+		val scene = assertNotNull(a.sceneEditor.createScene(parent = null, sceneName = "A Scene"))
+		a.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "alpha"))
+		assertTrue(a.syncNoConflict(), "A initial sync")
+
+		val b = secondDeviceFor(a, "stale alloc B")
+		assertTrue(b.syncNoConflict(), "B downloads A's scene")
+
+		// No editor re-open here: the adopt sync alone must have refreshed B's allocator.
+		val notes: NotesRepository = b.scope.get()
+		val created = notes.createNote("note on B")
+		assertTrue(isSuccess(created), "note create should succeed")
+		assertNotEquals(
+			scene.id,
+			created.data.id,
+			"new entity reused the id of a just-downloaded entity — allocator went stale after the sync",
+		)
+
+		assertTrue(b.syncNoConflict(), "B pushes its note")
+		assertTrue(a.syncNoConflict(), "A pulls B's note")
+		assertConverged(a.projectDef.name, a, b)
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/TwoDeviceSyncTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/TwoDeviceSyncTest.kt
@@ -1,0 +1,68 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Two real devices on one account, one server project. Exercises the realistic multi-actor path the
+ * single-client tests can't: a second device adopting the project, and independent edits on each
+ * device converging. Assertions use the model-free oracle — after everyone settles, every device
+ * holds exactly what the server holds, and an extra sync is silent.
+ */
+class TwoDeviceSyncTest : RoundTripTestBase() {
+
+	@Test
+	@Timeout(value = 120)
+	fun `a second device downloads the first device's project`() = runBlocking {
+		val a = newClient("two device download A")
+		val scene = assertNotNull(a.sceneEditor.createScene(parent = null, sceneName = "From A"))
+		a.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, "alpha"))
+		assertTrue(a.syncNoConflict(), "first device sync should succeed")
+
+		val b = secondDeviceFor(a, "two device download B")
+		assertTrue(b.syncNoConflict(), "second device sync should succeed")
+
+		assertConverged(a.projectDef.name, a, b)
+		val bScene = assertNotNull(b.sceneEditor.getSceneItemFromId(scene.id), "B should have A's scene")
+		assertEquals("alpha", b.sceneEditor.loadSceneMarkdownRaw(bScene), "content should round-trip to B")
+		assertResyncSilent(b)
+	}
+
+	@Test
+	@Timeout(value = 120)
+	fun `independent edits on two devices converge`() = runBlocking {
+		val a = newClient("two device merge A")
+		val sceneA = assertNotNull(a.sceneEditor.createScene(parent = null, sceneName = "Scene One"))
+		a.sceneEditor.storeSceneMarkdownRaw(SceneContent(sceneA, "one"))
+		assertTrue(a.syncNoConflict(), "A initial sync")
+
+		val b = secondDeviceFor(a, "two device merge B")
+		assertTrue(b.syncNoConflict(), "B adopts the project")
+		// A real second device re-derives its next id from the now-populated project on open;
+		// without this the allocator is stale from the empty-project sync start and the new scene
+		// collides with the just-downloaded one.
+		b.sceneEditor.initializeSceneEditor()
+
+		// Independent work on each device, touching different entities.
+		val notesA: NotesRepository = a.scope.get()
+		notesA.createNote("a note from A")
+		val sceneB = assertNotNull(b.sceneEditor.createScene(parent = null, sceneName = "Scene Two"))
+		b.sceneEditor.storeSceneMarkdownRaw(SceneContent(sceneB, "two"))
+
+		// Round-trip the changes through the server: A up, B up, then A again to pull B's work.
+		assertTrue(a.syncNoConflict(), "A pushes its note")
+		assertTrue(b.syncNoConflict(), "B pushes its scene")
+		assertTrue(a.syncNoConflict(), "A pulls B's scene")
+
+		assertConverged(a.projectDef.name, a, b)
+		assertResyncSilent(a)
+		assertResyncSilent(b)
+	}
+}

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/TwoDeviceSyncTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/TwoDeviceSyncTest.kt
@@ -45,10 +45,6 @@ class TwoDeviceSyncTest : RoundTripTestBase() {
 
 		val b = secondDeviceFor(a, "two device merge B")
 		assertTrue(b.syncNoConflict(), "B adopts the project")
-		// A real second device re-derives its next id from the now-populated project on open;
-		// without this the allocator is stale from the empty-project sync start and the new scene
-		// collides with the just-downloaded one.
-		b.sceneEditor.initializeSceneEditor()
 
 		// Independent work on each device, touching different entities.
 		val notesA: NotesRepository = a.scope.get()

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/UploadResyncStabilityMatrixTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/UploadResyncStabilityMatrixTest.kt
@@ -1,0 +1,126 @@
+package com.darkrockstudios.apps.hammer.integration.scenarios
+
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
+import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
+import com.darkrockstudios.apps.hammer.integration.HeadlessClient
+import com.darkrockstudios.apps.hammer.integration.RoundTripTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The upload-direction mirror of [ResyncStabilityMatrixTest]: when a client creates entities and
+ * syncs them up, syncing again with nothing changed must be silent over the wire — nothing
+ * re-uploaded, nothing pulled back. A client that uploads an entity it then can't reproduce the
+ * server's hash for would re-upload (or fight a download) on every sync.
+ *
+ * Sweeps each entity type across its hashed fields. The image case is intentionally omitted: the
+ * image hash is computed identically in both directions, and [ResyncStabilityMatrixTest] already
+ * proves it round-trips, so an upload-side image case would add setup cost without new coverage.
+ */
+class UploadResyncStabilityMatrixTest : RoundTripTestBase() {
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("cases")
+	@Timeout(value = 120)
+	fun `re-syncing locally-created entities is silent`(case: Case) = runBlocking {
+		val client = newClient("upload matrix ${case.label}")
+
+		case.create(client)
+
+		val wire = tapWire()
+
+		// First sync uploads the freshly-created entities.
+		assertTrue(client.syncNoConflict(), "first sync should succeed")
+		assertTrue(
+			wire.entitiesUploaded().isNotEmpty(),
+			"first sync should have uploaded the created entities",
+		)
+
+		wire.reset()
+
+		// Second sync must be completely silent.
+		assertTrue(client.syncNoConflict(), "second sync should succeed")
+		assertEquals(emptyList(), wire.entitiesPulled(), "resync downloaded a locally-created entity")
+		assertEquals(emptyList(), wire.entitiesUploaded(), "resync re-uploaded an unchanged entity")
+	}
+
+	class Case(val label: String, val create: suspend (HeadlessClient) -> Unit) {
+		override fun toString() = label
+	}
+
+	companion object {
+		private suspend fun newScene(client: HeadlessClient, name: String, content: String) =
+			assertNotNull(client.sceneEditor.createScene(parent = null, sceneName = name)).also { scene ->
+				client.sceneEditor.storeSceneMarkdownRaw(SceneContent(scene, content))
+			}
+
+		@JvmStatic
+		fun cases(): List<Arguments> = listOf(
+			Case("scene with content") { newScene(it, "Scene", "body text") },
+			Case("scene with empty content") { newScene(it, "Scene", "") },
+			Case("scene with outline, notes, and tags") { client ->
+				val scene = newScene(client, "Scene", "body")
+				val existing = client.sceneEditorService.loadSceneMetadata(scene.id)
+				client.sceneEditorService.storeMetadata(
+					existing.copy(outline = "an outline", notes = "some notes", tags = setOf("a", "b")),
+					scene.id,
+				)
+			},
+			Case("scene group") { client ->
+				assertNotNull(client.sceneEditorService.createGroup(parent = null, groupName = "Group"))
+			},
+			Case("archived scene") { client ->
+				val scene = newScene(client, "Doomed", "body")
+				assertTrue(client.sceneEditorService.archiveScene(scene), "archive should succeed")
+			},
+			Case("note without tags") { client ->
+				val notes: NotesRepository = client.scope.get()
+				notes.createNote("note body")
+			},
+			Case("note with tags") { client ->
+				val notes: NotesRepository = client.scope.get()
+				notes.createNote("note body", tags = setOf("x", "y"))
+			},
+			Case("timeline event without date") { client ->
+				val timeline: TimeLineRepository = client.scope.get()
+				timeline.initialize()
+				timeline.createEvent(content = "event", date = null)
+			},
+			Case("timeline event with date and tags") { client ->
+				val timeline: TimeLineRepository = client.scope.get()
+				timeline.initialize()
+				timeline.createEvent(content = "event", date = "1920", tags = setOf("war"))
+			},
+			Case("encyclopedia entry, minimal") { client ->
+				val encyclopedia: EncyclopediaRepository = client.scope.get()
+				encyclopedia.ensureEntriesLoaded()
+				encyclopedia.createEntry("Hero", EntryType.PERSON, "brave", emptySet(), imagePath = null)
+			},
+			Case("encyclopedia entry, tags and aliases") { client ->
+				val encyclopedia: EncyclopediaRepository = client.scope.get()
+				encyclopedia.ensureEntriesLoaded()
+				encyclopedia.createEntry(
+					name = "Hero",
+					type = EntryType.PERSON,
+					text = "brave",
+					tags = setOf("legend"),
+					imagePath = null,
+					aliases = listOf("The Brave", "Champion"),
+				)
+			},
+			Case("scene draft") { client ->
+				val scene = newScene(client, "Scene", "body")
+				assertNotNull(client.draftRepository.saveDraft(scene, "Draft One"))
+			},
+		).map { Arguments.of(it) }
+	}
+}


### PR DESCRIPTION
## Summary

Three fresh-sync bugs, all rooted in client/server hash or id-state divergence, plus a substantial e2e sync test build-out so this class of bug is caught going forward.

### 1. False project-data conflict on a fresh sync
A never-synced project baselined its default `project_data.toml` against `null` instead of the default-data hash, so empty local settings looked like a local edit and collided with the server's real settings. The baseline now normalizes a null `lastSyncedHash` to the default-data hash (matching `isProjectDataDirty`).

### 2. Scenes re-downloading on every sync
A scene uploaded before scenes tracked `created`/`lastEdited` arrives with null timestamps. `createScene` stamps local values and the old merge kept them via `?: existing`, but those fields are hashed — so the local copy never matched the server's null-timestamp hash and the scene re-downloaded **every sync, forever**.

Fix is **self-healing**: backfill the null timestamps with the project's creation time on download, then at the download chokepoint detect the resulting `localHash != serverHash` and upload the enriched copy — baselined on the server's just-recorded hash, so a lone client heals conflict-free in one sync. The check is generic, so any future field that round-trips lossily self-heals.

### 3. Stale id allocator after a download sync
`IdAllocator.findNextId()` ran only at project-open and sync-*start*, so a sync that downloaded entities with higher ids left the next-id snapshot stale. A device that adopted a project and then created an entity before the next sync minted an id that **collided with a just-downloaded entity**. `FinalizeSyncOperation` now re-derives the allocator after entity transfer. (Found while building the two-device tests.)

### 4. e2e sync test build-out
**Model-free oracle** (on `RoundTripTestBase`): `assertConverged` (every client holds exactly what the server holds, hash for hash) + `assertResyncSilent` (an extra sync moves nothing), built on a new `tapWire()` `HttpSend` interceptor that records real traffic (download 200 vs 304, uploads). Divergence shows up as a non-silent resync — no expected-state model needed.

Organized into three regimes (`integrationTests/README.md` documents the taxonomy + coverage map):
- **First-time** — `ServerDownloadsEntityTest`, `TwoDeviceSyncTest` (second device adopts a project).
- **No-change** — `ResyncStabilityMatrixTest` (server-originated, 14 cases) and `UploadResyncStabilityMatrixTest` (client-created, 12 cases) sweep every entity type × edge-case field values; plus `ResyncDownloadsNothingTest`.
- **Mixed** — `MixedSyncFuzzTest` (seeded property test: random create/edit/delete/rename across all types → converge + silent), `TwoDeviceSyncTest`, and `StaleAllocatorAfterSyncTest`.

Two-device support: `HeadlessClient`/`secondDeviceFor` lets a second real client join an existing server project with its own local dir.

## Testing
- `./gradlew :common:desktopTest` — green
- `./gradlew :integrationTests:jvmTest` — green (matrices, fuzzer across 3 seeds, two-device, allocator regression, existing scenarios)
- Each bug's test was confirmed to fail before its fix and pass after.
