### PR TITLE
feat(ios): write logs to disk and add Export Logs to About screen

### DIFF
--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/FileLogger.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/FileLogger.kt
@@ -1,0 +1,134 @@
+package com.darkrockstudios.apps.hammer.common
+
+import io.github.aakira.napier.Antilog
+import io.github.aakira.napier.DebugAntilog
+import io.github.aakira.napier.LogLevel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.launch
+import okio.BufferedSink
+import okio.FileHandle
+import okio.FileNotFoundException
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.buffer
+import kotlin.time.Clock
+
+/**
+ * iOS file logger. Mirrors the Android [com.darkrockstudios.apps.hammer.android.FileLogger]:
+ * it delegates console output to [DebugAntilog] and additionally appends each log line to a
+ * per-run file under [getLogDirectory]. A single consumer coroutine owns the sink so writes
+ * never race.
+ */
+class FileLogger(
+	private val fileSystem: FileSystem = getPlatformFilesystem(),
+	private val clock: Clock = Clock.System,
+	private val scope: CoroutineScope,
+) : Antilog() {
+	private val debugAntilog = DebugAntilog()
+	private val logsDir: Path = requireNotNull(getLogDirectory()) {
+		"getLogDirectory() must be non-null on iOS"
+	}.toPath()
+	private val logFileName = getLogFilename()
+	private val appendBuffer: BufferedSink
+	private val messageChannel = Channel<String>(
+		capacity = Channel.UNLIMITED,
+		onUndeliveredElement = {
+			if (getInDevelopmentMode()) {
+				error("Undelivered log message! $it")
+			}
+		}
+	)
+
+	init {
+		ensureLogsDirectory()
+		appendBuffer = createLogFile().appendingSink().buffer()
+
+		scope.launch {
+			cullLogs()
+			watchForLogs()
+		}
+	}
+
+	// The consumer coroutine is the sole owner of appendBuffer: it writes,
+	// flushes, and closes the sink so no other thread can race it.
+	private suspend fun watchForLogs() {
+		try {
+			messageChannel.consumeEach { message ->
+				appendBuffer.writeUtf8(message)
+				appendBuffer.flush()
+			}
+		} finally {
+			appendBuffer.close()
+		}
+	}
+
+	override fun performLog(
+		priority: LogLevel,
+		tag: String?,
+		throwable: Throwable?,
+		message: String?
+	) {
+		// Delegate to DebugAntilog for console output
+		debugAntilog.log(priority, tag, throwable, message)
+
+		// Write to file
+		if (message != null) {
+			val timestamp = clock.now()
+			val logLine = "$timestamp | $priority | ${tag ?: ""} | $message\n"
+			messageChannel.trySendBlocking(logLine)
+		}
+	}
+
+	fun close() {
+		// Closing the channel ends the consumer, which then closes the sink.
+		messageChannel.close()
+	}
+
+	private fun createLogFile(): FileHandle = fileSystem.openReadWrite(logFileName)
+
+	private fun ensureLogsDirectory() {
+		if (fileSystem.exists(logsDir).not()) {
+			fileSystem.createDirectories(logsDir)
+		}
+	}
+
+	private fun cullLogs() {
+		val backups = getLogs().toMutableList()
+
+		if (backups.size > MAX_LOGS) {
+			val overBudget = backups.size - MAX_LOGS
+			for (ii in 0 until overBudget) {
+				val oldBackup = backups[ii]
+				fileSystem.delete(oldBackup)
+			}
+		}
+	}
+
+	private fun getLogs(): List<Path> {
+		return fileSystem.list(logsDir)
+			.mapNotNull {
+				try {
+					val meta = fileSystem.metadata(it)
+					Pair(it, meta)
+				} catch (_: FileNotFoundException) {
+					null
+				}
+			}
+			.filter { it.second.isRegularFile }
+			.sortedBy { it.second.lastModifiedAtMillis }
+			.map { it.first }
+	}
+
+	private fun getLogFilename(): Path {
+		val time = clock.now().toString().replace(":", "")
+		return logsDir / "$time.txt"
+	}
+
+	companion object {
+		private const val MAX_LOGS = 20
+	}
+}

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/NapierProxy.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/NapierProxy.kt
@@ -1,8 +1,14 @@
 package com.darkrockstudios.apps.hammer.common
 
-import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
 fun debugBuild() {
-	Napier.base(DebugAntilog())
+	// Install the file logger so logs are persisted to disk (and still echoed to the
+	// console, since FileLogger delegates to DebugAntilog). The scope lives for the
+	// lifetime of the app, matching Android's applicationScope.
+	val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+	Napier.base(FileLogger(scope = scope))
 }

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/platform.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/platform.kt
@@ -45,7 +45,17 @@ actual fun getConfigDirectory(): String {
 	return (urls[0] as NSURL).path!!
 }
 
