### PR TITLE
Honor spell-check setting in Notes/Encyclopedia/Timeline editors

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/SpellCheckRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/SpellCheckRepository.kt
@@ -29,35 +29,45 @@ class SpellCheckRepository(
 	)
 	val dictionaryFlow: SharedFlow<PlatformSpellChecker?> = _dictionaryFlow
 	private var currentLanguage: Locale? = null
+	private var currentEnabled: Boolean? = null
 
-	private fun requestSpellChecker(language: Locale) {
-		scope.launch {
-			val spLocale = language.toSpLocale()
-			if (spellCheckFactory.hasLanguage(spLocale).not()) {
-				Napier.w("Unsupported Locale type: $language")
-			} else {
-				val checker = spellCheckFactory.createSpellChecker(spLocale)
-				currentLanguage = language
-				_dictionaryFlow.tryEmit(checker)
-
-				Napier.i("Spell Checker loaded for: ${language.toLanguageTag()}")
+	private suspend fun applySpellCheckSettings(enabled: Boolean, language: Locale) {
+		if (!enabled) {
+			if (currentEnabled != false) {
+				currentEnabled = false
+				currentLanguage = null
+				_dictionaryFlow.tryEmit(null)
+				Napier.i("Spell Check disabled: dictionary cleared")
 			}
+			return
+		}
+
+		if (currentEnabled == true && currentLanguage == language) return
+
+		val spLocale = language.toSpLocale()
+		if (spellCheckFactory.hasLanguage(spLocale).not()) {
+			Napier.w("Unsupported Locale type: $language")
+		} else {
+			val checker = spellCheckFactory.createSpellChecker(spLocale)
+			currentLanguage = language
+			currentEnabled = true
+			_dictionaryFlow.tryEmit(checker)
+
+			Napier.i("Spell Checker loaded for: ${language.toLanguageTag()}")
 		}
 	}
 
 	init {
 		scope.launch {
-			val initialLocale =
-				globalSettingsStore.globalSettings.spellCheckSettings.locale
-			requestSpellChecker(initialLocale)
-			Napier.i("Spell Check: Initial language set: $initialLocale")
+			val initial = globalSettingsStore.globalSettings.spellCheckSettings
+			applySpellCheckSettings(initial.enabled, initial.locale)
+			Napier.i("Spell Check: Initial settings applied: enabled=${initial.enabled}, locale=${initial.locale}")
 
 			globalSettingsStore.globalSettingsUpdates.collect { settings ->
-				val newLanguage = settings.spellCheckSettings.locale
-				if (currentLanguage != settings.spellCheckSettings.locale) {
-					Napier.i("Updating Spell Check Language: $newLanguage")
-					requestSpellChecker(newLanguage)
-				}
+				applySpellCheckSettings(
+					settings.spellCheckSettings.enabled,
+					settings.spellCheckSettings.locale,
+				)
 			}
 		}
 	}

--- a/common/src/desktopTest/kotlin/repositories/spellcheck/SpellCheckRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/spellcheck/SpellCheckRepositoryTest.kt
@@ -44,10 +44,10 @@ class SpellCheckRepositoryTest : BaseTest() {
 		setupKoin()
 	}
 
-	private fun settingsStore(locale: Locale): GlobalSettingsStore {
+	private fun settingsStore(locale: Locale, enabled: Boolean = true): GlobalSettingsStore {
 		coEvery { globalSettingsDatasource.loadSettings() } returns GlobalSettings(
 			projectsDirectory = "/projects",
-			spellCheckSettings = SpellCheckerSettings(locale = locale),
+			spellCheckSettings = SpellCheckerSettings(enabled = enabled, locale = locale),
 		)
 		coEvery { serverSettingsDatasource.loadServerSettings(any()) } returns null
 		return GlobalSettingsStore(globalSettingsDatasource, serverSettingsDatasource)
@@ -122,6 +122,68 @@ class SpellCheckRepositoryTest : BaseTest() {
 		advanceUntilIdle()
 
 		assertEquals(loadsAfterInit, loadCount)
+	}
+
+	@Test
+	fun `does not load or emit a checker when spell check is globally disabled`() = scope.runTest {
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } returns mockk()
+
+		val repo = SpellCheckRepository(settingsStore(Locale.forLanguageTag("en"), enabled = false), factory)
+		advanceUntilIdle()
+
+		assertTrue(repo.dictionaryFlow.replayCache.all { it == null })
+		coVerify(exactly = 0) { factory.createSpellChecker(any()) }
+	}
+
+	@Test
+	fun `emits null when spell check is disabled after being enabled`() = scope.runTest {
+		val checker = mockk<PlatformSpellChecker>()
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } returns checker
+		coEvery { globalSettingsDatasource.storeSettings(any()) } just Runs
+
+		val store = settingsStore(Locale.forLanguageTag("en"), enabled = true)
+		val repo = SpellCheckRepository(store, factory)
+
+		repo.dictionaryFlow.test {
+			assertSame(checker, awaitItem())
+
+			store.updateSettings { settings ->
+				settings.copy(
+					spellCheckSettings = settings.spellCheckSettings.copy(enabled = false)
+				)
+			}
+
+			assertEquals(null, awaitItem())
+			cancelAndConsumeRemainingEvents()
+		}
+	}
+
+	@Test
+	fun `reloads the checker when spell check is re-enabled`() = scope.runTest {
+		val checker = mockk<PlatformSpellChecker>()
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } returns checker
+		coEvery { globalSettingsDatasource.storeSettings(any()) } just Runs
+
+		val store = settingsStore(Locale.forLanguageTag("en"), enabled = false)
+		val repo = SpellCheckRepository(store, factory)
+		advanceUntilIdle()
+
+		repo.dictionaryFlow.test {
+			// Disabled at init: no checker handed out.
+			assertEquals(null, awaitItem())
+
+			store.updateSettings { settings ->
+				settings.copy(
+					spellCheckSettings = settings.spellCheckSettings.copy(enabled = true)
+				)
+			}
+
+			assertSame(checker, awaitItem())
+			cancelAndConsumeRemainingEvents()
+		}
 	}
 
 	@Test

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditField.kt
@@ -54,7 +54,9 @@ fun MarkdownEditField(
 	val textEditorState = rememberSpellCheckState(
 		spellChecker = platformSpellChecker.toEditorSpellChecker(),
 		initialText = null,
-		enableSpellChecking = enableSpellChecking,
+		// The repository only emits a dictionary while spell checking is globally enabled,
+		// so a null checker also means "disabled" — clear decorations rather than keep checking.
+		enableSpellChecking = enableSpellChecking && platformSpellChecker != null,
 	)
 	val markdownExtension = remember { textEditorState.withMarkdown(markdownConfig) }
 


### PR DESCRIPTION
## Problem

A user (Desktop, Windows) reported spell checking still happening with the spell-check setting **disabled**. It looked locale-specific (their OS is Dutch) and couldn't be reproduced in the scene editor.

Root cause is the editor surface, not locale: `MarkdownEditField` defaults `enableSpellChecking = true` and never reads the global setting. Its callers — **Create/View Note**, **Create/View Encyclopedia entry**, **Create/View Timeline event** — all take the default, so those editors spell-check unconditionally. Only `SceneEditorUi`/`FocusModeUi` wired the setting, which is why disabling appeared to work when tested there. Dutch text just made the stray squiggles obvious.

## Fix

Gate the shared dictionary at the source: `SpellCheckRepository.dictionaryFlow` now emits `null` whenever spell checking is globally disabled (`spellCheckSettings.enabled`), so no consumer — current or future — can obtain a checker while it's off. `MarkdownEditField` also treats a null checker as "disabled" so existing decorations clear if spell check is turned off while a field is open. The scene/focus editors keep their explicit flag as defense-in-depth.

## Tests

- `SpellCheckRepositoryTest`: disabled-at-init hands out no checker; enabled→disabled emits `null`; disabled→re-enabled reloads. Written failing-first.
- Full `:common:desktopTest` + `:composeUi:desktopTest` pass.

## Notes

- Ruled out: settings persistence (TOML round-trips `enabled=false` under nl-NL + Windows paths) and the editor library (2.2.6/2.3.0 already guard checks on the flag). The 2.3.0 bump (closed renovate PR #708) is unrelated/accessibility-only.