### PR TITLE
Add robots.txt and per-page indexing controls

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/AuthorPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/AuthorPage.kt
@@ -36,6 +36,9 @@ fun Route.authorPage(
 			}
 			val penNameForUrl = ProjectName.penNameForUrl(penName)
 
+			// Only surface author pages of community participants to search indexes.
+			call.applyRobotsTag(indexable = account.community_member)
+
 			// Get published stories for this author
 			val stories = projectAccessRepository.getPublishedStoriesByPenName(penName)
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -111,6 +111,7 @@ fun Route.frontend() {
 		etag(ETagProvider.StrongSha256)
 	}
 
+	robotsRoutes()
 	setupPage(serverConfig)
 	homePage(whiteListRepository, configRepository, serverConfig, accountsRepository, projectAccessRepository)
 	aboutPage(configRepository, serverConfig, accountsRepository, projectAccessRepository, markdownService)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PublicStoryPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PublicStoryPage.kt
@@ -76,6 +76,9 @@ fun Route.publicStoryPage(
 				}
 
 				is PublicProjectResult.PasswordRequired -> {
+					// Password-protected stories are private shares — never index them.
+					call.applyRobotsTag(indexable = false)
+
 					// Show password form
 					val model = call.withDefaults(
 						mapOf(
@@ -89,6 +92,13 @@ fun Route.publicStoryPage(
 				}
 
 				is PublicProjectResult.Success -> {
+					// Only publicly-published stories (no password) by authors who participate in
+					// the community feature are indexable. A crawler never supplies a password, so a
+					// Success it reaches is necessarily public access; the password check keeps
+					// private shares (reached with a valid password) out of the index too.
+					val indexable = password.isNullOrBlank() && account.community_member
+					call.applyRobotsTag(indexable = indexable)
+
 					// Best-effort unique-reader count, skipping the author viewing their own story.
 					val viewerId = call.sessions.get<UserSession>()?.userId
 					if (viewerId != resolved.userId) {

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/RobotsRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/RobotsRoutes.kt
@@ -1,0 +1,148 @@
+package com.darkrockstudios.apps.hammer.frontend
+
+import io.ktor.http.ContentType
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.header
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+
+/**
+ * Well-known AI/LLM training & data-harvesting crawler user-agent tokens.
+ *
+ * Sourced from the community-maintained https://github.com/ai-robots-txt/ai.robots.txt
+ * list (snapshot; see also https://www.fastly.com/blog/teach-your-robots-txt-a-new-trick-for-ai).
+ * This is a point-in-time copy — new crawlers appear constantly, so it should be
+ * refreshed periodically. Blocking is best-effort: a well-behaved crawler honours it,
+ * a hostile one ignores it.
+ *
+ * We deliberately DO NOT list general search crawlers (Googlebot, Bingbot, …) here so
+ * that public pages and publicly-published community stories remain indexable for search.
+ * `Google-Extended` and `Applebot-Extended` are the AI-training opt-out tokens for
+ * Google/Apple: listing them blocks AI training while Googlebot/Applebot keep crawling
+ * for search results.
+ *
+ * We also deliberately omit link-preview fetchers (e.g. facebookexternalhit, Twitterbot)
+ * so that sharing a story link on social media still renders a preview card.
+ */
+internal val AI_CRAWLER_USER_AGENTS: List<String> = listOf(
+	"AI2Bot",
+	"Ai2Bot-Dolma",
+	"Amazonbot",
+	"anthropic-ai",
+	"Applebot-Extended",
+	"Bytespider",
+	"CCBot",
+	"ChatGPT-User",
+	"Claude-Web",
+	"ClaudeBot",
+	"cohere-ai",
+	"cohere-training-data-crawler",
+	"Diffbot",
+	"DuckAssistBot",
+	"FacebookBot",
+	"FriendlyCrawler",
+	"Google-Extended",
+	"GPTBot",
+	"iaskspider/2.0",
+	"ICC-Crawler",
+	"ImagesiftBot",
+	"img2dataset",
+	"ISSCyberRiskCrawler",
+	"Kangaroo Bot",
+	"Meta-ExternalAgent",
+	"Meta-ExternalFetcher",
+	"OAI-SearchBot",
+	"omgili",
+	"omgilibot",
+	"PanguBot",
+	"Perplexity-User",
+	"PerplexityBot",
+	"PetalBot",
+	"Sidetrade indexer bot",
+	"Timpibot",
+	"VelenPublicWebCrawler",
+	"Webzio-Extended",
+	"YouBot",
+)
+
+/**
+ * App/functional areas that should never be indexed by any crawler. These are either
+ * authenticated surfaces, API endpoints, or one-off flows with no useful public content.
+ */
+internal val DISALLOWED_PATHS: List<String> = listOf(
+	"/api/",
+	"/admin",
+	"/dashboard",
+	"/login",
+	"/logout",
+	"/setup",
+	"/account",
+	"/reset-password",
+	"/forgot-password",
+	"/review/",
+)
+
+/**
+ * Builds the `robots.txt` body.
+ *
+ * Two groups:
+ *  - `User-agent: *` (search engines): everything is crawlable except the app/private
+ *    paths in [DISALLOWED_PATHS]. Story pages under `/a/` stay crawlable so that
+ *    publicly-published community stories can be indexed; non-indexable stories emit a
+ *    per-page `X-Robots-Tag: noindex` header instead (robots.txt can't tell them apart
+ *    by path).
+ *  - The AI-training crawlers in [AI_CRAWLER_USER_AGENTS]: `Disallow: /` (opt out entirely).
+ *
+ * @param sitemapUrl absolute URL of the sitemap, appended as a `Sitemap:` line when set.
+ */
+internal fun buildRobotsTxt(sitemapUrl: String? = null): String {
+	val sb = StringBuilder()
+
+	sb.appendLine("# Search engines: index public pages and publicly-published community")
+	sb.appendLine("# stories, but keep authenticated and functional areas out.")
+	sb.appendLine("User-agent: *")
+	for (path in DISALLOWED_PATHS) {
+		sb.appendLine("Disallow: $path")
+	}
+	sb.appendLine("Allow: /")
+	sb.appendLine()
+
+	sb.appendLine("# AI training / data-harvesting crawlers: opt out entirely.")
+	for (agent in AI_CRAWLER_USER_AGENTS) {
+		sb.appendLine("User-agent: $agent")
+	}
+	sb.appendLine("Disallow: /")
+
+	if (!sitemapUrl.isNullOrBlank()) {
+		sb.appendLine()
+		sb.appendLine("Sitemap: $sitemapUrl")
+	}
+
+	return sb.toString()
+}
+
+fun Route.robotsRoutes() {
+	get("/robots.txt") {
+		call.respondText(buildRobotsTxt(), ContentType.Text.Plain)
+	}
+}
+
+/**
+ * Directive sent to well-behaved crawlers to keep a specific page out of their index.
+ * Used on story/author pages, where indexability depends on per-record state
+ * (community membership, public vs. password-protected) that robots.txt path rules
+ * can't express.
+ */
+private const val ROBOTS_NOINDEX = "noindex, nofollow"
+
+/**
+ * Sets `X-Robots-Tag: noindex, nofollow` when [indexable] is false. When true, no header
+ * is added so the page is indexable by default. Must be called before the response body
+ * is sent.
+ */
+fun ApplicationCall.applyRobotsTag(indexable: Boolean) {
+	if (!indexable) {
+		response.header("X-Robots-Tag", ROBOTS_NOINDEX)
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/RobotsRoutesTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/RobotsRoutesTest.kt
@@ -1,0 +1,81 @@
+package com.darkrockstudios.apps.hammer.frontend
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RobotsRoutesTest {
+
+	@Test
+	fun `disallows every functional path for the default agent`() {
+		val body = buildRobotsTxt()
+		val defaultGroup = body.substringBefore("# AI training")
+
+		assertContains(defaultGroup, "User-agent: *")
+		for (path in DISALLOWED_PATHS) {
+			assertContains(defaultGroup, "Disallow: $path")
+		}
+		// Search engines may still crawl everything else (needed so public community
+		// stories under /a/ can be indexed).
+		assertContains(defaultGroup, "Allow: /")
+	}
+
+	@Test
+	fun `blocks every known AI crawler with a full disallow`() {
+		val body = buildRobotsTxt()
+		val aiGroup = body.substringAfter("# AI training")
+
+		for (agent in AI_CRAWLER_USER_AGENTS) {
+			assertContains(aiGroup, "User-agent: $agent")
+		}
+		assertContains(aiGroup, "Disallow: /")
+	}
+
+	@Test
+	fun `does not block general search crawlers`() {
+		val body = buildRobotsTxt()
+		assertFalse(body.contains("User-agent: Googlebot"), "Googlebot must stay allowed for search")
+		assertFalse(body.contains("User-agent: Bingbot"), "Bingbot must stay allowed for search")
+		// Link-preview fetchers must keep working so shared story links render cards.
+		assertFalse(body.contains("facebookexternalhit"))
+	}
+
+	@Test
+	fun `includes the AI training opt-out tokens for search engines that respect them`() {
+		val body = buildRobotsTxt()
+		assertContains(body, "User-agent: Google-Extended")
+		assertContains(body, "User-agent: Applebot-Extended")
+	}
+
+	@Test
+	fun `appends a sitemap line only when a url is provided`() {
+		assertFalse(buildRobotsTxt().contains("Sitemap:"))
+		assertContains(buildRobotsTxt("https://example.com/sitemap.xml"), "Sitemap: https://example.com/sitemap.xml")
+	}
+
+	@Test
+	fun `serves robots txt as plain text`() = testApplication {
+		application {
+			routing { robotsRoutes() }
+		}
+
+		val response = client.get("/robots.txt")
+
+		assertEquals(HttpStatusCode.OK, response.status)
+		assertTrue(
+			response.headers[HttpHeaders.ContentType]?.startsWith("text/plain") == true,
+			"expected text/plain, got ${response.headers[HttpHeaders.ContentType]}",
+		)
+		val body = response.bodyAsText()
+		assertTrue(body.startsWith("# Search engines"))
+		assertContains(body, "User-agent: GPTBot")
+	}
+}


### PR DESCRIPTION
Serve /robots.txt with two crawler groups: search engines may crawl
public pages and story pages (private/app areas disallowed), while known
AI training crawlers from the ai.robots.txt list are opted out entirely.
Google-Extended/Applebot-Extended tokens block AI training while keeping
Googlebot/Applebot indexing for search.

robots.txt can't distinguish community stories from other stories by path
(both live under /a/), so story and author pages emit X-Robots-Tag:
noindex unless the story is publicly published (no password) by a
community member, or the author participates in the community.