-actual fun getLogDirectory(): String? = null
+private fun getApplicationSupportDirectory(): String {
+	val urls = NSFileManager.defaultManager.URLsForDirectory(
+		directory = NSApplicationSupportDirectory,
+		inDomains = NSUserDomainMask,
+	)
+	return (urls[0] as NSURL).path!!
+}
+
+// Logs live in Application Support (OS-managed, not user-visible, and not purged
+// like Caches), keeping them out of the user-facing Documents/projects directory.
+actual fun getLogDirectory(): String? = "${getApplicationSupportDirectory()}/logs"
 
 fun initializeKoin(extraModules: List<Module>) {
 	val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/PlatformAboutSection.ios.kt
+++ b/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/PlatformAboutSection.ios.kt
@@ -1,11 +1,138 @@
 package com.darkrockstudios.apps.hammer.common.projectselection.about
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.about_logs_export_button
+import com.darkrockstudios.apps.hammer.about_logs_header
 import com.darkrockstudios.apps.hammer.common.components.projectselection.aboutapp.AboutApp
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineSection
+import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.getCacheDirectory
+import com.darkrockstudios.apps.hammer.common.getPlatformFilesystem
+import com.darkrockstudios.apps.hammer.common.platformIoDispatcher
+import com.darkrockstudios.apps.hammer.common.util.zip.zipDirectory
+import io.github.aakira.napier.Napier
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okio.Path
+import okio.Path.Companion.toPath
+import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSURL
+import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIApplication
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
+import platform.UIKit.popoverPresentationController
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 
 @Composable
 actual fun PlatformAboutSection(component: AboutApp, section: Int) {
-	// No-op for iOS - logs aren't written to disk
+	val scope = rememberCoroutineScope()
+	val state by component.state.subscribeAsState()
+	var exporting by remember { mutableStateOf(false) }
+
+	HdHairlineSection(
+		section = section,
+		title = Res.string.about_logs_header.get(),
+	) {
+		HdHairlineButton(
+			label = Res.string.about_logs_export_button.get(),
+			onClick = {
+				if (exporting) return@HdHairlineButton
+				exporting = true
+				scope.launch {
+					exportAndShareLogs(state.logDirectoryPath)
+					exporting = false
+				}
+			},
+		)
+	}
 }
 
-actual val platformAboutSectionCount: Int = 0
+actual val platformAboutSectionCount: Int = 1
+
+private const val LOGS_ZIP_NAME = "hammer-logs.zip"
+
+private suspend fun exportAndShareLogs(logDirPath: String) {
+	val zipPath = withContext(platformIoDispatcher) {
+		val fileSystem = getPlatformFilesystem()
+		val logsDir = logDirPath.toPath()
+
+		val hasLogs = try {
+			fileSystem.exists(logsDir) && fileSystem.list(logsDir).any { it.name.endsWith(".txt") }
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.e("Failed to list log files", e)
+			false
+		}
+
+		if (!hasLogs) {
+			Napier.i("No log files to share")
+			return@withContext null
+		}
+
+		val zipPath = getCacheDirectory().toPath() / LOGS_ZIP_NAME
+		try {
+			if (fileSystem.exists(zipPath)) fileSystem.delete(zipPath)
+			zipDirectory(fileSystem, logsDir, zipPath)
+			zipPath
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.e("Failed to zip logs for sharing", e)
+			null
+		}
+	} ?: return
+
+	presentShareSheet(zipPath)
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun presentShareSheet(zipPath: Path) {
+	val url = NSURL.fileURLWithPath(zipPath.toString())
+
+	dispatch_async(dispatch_get_main_queue()) {
+		val presenter = topViewController()
+		if (presenter == null) {
+			Napier.w("No view controller available to present log share sheet")
+			return@dispatch_async
+		}
+
+		val activityVC = UIActivityViewController(
+			activityItems = listOf(url),
+			applicationActivities = null,
+		)
+
+		// iPad requires a popover anchor; without it UIKit raises.
+		activityVC.popoverPresentationController?.apply {
+			sourceView = presenter.view
+			presenter.view.bounds.useContents {
+				sourceRect = CGRectMake(size.width / 2.0, size.height / 2.0, 0.0, 0.0)
+			}
+		}
+
+		presenter.presentViewController(activityVC, animated = true, completion = null)
+	}
+}
+
+private fun topViewController(): UIViewController? {
+	val scene = UIApplication.sharedApplication.connectedScenes
+		.firstOrNull { it is UIWindowScene } as? UIWindowScene ?: return null
+	val keyWindow = scene.windows.firstOrNull {
+		(it as? UIWindow)?.isKeyWindow() == true
+	} as? UIWindow ?: return null
+
+	var top: UIViewController? = keyWindow.rootViewController
+	while (top?.presentedViewController != null) {
+		top = top.presentedViewController
+	}
+	return top
+}


### PR DESCRIPTION
Brings iOS to parity with Android and Desktop on file-based logging.

## What
- Adds an iOS `FileLogger` that persists Napier logs to disk (while still echoing to the console via `DebugAntilog`).
- `getLogDirectory()` on iOS now returns `Application Support/logs` instead of `null`, keeping logs out of the user-facing Documents/projects directory and safe from Caches purging.
- Installs the file logger in `debugBuild()` on an app-lifetime scope, matching Android's `applicationScope`.
- Adds an **Export Logs** action to the iOS About screen.

## Notes
- Rebased onto current `develop` (was ~71 commits behind); clean rebase, no conflicts.
- iOS-only change; not compiled locally (requires a macOS/Xcode toolchain). Please verify on a Mac before merge.
