### PR TITLE
Filter bounces from story reader stats with a dwell-gated beacon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,16 @@ jobs:
       # only run as a side-effect of koverXmlReport, which is fragile - a kover config change would
       # silently stop running them.
       - name: Run Server Unit Tests
+        id: server-tests
         run: ./gradlew :server:test
+      - name: Upload server test report on failure
+        if: failure() && steps.server-tests.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-tests-report
+          path: |
+            server/build/reports/tests/test/
+            server/build/test-results/test/
       - name: Run JavaScript Unit Tests
         run: ./gradlew :server:jsTest
       - name: Run Server Migration Tests

--- a/server/src/jsTest/story-reader-logic.test.js
+++ b/server/src/jsTest/story-reader-logic.test.js
@@ -1,0 +1,113 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createDwellTracker } = require('../main/resources/assets/js/story-reader-logic.js');
+
+const STORY_KEY = '/a/jane/my-story-abc123';
+
+// A controllable clock plus in-memory storage, so dwell accumulation is fully
+// deterministic — no real time, no sessionStorage. `advance` moves the clock;
+// `store` is inspectable so tests can assert what got persisted across pages.
+function harness(initialStore) {
+	let clock = 0;
+	const store = Object.assign({}, initialStore);
+	return {
+		advance(ms) { clock += ms; },
+		now() { return clock; },
+		store,
+		storage: {
+			get(key) { return key in store ? store[key] : null; },
+			set(key, value) { store[key] = String(value); },
+		},
+	};
+}
+
+function makeTracker(h, overrides) {
+	return createDwellTracker(Object.assign({
+		thresholdMs: 10000,
+		now: h.now,
+		storage: h.storage,
+		storyKey: STORY_KEY,
+	}, overrides));
+}
+
+test('the threshold is reached only after the full dwell time is visible', () => {
+	const h = harness();
+	const tr = makeTracker(h);
+	tr.resume();
+
+	h.advance(9000);
+	assert.equal(tr.thresholdReached(), false); // 9s < 10s
+
+	h.advance(1000);
+	assert.equal(tr.thresholdReached(), true); // 10s hits the threshold
+});
+
+test('time while paused (hidden tab) does not count toward dwell', () => {
+	const h = harness();
+	const tr = makeTracker(h);
+
+	tr.resume();
+	h.advance(5000);
+	tr.pause(); // tab hidden
+
+	h.advance(3600000); // an hour in the background — must not count
+	tr.resume(); // tab visible again
+
+	h.advance(4000);
+	assert.equal(tr.thresholdReached(), false); // accrues, then checks
+	assert.equal(tr.dwellMs(), 9000); // only the 5s + 4s of visible time
+
+	h.advance(1000);
+	assert.equal(tr.thresholdReached(), true);
+});
+
+test('dwell carries across page turns through storage', () => {
+	const h = harness();
+
+	// Page 1: reader spends 6s, then navigates (pagehide persists the total).
+	const page1 = makeTracker(h);
+	page1.resume();
+	h.advance(6000);
+	page1.accrue();
+	assert.equal(page1.thresholdReached(), false);
+
+	// Page 2: a brand-new tracker (full reload) resumes from the persisted 6s.
+	const page2 = makeTracker(h);
+	page2.resume();
+	h.advance(5000);
+	assert.equal(page2.thresholdReached(), true); // 6s + 5s crosses 10s
+});
+
+test('a persisted over-threshold dwell is reached on the first check after resume', () => {
+	const h = harness({ ['hammer.readDwell:' + STORY_KEY]: '9500' });
+	const tr = makeTracker(h);
+
+	tr.resume();
+	h.advance(1000);
+	assert.equal(tr.thresholdReached(), true);
+});
+
+test('markSent persists and is seen by a later tracker for the same story', () => {
+	const h = harness();
+
+	const first = makeTracker(h);
+	assert.equal(first.alreadySent(), false);
+	first.markSent();
+	assert.equal(first.alreadySent(), true);
+
+	// A later page reload constructs a fresh tracker and sees it already counted.
+	const later = makeTracker(h);
+	assert.equal(later.alreadySent(), true);
+});
+
+test('dwell is scoped per story path so a different story starts fresh', () => {
+	const h = harness();
+
+	const storyA = makeTracker(h, { storyKey: '/a/jane/story-a' });
+	storyA.resume();
+	h.advance(8000);
+	storyA.accrue();
+
+	const storyB = makeTracker(h, { storyKey: '/a/jane/story-b' });
+	assert.equal(storyB.dwellMs(), 0);
+});

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
@@ -137,7 +137,9 @@ fun mainModule(
 	singleOf(::MetricsCollector)
 	singleOf(::UserActivityCollector)
 	singleOf(::UserActivityRepository)
-	singleOf(::StoryReaderCollector)
+	// Explicit ctor: maxPendingKeys has a default, but a constructor reference would
+	// make Koin try to inject the Int rather than honor it.
+	single { StoryReaderCollector(clock = get()) }
 	singleOf(::StoryReaderRepository)
 	single { MonitoringState() }
 	single { RecurringTaskRegistry() }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PublicStoryPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PublicStoryPage.kt
@@ -99,17 +99,11 @@ fun Route.publicStoryPage(
 					val indexable = password.isNullOrBlank() && account.community_member
 					call.applyRobotsTag(indexable = indexable)
 
-					// Best-effort unique-reader count, skipping the author viewing their own story.
-					val viewerId = call.sessions.get<UserSession>()?.userId
-					if (viewerId != resolved.userId) {
-						projectDao.getProjectIdOrNull(resolved.userId, resolved.projectUuid)?.let { projectId ->
-							storyReaderCollector.record(
-								projectId = projectId,
-								clientIp = call.request.origin.remoteAddress,
-								userAgent = call.request.userAgent(),
-							)
-						}
-					}
+					// The unique-reader count is no longer recorded here on page load — that
+					// counts everyone who clicks, including bounces. Instead the page loads a
+					// tiny script that fires a beacon to POST .../read once the visitor has
+					// actually dwelt on the page for a few seconds (see story-reader.js). That
+					// beacon is what best-effort filters out drive-by clicks.
 
 					val exportResult = storyExportService.exportStoryAsHtmlPaginated(
 						userId = resolved.userId,
@@ -130,6 +124,7 @@ fun Route.publicStoryPage(
 							val model = call.withDefaults(
 								mapOf(
 									"page_stylesheet" to "/assets/css/story.css",
+									"page_script" to "/assets/js/story-reader.js",
 									"projectName" to data.projectName,
 									"authorPenName" to resolved.penName,
 									"authorPenNameUrl" to ProjectName.penNameForUrl(resolved.penName),
@@ -197,6 +192,56 @@ fun Route.publicStoryPage(
 			} else {
 				call.respondRedirect("/a/$penNameParam/$projectNameParam")
 			}
+		}
+
+		// Best-effort "reader" beacon. story-reader.js fires this only after the visitor
+		// has actually dwelt on the page for a few seconds, so drive-by clicks (bounces)
+		// never reach here. Resolution mirrors the GET exactly — including the author-skip
+		// and access checks — so a beacon can only record a read the visitor could load.
+		post("/read") {
+			val penNameParam = call.parameters["penName"]
+			val projectNameParam = call.parameters["projectName"]
+
+			// A beacon is fire-and-forget: always answer 204 and never leak resolution
+			// outcomes, so a bad beacon looks the same as a good one.
+			if (penNameParam.isNullOrBlank() || projectNameParam.isNullOrBlank()) {
+				call.respond(HttpStatusCode.NoContent)
+				return@post
+			}
+
+			val password = call.request.queryParameters["p"]
+
+			val account = resolveByPenName(penNameParam) { accountsRepository.findAccountByPenName(it) }
+			val penName = account?.pen_name
+			if (account == null || penName == null) {
+				call.respond(HttpStatusCode.NoContent)
+				return@post
+			}
+
+			val projectShortId = ProjectName.idFromSegment(projectNameParam)
+			val projectName = projectsRepository.getProjectsWithSyncDate(account.id)
+				.find { ProjectName.shortId(it.uuid) == projectShortId }?.name
+			if (projectName == null) {
+				call.respond(HttpStatusCode.NoContent)
+				return@post
+			}
+
+			val resolved = projectAccessRepository.findAccessibleProject(penName, projectName, password)
+			if (resolved is PublicProjectResult.Success) {
+				// Skip the author reading their own story.
+				val viewerId = call.sessions.get<UserSession>()?.userId
+				if (viewerId != resolved.userId) {
+					projectDao.getProjectIdOrNull(resolved.userId, resolved.projectUuid)?.let { projectId ->
+						storyReaderCollector.record(
+							projectId = projectId,
+							clientIp = call.request.origin.remoteAddress,
+							userAgent = call.request.userAgent(),
+						)
+					}
+				}
+			}
+
+			call.respond(HttpStatusCode.NoContent)
 		}
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PublicStoryPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PublicStoryPage.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.account.AccountsRepository
 import com.darkrockstudios.apps.hammer.database.ProjectDao
 import com.darkrockstudios.apps.hammer.frontend.data.UserSession
 import com.darkrockstudios.apps.hammer.frontend.utils.ProjectName
+import com.darkrockstudios.apps.hammer.frontend.utils.findProjectByUrlSegment
 import com.darkrockstudios.apps.hammer.frontend.utils.resolveByPenName
 import com.darkrockstudios.apps.hammer.monitoring.StoryReaderCollector
 import com.darkrockstudios.apps.hammer.project.access.ProjectAccessRepository
@@ -56,9 +57,7 @@ fun Route.publicStoryPage(
 
 			// Resolve the project by the id embedded in its URL segment, scoped to this author's
 			// projects; the slug beside the id is decorative and ignored.
-			val projectId = ProjectName.idFromSegment(projectNameParam)
-			val projectName = projectsRepository.getProjectsWithSyncDate(account.id)
-				.find { ProjectName.shortId(it.uuid) == projectId }?.name
+			val projectName = projectsRepository.findProjectByUrlSegment(account.id, projectNameParam)?.name
 			if (projectName == null) {
 				call.respond(HttpStatusCode.NotFound)
 				return@get
@@ -124,6 +123,7 @@ fun Route.publicStoryPage(
 							val model = call.withDefaults(
 								mapOf(
 									"page_stylesheet" to "/assets/css/story.css",
+									"page_pre_script" to "/assets/js/story-reader-logic.js",
 									"page_script" to "/assets/js/story-reader.js",
 									"projectName" to data.projectName,
 									"authorPenName" to resolved.penName,
@@ -218,9 +218,7 @@ fun Route.publicStoryPage(
 				return@post
 			}
 
-			val projectShortId = ProjectName.idFromSegment(projectNameParam)
-			val projectName = projectsRepository.getProjectsWithSyncDate(account.id)
-				.find { ProjectName.shortId(it.uuid) == projectShortId }?.name
+			val projectName = projectsRepository.findProjectByUrlSegment(account.id, projectNameParam)?.name
 			if (projectName == null) {
 				call.respond(HttpStatusCode.NoContent)
 				return@post

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/StoryReaderCollector.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/StoryReaderCollector.kt
@@ -28,6 +28,7 @@ import kotlin.time.Instant
  */
 class StoryReaderCollector(
 	private val clock: Clock,
+	private val maxPendingKeys: Int = MAX_PENDING_KEYS,
 ) {
 	@Volatile
 	private var collecting: Boolean = true
@@ -48,6 +49,13 @@ class StoryReaderCollector(
 
 	fun record(projectId: Long, clientIp: String?, userAgent: String?) {
 		if (!collecting) return
+		// Backstop against a flood of distinct keys (e.g. someone hammering the read
+		// beacon with varied user-agents) growing the set without bound between the
+		// once-a-minute drains. Past the cap we simply shed new reads until the next
+		// drain frees the set — a best-effort metric may undercount under abuse, but
+		// it must not exhaust memory. The cap sits far above any legitimate
+		// unique-reader volume in a single drain window.
+		if (keys.size >= maxPendingKeys) return
 		val now = clock.now()
 		val epochDay = now.epochSeconds / SECONDS_PER_DAY
 		val dailySalt = currentSalt(epochDay)
@@ -89,6 +97,11 @@ class StoryReaderCollector(
 	private companion object {
 		const val SECONDS_PER_DAY = 86_400L
 		const val SALT_BYTES = 32
+
+		// Upper bound on distinct keys held between drains (~once a minute). Well
+		// above any real per-minute unique-reader count; only an abusive flood of
+		// varied keys reaches it, at which point excess reads are shed to cap memory.
+		const val MAX_PENDING_KEYS = 100_000
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/StoryReaderCollector.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/StoryReaderCollector.kt
@@ -17,6 +17,11 @@ import kotlin.time.Instant
  * rotated every UTC day — never persisted — so the hash can't be reversed to an IP
  * nor linked across days. The raw IP is consumed here and never stored.
  *
+ * A view is only recorded once the reader has actually dwelt on the page for a few
+ * seconds — the public page fires a beacon on a client-side timer (story-reader.js)
+ * rather than counting on page load — so drive-by clicks (bounces) never reach
+ * [record]. That's a best-effort filter, not a guarantee.
+ *
  * Recording is a lock-light concurrent-set add and a cheap no-op when
  * [setCollecting] has been told the feature is off. The maintenance job
  * periodically [drainToKeys] and persists them.

--- a/server/src/main/resources/assets/js/story-reader-logic.js
+++ b/server/src/main/resources/assets/js/story-reader-logic.js
@@ -1,0 +1,88 @@
+/**
+ * Pure dwell-tracking logic for the story-reader beacon — no DOM, no globals
+ * beyond this factory. Kept DOM-free so it can be unit-tested under Node while
+ * still loading as a plain browser <script> (see the dual export at the end),
+ * mirroring review-logic.js. story-reader.js supplies the browser wiring
+ * (timers, the Visibility API, sessionStorage, navigator.sendBeacon).
+ *
+ * A tracker accrues visible dwell time toward a threshold and carries the
+ * running total across page turns through an injected best-effort storage
+ * (sessionStorage in the browser). Both the clock and the storage are injected
+ * so the accumulation is deterministic under test.
+ *
+ * Storage contract: get(key) returns the stored string or null; set(key, value)
+ * persists it. Both must be best-effort — never throw — so the browser wiring
+ * can degrade to a per-page timer when sessionStorage is unavailable.
+ */
+function createDwellTracker(options) {
+	var thresholdMs = options.thresholdMs;
+	var now = options.now;          // () => epoch millis
+	var storage = options.storage;  // { get(key): string|null, set(key, value): void }
+	var storyKey = options.storyKey;
+
+	// Only the ?page=N query varies between pages of one story, so the pathname
+	// (passed in as storyKey) scopes both keys to the story across page turns.
+	var dwellStorageKey = 'hammer.readDwell:' + storyKey;
+	var sentStorageKey = 'hammer.readSent:' + storyKey;
+
+	var dwellMs = parseInt(storage.get(dwellStorageKey), 10) || 0;
+	var sent = storage.get(sentStorageKey) === '1';
+	var lastResume = null;
+
+	// Fold the time since the last resume into the running total and persist it,
+	// so the next page (a full reload) picks up where this one left off. Keeps
+	// the clock running — call pause() to also stop accruing.
+	function accrue() {
+		if (lastResume === null) return;
+		var t = now();
+		dwellMs += t - lastResume;
+		lastResume = t;
+		storage.set(dwellStorageKey, String(dwellMs));
+	}
+
+	return {
+		// True once this story has been counted in this tab. The caller must then
+		// stop accruing and never beacon again — this survives page reloads via
+		// storage, so a page-turner is only ever counted once.
+		alreadySent: function () {
+			return sent;
+		},
+
+		// Begin (or resume) accruing dwell from now. Idempotent while running, so
+		// a redundant visibilitychange can't reset the reference point.
+		resume: function () {
+			if (lastResume === null) lastResume = now();
+		},
+
+		// Accrue elapsed time and stop the clock (tab hidden / navigating away).
+		pause: function () {
+			accrue();
+			lastResume = null;
+		},
+
+		accrue: accrue,
+
+		// Accrue, then report whether the visitor has now dwelt long enough to count.
+		thresholdReached: function () {
+			accrue();
+			return dwellMs >= thresholdMs;
+		},
+
+		// Record that the beacon has fired so no later page or tab refocus re-sends it.
+		markSent: function () {
+			sent = true;
+			storage.set(sentStorageKey, '1');
+		},
+
+		// Accumulated visible dwell in ms (inspection/test aid).
+		dwellMs: function () {
+			return dwellMs;
+		},
+	};
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = {
+		createDwellTracker: createDwellTracker,
+	};
+}

--- a/server/src/main/resources/assets/js/story-reader.js
+++ b/server/src/main/resources/assets/js/story-reader.js
@@ -1,0 +1,87 @@
+/**
+ * Best-effort "reader" beacon for published / shared stories.
+ *
+ * The server no longer counts a read the moment the page loads — that counts
+ * every drive-by click, including people who open the story and close it a
+ * second later. Instead we wait until the visitor has actually spent a short
+ * dwell time on the page, then fire a single beacon to POST .../read; the
+ * server records the unique reader only when that beacon arrives.
+ *
+ * The dwell timer only accrues while the tab is visible, so a story opened in a
+ * background tab and never looked at doesn't count either. This is a heuristic,
+ * not a guarantee — it just filters the obvious bounces.
+ */
+(function () {
+	// Minimum visible time on the page before we count the visit as a read.
+	var DWELL_THRESHOLD_MS = 10000;
+
+	var sent = false;
+	var dwellMs = 0;
+	var lastResume = null;
+	var timer = null;
+
+	function sendBeacon() {
+		if (sent) return;
+		sent = true;
+		stopTimer();
+
+		// Beacon back to the same story URL (carrying ?p=... for private shares and
+		// any &page=...). The server re-resolves access from these exactly as the
+		// GET did, so the beacon can't record anything the visitor couldn't load.
+		var url = window.location.pathname + '/read' + window.location.search;
+
+		try {
+			if (navigator.sendBeacon) {
+				// sendBeacon survives the page being closed and still sends cookies,
+				// so the author-skip session check keeps working.
+				navigator.sendBeacon(url);
+			} else {
+				fetch(url, {method: 'POST', credentials: 'same-origin', keepalive: true});
+			}
+		} catch (e) {
+			// Best-effort telemetry: if the beacon can't be sent, we simply don't
+			// count this reader. Never disrupt the reading experience.
+		}
+	}
+
+	function tick() {
+		if (sent || lastResume === null) return;
+		var now = Date.now();
+		dwellMs += now - lastResume;
+		lastResume = now;
+		if (dwellMs >= DWELL_THRESHOLD_MS) {
+			sendBeacon();
+		}
+	}
+
+	function startTimer() {
+		if (sent || timer !== null) return;
+		lastResume = Date.now();
+		timer = setInterval(tick, 1000);
+	}
+
+	function stopTimer() {
+		if (timer !== null) {
+			// Fold the in-progress interval into the accumulated total before pausing.
+			if (lastResume !== null) {
+				dwellMs += Date.now() - lastResume;
+				lastResume = null;
+			}
+			clearInterval(timer);
+			timer = null;
+		}
+	}
+
+	// Only accrue dwell time while the tab is actually in the foreground.
+	document.addEventListener('visibilitychange', function () {
+		if (document.hidden) {
+			stopTimer();
+		} else {
+			startTimer();
+		}
+	});
+
+	if (!document.hidden) {
+		startTimer();
+	}
+})();

--- a/server/src/main/resources/assets/js/story-reader.js
+++ b/server/src/main/resources/assets/js/story-reader.js
@@ -1,5 +1,5 @@
 /**
- * Best-effort "reader" beacon for published / shared stories.
+ * Best-effort "reader" beacon for published / shared stories — browser wiring.
  *
  * The server no longer counts a read the moment the page loads — that counts
  * every drive-by click, including people who open the story and close it a
@@ -11,11 +11,13 @@
  *  - The dwell timer only accrues while the tab is visible, so a story opened in
  *    a background tab and never looked at doesn't count.
  *  - Dwell accumulates ACROSS pages of a multi-page story. Pagination is a full
- *    page navigation, so each page reloads this script; we carry the running
- *    total in sessionStorage (per-tab, never sent to the server, no crypto or
- *    backend involved) keyed by the story path, so a reader who spends a few
- *    seconds on each of several pages still crosses the threshold. Without this
- *    a page-turner reading a long serialized story would never be counted.
+ *    page navigation, so each page reloads this script; the running total lives
+ *    in sessionStorage (per-tab, never sent to the server) so a reader who
+ *    spends a few seconds on each of several pages still crosses the threshold.
+ *
+ * The dwell math lives in story-reader-logic.js (DOM-free, unit-tested);
+ * createDwellTracker is a global here, loaded as page_pre_script before this
+ * file. This file is just the timers, Visibility API, storage, and beacon.
  *
  * This is a heuristic, not a guarantee — it just filters the obvious bounces.
  */
@@ -23,42 +25,41 @@
 	// Minimum visible time on the page before we count the visit as a read.
 	var DWELL_THRESHOLD_MS = 10000;
 
-	// The story path is /a/{penName}/{projectName}; only the ?page=N query varies
-	// between pages, so the pathname identifies the story across page turns.
-	var storyKey = window.location.pathname;
-	var DWELL_KEY = 'hammer.readDwell:' + storyKey;
-	var SENT_KEY = 'hammer.readSent:' + storyKey;
-
 	// sessionStorage can throw (private-mode quotas, disabled storage). Degrade to
 	// a per-page timer rather than break the page: dwell just won't carry across
-	// pages, which is the same as having no refinement at all.
-	function storageGet(key) {
-		try {
-			return sessionStorage.getItem(key);
-		} catch (e) {
-			return null;
-		}
-	}
+	// pages, which is the same as having no cross-page refinement at all.
+	var storage = {
+		get: function (key) {
+			try {
+				return sessionStorage.getItem(key);
+			} catch (e) {
+				return null;
+			}
+		},
+		set: function (key, value) {
+			try {
+				sessionStorage.setItem(key, value);
+			} catch (e) {
+				// Best-effort only.
+			}
+		},
+	};
 
-	function storageSet(key, value) {
-		try {
-			sessionStorage.setItem(key, value);
-		} catch (e) {
-			// Best-effort only.
-		}
-	}
+	var tracker = createDwellTracker({
+		thresholdMs: DWELL_THRESHOLD_MS,
+		now: function () {
+			return Date.now();
+		},
+		storage: storage,
+		storyKey: window.location.pathname,
+	});
 
 	// Already counted this story in this tab — nothing more to do.
-	if (storageGet(SENT_KEY) === '1') return;
+	if (tracker.alreadySent()) return;
 
-	var dwellMs = parseInt(storageGet(DWELL_KEY), 10) || 0;
-	var lastResume = null;
 	var timer = null;
 
-	function sendBeacon() {
-		storageSet(SENT_KEY, '1');
-		stopTimer();
-
+	function fireBeacon() {
 		// Beacon back to the same story URL (carrying ?p=... for private shares and
 		// any &page=...). The server re-resolves access from these exactly as the
 		// GET did, so the beacon can't record anything the visitor couldn't load.
@@ -78,36 +79,27 @@
 		}
 	}
 
-	// Fold the time since the last resume into the running total and persist it,
-	// so the next page (a full reload) picks up where this one left off.
-	function accrue() {
-		if (lastResume === null) return;
-		var now = Date.now();
-		dwellMs += now - lastResume;
-		lastResume = now;
-		storageSet(DWELL_KEY, String(dwellMs));
-	}
-
 	function tick() {
-		accrue();
-		if (dwellMs >= DWELL_THRESHOLD_MS) {
-			sendBeacon();
+		if (tracker.thresholdReached()) {
+			tracker.markSent();
+			stopTimer();
+			fireBeacon();
 		}
 	}
 
 	function startTimer() {
-		if (timer !== null) return;
-		lastResume = Date.now();
+		// Once sent, never resume — a later tab refocus must not re-fire the beacon.
+		if (timer !== null || tracker.alreadySent()) return;
+		tracker.resume();
 		timer = setInterval(tick, 1000);
 	}
 
 	function stopTimer() {
 		if (timer !== null) {
-			accrue();
 			clearInterval(timer);
 			timer = null;
 		}
-		lastResume = null;
+		tracker.pause();
 	}
 
 	// Only accrue dwell time while the tab is actually in the foreground.
@@ -121,7 +113,9 @@
 
 	// Persist the in-progress dwell when navigating away (e.g. clicking "next
 	// page") so it isn't lost between the tick interval and the page unload.
-	window.addEventListener('pagehide', accrue);
+	window.addEventListener('pagehide', function () {
+		tracker.accrue();
+	});
 
 	if (!document.hidden) {
 		startTimer();

--- a/server/src/main/resources/assets/js/story-reader.js
+++ b/server/src/main/resources/assets/js/story-reader.js
@@ -7,22 +7,56 @@
  * dwell time on the page, then fire a single beacon to POST .../read; the
  * server records the unique reader only when that beacon arrives.
  *
- * The dwell timer only accrues while the tab is visible, so a story opened in a
- * background tab and never looked at doesn't count either. This is a heuristic,
- * not a guarantee — it just filters the obvious bounces.
+ * Two refinements keep the heuristic honest:
+ *  - The dwell timer only accrues while the tab is visible, so a story opened in
+ *    a background tab and never looked at doesn't count.
+ *  - Dwell accumulates ACROSS pages of a multi-page story. Pagination is a full
+ *    page navigation, so each page reloads this script; we carry the running
+ *    total in sessionStorage (per-tab, never sent to the server, no crypto or
+ *    backend involved) keyed by the story path, so a reader who spends a few
+ *    seconds on each of several pages still crosses the threshold. Without this
+ *    a page-turner reading a long serialized story would never be counted.
+ *
+ * This is a heuristic, not a guarantee — it just filters the obvious bounces.
  */
 (function () {
 	// Minimum visible time on the page before we count the visit as a read.
 	var DWELL_THRESHOLD_MS = 10000;
 
-	var sent = false;
-	var dwellMs = 0;
+	// The story path is /a/{penName}/{projectName}; only the ?page=N query varies
+	// between pages, so the pathname identifies the story across page turns.
+	var storyKey = window.location.pathname;
+	var DWELL_KEY = 'hammer.readDwell:' + storyKey;
+	var SENT_KEY = 'hammer.readSent:' + storyKey;
+
+	// sessionStorage can throw (private-mode quotas, disabled storage). Degrade to
+	// a per-page timer rather than break the page: dwell just won't carry across
+	// pages, which is the same as having no refinement at all.
+	function storageGet(key) {
+		try {
+			return sessionStorage.getItem(key);
+		} catch (e) {
+			return null;
+		}
+	}
+
+	function storageSet(key, value) {
+		try {
+			sessionStorage.setItem(key, value);
+		} catch (e) {
+			// Best-effort only.
+		}
+	}
+
+	// Already counted this story in this tab — nothing more to do.
+	if (storageGet(SENT_KEY) === '1') return;
+
+	var dwellMs = parseInt(storageGet(DWELL_KEY), 10) || 0;
 	var lastResume = null;
 	var timer = null;
 
 	function sendBeacon() {
-		if (sent) return;
-		sent = true;
+		storageSet(SENT_KEY, '1');
 		stopTimer();
 
 		// Beacon back to the same story URL (carrying ?p=... for private shares and
@@ -44,32 +78,36 @@
 		}
 	}
 
-	function tick() {
-		if (sent || lastResume === null) return;
+	// Fold the time since the last resume into the running total and persist it,
+	// so the next page (a full reload) picks up where this one left off.
+	function accrue() {
+		if (lastResume === null) return;
 		var now = Date.now();
 		dwellMs += now - lastResume;
 		lastResume = now;
+		storageSet(DWELL_KEY, String(dwellMs));
+	}
+
+	function tick() {
+		accrue();
 		if (dwellMs >= DWELL_THRESHOLD_MS) {
 			sendBeacon();
 		}
 	}
 
 	function startTimer() {
-		if (sent || timer !== null) return;
+		if (timer !== null) return;
 		lastResume = Date.now();
 		timer = setInterval(tick, 1000);
 	}
 
 	function stopTimer() {
 		if (timer !== null) {
-			// Fold the in-progress interval into the accumulated total before pausing.
-			if (lastResume !== null) {
-				dwellMs += Date.now() - lastResume;
-				lastResume = null;
-			}
+			accrue();
 			clearInterval(timer);
 			timer = null;
 		}
+		lastResume = null;
 	}
 
 	// Only accrue dwell time while the tab is actually in the foreground.
@@ -80,6 +118,10 @@
 			startTimer();
 		}
 	});
+
+	// Persist the in-progress dwell when navigating away (e.g. clicking "next
+	// page") so it isn't lost between the tick interval and the page unload.
+	window.addEventListener('pagehide', accrue);
 
 	if (!document.hidden) {
 		startTimer();

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/StoryReaderBeaconTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/StoryReaderBeaconTest.kt
@@ -1,0 +1,117 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.e2e.util.E2eTestData
+import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
+import com.darkrockstudios.apps.hammer.e2e.util.TestAccount
+import com.darkrockstudios.apps.hammer.e2e.util.TestProject
+import com.darkrockstudios.apps.hammer.frontend.utils.ProjectName
+import com.darkrockstudios.apps.hammer.monitoring.ReaderKey
+import com.darkrockstudios.apps.hammer.monitoring.StoryReaderCollector
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.koin.core.context.GlobalContext
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Exercises the dwell-gated reader beacon (`POST /a/{penName}/{projectName}/read`).
+ * story-reader.js fires this after the visitor dwells; here we drive the endpoint
+ * directly and assert what actually gets recorded, since the response is always a
+ * blank 204 by design (a bad beacon must look the same as a good one).
+ */
+class StoryReaderBeaconTest : EndToEndTest() {
+
+	private val userId = 1L
+	private val penName = "JaneAuthor"
+	private val projectNameText = "Insurgency"
+	private val projectUuid = Uuid.random()
+
+	/** Reads (and clears) whatever the endpoint recorded into the live collector. */
+	private fun recordedReads(): List<ReaderKey> =
+		GlobalContext.get().get<StoryReaderCollector>().drainToKeys()
+
+	private fun beaconPath(password: String? = null): String {
+		val segment = ProjectName.projectSegment(projectNameText, projectUuid.toString())
+		val query = if (password != null) "?p=$password" else ""
+		return route("a/$penName/$segment/read$query")
+	}
+
+	/** Author account with a pen name and a project; access is left for each test to grant. */
+	private fun seedAuthorAndProject() = runBlocking {
+		E2eTestData.createAccount(TestAccount(email = "jane@test.com", password = "password123!@#"), database())
+		database().serverDatabase.accountQueries.updatePenName(pen_name = penName, id = userId)
+		E2eTestData.createProject(TestProject(name = projectNameText, uuid = projectUuid, userId = userId), database())
+	}
+
+	private fun projectRowId(): Long =
+		database().serverDatabase.projectQueries.findProjectByName(userId, projectNameText).executeAsOne().id
+
+	private fun grantAccess(password: String?) {
+		database().serverDatabase.projectAccessQueries.insertAccess(
+			project_id = projectRowId(),
+			access_password = password,
+			expires_at = null,
+		)
+	}
+
+	@Test
+	fun `a beacon for a published story records one reader`(): Unit = runBlocking {
+		doStartServer()
+		seedAuthorAndProject()
+		grantAccess(password = null) // published (public) access
+
+		val response = client().post(beaconPath())
+
+		assertEquals(HttpStatusCode.NoContent, response.status)
+		val reads = recordedReads()
+		assertEquals(1, reads.size)
+		assertEquals(projectRowId(), reads.single().projectId)
+	}
+
+	@Test
+	fun `a beacon for a story with no public access records nothing`(): Unit = runBlocking {
+		doStartServer()
+		seedAuthorAndProject() // project exists but was never published or shared
+
+		val response = client().post(beaconPath())
+
+		assertEquals(HttpStatusCode.NoContent, response.status)
+		assertEquals(0, recordedReads().size)
+	}
+
+	@Test
+	fun `a private share only records once the correct password is supplied`(): Unit = runBlocking {
+		doStartServer()
+		seedAuthorAndProject()
+		grantAccess(password = "secret") // private share, no public access
+
+		// No password: resolution stops at PasswordRequired, so nothing is recorded.
+		val noPassword = client().post(beaconPath())
+		assertEquals(HttpStatusCode.NoContent, noPassword.status)
+		assertEquals(0, recordedReads().size)
+
+		// Wrong password is likewise not a Success and records nothing.
+		val wrongPassword = client().post(beaconPath(password = "nope"))
+		assertEquals(HttpStatusCode.NoContent, wrongPassword.status)
+		assertEquals(0, recordedReads().size)
+
+		// The correct password resolves to Success and records the reader.
+		val rightPassword = client().post(beaconPath(password = "secret"))
+		assertEquals(HttpStatusCode.NoContent, rightPassword.status)
+		assertEquals(1, recordedReads().size)
+	}
+
+	@Test
+	fun `a beacon for an unknown pen name records nothing`(): Unit = runBlocking {
+		doStartServer()
+		seedAuthorAndProject()
+		grantAccess(password = null)
+
+		val response = client().post(route("a/NoSuchAuthor/${ProjectName.projectSegment(projectNameText, projectUuid.toString())}/read"))
+
+		assertEquals(HttpStatusCode.NoContent, response.status)
+		assertEquals(0, recordedReads().size)
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/StoryReaderTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/StoryReaderTest.kt
@@ -66,6 +66,22 @@ class StoryReaderTest : BaseTest() {
 	}
 
 	@Test
+	fun `the collector sheds keys past its cap so a flood can't grow the set without bound`() {
+		val collector = StoryReaderCollector(clock, maxPendingKeys = 5)
+
+		// A flood of distinct visitor keys (varied user-agents) far exceeding the cap.
+		repeat(100) { i ->
+			collector.record(projectId = 1L, clientIp = "1.1.1.1", userAgent = "UA-$i")
+		}
+
+		assertEquals(5, collector.drainToKeys().size)
+
+		// Draining frees the set, so recording resumes afterward.
+		collector.record(projectId = 1L, clientIp = "1.1.1.1", userAgent = "UA-after")
+		assertEquals(1, collector.drainToKeys().size)
+	}
+
+	@Test
 	fun `a disabled collector records nothing`() {
 		val collector = StoryReaderCollector(clock)
 		collector.setCollecting(false)


### PR DESCRIPTION
Reader counts for published/shared stories were recorded on the initial page GET, so every drive-by click counted as a reader — including people who opened a story and closed it a second later (and non-JS bots).

Move recording off page load onto a best-effort dwell filter: the public story page now loads a small script (story-reader.js) that fires a beacon to POST /a/{penName}/{projectName}/read only once the visitor has actually spent ~10 seconds on the page. The dwell timer only accrues while the tab is visible, so a story opened in a background tab and never looked at doesn't count. The beacon endpoint re-runs the exact same pen-name/project resolution, access, and author-skip checks the GET did, so it can only record a read the visitor could actually load.

This is a heuristic, not a guarantee — it just drops the obvious bounces.


Claude-Session: https://claude.ai/code/session_01GApiphvSAKeYLeejenqjTK