### PR TITLE
Show an "update your client" dialog on sync protocol mismatch

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -228,8 +228,8 @@
 	<string name="protocol_mismatch_title_server">The sync server is out of date</string>
 	<string name="protocol_mismatch_body_client">This version of Hammer can no longer sync with the server. Update to the latest version to keep syncing your work.</string>
 	<string name="protocol_mismatch_body_server">The sync server is running an older protocol than this app. The server needs to be updated before syncing will work again.</string>
-	<string name="protocol_mismatch_latest_version">Latest version: %1$s</string>
-	<string name="protocol_mismatch_current_version">You have: %1$s</string>
+	<string name="protocol_mismatch_latest_version">Latest version: %s</string>
+	<string name="protocol_mismatch_current_version">You have: %s</string>
 	<string name="protocol_mismatch_open_release_button">Get the Update</string>
 	<string name="protocol_mismatch_dismiss_button">Dismiss</string>
 

--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -223,6 +223,16 @@
 	<string name="sync_unauthorized">Unauthorized</string>
 	<string name="sync_general_error">Unhandled server error</string>
 
+	<string name="protocol_mismatch_section">UPDATE REQUIRED</string>
+	<string name="protocol_mismatch_title_client">Your app is out of date</string>
+	<string name="protocol_mismatch_title_server">The sync server is out of date</string>
+	<string name="protocol_mismatch_body_client">This version of Hammer can no longer sync with the server. Update to the latest version to keep syncing your work.</string>
+	<string name="protocol_mismatch_body_server">The sync server is running an older protocol than this app. The server needs to be updated before syncing will work again.</string>
+	<string name="protocol_mismatch_latest_version">Latest version: %1$s</string>
+	<string name="protocol_mismatch_current_version">You have: %1$s</string>
+	<string name="protocol_mismatch_open_release_button">Get the Update</string>
+	<string name="protocol_mismatch_dismiss_button">Dismiss</string>
+
 	<string name="reauth_title">Reauthorize</string>
 	<string name="reauth_explanation">Your token has expired, please reauthorize with your sync server.</string>
 	<string name="reauth_token_expired">Token Expired</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRoot.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRoot.kt
@@ -12,6 +12,7 @@ import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSear
 import com.darkrockstudios.apps.hammer.common.components.notes.Notes
 import com.darkrockstudios.apps.hammer.common.components.projecthome.ProjectHome
 import com.darkrockstudios.apps.hammer.common.components.projectsync.ProjectSynchronization
+import com.darkrockstudios.apps.hammer.common.components.protocolmismatch.ProtocolMismatch
 import com.darkrockstudios.apps.hammer.common.components.serverreauthentication.ServerReauthentication
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.StoryEditor
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.focusmode.FocusMode
@@ -95,6 +96,8 @@ interface ProjectRoot : AppCloseManager, HammerComponent, BackHandlerOwner {
 		data class GlobalSearchModal(val component: GlobalSearch) : ModalDestination()
 
 		data class FocusModeModal(val component: FocusMode) : ModalDestination()
+
+		data class ProtocolMismatchModal(val component: ProtocolMismatch) : ModalDestination()
 	}
 
 	enum class DestinationTypes(val text: StringResource, val shortText: StringResource) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
