### PR TITLE
Fix crash on ios image import

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -17,6 +17,10 @@ group = "com.darkrockstudios.apps.hammer"
 version = libs.versions.app.get()
 
 kotlin {
+	jvmToolchain {
+		languageVersion.set(JavaLanguageVersion.of(libs.versions.jvm.get().toInt()))
+		vendor.set(JvmVendorSpec.JETBRAINS)
+	}
 	androidLibrary {
 		namespace = "com.darkrockstudios.apps.hammer.common"
 		compileSdk = libs.versions.android.sdk.compile.get().toInt()

--- a/common/src/commonMain/composeResources/values/strings_encyclopedia.xml
+++ b/common/src/commonMain/composeResources/values/strings_encyclopedia.xml
@@ -32,6 +32,7 @@
 	<string name="encyclopedia_create_entry_image_attached">1 attached</string>
 	<string name="encyclopedia_create_entry_image_replace">Replace</string>
 	<string name="encyclopedia_create_entry_image_too_large">Image is too large. Maximum size is %1$d MB.</string>
+	<string name="encyclopedia_create_entry_image_load_failed">Could not read the selected image.</string>
 	<string name="encyclopedia_create_entry_remove_image_button">Remove Image</string>
 	<string name="encyclopedia_create_entry_select_image_button">Select Image</string>
 	<string name="encyclopedia_create_entry_create_button">Create entry</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/BrowseEntries.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/BrowseEntries.kt
@@ -19,6 +19,7 @@ interface BrowseEntries {
 	fun getFilteredEntries(): List<EntryDef>
 	suspend fun loadEntryContent(entryDef: EntryDef): EntryContent
 	fun getImagePath(entryDef: EntryDef): String?
+	suspend fun calculateEntryImageHash(entryDef: EntryDef): String?
 	fun addTagToSearch(tag: String)
 	fun clearFilterText()
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/BrowseEntriesComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/BrowseEntriesComponent.kt
@@ -175,6 +175,11 @@ class BrowseEntriesComponent(
 		return encyclopediaService.findEntryImagePath(entryDef)?.path
 	}
 
+	override suspend fun calculateEntryImageHash(entryDef: EntryDef): String? {
+		return encyclopediaService.findEntryImageExtension(entryDef)
+			?.let { ext -> encyclopediaService.calculateEntryImageHash(entryDef, ext) }
+	}
+
 	override fun clearFilterText() {
 		_filterText.update { "" }
 	}

--- a/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryImageTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryImageTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import utils.BaseTest
 import kotlin.test.assertContentEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -184,6 +185,24 @@ class EncyclopediaRepositoryImageTest : BaseTest() {
 
 		repo.setEntryImage(def, sourcePath)
 		assertNotNull(repo.calculateEntryImageHash(def, "jpg"))
+	}
+
+	@Test
+	fun `calculateEntryImageHash changes when the image is replaced with different bytes`() = runTest {
+		val repo = repository()
+		val def = entry1().toDef(projDef)
+
+		repo.setEntryImage(def, sourcePath)
+		val originalHash = repo.calculateEntryImageHash(def, "jpg")
+
+		val replacementSource = "/external/replacement.jpg"
+		every { externalFileIo.readExternalFile(replacementSource) } returns byteArrayOf(9, 8, 7, 6)
+		repo.setEntryImage(def, replacementSource)
+		val replacedHash = repo.calculateEntryImageHash(def, "jpg")
+
+		assertNotNull(originalHash)
+		assertNotNull(replacedHash)
+		assertNotEquals(originalHash, replacedHash)
 	}
 
 	@Test

--- a/composeUi/build.gradle.kts
+++ b/composeUi/build.gradle.kts
@@ -15,6 +15,10 @@ group = "com.darkrockstudios.apps.hammer.composeui"
 version = libs.versions.app.get()
 
 kotlin {
+	jvmToolchain {
+		languageVersion.set(JavaLanguageVersion.of(libs.versions.jvm.get().toInt()))
+		vendor.set(JvmVendorSpec.JETBRAINS)
+	}
 	androidLibrary {
 		namespace = "com.darkrockstudios.apps.hammer.composeui"
 		compileSdk = libs.versions.android.sdk.compile.get().toInt()

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/PickedFileStaging.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/PickedFileStaging.kt
@@ -1,0 +1,29 @@
+package com.darkrockstudios.apps.hammer.common.compose
+
+import io.github.aakira.napier.Napier
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.cacheDir
+import io.github.vinceglb.filekit.div
+import io.github.vinceglb.filekit.name
+import io.github.vinceglb.filekit.readBytes
+import io.github.vinceglb.filekit.write
+import kotlin.coroutines.cancellation.CancellationException
+
+// Files picked outside the app sandbox (e.g. iCloud on iOS) are only readable through the
+// security-scoped access granted at pick time. Copy the bytes into the app cache now, while
+// that scope is live, so downstream code can re-open the file by path. Returns null if the
+// copy fails.
+suspend fun PlatformFile.stageIntoCache(): PlatformFile? {
+	return try {
+		val bytes = readBytes()
+		val localCopy = FileKit.cacheDir / name
+		localCopy.write(bytes)
+		localCopy
+	} catch (e: CancellationException) {
+		throw e
+	} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+		Napier.e("Failed to stage picked file into cache", e)
+		null
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/PickedFileStaging.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/PickedFileStaging.kt
@@ -10,10 +10,12 @@ import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.write
 import kotlin.coroutines.cancellation.CancellationException
 
-// Files picked outside the app sandbox (e.g. iCloud on iOS) are only readable through the
-// security-scoped access granted at pick time. Copy the bytes into the app cache now, while
-// that scope is live, so downstream code can re-open the file by path. Returns null if the
-// copy fails.
+/**
+ * Files picked from outside the app sandbox — iCloud on iOS, `content://` providers on Android —
+ * are only readable through the scoped access granted at pick time. Copy the bytes into the app
+ * cache now, while that scope is live, so downstream code can re-open the file by path. Returns
+ * null if the copy fails.
+ */
 suspend fun PlatformFile.stageIntoCache(): PlatformFile? {
 	return try {
 		val bytes = readBytes()

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
@@ -32,17 +32,13 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryE
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.cacheDir
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import io.github.vinceglb.filekit.div
-import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.path
-import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.size
-import io.github.vinceglb.filekit.write
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 const val ENCYCLOPEDIA_CREATE_NAME_TAG = "encyclopedia-create-name"
 const val ENCYCLOPEDIA_CREATE_TAGS_TAG = "encyclopedia-create-tags"
@@ -59,6 +55,7 @@ internal fun CreateEntryUi(
 ) {
 	val state by component.state.subscribeAsState()
 	val strRes = rememberStrRes()
+	val dispatcherIo = rememberIoDispatcher()
 
 	var name by rememberSaveable { mutableStateOf("") }
 	var description by rememberSaveable { mutableStateOf("") }
@@ -155,10 +152,14 @@ internal fun CreateEntryUi(
 									)
 								)
 							} else if (picked != null) {
-								val bytes = picked.readBytes()
-								val localCopy = FileKit.cacheDir / picked.name
-								localCopy.write(bytes)
-								imagePath = localCopy
+								val localCopy = withContext(dispatcherIo) { picked.stageIntoCache() }
+								if (localCopy != null) {
+									imagePath = localCopy
+								} else {
+									rootSnackbar.showSnackbar(
+										strRes.get(Res.string.encyclopedia_create_entry_image_load_failed)
+									)
+								}
 							} else {
 								imagePath = null
 							}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
@@ -32,10 +32,15 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryE
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.cacheDir
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
+import io.github.vinceglb.filekit.div
+import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.path
+import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.size
+import io.github.vinceglb.filekit.write
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -149,8 +154,13 @@ internal fun CreateEntryUi(
 										EncyclopediaDatasource.MAX_IMAGE_SIZE_MB,
 									)
 								)
+							} else if (picked != null) {
+								val bytes = picked.readBytes()
+								val localCopy = FileKit.cacheDir / picked.name
+								localCopy.write(bytes)
+								imagePath = localCopy
 							} else {
-								imagePath = picked
+								imagePath = null
 							}
 						}
 					},

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/EncyclopediaEntryItem.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/EncyclopediaEntryItem.kt
@@ -83,20 +83,27 @@ internal fun EncyclopediaEntryItem(
 	var loadContentJob = remember<Job?> { null }
 	var entryContent by remember { mutableStateOf<EntryContent?>(null) }
 	var entryImagePath by remember { mutableStateOf<String?>(null) }
+	var entryImageHash by remember { mutableStateOf<String?>(null) }
 	var hasImage by remember { mutableStateOf<Boolean?>(null) }
 
 	val paletteState = rememberPaletteState(loader = FilePathLoader)
 
 	LaunchedEffect(entryDef) {
 		entryImagePath = null
+		entryImageHash = null
 		hasImage = null
 		paletteState.reset()
 		loadContentJob?.cancel()
 		loadContentJob = scope.launch(ioDispatcher) {
 			val imagePath = component.getImagePath(entryDef)
+			// The image's filename is stable across replacement, so the cache key must include
+			// a content hash — otherwise Coil keeps serving the old cached bytes after a photo
+			// is replaced (same path key, stale cache entry).
+			val imageHash = imagePath?.let { component.calculateEntryImageHash(entryDef) }
 			val content = component.loadEntryContent(entryDef)
 			withContext(mainDispatcher) {
 				entryImagePath = imagePath
+				entryImageHash = imageHash
 				hasImage = imagePath != null
 				entryContent = content
 				loadContentJob = null
@@ -168,10 +175,12 @@ internal fun EncyclopediaEntryItem(
 							val context = LocalPlatformContext.current
 							with(animatedVisibilityScope) {
 								AsyncImage(
-									model = remember(imagePath) {
+									model = remember(imagePath, entryImageHash) {
 										ImageRequest.Builder(context)
 											.data(imagePath)
-											.memoryCacheKey(imagePath)
+											.memoryCacheKeyExtras(
+												mapOf("hash" to entryImageHash.toString()),
+											)
 											.placeholderMemoryCacheKey(imagePath)
 											.crossfade(300)
 											.build()

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/EncyclopediaEntryItem.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/EncyclopediaEntryItem.kt
@@ -96,9 +96,7 @@ internal fun EncyclopediaEntryItem(
 		loadContentJob?.cancel()
 		loadContentJob = scope.launch(ioDispatcher) {
 			val imagePath = component.getImagePath(entryDef)
-			// The image's filename is stable across replacement, so the cache key must include
-			// a content hash — otherwise Coil keeps serving the old cached bytes after a photo
-			// is replaced (same path key, stale cache entry).
+			// The image's filename is stable across replacement, so the cache key must be unique
 			val imageHash = imagePath?.let { component.calculateEntryImageHash(entryDef) }
 			val content = component.loadEntryContent(entryDef)
 			withContext(mainDispatcher) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
@@ -54,10 +54,15 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryR
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.cacheDir
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
+import io.github.vinceglb.filekit.div
+import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.path
+import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.size
+import io.github.vinceglb.filekit.write
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -304,7 +309,13 @@ internal fun ViewEntryUi(
 						)
 					)
 				} else {
-					scope.launch { component.setImage(file.path) }
+					val localPath = withContext(dispatcherDefault) {
+						val bytes = file.readBytes()
+						val localCopy = FileKit.cacheDir / file.name
+						localCopy.write(bytes)
+						localCopy.path
+					}
+					scope.launch { component.setImage(localPath) }
 				}
 			}
 			component.closeAddImageDialog()

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
@@ -54,15 +54,10 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryR
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.github.vinceglb.filekit.FileKit
-import io.github.vinceglb.filekit.cacheDir
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import io.github.vinceglb.filekit.div
-import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.path
-import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.size
-import io.github.vinceglb.filekit.write
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -86,6 +81,7 @@ internal fun ViewEntryUi(
 	val strRes = rememberStrRes()
 	val dispatcherMain = rememberMainDispatcher()
 	val dispatcherDefault = rememberDefaultDispatcher()
+	val dispatcherIo = rememberIoDispatcher()
 	val state by component.state.subscribeAsState()
 
 	var entryNameText by rememberSaveable { mutableStateOf(state.content?.name ?: "") }
@@ -309,13 +305,14 @@ internal fun ViewEntryUi(
 						)
 					)
 				} else {
-					val localPath = withContext(dispatcherDefault) {
-						val bytes = file.readBytes()
-						val localCopy = FileKit.cacheDir / file.name
-						localCopy.write(bytes)
-						localCopy.path
+					val localCopy = withContext(dispatcherIo) { file.stageIntoCache() }
+					if (localCopy != null) {
+						scope.launch { component.setImage(localCopy.path) }
+					} else {
+						rootSnackbar.showSnackbar(
+							strRes.get(Res.string.encyclopedia_create_entry_image_load_failed)
+						)
 					}
-					scope.launch { component.setImage(localPath) }
 				}
 			}
 			component.closeAddImageDialog()
@@ -769,7 +766,7 @@ private fun InsetFigure(
 			val context = LocalPlatformContext.current
 			with(sharedTransitionScope) {
 				AsyncImage(
-					model = remember(imagePath) {
+					model = remember(imagePath, state.entryImageHash) {
 						ImageRequest.Builder(context)
 							.data(imagePath)
 							.memoryCacheKeyExtras(

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/EncyclopediaUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/EncyclopediaUi.Preview.kt
@@ -87,6 +87,7 @@ private val browseEntriesComponent: BrowseEntries = object : BrowseEntries {
 	}
 
 	override fun getImagePath(entryDef: EntryDef) = null
+	override suspend fun calculateEntryImageHash(entryDef: EntryDef) = null
 	override fun addTagToSearch(tag: String) {}
 	override fun clearFilterText() {}
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/encyclopedia/BrowseEntriesUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/encyclopedia/BrowseEntriesUi.Preview.kt
@@ -79,6 +79,7 @@ private val component = object : BrowseEntries {
 	)
 
 	override fun getImagePath(entryDef: EntryDef) = null
+	override suspend fun calculateEntryImageHash(entryDef: EntryDef) = null
 	override fun addTagToSearch(tag: String) {}
 	override fun clearFilterText() {}
 }


### PR DESCRIPTION
Adding an image to an encyclopedia entry crashes the app because this wasn't handling images from the ios file picker originating from places like iCloud.

This also makes a small fix to the build file to make sure users with an older jvm (don't know who would have that) can run the tests. You can drop that commit if you don't think it's needed.