### PR TITLE
Add iOS uncaught-exception handler with crash dump logging

### DIFF
--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/NapierProxy.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/NapierProxy.kt
@@ -1,9 +1,15 @@
 package com.darkrockstudios.apps.hammer.common
 
+import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import okio.Path.Companion.toPath
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.setUnhandledExceptionHook
+import kotlin.native.terminateWithUnhandledException
+import kotlin.time.Clock
 
 fun debugBuild() {
 	// Install the file logger so logs are persisted to disk (and still echoed to the
@@ -11,4 +17,35 @@ fun debugBuild() {
 	// lifetime of the app, matching Android's applicationScope.
 	val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 	Napier.base(FileLogger(scope = scope))
+	installGlobalExceptionHandler()
+}
+
+/**
+ * Catch, log, and write a crash dump for any otherwise-unhandled Kotlin exception before the app
+ * dies, then hand back to the runtime so the OS still records its own crash report. Mirrors the
+ * desktop/Android handlers. Note the narrower reach: only Kotlin exceptions (including those
+ * crossing the Kotlin→Obj-C interop boundary) reach this hook — pure Obj-C NSExceptions and native
+ * signals (e.g. SIGSEGV) are not caught here.
+ */
+@OptIn(ExperimentalNativeApi::class)
+private fun installGlobalExceptionHandler() {
+	setUnhandledExceptionHook { throwable ->
+		runCatching { Napier.e("Uncaught exception, terminating", throwable) }
+		runCatching { writeCrashDump(throwable) }
+		// Preserve the standard termination so a native crash report is still produced.
+		terminateWithUnhandledException(throwable)
+	}
+}
+
+/** Synchronous, self-contained crash record in the logs dir — the guaranteed artifact when the app dies. */
+private fun writeCrashDump(throwable: Throwable) {
+	val dir = getLogDirectory()?.toPath() ?: return
+	val fileSystem = getPlatformFilesystem()
+	fileSystem.createDirectories(dir)
+	val file = dir / "crash-${Clock.System.now().toEpochMilliseconds()}.txt"
+	fileSystem.write(file) {
+		writeUtf8("Hammer v${BuildMetadata.APP_VERSION} | ${platformStartupInfo()}\n")
+		writeUtf8("Uncaught exception\n\n")
+		writeUtf8(throwable.stackTraceToString())
+	}
 }


### PR DESCRIPTION
Follows up the Android/desktop crash logging by adding the iOS equivalent, so unhandled crashes leave a stack trace on disk instead of vanishing.

## What it does
- Installs a Kotlin/Native `setUnhandledExceptionHook` alongside the iOS file logger in `debugBuild()`.
- Logs the throwable via Napier and writes a synchronous `crash-<ts>.txt` to the logs dir (`getLogDirectory()`), matching where the iOS `FileLogger` writes.
- Calls `terminateWithUnhandledException` afterwards so the OS still produces its own crash report.

## Limitations
- Only Kotlin exceptions reach the hook, including those crossing the Kotlin/Obj-C interop boundary (e.g. Compose/UIKit callbacks). Pure Obj-C `NSException`s and native signals (SIGSEGV/SIGABRT) are not caught.
- Not build-verified yet: Apple targets need a macOS toolchain, which wasn't available where this was written. APIs and imports were checked against existing codebase usage, but a macOS build should confirm before merge.
- `debugBuild()` is the install point; if release builds don't call it they won't get the handler (or file logging).