@@ -20,6 +20,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.
 import com.darkrockstudios.apps.hammer.common.data.globalsearch.SearchProjectUseCase
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.sync_menu_group
@@ -46,6 +47,7 @@ class ProjectRootComponent(
 	private val encyclopediaService: EncyclopediaService by projectInject()
 	private val settingsRepository: GlobalSettingsStore by inject()
 	private val searchProjectUseCase: SearchProjectUseCase by projectInject()
+	private val protocolMismatchRepository: ProtocolMismatchRepository by inject()
 
 	// Retained on this long-lived parent so search state survives the modal being dismissed/reopened
 	// and config changes; stateKeeper carries the query/filter slice across process death.
@@ -148,6 +150,14 @@ class ProjectRootComponent(
 		pendingDeepLink?.let { link ->
 			pendingDeepLink = null
 			navigateToDeepLink(link)
+		}
+
+		scope.launch {
+			protocolMismatchRepository.mismatches.collect { info ->
+				withContext(dispatcherMain) {
+					modalRouter.showProtocolMismatch(info)
+				}
+			}
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootModalRouter.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootModalRouter.kt
@@ -11,10 +11,12 @@ import com.darkrockstudios.apps.hammer.common.components.globalsearch.GlobalSear
 import com.darkrockstudios.apps.hammer.common.components.globalsearch.SearchResult
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot.ModalDestination.*
 import com.darkrockstudios.apps.hammer.common.components.projectsync.ProjectSynchronizationComponent
+import com.darkrockstudios.apps.hammer.common.components.protocolmismatch.ProtocolMismatchComponent
 import com.darkrockstudios.apps.hammer.common.components.serverreauthentication.ServerReauthenticationComponent
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.focusmode.FocusModeComponent
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchInfo
 import kotlinx.serialization.Serializable
 
 class ProjectRootModalRouter(
@@ -86,6 +88,17 @@ class ProjectRootModalRouter(
 					},
 				)
 			)
+
+			is Config.ProtocolMismatch -> ProtocolMismatchModal(
+				ProtocolMismatchComponent(
+					componentContext,
+					info = ProtocolMismatchInfo(
+						clientProtocolVersion = config.clientProtocolVersion,
+						serverProtocolVersion = config.serverProtocolVersion,
+					),
+					dismissDialog = ::dismissProtocolMismatch,
+				)
+			)
 		}
 
 	fun showProjectSync() {
@@ -109,6 +122,19 @@ class ProjectRootModalRouter(
 	}
 
 	fun dismissGlobalSearch() {
+		navigation.activate(Config.None)
+	}
+
+	fun showProtocolMismatch(info: ProtocolMismatchInfo) {
+		navigation.activate(
+			Config.ProtocolMismatch(
+				clientProtocolVersion = info.clientProtocolVersion,
+				serverProtocolVersion = info.serverProtocolVersion,
+			)
+		)
+	}
+
+	fun dismissProtocolMismatch() {
 		navigation.activate(Config.None)
 	}
 
@@ -140,5 +166,11 @@ class ProjectRootModalRouter(
 
 		@Serializable
 		data class FocusMode(val sceneItem: SceneItem) : Config()
+
+		@Serializable
+		data class ProtocolMismatch(
+			val clientProtocolVersion: Int,
+			val serverProtocolVersion: Int?,
+		) : Config()
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectListModalRouter.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectListModalRouter.kt
@@ -8,8 +8,10 @@ import com.arkivanov.decompose.router.slot.childSlot
 import com.arkivanov.decompose.value.Value
 import com.darkrockstudios.apps.hammer.common.components.projectroot.CloseConfirm
 import com.darkrockstudios.apps.hammer.common.components.projectroot.Router
+import com.darkrockstudios.apps.hammer.common.components.protocolmismatch.ProtocolMismatchComponent
 import com.darkrockstudios.apps.hammer.common.components.serverreauthentication.ServerReauthenticationComponent
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchInfo
 import kotlinx.serialization.Serializable
 
 class ProjectListModalRouter(
@@ -48,6 +50,17 @@ class ProjectListModalRouter(
 					componentContext = componentContext,
 					dismissAuth = ::dismissServerReauthentication,
 					onReauthSuccess = onReauthSuccess,
+				)
+			)
+
+			is Config.ProtocolMismatch -> ProjectsList.ModalDestination.ProtocolMismatch(
+				ProtocolMismatchComponent(
+					componentContext = componentContext,
+					info = ProtocolMismatchInfo(
+						clientProtocolVersion = config.clientProtocolVersion,
+						serverProtocolVersion = config.serverProtocolVersion,
+					),
+					dismissDialog = ::dismissProtocolMismatch,
 				)
 			)
 		}
@@ -92,6 +105,19 @@ class ProjectListModalRouter(
 		navigation.activate(Config.None)
 	}
 
+	fun showProtocolMismatch(info: ProtocolMismatchInfo) {
+		navigation.activate(
+			Config.ProtocolMismatch(
+				clientProtocolVersion = info.clientProtocolVersion,
+				serverProtocolVersion = info.serverProtocolVersion,
+			)
+		)
+	}
+
+	fun dismissProtocolMismatch() {
+		navigation.activate(Config.None)
+	}
+
 	@Serializable
 	sealed class Config {
 		@Serializable
@@ -111,5 +137,11 @@ class ProjectListModalRouter(
 
 		@Serializable
 		data object ServerReauth : Config()
+
+		@Serializable
+		data class ProtocolMismatch(
+			val clientProtocolVersion: Int,
+			val serverProtocolVersion: Int?,
+		) : Config()
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsList.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsList.kt
@@ -98,6 +98,8 @@ interface ProjectsList : HammerComponent, ComponentToaster {
 		data object ProjectCreate : ModalDestination()
 		data class ProjectDelete(val projectDef: ProjectDef) : ModalDestination()
 		data class ServerReauth(val component: ServerReauthentication) : ModalDestination()
+		data class ProtocolMismatch(val component: com.darkrockstudios.apps.hammer.common.components.protocolmismatch.ProtocolMismatch) :
+			ModalDestination()
 	}
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
@@ -26,6 +26,7 @@ import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetada
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.ProjectStatisticsCacheReader
 import com.darkrockstudios.apps.hammer.base.http.storyideas.StoryIdea
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.accountsync.ClientAccountSynchronizer
 import com.darkrockstudios.apps.hammer.common.data.sync.ideassync.IdeaConflict
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ClientProjectSynchronizer
@@ -88,6 +89,7 @@ class ProjectsListComponent(
 	private val globalSettingsStore: GlobalSettingsStore by inject()
 	private val projectsRepository: ProjectsRepository by inject()
 	private val projectsSynchronizer: ClientAccountSynchronizer by inject()
+	private val protocolMismatchRepository: ProtocolMismatchRepository by inject()
 	private val networkConnectivity: NetworkConnectivity by inject()
 	private val projectMetadataDatasource: ProjectMetadataDatasource by inject()
 	private val statisticsCacheReader: ProjectStatisticsCacheReader by inject()
@@ -153,6 +155,17 @@ class ProjectsListComponent(
 		super.onCreate()
 		watchSettingsUpdates()
 		initialProjectSync()
+		watchProtocolMismatch()
+	}
+
+	private fun watchProtocolMismatch() {
+		scope.launch {
+			protocolMismatchRepository.mismatches.collect { info ->
+				withContext(mainDispatcher) {
+					modalRouter.showProtocolMismatch(info)
+				}
+			}
+		}
 	}
 
 	override fun onResume() {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/protocolmismatch/ProtocolMismatch.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/protocolmismatch/ProtocolMismatch.kt
@@ -1,0 +1,21 @@
+package com.darkrockstudios.apps.hammer.common.components.protocolmismatch
+
+import com.arkivanov.decompose.value.Value
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.HammerComponent
+
+interface ProtocolMismatch : HammerComponent {
+	val state: Value<State>
+
+	fun openReleaseUrl()
+	fun dismiss()
+
+	data class State(
+		val clientProtocolVersion: Int,
+		val serverProtocolVersion: Int?,
+		val clientIsBehind: Boolean,
+		val currentVersion: String,
+		val latestVersionTag: String? = null,
+		val isNewVersionAvailable: Boolean = false,
+		val releaseUrl: String? = null,
+	)
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/protocolmismatch/ProtocolMismatchComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/protocolmismatch/ProtocolMismatchComponent.kt
@@ -1,0 +1,60 @@
+package com.darkrockstudios.apps.hammer.common.components.protocolmismatch
+
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.decompose.value.update
+import com.darkrockstudios.apps.hammer.base.GITHUB_URL
+import com.darkrockstudios.apps.hammer.common.components.ComponentBase
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchInfo
+import com.darkrockstudios.apps.hammer.common.data.versioncheck.VersionCheckRepository
+import com.darkrockstudios.apps.hammer.common.util.UrlLauncher
+import com.darkrockstudios.apps.hammer.common.util.getAppVersionString
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.core.component.inject
+
+class ProtocolMismatchComponent(
+	componentContext: ComponentContext,
+	info: ProtocolMismatchInfo,
+	private val dismissDialog: () -> Unit,
+) : ComponentBase(componentContext), ProtocolMismatch {
+
+	private val urlLauncher: UrlLauncher by inject()
+	private val versionCheckRepository: VersionCheckRepository by inject()
+
+	private val _state = MutableValue(
+		ProtocolMismatch.State(
+			clientProtocolVersion = info.clientProtocolVersion,
+			serverProtocolVersion = info.serverProtocolVersion,
+			clientIsBehind = info.clientIsBehind,
+			currentVersion = getAppVersionString(),
+		)
+	)
+	override val state: Value<ProtocolMismatch.State> = _state
+
+	init {
+		scope.launch {
+			val result = versionCheckRepository.checkForUpdate()
+			val release = result.latestRelease
+			withContext(dispatcherMain) {
+				_state.update {
+					it.copy(
+						latestVersionTag = release?.bareVersion,
+						isNewVersionAvailable = result.isNewVersionAvailable,
+						releaseUrl = release?.htmlUrl,
+					)
+				}
+			}
+		}
+	}
+
+	override fun openReleaseUrl() {
+		val url = _state.value.releaseUrl ?: "${GITHUB_URL}releases"
+		urlLauncher.openInBrowser(url)
+	}
+
+	override fun dismiss() {
+		dismissDialog()
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/protocolmismatch/ProtocolMismatchRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/protocolmismatch/ProtocolMismatchRepository.kt
@@ -1,0 +1,42 @@
+package com.darkrockstudios.apps.hammer.common.data.protocolmismatch
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * App-scoped signal that a server rejected the client's protocol version (HTTP 426).
+ * The HTTP layer emits here from a single choke point; UI observes and surfaces the
+ * "update your client" dialog. Conflated with `replay = 1` so a subscriber that
+ * connects after the rejection still sees it.
+ */
+class ProtocolMismatchRepository {
+	private val _mismatches = MutableSharedFlow<ProtocolMismatchInfo>(
+		extraBufferCapacity = 1,
+		replay = 1,
+		onBufferOverflow = BufferOverflow.DROP_OLDEST,
+	)
+	val mismatches: SharedFlow<ProtocolMismatchInfo> = _mismatches
+
+	fun notifyMismatch(clientProtocolVersion: Int, serverProtocolVersion: Int?) {
+		_mismatches.tryEmit(
+			ProtocolMismatchInfo(
+				clientProtocolVersion = clientProtocolVersion,
+				serverProtocolVersion = serverProtocolVersion,
+			)
+		)
+	}
+}
+
+data class ProtocolMismatchInfo(
+	val clientProtocolVersion: Int,
+	val serverProtocolVersion: Int?,
+) {
+	/**
+	 * True when the client should update: the server is on a newer protocol, or the
+	 * direction is unknown (no server version header — the common "update your client"
+	 * case). Only a server that is provably older flips this to false.
+	 */
+	val clientIsBehind: Boolean
+		get() = serverProtocolVersion == null || serverProtocolVersion > clientProtocolVersion
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -94,6 +94,7 @@ import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRe
 import com.darkrockstudios.apps.hammer.common.data.versioncheck.GithubVersionCheckDataSource
 import com.darkrockstudios.apps.hammer.common.data.versioncheck.ShouldNotifyOfUpdateUseCase
 import com.darkrockstudios.apps.hammer.common.data.versioncheck.VersionCheckDataSource
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchRepository
 import com.darkrockstudios.apps.hammer.common.data.versioncheck.VersionCheckRepository
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityDatasource
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityRepository
@@ -155,6 +156,7 @@ val mainModule = module {
 
 	includes(platformModule)
 
+	singleOf(::ProtocolMismatchRepository)
 	single { createHttpClient(get()) } bind HttpClient::class
 	singleOf(::ServerAccountApi)
 	singleOf(::ServerProjectApi)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
@@ -1,8 +1,11 @@
 package com.darkrockstudios.apps.hammer.common.server
 
 import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
 import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispatcher
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.url
 import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
@@ -47,6 +50,7 @@ abstract class Api(
 
 	private val ioDispatcher by injectIoDispatcher()
 	private val localeResolver: DeviceLocaleResolver by inject()
+	private val protocolMismatchRepository: ProtocolMismatchRepository by inject()
 
 	private suspend fun <T> makeRequest(
 		path: String,
@@ -72,6 +76,12 @@ abstract class Api(
 				val value = parse(response)
 				Result.success(value)
 			} else {
+				if (response.status == HttpStatusCode.UpgradeRequired) {
+					protocolMismatchRepository.notifyMismatch(
+						clientProtocolVersion = HAMMER_PROTOCOL_VERSION,
+						serverProtocolVersion = response.headers[HAMMER_PROTOCOL_HEADER]?.toIntOrNull(),
+					)
+				}
 				Result.failure(
 					failureHandler(response)
 				)

--- a/common/src/desktopTest/kotlin/components/projectselection/projectslist/ProjectsListComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/projectslist/ProjectsListComponentTest.kt
@@ -19,12 +19,16 @@ import com.darkrockstudios.apps.hammer.common.data.importer.StoryImporterRegistr
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.ProjectStatisticsCacheReader
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.accountsync.ClientAccountSynchronizer
 import com.darkrockstudios.apps.hammer.common.data.toMsg
+import com.darkrockstudios.apps.hammer.common.data.versioncheck.VersionCheckDataSource
+import com.darkrockstudios.apps.hammer.common.data.versioncheck.VersionCheckRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.util.NetworkConnectivity
 import com.darkrockstudios.apps.hammer.common.util.StrRes
+import com.darkrockstudios.apps.hammer.common.util.UrlLauncher
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -41,6 +45,7 @@ import okio.fakefilesystem.FakeFileSystem
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.dsl.module
+import org.koin.test.get
 import utils.ComponentTest
 import utils.TestStrRes
 import kotlin.test.assertEquals
@@ -107,6 +112,9 @@ class ProjectsListComponentTest : ComponentTest() {
 			single<StrRes> { TestStrRes() }
 			single<Clock> { Clock.System }
 			single { StoryImporterRegistry(listOf(MarkdownStoryImporter(), RtfStoryImporter())) }
+			single<UrlLauncher> { mockk(relaxed = true) }
+			single<VersionCheckDataSource> { mockk(relaxed = true) }
+			single { VersionCheckRepository(get()) }
 		})
 
 		selectedProject = null
@@ -472,6 +480,24 @@ class ProjectsListComponentTest : ComponentTest() {
 				comp.state.value.projects.map { it.definition.name },
 			)
 		}
+
+	@Test
+	fun `a protocol mismatch shows the update dialog`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		// Start the lifecycle so onCreate() subscribes the mismatch observer.
+		context.resume()
+		advanceUntilIdle()
+
+		get<ProtocolMismatchRepository>().notifyMismatch(
+			clientProtocolVersion = 3,
+			serverProtocolVersion = 5,
+		)
+		advanceUntilIdle()
+
+		assertIs<ProjectsList.ModalDestination.ProtocolMismatch>(
+			comp.modalRouterState.value.child?.instance,
+		)
+	}
 
 	@Test
 	fun `loadProjectList skips a project whose metadata fails to load`() =

--- a/common/src/desktopTest/kotlin/components/protocolmismatch/ProtocolMismatchComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/protocolmismatch/ProtocolMismatchComponentTest.kt
@@ -1,0 +1,145 @@
+package components.protocolmismatch
+
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.resume
+import com.darkrockstudios.apps.hammer.base.GITHUB_URL
+import com.darkrockstudios.apps.hammer.common.components.protocolmismatch.ProtocolMismatchComponent
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchInfo
+import com.darkrockstudios.apps.hammer.common.data.versioncheck.GithubReleaseInfo
+import com.darkrockstudios.apps.hammer.common.data.versioncheck.VersionCheckDataSource
+import com.darkrockstudios.apps.hammer.common.data.versioncheck.VersionCheckRepository
+import com.darkrockstudios.apps.hammer.common.util.UrlLauncher
+import com.darkrockstudios.apps.hammer.common.util.getAppVersionString
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.dsl.bind
+import org.koin.dsl.module
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProtocolMismatchComponentTest : BaseTest() {
+
+	private lateinit var lifecycle: LifecycleRegistry
+	private lateinit var context: DefaultComponentContext
+	private lateinit var dataSource: VersionCheckDataSource
+	private lateinit var urlLauncher: UrlLauncher
+	private var dismissed = false
+
+	private val release = GithubReleaseInfo(
+		tagName = "v9.9.9",
+		name = "Big Release",
+		body = "notes",
+		htmlUrl = "https://github.com/Wavesonics/hammer-editor/releases/tag/v9.9.9",
+	)
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+
+		lifecycle = LifecycleRegistry()
+		context = DefaultComponentContext(lifecycle = lifecycle)
+		dataSource = mockk(relaxed = true)
+		urlLauncher = mockk(relaxed = true)
+		dismissed = false
+
+		setupKoin(
+			module {
+				single { dataSource } bind VersionCheckDataSource::class
+				single { VersionCheckRepository(get()) }
+				single { urlLauncher } bind UrlLauncher::class
+			}
+		)
+		lifecycle.resume()
+	}
+
+	private fun newComponent(
+		clientVersion: Int = 3,
+		serverVersion: Int? = 5,
+	) = ProtocolMismatchComponent(
+		componentContext = context,
+		info = ProtocolMismatchInfo(
+			clientProtocolVersion = clientVersion,
+			serverProtocolVersion = serverVersion,
+		),
+		dismissDialog = { dismissed = true },
+	)
+
+	@Test
+	fun `populates state from the latest release`() = runTest {
+		coEvery { dataSource.fetchLatestRelease() } returns release
+
+		val component = newComponent()
+		advanceUntilIdle()
+
+		val state = component.state.value
+		assertEquals("v9.9.9", state.latestVersionTag)
+		assertEquals(release.htmlUrl, state.releaseUrl)
+		assertEquals(getAppVersionString(), state.currentVersion)
+	}
+
+	@Test
+	fun `a newer server protocol means the client is behind`() = runTest {
+		coEvery { dataSource.fetchLatestRelease() } returns release
+
+		val component = newComponent(clientVersion = 3, serverVersion = 5)
+		advanceUntilIdle()
+
+		assertTrue(component.state.value.clientIsBehind)
+	}
+
+	@Test
+	fun `an older server protocol means the server is behind`() = runTest {
+		coEvery { dataSource.fetchLatestRelease() } returns release
+
+		val component = newComponent(clientVersion = 5, serverVersion = 3)
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.clientIsBehind)
+	}
+
+	@Test
+	fun `openReleaseUrl opens the release page`() = runTest {
+		coEvery { dataSource.fetchLatestRelease() } returns release
+
+		val component = newComponent()
+		advanceUntilIdle()
+		component.openReleaseUrl()
+
+		verify { urlLauncher.openInBrowser(release.htmlUrl) }
+	}
+
+	@Test
+	fun `openReleaseUrl falls back to the releases page when no release is known`() = runTest {
+		coEvery { dataSource.fetchLatestRelease() } returns null
+
+		val component = newComponent()
+		advanceUntilIdle()
+		assertNull(component.state.value.releaseUrl)
+
+		component.openReleaseUrl()
+
+		verify { urlLauncher.openInBrowser("${GITHUB_URL}releases") }
+	}
+
+	@Test
+	fun `dismiss invokes the dismiss callback`() = runTest {
+		coEvery { dataSource.fetchLatestRelease() } returns release
+
+		val component = newComponent()
+		advanceUntilIdle()
+		component.dismiss()
+
+		assertTrue(dismissed)
+	}
+}

--- a/common/src/desktopTest/kotlin/server/ProtocolMismatchDetectionTest.kt
+++ b/common/src/desktopTest/kotlin/server/ProtocolMismatchDetectionTest.kt
@@ -1,0 +1,117 @@
+package server
+
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchRepository
+import com.darkrockstudios.apps.hammer.common.server.ServerProjectsApi
+import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.koin.dsl.module
+import org.koin.test.get
+import utils.BaseTest
+import utils.TestStrRes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The server answers a protocol mismatch with 426 Upgrade Required (API errors carry no body,
+ * so the status is the only signal). The client turns that into a mismatch notification.
+ */
+class ProtocolMismatchDetectionTest : BaseTest() {
+
+	private lateinit var globalSettingsStore: GlobalSettingsStore
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+
+		globalSettingsStore = mockk(relaxed = true)
+		every { globalSettingsStore.serverSettings } returns ServerSettings(
+			ssl = false,
+			url = "example.com",
+			email = "user@example.com",
+			userId = 42L,
+			bearerToken = "token",
+			refreshToken = "refresh",
+		)
+
+		setupKoin(
+			module {
+				single { DeviceLocaleResolver() }
+			}
+		)
+	}
+
+	private fun createApi(engine: MockEngine): ServerProjectsApi {
+		val client = HttpClient(engine) {
+			install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+		}
+		return ServerProjectsApi(client, globalSettingsStore, TestStrRes())
+	}
+
+	@Test
+	fun `a 426 response notifies the repository with the server protocol version`() = runTest {
+		val serverVersion = HAMMER_PROTOCOL_VERSION + 2
+		val engine = MockEngine {
+			respond(
+				content = "",
+				status = HttpStatusCode.UpgradeRequired,
+				headers = headersOf(HAMMER_PROTOCOL_HEADER, serverVersion.toString()),
+			)
+		}
+		val api = createApi(engine)
+		val repository = get<ProtocolMismatchRepository>()
+
+		val result = api.endProjectsSync("sync-1")
+
+		assertTrue(result.isFailure)
+		val info = repository.mismatches.replayCache.firstOrNull()
+		assertNotNull(info)
+		assertEquals(HAMMER_PROTOCOL_VERSION, info.clientProtocolVersion)
+		assertEquals(serverVersion, info.serverProtocolVersion)
+		assertTrue(info.clientIsBehind)
+	}
+
+	@Test
+	fun `a 426 without a version header still notifies and defaults to client behind`() = runTest {
+		val engine = MockEngine { respond("", HttpStatusCode.UpgradeRequired) }
+		val api = createApi(engine)
+		val repository = get<ProtocolMismatchRepository>()
+
+		val result = api.endProjectsSync("sync-1")
+
+		assertTrue(result.isFailure)
+		val info = repository.mismatches.replayCache.firstOrNull()
+		assertNotNull(info)
+		assertNull(info.serverProtocolVersion)
+		assertTrue(info.clientIsBehind)
+	}
+
+	@Test
+	fun `an ordinary failure does not notify the repository`() = runTest {
+		val engine = MockEngine { respond("", HttpStatusCode.BadRequest) }
+		val api = createApi(engine)
+		val repository = get<ProtocolMismatchRepository>()
+
+		val result = api.endProjectsSync("sync-1")
+
+		assertTrue(result.isFailure)
+		assertTrue(repository.mismatches.replayCache.isEmpty())
+	}
+}

--- a/common/src/desktopTest/kotlin/utils/BaseTest.kt
+++ b/common/src/desktopTest/kotlin/utils/BaseTest.kt
@@ -1,5 +1,6 @@
 package utils
 
+import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_IO
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_MAIN
@@ -63,6 +64,7 @@ open class BaseTest : KoinTest {
 							name = "IO dispatcher"
 						)
 					}
+					single { ProtocolMismatchRepository() }
 				},
 				*modules
 			)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootUi.kt
@@ -37,6 +37,7 @@ import com.darkrockstudios.apps.hammer.common.notes.NotesFab
 import com.darkrockstudios.apps.hammer.common.notes.NotesUi
 import com.darkrockstudios.apps.hammer.common.projecthome.ProjectHomeUi
 import com.darkrockstudios.apps.hammer.common.projectsync.ProjectSynchronization
+import com.darkrockstudios.apps.hammer.common.protocolmismatch.ProtocolMismatchDialog
 import com.darkrockstudios.apps.hammer.common.reauthentication.ReauthenticationUi
 import com.darkrockstudios.apps.hammer.common.storyeditor.StoryEditorUi
 import com.darkrockstudios.apps.hammer.common.storyeditor.focusmode.FocusModeUi
@@ -169,6 +170,10 @@ fun ModalContent(component: ProjectRoot, showSnackbar: (String) -> Unit) {
 
 		is ProjectRoot.ModalDestination.FocusModeModal -> {
 			FocusModeModalContent(overlay.component)
+		}
+
+		is ProjectRoot.ModalDestination.ProtocolMismatchModal -> {
+			ProtocolMismatchDialog(overlay.component)
 		}
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
@@ -72,6 +72,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdTagChip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdToolButton
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
+import com.darkrockstudios.apps.hammer.common.protocolmismatch.ProtocolMismatchDialog
 import com.darkrockstudios.apps.hammer.common.reauthentication.ReauthenticationUi
 import com.darkrockstudios.apps.hammer.project_select_project_list_empty
 import com.darkrockstudios.apps.hammer.projects_list_create_button
@@ -637,6 +638,10 @@ fun ModalContent(component: ProjectsList, rootSnackbar: RootSnackbarHostState) {
 
 		is ProjectsList.ModalDestination.ServerReauth -> {
 			ReauthenticationUi(overlay.component)
+		}
+
+		is ProjectsList.ModalDestination.ProtocolMismatch -> {
+			ProtocolMismatchDialog(overlay.component)
 		}
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/protocolmismatch/ProtocolMismatchDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/protocolmismatch/ProtocolMismatchDialog.kt
@@ -49,50 +49,68 @@ import korlibs.io.lang.format
 @Composable
 fun ProtocolMismatchDialog(component: ProtocolMismatch) {
 	val state by component.state.subscribeAsState()
-	val versionTag = state.latestVersionTag
 	AnimatedDialog(
 		visible = true,
 		onCloseRequest = { component.dismiss() },
 		modifier = Modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-		Surface(
-			shape = RectangleShape,
-			color = MaterialTheme.colorScheme.surface,
-			contentColor = MaterialTheme.colorScheme.onSurface,
-			shadowElevation = Ui.Elevation.LARGE,
-			modifier = Modifier
-				.padding(horizontal = Ui.Padding.XL)
-				.widthIn(max = 560.dp)
-				.fillMaxWidth(),
-		) {
-			Column {
-				HdMasthead(
-					section = Res.string.protocol_mismatch_section.get(),
-					leadingMeta = listOfNotNull(versionTag),
-					trailing = {
-						HdMastheadAction(
-							label = "× CLOSE",
-							onClick = { component.dismiss() },
-						)
-					},
-				)
-				HdFolioDivider()
-				Body(
-					clientIsBehind = state.clientIsBehind,
-					currentVersion = state.currentVersion,
-					latestVersionTag = versionTag,
-					showLatestVersion = state.isNewVersionAvailable,
-				)
-				HorizontalDivider(
-					color = MaterialTheme.colorScheme.outlineVariant,
-					thickness = 1.dp,
-				)
-				Footer(
-					onOpenRelease = component::openReleaseUrl,
-					onDismiss = component::dismiss,
-				)
-			}
+		ProtocolMismatchContent(
+			state = state,
+			onOpenRelease = component::openReleaseUrl,
+			onDismiss = component::dismiss,
+		)
+	}
+}
+
+/**
+ * The dialog's chrome without the animated [AnimatedDialog] window wrapper, so it can be
+ * rendered directly in a Compose preview (the live dialog hangs in its own window and won't
+ * settle to a static frame).
+ */
+@Composable
+fun ProtocolMismatchContent(
+	state: ProtocolMismatch.State,
+	onOpenRelease: () -> Unit,
+	onDismiss: () -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	Surface(
+		shape = RectangleShape,
+		color = MaterialTheme.colorScheme.surface,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+		shadowElevation = Ui.Elevation.LARGE,
+		modifier = modifier
+			.padding(horizontal = Ui.Padding.XL)
+			.widthIn(max = 560.dp)
+			.fillMaxWidth(),
+	) {
+		Column {
+			HdMasthead(
+				section = Res.string.protocol_mismatch_section.get(),
+				leadingMeta = listOfNotNull(state.latestVersionTag),
+				trailing = {
+					HdMastheadAction(
+						label = "× CLOSE",
+						onClick = onDismiss,
+					)
+				},
+			)
+			HdFolioDivider()
+			Body(
+				clientIsBehind = state.clientIsBehind,
+				currentVersion = state.currentVersion,
+				latestVersionTag = state.latestVersionTag,
+				showLatestVersion = state.isNewVersionAvailable,
+			)
+			HorizontalDivider(
+				color = MaterialTheme.colorScheme.outlineVariant,
+				thickness = 1.dp,
+			)
+			Footer(
+				onOpenRelease = onOpenRelease,
+				onDismiss = onDismiss,
+			)
 		}
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/protocolmismatch/ProtocolMismatchDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/protocolmismatch/ProtocolMismatchDialog.kt
@@ -49,7 +49,7 @@ import korlibs.io.lang.format
 @Composable
 fun ProtocolMismatchDialog(component: ProtocolMismatch) {
 	val state by component.state.subscribeAsState()
-	val versionTag = state.latestVersionTag?.let { "v$it" }
+	val versionTag = state.latestVersionTag
 	AnimatedDialog(
 		visible = true,
 		onCloseRequest = { component.dismiss() },

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/protocolmismatch/ProtocolMismatchDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/protocolmismatch/ProtocolMismatchDialog.kt
@@ -1,0 +1,179 @@
+package com.darkrockstudios.apps.hammer.common.protocolmismatch
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.common.components.protocolmismatch.ProtocolMismatch
+import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialog
+import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMasthead
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
+import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.protocol_mismatch_body_client
+import com.darkrockstudios.apps.hammer.protocol_mismatch_body_server
+import com.darkrockstudios.apps.hammer.protocol_mismatch_current_version
+import com.darkrockstudios.apps.hammer.protocol_mismatch_dismiss_button
+import com.darkrockstudios.apps.hammer.protocol_mismatch_latest_version
+import com.darkrockstudios.apps.hammer.protocol_mismatch_open_release_button
+import com.darkrockstudios.apps.hammer.protocol_mismatch_section
+import com.darkrockstudios.apps.hammer.protocol_mismatch_title_client
+import com.darkrockstudios.apps.hammer.protocol_mismatch_title_server
+import korlibs.io.lang.format
+
+@Composable
+fun ProtocolMismatchDialog(component: ProtocolMismatch) {
+	val state by component.state.subscribeAsState()
+	val versionTag = state.latestVersionTag?.let { "v$it" }
+	AnimatedDialog(
+		visible = true,
+		onCloseRequest = { component.dismiss() },
+		modifier = Modifier.fillMaxSize(),
+		contentAlignment = Alignment.Center,
+	) {
+		Surface(
+			shape = RectangleShape,
+			color = MaterialTheme.colorScheme.surface,
+			contentColor = MaterialTheme.colorScheme.onSurface,
+			shadowElevation = Ui.Elevation.LARGE,
+			modifier = Modifier
+				.padding(horizontal = Ui.Padding.XL)
+				.widthIn(max = 560.dp)
+				.fillMaxWidth(),
+		) {
+			Column {
+				HdMasthead(
+					section = Res.string.protocol_mismatch_section.get(),
+					leadingMeta = listOfNotNull(versionTag),
+					trailing = {
+						HdMastheadAction(
+							label = "× CLOSE",
+							onClick = { component.dismiss() },
+						)
+					},
+				)
+				HdFolioDivider()
+				Body(
+					clientIsBehind = state.clientIsBehind,
+					currentVersion = state.currentVersion,
+					latestVersionTag = versionTag,
+					showLatestVersion = state.isNewVersionAvailable,
+				)
+				HorizontalDivider(
+					color = MaterialTheme.colorScheme.outlineVariant,
+					thickness = 1.dp,
+				)
+				Footer(
+					onOpenRelease = component::openReleaseUrl,
+					onDismiss = component::dismiss,
+				)
+			}
+		}
+	}
+}
+
+@Composable
+private fun Body(
+	clientIsBehind: Boolean,
+	currentVersion: String,
+	latestVersionTag: String?,
+	showLatestVersion: Boolean,
+) {
+	val title = if (clientIsBehind) {
+		Res.string.protocol_mismatch_title_client.get()
+	} else {
+		Res.string.protocol_mismatch_title_server.get()
+	}
+	val body = if (clientIsBehind) {
+		Res.string.protocol_mismatch_body_client.get()
+	} else {
+		Res.string.protocol_mismatch_body_server.get()
+	}
+	Column(
+		modifier = Modifier.padding(start = 26.dp, end = 26.dp, top = 22.dp, bottom = 22.dp),
+		verticalArrangement = Arrangement.spacedBy(16.dp),
+	) {
+		Text(
+			text = title,
+			style = MaterialTheme.typography.headlineSmall.copy(
+				fontWeight = FontWeight.Normal,
+				letterSpacing = (-0.26).sp,
+				lineHeight = 30.sp,
+			),
+			color = MaterialTheme.colorScheme.onSurface,
+		)
+		Text(
+			text = body,
+			style = MaterialTheme.typography.bodyMedium,
+			color = MaterialTheme.colorScheme.onSurfaceVariant,
+		)
+		Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+			HdMonoLabel(
+				text = Res.string.protocol_mismatch_current_version.get().format(currentVersion),
+			)
+			if (showLatestVersion && latestVersionTag != null) {
+				HdMonoLabel(
+					text = Res.string.protocol_mismatch_latest_version.get().format(latestVersionTag),
+					color = MaterialTheme.colorScheme.primary,
+				)
+			}
+		}
+	}
+}
+
+@Composable
+private fun Footer(
+	onOpenRelease: () -> Unit,
+	onDismiss: () -> Unit,
+) {
+	Row(
+		modifier = Modifier
+			.fillMaxWidth()
+			.background(MaterialTheme.colorScheme.surfaceContainerLow)
+			.padding(start = 22.dp, end = 14.dp, top = 10.dp, bottom = 10.dp),
+		verticalAlignment = Alignment.CenterVertically,
+		horizontalArrangement = Arrangement.spacedBy(10.dp),
+	) {
+		Spacer(modifier = Modifier.weight(1f))
+		TextButton(
+			onClick = onDismiss,
+			shape = RoundedCornerShape(4.dp),
+		) {
+			Text(Res.string.protocol_mismatch_dismiss_button.get())
+		}
+		OutlinedButton(
+			onClick = onOpenRelease,
+			shape = RoundedCornerShape(4.dp),
+			colors = ButtonDefaults.outlinedButtonColors(
+				contentColor = MaterialTheme.colorScheme.primary,
+			),
+		) {
+			Text(Res.string.protocol_mismatch_open_release_button.get())
+		}
+	}
+}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/protocolmismatch/ProtocolMismatchDialog.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/protocolmismatch/ProtocolMismatchDialog.Preview.kt
@@ -1,0 +1,83 @@
+package com.darkrockstudios.apps.hammer.common.preview.protocolmismatch
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.darkrockstudios.apps.hammer.common.components.protocolmismatch.ProtocolMismatch
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.preview.globalSettingsPreview
+import com.darkrockstudios.apps.hammer.common.protocolmismatch.ProtocolMismatchContent
+
+private fun previewState(
+	clientIsBehind: Boolean = true,
+	latestVersionTag: String? = "v9.9.9",
+	isNewVersionAvailable: Boolean = true,
+	releaseUrl: String? = "https://github.com/Wavesonics/hammer-editor/releases/tag/v9.9.9",
+) = ProtocolMismatch.State(
+	clientProtocolVersion = 3,
+	serverProtocolVersion = if (clientIsBehind) 5 else 2,
+	clientIsBehind = clientIsBehind,
+	currentVersion = "v3.5.3",
+	latestVersionTag = latestVersionTag,
+	isNewVersionAvailable = isNewVersionAvailable,
+	releaseUrl = releaseUrl,
+)
+
+@Composable
+private fun ProtocolMismatchPreviewScaffold(
+	state: ProtocolMismatch.State,
+	darkTheme: Boolean,
+) {
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, useDarkTheme = darkTheme) {
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f)),
+				contentAlignment = Alignment.Center,
+			) {
+				ProtocolMismatchContent(
+					state = state,
+					onOpenRelease = {},
+					onDismiss = {},
+				)
+			}
+		}
+	}
+}
+
+@Preview(widthDp = 640, heightDp = 480)
+@Composable
+fun ProtocolMismatchClientBehindPreview() {
+	ProtocolMismatchPreviewScaffold(previewState(), darkTheme = false)
+}
+
+@Preview(widthDp = 640, heightDp = 480)
+@Composable
+fun ProtocolMismatchClientBehindDarkPreview() {
+	ProtocolMismatchPreviewScaffold(previewState(), darkTheme = true)
+}
+
+@Preview(widthDp = 640, heightDp = 480)
+@Composable
+fun ProtocolMismatchServerBehindPreview() {
+	ProtocolMismatchPreviewScaffold(
+		previewState(clientIsBehind = false, isNewVersionAvailable = false),
+		darkTheme = false,
+	)
+}
+
+@Preview(widthDp = 640, heightDp = 480)
+@Composable
+fun ProtocolMismatchNoVersionInfoPreview() {
+	ProtocolMismatchPreviewScaffold(
+		previewState(latestVersionTag = null, isNewVersionAvailable = false, releaseUrl = null),
+		darkTheme = false,
+	)
+}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/ApiProtocolEnforcerPlugin.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/ApiProtocolEnforcerPlugin.kt
@@ -14,6 +14,8 @@ val ApiProtocolEnforcerPlugin = createApplicationPlugin("ProtocolEnforcerPlugin"
 		if (firstPathSegment == API_ROUTE_PREFIX) {
 			val clientProtocolVersion = call.request.headers[HAMMER_PROTOCOL_HEADER]?.toIntOrNull()
 			if (clientProtocolVersion != HAMMER_PROTOCOL_VERSION) {
+				// Echo the server's protocol version so the client can tell which side is behind.
+				call.response.headers.append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
 				throw UnsupportedProtocolVersionException(
 					clientProtocolVersion,
 					HAMMER_PROTOCOL_VERSION

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HttpStatusException.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HttpStatusException.kt
@@ -13,11 +13,15 @@ abstract class HttpStatusException(
 	message: String,
 ) : Exception(message)
 
-/** A request hit an `/api` route without a matching protocol version header. */
+/**
+ * A request hit an `/api` route without a matching protocol version header. Resolves to
+ * 426 Upgrade Required so the client can distinguish a version mismatch from an ordinary
+ * bad request — API error responses carry no body, so the status code is the only signal.
+ */
 class UnsupportedProtocolVersionException(
 	clientVersion: Int?,
 	expectedVersion: Int,
 ) : HttpStatusException(
-	HttpStatusCode.BadRequest,
+	HttpStatusCode.UpgradeRequired,
 	"Unsupported protocol version: $clientVersion (expected: $expectedVersion)",
 )

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProtocolVersionEnforcerTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProtocolVersionEnforcerTest.kt
@@ -1,0 +1,39 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
+import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ProtocolVersionEnforcerTest : EndToEndTest() {
+
+	@Test
+	fun `mismatched protocol version is rejected with 426 and the server version header`(): Unit = runBlocking {
+		doStartServer()
+		val response: HttpResponse = client().get(api("teapot")) {
+			headers {
+				append(HAMMER_PROTOCOL_HEADER, (HAMMER_PROTOCOL_VERSION + 1).toString())
+			}
+		}
+
+		assertEquals(HttpStatusCode.UpgradeRequired, response.status)
+		assertEquals(
+			HAMMER_PROTOCOL_VERSION.toString(),
+			response.headers[HAMMER_PROTOCOL_HEADER],
+		)
+	}
+
+	@Test
+	fun `missing protocol version is rejected with 426`(): Unit = runBlocking {
+		doStartServer()
+		val response: HttpResponse = client().get(api("teapot"))
+
+		assertEquals(HttpStatusCode.UpgradeRequired, response.status)
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/ErrorStatusClassificationTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/ErrorStatusClassificationTest.kt
@@ -10,8 +10,8 @@ import kotlin.test.assertEquals
 class ErrorStatusClassificationTest {
 
 	@Test
-	fun `protocol-version rejections carry their own 400 status`() {
-		assertEquals(400, UnsupportedProtocolVersionException(null, 1).toMonitoredStatus())
+	fun `protocol-version rejections carry their own 426 status`() {
+		assertEquals(426, UnsupportedProtocolVersionException(null, 1).toMonitoredStatus())
 	}
 
 	@Test


### PR DESCRIPTION
## What

When a sync (or any API call) is rejected because the client and server protocol versions don't match, the app now shows a dedicated **"Your app is out of date"** dialog — instead of a generic "sync failed" toast — that tells the user to update, shows the latest available version from GitHub, and offers a **"Get the Update"** button linking to the release.

## Why it needed a server change

API error responses carry **no body** (`Frontend.kt` responds with just a status for `/api/*`), so the client could only ever see a bare `400` for a protocol mismatch — indistinguishable from any other bad request. To make the mismatch reliably detectable, the signal has to be in the **status code**:

- `UnsupportedProtocolVersionException` now returns **426 Upgrade Required** (was 400). Backward-safe: existing clients already treat any non-2xx as a sync failure.
- The protocol enforcer echoes the server's protocol version in an `X-Hammer-Protocol-Version` response header, so the client can tell whether the **client** is behind (→ "update your app") or the **server** is behind (→ "the server is out of date"; relevant for self-hosters).

## How the client detects it

A single choke point, no plumbing through the sync callback chains: `Api.makeRequest` emits to a new app-scoped `ProtocolMismatchRepository` (a conflated flow) whenever a response is `426`. This catches every API call — account sync, project sync, login.

## UI

Mirrors the existing re-auth dialog pattern: a `ProtocolMismatch` modal destination in **both** the projects-list router and the in-editor project router, observed by `ProjectsListComponent` and `ProjectRootComponent`. The `ProtocolMismatchDialog` is styled like the existing `UpdateAvailableDialog` and enriches itself from `VersionCheckRepository` (latest version + release URL).

## Tests

- **Server** — `ProtocolVersionEnforcerTest`: a mismatched/missing protocol version is rejected with `426` and the server-version response header.
- **Client** — `ProtocolMismatchDetectionTest`: a `426` notifies the repository (with and without the version header, defaulting to "client behind"); an ordinary failure does **not** notify.
- `ProtocolMismatchRepository` is registered in the shared test Koin module (`BaseTest`) since `Api` now depends on it. Existing component, synchronizer, and API tests still pass.

## Notes for review

- The mismatch signal replays to new subscribers, so the dialog re-appears each time the user enters the library or a project while the condition persists — intentional for a "must update" state, and dismissable. Happy to gate it to once-per-session if preferred.
- This is forward-looking: the graceful dialog appears for clients built with this change on a future protocol bump. Clients predating it still just fail generically (they have no 426-handling code), which is unavoidable.
