### PR TITLE
Count unsealed writing sessions in project stats

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsService.kt
@@ -170,7 +170,14 @@ class StatisticsService(
 			writingActivityRepository.loadAllLogs().values.forEach { deviceLog ->
 				var deviceTotal = 0
 				deviceLog.sessions.forEach { session ->
-					if (!session.sealed || session.wordsWritten <= 0) return@forEach
+					// Count every session with words, sealed or not. `sealed` is a
+					// lifecycle flag for the extend-vs-open-new merge rules; it only
+					// flips when a *later* write crosses a day/gap boundary, so the
+					// current day's in-progress session is never sealed. Requiring
+					// `sealed` here dropped the most recent day of writing entirely —
+					// zeroing out "today", "this week" and the current streak while
+					// older days still showed in the heatmap.
+					if (session.wordsWritten <= 0) return@forEach
 					val date = session.startedAt.toLocalDateTime(timeZone).date.toString()
 					dailyWordTotals[date] = (dailyWordTotals[date] ?: 0) + session.wordsWritten
 					deviceTotal += session.wordsWritten

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsService.kt
@@ -170,13 +170,7 @@ class StatisticsService(
 			writingActivityRepository.loadAllLogs().values.forEach { deviceLog ->
 				var deviceTotal = 0
 				deviceLog.sessions.forEach { session ->
-					// Count every session with words, sealed or not. `sealed` is a
-					// lifecycle flag for the extend-vs-open-new merge rules; it only
-					// flips when a *later* write crosses a day/gap boundary, so the
-					// current day's in-progress session is never sealed. Requiring
-					// `sealed` here dropped the most recent day of writing entirely —
-					// zeroing out "today", "this week" and the current streak while
-					// older days still showed in the heatmap.
+					// Count every session with words, sealed or not.
 					if (session.wordsWritten <= 0) return@forEach
 					val date = session.startedAt.toLocalDateTime(timeZone).date.toString()
 					dailyWordTotals[date] = (dailyWordTotals[date] ?: 0) + session.wordsWritten

--- a/common/src/desktopTest/kotlin/repositories/statistics/StatisticsServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/statistics/StatisticsServiceTest.kt
@@ -17,6 +17,8 @@ import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineCo
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
 import com.darkrockstudios.apps.hammer.common.data.tree.ImmutableTree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeValue
+import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
+import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingSession
 import com.darkrockstudios.apps.hammer.common.data.writingactivity.WritingActivityRepository
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import io.mockk.*
@@ -198,5 +200,34 @@ class StatisticsServiceTest : BaseTest() {
 			assertEquals(stats, saved.captured)
 			// Calculation flag is reset once finished.
 			assertFalse(service.isCalculating.value)
+		}
+
+	@Test
+	fun `recalculateStatistics counts unsealed sessions in daily totals and per-device`() =
+		runTest(mainTestDispatcher) {
+			// A sealed session (an older, finalized day) plus an unsealed one (the
+			// current, in-progress day). Both must be reflected in the stats; the
+			// unsealed one is the day the user is actively writing.
+			val day1 = Instant.parse("2026-04-27T09:00:00Z")
+			val day2 = Instant.parse("2026-04-28T09:00:00Z")
+			coEvery { writingActivityRepository.loadAllLogs() } returns mapOf(
+				"device-1" to DeviceLog(
+					deviceLabel = "Laptop",
+					sessions = listOf(
+						WritingSession(startedAt = day1, endedAt = day1, wordsWritten = 100, sealed = true),
+						WritingSession(startedAt = day2, endedAt = day2, wordsWritten = 250, sealed = false),
+					),
+				),
+			)
+			coEvery { statisticsRepository.loadStatistics() } returns null
+
+			val stats = makeService().recalculateStatistics()
+
+			// Two distinct calendar days regardless of the host timezone (the two
+			// sessions are 24h apart), and the unsealed (current-day) session must be
+			// counted rather than dropped: 100 sealed + 250 unsealed = 350.
+			assertEquals(2, stats.dailyWordTotals.size)
+			assertEquals(350, stats.dailyWordTotals.values.sum())
+			assertEquals(350, stats.wordsPerDevice["Laptop"])
 		}
 }

--- a/common/src/desktopTest/kotlin/repositories/statistics/StatisticsServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/statistics/StatisticsServiceTest.kt
@@ -207,15 +207,19 @@ class StatisticsServiceTest : BaseTest() {
 		runTest(mainTestDispatcher) {
 			// A sealed session (an older, finalized day) plus an unsealed one (the
 			// current, in-progress day). Both must be reflected in the stats; the
-			// unsealed one is the day the user is actively writing.
+			// unsealed one is the day the user is actively writing. A third, empty
+			// session guards the other side of the filter: sessions with no words
+			// are skipped regardless of their sealed state.
 			val day1 = Instant.parse("2026-04-27T09:00:00Z")
 			val day2 = Instant.parse("2026-04-28T09:00:00Z")
+			val day3 = Instant.parse("2026-04-29T09:00:00Z")
 			coEvery { writingActivityRepository.loadAllLogs() } returns mapOf(
 				"device-1" to DeviceLog(
 					deviceLabel = "Laptop",
 					sessions = listOf(
 						WritingSession(startedAt = day1, endedAt = day1, wordsWritten = 100, sealed = true),
 						WritingSession(startedAt = day2, endedAt = day2, wordsWritten = 250, sealed = false),
+						WritingSession(startedAt = day3, endedAt = day3, wordsWritten = 0, sealed = false),
 					),
 				),
 			)
@@ -223,9 +227,10 @@ class StatisticsServiceTest : BaseTest() {
 
 			val stats = makeService().recalculateStatistics()
 
-			// Two distinct calendar days regardless of the host timezone (the two
-			// sessions are 24h apart), and the unsealed (current-day) session must be
-			// counted rather than dropped: 100 sealed + 250 unsealed = 350.
+			// Only the two word-bearing days appear (the empty session is skipped),
+			// regardless of the host timezone (the sessions are 24h apart), and the
+			// unsealed (current-day) session must be counted rather than dropped:
+			// 100 sealed + 250 unsealed = 350.
 			assertEquals(2, stats.dailyWordTotals.size)
 			assertEquals(350, stats.dailyWordTotals.values.sum())
 			assertEquals(350, stats.wordsPerDevice["Laptop"])


### PR DESCRIPTION
## Problem

Writing-activity stats (Today, This Week, current streak) show **nothing** for actively-writing users — even when the activity heatmap still renders older history.

A user reported this with a full project (8 scenes, ~24k words, activity syncing across 3 devices). Their heatmap showed weeks of data with `Avg weekday 104` / `Avg weekend 213`, yet `This Week +0`, `Today 0`, and current `Streak 0 days` (with `Longest: 3`). Logs confirmed they were actively editing and syncing at the time.

## Root cause

`StatisticsService.recalculateStatistics()` only folded **sealed** sessions into `dailyWordTotals`:

```kotlin
if (!session.sealed || session.wordsWritten <= 0) return@forEach
```

But a session is sealed *lazily* — `WritingSessionTracker` only seals the previous session when a **later** write crosses a calendar-day rollover or a 6h gap. There is no seal-on-close / seal-on-sync / time-based sealing. So the current day's in-progress session is **never** sealed, and the most recent day of writing was dropped entirely — zeroing out Today / This Week / current streak while older sealed days still rendered in the heatmap.

The existing example-project generator already worked around this by force-sealing every fabricated session (`"Every session is sealed so [StatisticsService] counts it."`), which was the tell.

## Fix

Count any session with `wordsWritten > 0`, sealed or not. `sealed` governs the extend-vs-open-new merge lifecycle, not display validity. There is only ever one unsealed tail session per device, and it seals in place at the same `startedAt`, so no double-counting results.

## Tests

Adds a `StatisticsServiceTest` regression: a sealed session plus an unsealed session, asserting both are counted in `dailyWordTotals` and `wordsPerDevice` (timezone-independent).

> Note: I was unable to run the Gradle suite in my sandbox (the 9.5.1 distribution download is blocked by an egress policy), so I'm relying on CI here to execute the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh4WF4WkBF1JoXjzLsiNsL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gh4WF4WkBF1JoXjzLsiNsL)_