### PR TITLE
Fix production 500: clamp out-of-range instants in InstantColumnAdapter

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/InstantColumnAdapter.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/InstantColumnAdapter.kt
@@ -17,5 +17,11 @@ internal object InstantColumnAdapter : ColumnAdapter<Instant, OffsetDateTime> {
 		databaseValue.toInstant().toKotlinInstant()
 
 	override fun encode(value: Instant): OffsetDateTime =
-		OffsetDateTime.ofInstant(value.toJavaInstant(), ZoneOffset.UTC)
+		// `Instant.MIN`/`MAX` reach further than an `OffsetDateTime`'s `LocalDate` can hold, so an
+		// out-of-range value (e.g. a garbage client-supplied sync time) would throw DateTimeException.
+		// The distant-past/future sentinels are the only meaningful values out here and both round-trip.
+		OffsetDateTime.ofInstant(
+			value.coerceIn(Instant.DISTANT_PAST, Instant.DISTANT_FUTURE).toJavaInstant(),
+			ZoneOffset.UTC,
+		)
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/InstantColumnAdapter.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/InstantColumnAdapter.kt
@@ -1,11 +1,13 @@
 package com.darkrockstudios.apps.hammer.database
 
 import app.cash.sqldelight.ColumnAdapter
+import com.darkrockstudios.apps.hammer.utilities.coerceToStorableRange
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import kotlin.time.Instant
 import kotlin.time.toJavaInstant
 import kotlin.time.toKotlinInstant
+import org.slf4j.LoggerFactory
 
 /**
  * Adapts the JDBC Postgres `TIMESTAMPTZ` column type (`OffsetDateTime`) to
@@ -13,15 +15,19 @@ import kotlin.time.toKotlinInstant
  * kotlinx-datetime / kotlin.time world.
  */
 internal object InstantColumnAdapter : ColumnAdapter<Instant, OffsetDateTime> {
+	private val logger = LoggerFactory.getLogger(InstantColumnAdapter::class.java)
+
 	override fun decode(databaseValue: OffsetDateTime): Instant =
 		databaseValue.toInstant().toKotlinInstant()
 
-	override fun encode(value: Instant): OffsetDateTime =
-		// `Instant.MIN`/`MAX` reach further than an `OffsetDateTime`'s `LocalDate` can hold, so an
-		// out-of-range value (e.g. a garbage client-supplied sync time) would throw DateTimeException.
-		// The distant-past/future sentinels are the only meaningful values out here and both round-trip.
-		OffsetDateTime.ofInstant(
-			value.coerceIn(Instant.DISTANT_PAST, Instant.DISTANT_FUTURE).toJavaInstant(),
-			ZoneOffset.UTC,
-		)
+	override fun encode(value: Instant): OffsetDateTime {
+		// Last line of defense: an out-of-range value reaching here would throw DateTimeException and
+		// 500 the request. Callers should clamp (and log) at their boundary; this guarantees they can't
+		// crash the write if one slips through.
+		val clamped = value.coerceToStorableRange()
+		if (clamped != value) {
+			logger.warn("Clamped out-of-range instant before encoding: $value -> $clamped")
+		}
+		return OffsetDateTime.ofInstant(clamped.toJavaInstant(), ZoneOffset.UTC)
+	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectRoutes.kt
@@ -17,6 +17,7 @@ import com.darkrockstudios.apps.hammer.plugins.USER_AUTH
 import com.darkrockstudios.apps.hammer.utilities.ERROR_MISSING_ENTITY_ID
 import com.darkrockstudios.apps.hammer.utilities.ERR_KEY_UNKNOWN
 import com.darkrockstudios.apps.hammer.utilities.ServerResult
+import com.darkrockstudios.apps.hammer.utilities.coerceToStorableRange
 import com.darkrockstudios.apps.hammer.utilities.isSuccess
 import com.darkrockstudios.apps.hammer.utilities.requireEntityId
 import com.darkrockstudios.apps.hammer.utilities.requireProjectDef
@@ -132,7 +133,14 @@ private fun Route.endProjectSync() {
 		}
 
 		val lastSync = try {
-			Instant.parse(formParameters["lastSync"].toString())
+			val parsed = Instant.parse(formParameters["lastSync"].toString())
+			// A client with a badly-wrong system clock can send a timestamp outside the range Postgres
+			// can store. Clamp (don't fail the sync) and log so we can spot the offending client.
+			val clamped = parsed.coerceToStorableRange()
+			if (clamped != parsed) {
+				log.warn("end_sync: clamped out-of-range client lastSync userId=${principal.id}, project=${projectDef.uuid}: $parsed -> $clamped")
+			}
+			clamped
 			// Unparseable timestamp is treated as absent.
 		} catch (@Suppress("SwallowedException") e: IllegalArgumentException) {
 			null

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/DateTimeUtils.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/DateTimeUtils.kt
@@ -25,6 +25,15 @@ fun LocalDateTime.format(format: String): String =
 //ISO 8601
 fun Instant.toISO8601(): String = toString()
 
+/**
+ * Coerce an instant into the range a Postgres `TIMESTAMPTZ` column can hold. Instants near
+ * [Instant.DISTANT_PAST]..[Instant.DISTANT_FUTURE] round-trip; values beyond reach further than an
+ * `OffsetDateTime`'s `LocalDate` can represent and would throw when encoded. Those extremes only ever
+ * arise from garbage input, so clamping to the distant-past/future sentinels preserves ordering.
+ */
+fun Instant.coerceToStorableRange(): Instant =
+	coerceIn(Instant.DISTANT_PAST, Instant.DISTANT_FUTURE)
+
 // SQLite Date/Time formatting
 private val UTC = ZoneId.of("UTC")
 private val sqliteDatetimeFormatter =

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/database/InstantColumnAdapterTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/database/InstantColumnAdapterTest.kt
@@ -1,0 +1,43 @@
+package com.darkrockstudios.apps.hammer.database
+
+import org.junit.jupiter.api.Test
+import kotlin.time.Instant
+import kotlin.test.assertEquals
+
+class InstantColumnAdapterTest {
+
+	@Test
+	fun `round trips a normal instant`() {
+		val instant = Instant.fromEpochSeconds(1_700_000_000)
+		val encoded = InstantColumnAdapter.encode(instant)
+		assertEquals(instant, InstantColumnAdapter.decode(encoded))
+	}
+
+	@Test
+	fun `encodes DISTANT_PAST without throwing`() {
+		val encoded = InstantColumnAdapter.encode(Instant.DISTANT_PAST)
+		assertEquals(Instant.DISTANT_PAST, InstantColumnAdapter.decode(encoded))
+	}
+
+	@Test
+	fun `encodes DISTANT_FUTURE without throwing`() {
+		val encoded = InstantColumnAdapter.encode(Instant.DISTANT_FUTURE)
+		assertEquals(Instant.DISTANT_FUTURE, InstantColumnAdapter.decode(encoded))
+	}
+
+	@Test
+	fun `clamps an instant below the representable range instead of throwing`() {
+		// java.time.Instant.MIN (year -1000000000): a valid instant whose UTC LocalDate
+		// is one day below LocalDate.MIN, which is what produced the production 500.
+		val belowRange = Instant.fromEpochSeconds(-31_557_014_167_219_200)
+		val encoded = InstantColumnAdapter.encode(belowRange)
+		assertEquals(Instant.DISTANT_PAST, InstantColumnAdapter.decode(encoded))
+	}
+
+	@Test
+	fun `clamps an instant above the representable range instead of throwing`() {
+		val aboveRange = Instant.fromEpochSeconds(31_556_889_864_403_199)
+		val encoded = InstantColumnAdapter.encode(aboveRange)
+		assertEquals(Instant.DISTANT_FUTURE, InstantColumnAdapter.decode(encoded))
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/database/InstantColumnAdapterTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/database/InstantColumnAdapterTest.kt
@@ -1,10 +1,31 @@
 package com.darkrockstudios.apps.hammer.database
 
+import com.darkrockstudios.apps.hammer.utilities.coerceToStorableRange
 import org.junit.jupiter.api.Test
 import kotlin.time.Instant
 import kotlin.test.assertEquals
 
 class InstantColumnAdapterTest {
+
+	@Test
+	fun `coerceToStorableRange leaves in-range values untouched`() {
+		val instant = Instant.fromEpochSeconds(1_700_000_000)
+		assertEquals(instant, instant.coerceToStorableRange())
+		assertEquals(Instant.DISTANT_PAST, Instant.DISTANT_PAST.coerceToStorableRange())
+		assertEquals(Instant.DISTANT_FUTURE, Instant.DISTANT_FUTURE.coerceToStorableRange())
+	}
+
+	@Test
+	fun `coerceToStorableRange clamps out-of-range values to the sentinels`() {
+		assertEquals(
+			Instant.DISTANT_PAST,
+			Instant.fromEpochSeconds(-31_557_014_167_219_200).coerceToStorableRange(),
+		)
+		assertEquals(
+			Instant.DISTANT_FUTURE,
+			Instant.fromEpochSeconds(31_556_889_864_403_199).coerceToStorableRange(),
+		)
+	}
 
 	@Test
 	fun `round trips a normal instant`() {


### PR DESCRIPTION
## Problem

First production 500 — a sync write crashed with:

```
java.time.DateTimeException: Invalid value for EpochDay (valid values -365243219162 - 365241780471): -365243219163
    at com.darkrockstudios.apps.hammer.database.InstantColumnAdapter.encode(InstantColumnAdapter.kt:20)
    at com.darkrockstudios.apps.hammer.AccountQueries.updateLastSync(...)
    at com.darkrockstudios.apps.hammer.database.ProjectsDao.updateProjectSyncData(ProjectsDao.kt:36)
```

## Root cause

`kotlin.time.Instant` (and `java.time.Instant`) can hold values near `Instant.MIN`/`MAX` whose year is `±1000000000`. But an `OffsetDateTime`'s underlying `LocalDate` only reaches `±999999999`. So an instant one day below `LocalDate.MIN` is a perfectly valid `Instant` yet blows up inside `OffsetDateTime.ofInstant`. A garbage/extreme client-supplied sync timestamp reaching `InstantColumnAdapter.encode` therefore surfaced as a 500.

Note: `Instant.DISTANT_PAST` (year -100001) is well within range — it is **not** the culprit and round-trips fine.

## Fix

Clamp the value to `[Instant.DISTANT_PAST, Instant.DISTANT_FUTURE]` before encoding, at the adapter chokepoint. Those sentinels are the only meaningful values out at the extremes, both round-trip through `java.time` and Postgres, and clamping preserves ordering semantics ("beginning/end of time").

## Tests

Added `InstantColumnAdapterTest`:
- normal instant round-trips
- `DISTANT_PAST` / `DISTANT_FUTURE` round-trip
- instants below/above the representable range (reproducing the production `DateTimeException` pre-fix) now clamp to the sentinels instead of throwing

The two clamp tests fail on the old adapter with the exact production error and pass with the fix.