### PR TITLE
Migrate :common DI to Koin compiler plugin DSL (compile-time safety)

### DIFF
--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -43,6 +43,8 @@ kotlin {
 
 		val commonMain by getting {
 			dependencies {
+				api(project.dependencies.platform(libs.koin.bom.get()))
+				api(libs.koin.core)
 				implementation(libs.serialization.core)
 				implementation(libs.coroutines.core)
 				implementation(libs.kotlinx.datetime)

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/di/DispatcherModule.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/di/DispatcherModule.kt
@@ -6,21 +6,12 @@ import org.koin.dsl.module
 import kotlin.coroutines.CoroutineContext
 
 /**
- * Builds the qualified [CoroutineContext] dispatcher definitions in a module that does
- * NOT carry the Koin compiler plugin.
- *
- * Under `compileSafety = true` the plugin emits a synthetic `dsl_single` hint for every
- * definition in a plugin-processed `module { }`, encoding the `named()` qualifier as a
- * value-parameter NAME. Kotlin/Native's `IdSignature` ignores parameter names, so our
- * three same-type qualified dispatchers (main/default/io — all `CoroutineContext`)
- * collapse to one signature and fail klib serialization. Keeping these three definitions
- * out of the plugin's reach (here, in the plugin-less `:base`) sidesteps the clash while
- * leaving the rest of the graph fully validated. The dispatchers are only ever consumed
- * via runtime `inject(named(...))`, never constructor auto-wiring, so nothing the plugin
- * validates depends on them.
- *
- * Qualifier names are passed in so the `DISPATCHER_*` constants can stay in `:common`
- * alongside their consumers.
+ * The three same-type qualified [CoroutineContext] dispatchers live here, in the
+ * plugin-less `:base`, rather than in a Koin-compiler-plugin module. Under
+ * `compileSafety = true` the plugin encodes each `named()` qualifier as a parameter NAME,
+ * which Kotlin/Native's `IdSignature` ignores — so same-type qualified definitions clash
+ * during klib serialization. Qualifier names are passed in so the `DISPATCHER_*` constants
+ * can stay in `:common` with their consumers.
  */
 fun dispatcherModule(
 	mainQualifier: String,

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/di/DispatcherModule.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/di/DispatcherModule.kt
@@ -1,0 +1,36 @@
+package com.darkrockstudios.apps.hammer.base.di
+
+import org.koin.core.module.Module
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Builds the qualified [CoroutineContext] dispatcher definitions in a module that does
+ * NOT carry the Koin compiler plugin.
+ *
+ * Under `compileSafety = true` the plugin emits a synthetic `dsl_single` hint for every
+ * definition in a plugin-processed `module { }`, encoding the `named()` qualifier as a
+ * value-parameter NAME. Kotlin/Native's `IdSignature` ignores parameter names, so our
+ * three same-type qualified dispatchers (main/default/io — all `CoroutineContext`)
+ * collapse to one signature and fail klib serialization. Keeping these three definitions
+ * out of the plugin's reach (here, in the plugin-less `:base`) sidesteps the clash while
+ * leaving the rest of the graph fully validated. The dispatchers are only ever consumed
+ * via runtime `inject(named(...))`, never constructor auto-wiring, so nothing the plugin
+ * validates depends on them.
+ *
+ * Qualifier names are passed in so the `DISPATCHER_*` constants can stay in `:common`
+ * alongside their consumers.
+ */
+fun dispatcherModule(
+	mainQualifier: String,
+	defaultQualifier: String,
+	ioQualifier: String,
+	mainDispatcher: CoroutineContext,
+	defaultDispatcher: CoroutineContext,
+	ioDispatcher: CoroutineContext,
+): Module = module {
+	single(qualifier = named(mainQualifier)) { mainDispatcher }
+	single(qualifier = named(defaultQualifier)) { defaultDispatcher }
+	single(qualifier = named(ioQualifier)) { ioDispatcher }
+}

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/di/KoinBootstrap.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/di/KoinBootstrap.kt
@@ -1,0 +1,16 @@
+package com.darkrockstudios.apps.hammer.base.di
+
+import org.koin.core.KoinApplication
+import org.koin.core.context.startKoin
+import org.koin.dsl.KoinAppDeclaration
+
+/**
+ * Starts Koin from a module that does not carry the Koin compiler plugin.
+ *
+ * The plugin runs its full-graph (A3) safety pass wherever a [startKoin] call is
+ * compiled. Keeping that call here — outside the plugin — means a platform bootstrap
+ * (notably iOS, whose entry point lives in the plugin-processed common module) can
+ * start Koin without turning its own compilation into an A3 aggregator. This matches
+ * how the desktop and android app modules already sit outside the plugin.
+ */
+fun bootstrapKoin(declaration: KoinAppDeclaration): KoinApplication = startKoin(declaration)

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/di/KoinBootstrap.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/di/KoinBootstrap.kt
@@ -5,12 +5,8 @@ import org.koin.core.context.startKoin
 import org.koin.dsl.KoinAppDeclaration
 
 /**
- * Starts Koin from a module that does not carry the Koin compiler plugin.
- *
- * The plugin runs its full-graph (A3) safety pass wherever a [startKoin] call is
- * compiled. Keeping that call here — outside the plugin — means a platform bootstrap
- * (notably iOS, whose entry point lives in the plugin-processed common module) can
- * start Koin without turning its own compilation into an A3 aggregator. This matches
- * how the desktop and android app modules already sit outside the plugin.
+ * Starts Koin from the plugin-less `:base`. The Koin compiler plugin runs its full-graph
+ * (A3) safety pass wherever [startKoin] is compiled; keeping the call here stops iOS's
+ * bootstrap from becoming an A3 aggregator, matching the desktop/android app modules.
  */
 fun bootstrapKoin(declaration: KoinAppDeclaration): KoinApplication = startKoin(declaration)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -18,14 +18,16 @@ group = "com.darkrockstudios.apps.hammer"
 version = libs.versions.app.get()
 
 // compileSafety validates the DI graph at compile time (missing definitions become
-// compile errors). Passes on desktop, android, and the common metadata compilation.
+// compile errors). Passes on all targets: desktop, android, common metadata, and iOS.
 //
-// Kotlin/Native (iOS) currently trips an upstream plugin bug: the generated `dsl_single`
-// hint functions encode a definition's named() qualifier as a value-parameter NAME, and
-// K/N's IdSignature ignores parameter names — so multiple same-type qualified definitions
-// (our main/default/io CoroutineContext dispatchers) collapse to one signature and fail
-// klib serialization with an Ir SignatureClashDetector AssertionError. Tracked upstream in
-// koin-compiler-plugin; revisit iOS once fixed.
+// Kotlin/Native (iOS) can't host multiple same-type qualified definitions in a plugin-
+// processed module: the generated `dsl_single` hint functions encode a definition's
+// named() qualifier as a value-parameter NAME, and K/N's IdSignature ignores parameter
+// names — so same-type qualified definitions collapse to one signature and fail klib
+// serialization with an Ir SignatureClashDetector AssertionError. Our three main/default/io
+// CoroutineContext dispatchers hit this, so they're defined in a plugin-less module in
+// :base instead (see dispatcherModule); they're only consumed via runtime inject(named()),
+// never auto-wiring, so nothing the plugin validates depends on them.
 koinCompiler {
 	compileSafety = true
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -11,10 +11,24 @@ plugins {
 	alias(libs.plugins.jetbrains.compose)
 	alias(libs.plugins.compose.compiler)
 	alias(libs.plugins.buildconfig)
+	alias(libs.plugins.koin.compiler)
 }
 
 group = "com.darkrockstudios.apps.hammer"
 version = libs.versions.app.get()
+
+// compileSafety validates the DI graph at compile time (missing definitions become
+// compile errors). Passes on desktop, android, and the common metadata compilation.
+//
+// Kotlin/Native (iOS) currently trips an upstream plugin bug: the generated `dsl_single`
+// hint functions encode a definition's named() qualifier as a value-parameter NAME, and
+// K/N's IdSignature ignores parameter names — so multiple same-type qualified definitions
+// (our main/default/io CoroutineContext dispatchers) collapse to one signature and fail
+// klib serialization with an Ir SignatureClashDetector AssertionError. Tracked upstream in
+// koin-compiler-plugin; revisit iOS once fixed.
+koinCompiler {
+	compileSafety = true
+}
 
 kotlin {
 	jvmToolchain {
@@ -65,6 +79,7 @@ kotlin {
 				api(libs.coroutines.core)
 				api(project.dependencies.platform(libs.koin.bom.get()))
 				api(libs.koin.core)
+				api(libs.koin.annotations)
 				api(libs.okio)
 
 				implementation(libs.bundles.ktor.client)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -17,17 +17,6 @@ plugins {
 group = "com.darkrockstudios.apps.hammer"
 version = libs.versions.app.get()
 
-// compileSafety validates the DI graph at compile time (missing definitions become
-// compile errors). Passes on all targets: desktop, android, common metadata, and iOS.
-//
-// Kotlin/Native (iOS) can't host multiple same-type qualified definitions in a plugin-
-// processed module: the generated `dsl_single` hint functions encode a definition's
-// named() qualifier as a value-parameter NAME, and K/N's IdSignature ignores parameter
-// names — so same-type qualified definitions collapse to one signature and fail klib
-// serialization with an Ir SignatureClashDetector AssertionError. Our three main/default/io
-// CoroutineContext dispatchers hit this, so they're defined in a plugin-less module in
-// :base instead (see dispatcherModule); they're only consumed via runtime inject(named()),
-// never auto-wiring, so nothing the plugin validates depends on them.
 koinCompiler {
 	compileSafety = true
 }

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryAndroid.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryAndroid.kt
@@ -5,14 +5,14 @@ import com.darkrockstudios.apps.hammer.common.util.zip.unzipBytesToDirectory
 import io.github.aakira.napier.Napier
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
 import java.io.InputStream
 import kotlin.time.Clock
 
 actual val exampleProjectModule = module {
-	singleOf(::ExampleProjectRepositoryAndroid) bind ExampleProjectRepository::class
+	single<ExampleProjectRepositoryAndroid>() bind ExampleProjectRepository::class
 }
 
 class ExampleProjectRepositoryAndroid(

--- a/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
+++ b/common/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
@@ -9,18 +9,18 @@ import com.darkrockstudios.apps.hammer.common.data.projectbackup.BackupManagerSe
 import com.darkrockstudios.apps.hammer.common.spellcheck.LanguageUtil
 import com.darkrockstudios.apps.hammer.common.util.*
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
-import org.koin.core.module.dsl.factoryOf
-import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
+import org.koin.plugin.module.dsl.factory
 
 actual val platformModule = module {
-	singleOf(::NetworkConnectivity)
-	singleOf(::StrResImpl) bind StrRes::class
-	singleOf(::DeviceLocaleResolver)
-	singleOf(::UrlLauncherAndroid) bind UrlLauncher::class
-	singleOf(::LanguageUtil)
+	single<NetworkConnectivity>()
+	single<StrResImpl>() bind StrRes::class
+	single<DeviceLocaleResolver>()
+	single<UrlLauncherAndroid>() bind UrlLauncher::class
+	single<LanguageUtil>()
 	factory { params ->
 		AndroidPlatformSettingsComponent(
 			componentContext = params.get(),
@@ -30,9 +30,9 @@ actual val platformModule = module {
 			fileSystem = get(named(RAW_FILESYSTEM)),
 		)
 	} bind PlatformSettings::class
-	singleOf(::PlatformSpellCheckerFactory)
-	factoryOf(::FocusModeService)
-	singleOf(::AndroidShareService)
-	singleOf(::BackupManagerService)
+	single<PlatformSpellCheckerFactory>()
+	factory<FocusModeService>()
+	single<AndroidShareService>()
+	single<BackupManagerService>()
 	single<GlobalSettingsDatasource> { get<GlobalSettingsFilesystemDatasource>() }
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/MigratorModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/MigratorModule.kt
@@ -5,13 +5,13 @@ import com.darkrockstudios.apps.hammer.common.data.migrator.MigrateInlineAuthTok
 import com.darkrockstudios.apps.hammer.common.data.migrator.MigrateInstallIdToGlobal
 import com.darkrockstudios.apps.hammer.common.data.migrator.Migration0_1
 import com.darkrockstudios.apps.hammer.common.data.migrator.Migration1_2
-import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.factory
 
 val migratorModule = module {
-	factoryOf(::DataMigrator)
-	factoryOf(::Migration0_1)
-	factoryOf(::Migration1_2)
-	factoryOf(::MigrateInstallIdToGlobal)
-	factoryOf(::MigrateInlineAuthTokens)
+	factory<DataMigrator>()
+	factory<Migration0_1>()
+	factory<Migration1_2>()
+	factory<MigrateInstallIdToGlobal>()
+	factory<MigrateInlineAuthTokens>()
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.dependencyinjection
 
+import com.darkrockstudios.apps.hammer.base.di.dispatcherModule
 import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.components.projecthome.ExportStoryUseCase
 import com.darkrockstudios.apps.hammer.common.components.projecthome.ImportStoryUseCase
@@ -146,9 +147,19 @@ val mainModule = module {
 	includes(authTokenStoreModule)
 	includes(exampleProjectModule)
 
-	single(named(DISPATCHER_MAIN)) { platformMainDispatcher }
-	single(named(DISPATCHER_DEFAULT)) { platformDefaultDispatcher }
-	single(named(DISPATCHER_IO)) { platformIoDispatcher }
+	// Dispatchers live in a plugin-less module (see dispatcherModule): three same-type
+	// qualified definitions would otherwise collapse to one K/N hint signature under
+	// compileSafety and break the iOS klib link.
+	includes(
+		dispatcherModule(
+			mainQualifier = DISPATCHER_MAIN,
+			defaultQualifier = DISPATCHER_DEFAULT,
+			ioQualifier = DISPATCHER_IO,
+			mainDispatcher = platformMainDispatcher,
+			defaultDispatcher = platformDefaultDispatcher,
+			ioDispatcher = platformIoDispatcher,
+		)
+	)
 
 	single { Clock.System } bind Clock::class
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -122,12 +122,13 @@ import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
-import org.koin.core.module.dsl.factoryOf
-import org.koin.core.module.dsl.scopedOf
-import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
+import org.koin.plugin.module.dsl.factory
+import org.koin.plugin.module.dsl.scoped
+import org.koin.plugin.module.dsl.create
 import kotlin.time.Clock
 
 const val DISPATCHER_MAIN = "main-dispatcher"
@@ -156,26 +157,26 @@ val mainModule = module {
 
 	includes(platformModule)
 
-	singleOf(::ProtocolMismatchRepository)
-	single { createHttpClient(get()) } bind HttpClient::class
-	singleOf(::ServerAccountApi)
-	singleOf(::ServerProjectApi)
-	singleOf(::ServerProjectsApi)
-	singleOf(::WritingActivityApi)
-	singleOf(::ProjectDataApi)
-	singleOf(::ServerIdeasApi)
-	singleOf(::ServerAdminApi)
+	single<ProtocolMismatchRepository>()
+	single { create(::createHttpClient) } bind HttpClient::class
+	single<ServerAccountApi>()
+	single<ServerProjectApi>()
+	single<ServerProjectsApi>()
+	single<WritingActivityApi>()
+	single<ProjectDataApi>()
+	single<ServerIdeasApi>()
+	single<ServerAdminApi>()
 
-	singleOf(::ServerSettingsFilesystemDatasource) bind ServerSettingsDatasource::class
-	singleOf(::GlobalSettingsFilesystemDatasource)
-	singleOf(::GlobalSettingsStore) bind GlobalSettingsStore::class
+	single<ServerSettingsFilesystemDatasource>() bind ServerSettingsDatasource::class
+	single<GlobalSettingsFilesystemDatasource>()
+	single<GlobalSettingsStore>()
 
-	singleOf(::GithubVersionCheckDataSource) bind VersionCheckDataSource::class
-	singleOf(::VersionCheckRepository)
-	factoryOf(::ShouldNotifyOfUpdateUseCase)
+	single<GithubVersionCheckDataSource>() bind VersionCheckDataSource::class
+	single<VersionCheckRepository>()
+	factory<ShouldNotifyOfUpdateUseCase>()
 
-	factory { AccountUseCase(get(), get(), get(), get()) }
-	factoryOf(::AccountReauthUseCase)
+	factory<AccountUseCase>()
+	factory<AccountReauthUseCase>()
 
 	single(named(RAW_FILESYSTEM)) { getPlatformFilesystem() } bind FileSystem::class
 
@@ -185,45 +186,45 @@ val mainModule = module {
 		ContainedFileSystem(getPlatformFilesystem()) { managedStorageRoots(koin) }
 	}
 
-	singleOf(::ProjectsRepository)
+	single<ProjectsRepository>()
 
-	singleOf(::StoryIdeaCodec)
-	singleOf(::IdeasDatasource)
-	singleOf(::IdeasSyncDatasource)
-	singleOf(::IdeasRepository)
-	factoryOf(::PromoteIdeaUseCase)
+	single<StoryIdeaCodec>()
+	single<IdeasDatasource>()
+	single<IdeasSyncDatasource>()
+	single<IdeasRepository>()
+	factory<PromoteIdeaUseCase>()
 
-	singleOf(::AccountTagService)
+	single<AccountTagService>()
 
-	singleOf(::createTomlSerializer) bind Toml::class
+	single { create(::createTomlSerializer) } bind Toml::class
 
-	singleOf(::createJsonSerializer) bind Json::class
+	single { create(::createJsonSerializer) } bind Json::class
 
-	singleOf(::ClientIdeasSynchronizer)
-	singleOf(::ClientAccountSynchronizer)
+	single<ClientIdeasSynchronizer>()
+	single<ClientAccountSynchronizer>()
 
-	singleOf(::ProjectBackupRepository)
+	single<ProjectBackupRepository>()
 
-	singleOf(::ProjectMetadataDatasource)
+	single<ProjectMetadataDatasource>()
 
-	singleOf(::ProjectStatisticsCacheReader)
+	single<ProjectStatisticsCacheReader>()
 
-	singleOf(::Settings) bind Settings::class
+	single { create(::Settings) } bind Settings::class
 
 	includes(migratorModule)
 
-	singleOf(::SpellCheckRepository)
+	single<SpellCheckRepository>()
 
 	single { StoryImporterRegistry(listOf(MarkdownStoryImporter(), RtfStoryImporter())) }
 
 	scope<ProjectDefScope> {
 		scoped<ProjectDef> { get<ProjectDefScope>().projectDef }
 
-		scopedOf(::SceneDatasource)
-		scopedOf(::SceneContentRepository)
-		scopedOf(::SceneRepository)
-		scopedOf(::SceneEditorService)
-		scopedOf(::ImportStoryUseCase)
+		scoped<SceneDatasource>()
+		scoped<SceneContentRepository>()
+		scoped<SceneRepository>()
+		scoped<SceneEditorService>()
+		scoped<ImportStoryUseCase>()
 		// Export writes to a user-chosen path, so it uses the unguarded filesystem.
 		scoped {
 			ExportStoryUseCase(
@@ -234,79 +235,79 @@ val mainModule = module {
 				strRes = get(),
 			)
 		}
-		scopedOf(::SceneDraftsDatasource)
-		scopedOf(::SceneDraftRepository)
-		scopedOf(::SceneMetadataDatasource)
-		scopedOf(::SceneMetadataRepository)
+		scoped<SceneDraftsDatasource>()
+		scoped<SceneDraftRepository>()
+		scoped<SceneMetadataDatasource>()
+		scoped<SceneMetadataRepository>()
 
-		factoryOf(::SceneIdDatasource)
-		factoryOf(::NotesIdDatasource)
-		factoryOf(::EncyclopediaIdDatasource)
-		factoryOf(::TimeLineEventIdDatasource)
-		factoryOf(::SceneDraftIdDatasource)
-		scopedOf(::IdAllocator)
+		factory<SceneIdDatasource>()
+		factory<NotesIdDatasource>()
+		factory<EncyclopediaIdDatasource>()
+		factory<TimeLineEventIdDatasource>()
+		factory<SceneDraftIdDatasource>()
+		scoped<IdAllocator>()
 
-		scopedOf(::NotesDatasource)
-		scopedOf(::NotesRepository)
+		scoped<NotesDatasource>()
+		scoped<NotesRepository>()
 
-		factoryOf(::EncyclopediaDatasource)
-		scopedOf(::EncyclopediaRepository)
-		scopedOf(::EncyclopediaService)
+		factory<EncyclopediaDatasource>()
+		scoped<EncyclopediaRepository>()
+		scoped<EncyclopediaService>()
 
-		scopedOf(::TimeLineDatasource)
-		scopedOf(::TimeLineRepository)
+		scoped<TimeLineDatasource>()
+		scoped<TimeLineRepository>()
 
-		scopedOf(::SearchProjectUseCase)
+		scoped<SearchProjectUseCase>()
 
-		scopedOf(::StatisticsDatasource)
-		scopedOf(::StatisticsRepository)
-		scopedOf(::StatisticsService)
+		scoped<StatisticsDatasource>()
+		scoped<StatisticsRepository>()
+		scoped<StatisticsService>()
 
-		scopedOf(::WritingActivityDatasource)
-		scopedOf(::WritingActivityRepository)
-		scopedOf(::WritingSessionTracker)
+		scoped<WritingActivityDatasource>()
+		scoped<WritingActivityRepository>()
+		scoped<WritingSessionTracker>()
 
-		scopedOf(::ProjectDataDatasource)
-		scopedOf(::ProjectDataRepository)
-		scopedOf(::ProjectDataConflictBroker)
+		scoped<ProjectDataDatasource>()
+		scoped<ProjectDataRepository>()
+		scoped<ProjectDataConflictBroker>()
 
-		scopedOf(::ReferenceIndexDatasource)
-		scopedOf(::ReferenceIndexRepository)
-		scopedOf(::ReferenceIndexService)
+		scoped<ReferenceIndexDatasource>()
+		scoped<ReferenceIndexRepository>()
+		scoped<ReferenceIndexService>()
 
-		scopedOf(::BuildTagIndexUseCase)
-		scopedOf(::TagIndexService)
-		scopedOf(::ScrubInvalidReferencesUseCase)
-		scopedOf(::AutoConfirmReferencesUseCase)
-		scopedOf(::BackfillEntryReferencesUseCase)
-		scopedOf(::CleanupReferencesOnEntryDeleteUseCase)
-		scopedOf(::SceneMetadataReferenceRemapper) bind ReferenceRemapper::class
+		scoped<BuildTagIndexUseCase>()
+		scoped<TagIndexService>()
+		scoped<ScrubInvalidReferencesUseCase>()
+		scoped<AutoConfirmReferencesUseCase>()
+		scoped<BackfillEntryReferencesUseCase>()
+		scoped<CleanupReferencesOnEntryDeleteUseCase>()
+		scoped<SceneMetadataReferenceRemapper>() bind ReferenceRemapper::class
 
-		scopedOf(::SyncDataDatasource)
+		scoped<SyncDataDatasource>()
 
-		scopedOf(::ClientSceneSynchronizer)
-		scopedOf(::ClientNoteSynchronizer)
-		scopedOf(::ClientTimelineSynchronizer)
-		scopedOf(::ClientEncyclopediaSynchronizer)
-		scopedOf(::ClientSceneDraftSynchronizer)
+		scoped<ClientSceneSynchronizer>()
+		scoped<ClientNoteSynchronizer>()
+		scoped<ClientTimelineSynchronizer>()
+		scoped<ClientEncyclopediaSynchronizer>()
+		scoped<ClientSceneDraftSynchronizer>()
 
-		factoryOf(::PrepareForSyncOperation)
-		factoryOf(::EnsureProjectIdOperation)
-		factoryOf(::FetchLocalDataOperation)
-		factoryOf(::FetchServerDataOperation)
-		factoryOf(::CollateIdsOperation)
-		factoryOf(::BackupOperation)
-		factoryOf(::IdConflictResolutionOperation)
-		factoryOf(::EntityDeleteOperation)
-		factoryOf(::EntityTransferOperation)
-		factoryOf(::WritingActivitySyncOperation)
-		factoryOf(::ProjectDataSyncOperation)
-		factoryOf(::FinalizeSyncOperation)
+		factory<PrepareForSyncOperation>()
+		factory<EnsureProjectIdOperation>()
+		factory<FetchLocalDataOperation>()
+		factory<FetchServerDataOperation>()
+		factory<CollateIdsOperation>()
+		factory<BackupOperation>()
+		factory<IdConflictResolutionOperation>()
+		factory<EntityDeleteOperation>()
+		factory<EntityTransferOperation>()
+		factory<WritingActivitySyncOperation>()
+		factory<ProjectDataSyncOperation>()
+		factory<FinalizeSyncOperation>()
 
-		scopedOf(::SyncJournal)
-		scopedOf(::ClientProjectSynchronizer)
+		scoped<SyncJournal>()
+		scoped<ClientProjectSynchronizer>()
 
-		scopedOf(::EntitySynchronizers)
+		scoped<EntitySynchronizers>()
 	}
 }
 

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryDesktop.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryDesktop.kt
@@ -5,15 +5,15 @@ import com.darkrockstudios.apps.hammer.common.util.zip.unzipBytesToDirectory
 import io.github.aakira.napier.Napier
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
 import java.io.InputStream
 import kotlin.time.Clock
 
 
 actual val exampleProjectModule = module {
-	singleOf(::ExampleProjectRepositoryDesktop) bind ExampleProjectRepository::class
+	single<ExampleProjectRepositoryDesktop>() bind ExampleProjectRepository::class
 }
 
 class ExampleProjectRepositoryDesktop(

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
@@ -9,19 +9,20 @@ import com.darkrockstudios.apps.hammer.common.data.projectbackup.BackupManagerSe
 import com.darkrockstudios.apps.hammer.common.spellcheck.LanguageUtil
 import com.darkrockstudios.apps.hammer.common.util.*
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
+import org.koin.plugin.module.dsl.factory
 
 actual val platformModule = module {
-	singleOf(::NetworkConnectivity)
-	singleOf(::StrResImpl) bind StrRes::class
-	singleOf(::DeviceLocaleResolver)
-	singleOf(::UrlLauncherDesktop) bind UrlLauncher::class
-	singleOf(::LanguageUtil)
+	single<NetworkConnectivity>()
+	single<StrResImpl>() bind StrRes::class
+	single<DeviceLocaleResolver>()
+	single<UrlLauncherDesktop>() bind UrlLauncher::class
+	single<LanguageUtil>()
 	factory { params -> DesktopPlatformSettingsComponent(componentContext = params.get()) } bind PlatformSettings::class
-	singleOf(::PlatformSpellCheckerFactory)
-	factory { FocusModeService() } bind FocusModeService::class
-	singleOf(::BackupManagerService)
+	single<PlatformSpellCheckerFactory>()
+	factory<FocusModeService>()
+	single<BackupManagerService>()
 	single<GlobalSettingsDatasource> { get<GlobalSettingsFilesystemDatasource>() }
 }

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/sandbox/SandboxFileAccess.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/sandbox/SandboxFileAccess.kt
@@ -1,5 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.sandbox
 
+import org.koin.core.annotation.Provided
+
 /**
  * Abstraction over macOS security-scoped bookmark APIs used to persist
  * access to a user-picked directory across app launches in the sandboxed
@@ -9,7 +11,11 @@ package com.darkrockstudios.apps.hammer.common.sandbox
  *
  * On Linux/Windows/non-App-Store desktop builds, [NoopSandboxFileAccess]
  * is bound — [isSandboxed] is false and all calls return null / do nothing.
+ *
+ * [Provided]: the Koin definition lives in the desktop app module, so it is
+ * external to this module's compile-time dependency graph.
  */
+@Provided
 interface SandboxFileAccess {
 	/** True only on Mac App Store builds with the bookmark dylib successfully loaded. */
 	val isSandboxed: Boolean

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryIos.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepositoryIos.kt
@@ -9,9 +9,9 @@ import kotlinx.cinterop.convert
 import kotlinx.cinterop.usePinned
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
 import platform.Foundation.NSBundle
 import platform.Foundation.NSData
 import platform.Foundation.dataWithContentsOfFile
@@ -19,7 +19,7 @@ import platform.posix.memcpy
 import kotlin.time.Clock
 
 actual val exampleProjectModule = module {
-	singleOf(::ExampleProjectRepositoryiOs) bind ExampleProjectRepository::class
+	single<ExampleProjectRepositoryiOs>() bind ExampleProjectRepository::class
 }
 
 private class ExampleProjectRepositoryiOs(

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/platformModule.kt
@@ -9,19 +9,20 @@ import com.darkrockstudios.apps.hammer.common.data.projectbackup.BackupManagerSe
 import com.darkrockstudios.apps.hammer.common.spellcheck.LanguageUtil
 import com.darkrockstudios.apps.hammer.common.util.*
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
+import org.koin.plugin.module.dsl.factory
 
 actual val platformModule = module {
-	singleOf(::NetworkConnectivity)
-	singleOf(::StrResImpl) bind StrRes::class
-	singleOf(::DeviceLocaleResolver)
-	singleOf(::UrlLauncherDarwin) bind UrlLauncher::class
-	singleOf(::LanguageUtil)
+	single<NetworkConnectivity>()
+	single<StrResImpl>() bind StrRes::class
+	single<DeviceLocaleResolver>()
+	single<UrlLauncherDarwin>() bind UrlLauncher::class
+	single<LanguageUtil>()
 	factory { params -> IosSettingsComponent(componentContext = params.get()) } bind PlatformSettings::class
-	singleOf(::PlatformSpellCheckerFactory)
-	factory { FocusModeService() } bind FocusModeService::class
-	singleOf(::BackupManagerService)
-	singleOf(::IosRebasingGlobalSettingsDatasource) bind GlobalSettingsDatasource::class
+	single<PlatformSpellCheckerFactory>()
+	factory<FocusModeService>()
+	single<BackupManagerService>()
+	single<IosRebasingGlobalSettingsDatasource>() bind GlobalSettingsDatasource::class
 }

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/platform.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/platform.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.common
 
+import com.darkrockstudios.apps.hammer.base.di.bootstrapKoin
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.NapierLogger
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.appModule
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.mainModule
@@ -7,7 +8,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import okio.FileSystem
-import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import platform.Foundation.*
 import kotlin.coroutines.CoroutineContext
@@ -59,7 +59,7 @@ actual fun getLogDirectory(): String? = "${getApplicationSupportDirectory()}/log
 
 fun initializeKoin(extraModules: List<Module>) {
 	val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-	startKoin {
+	bootstrapKoin {
 		logger(NapierLogger())
 		modules(listOf(mainModule, appModule(appScope)) + extraModules)
 	}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ coil = "3.5.0"
 kmpalette = "3.1.0"
 
 koin_bom = "4.2.2"
+koin_plugin = "1.0.2"
 
 ktor = "3.5.1"
 ktor_plugin = "3.5.1"
@@ -215,6 +216,7 @@ coroutines_test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-
 
 koin_bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin_bom" }
 koin_core = { group = "io.insert-koin", name = "koin-core" }
+koin_annotations = { group = "io.insert-koin", name = "koin-annotations" }
 koin_core_coroutines = { group = "io.insert-koin", name = "koin-core-coroutines" }
 koin_android = { group = "io.insert-koin", name = "koin-android" }
 koin_test = { group = "io.insert-koin", name = "koin-test" }
@@ -351,6 +353,7 @@ sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 aboutlibraries_plugin = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 aboutlibraries_plugin_android = { id = "com.mikepenz.aboutlibraries.plugin.android", version.ref = "aboutlibraries" }
+koin_compiler = { id = "io.insert-koin.compiler.plugin", version.ref = "koin_plugin" }
 
 [bundles]
 koin_server = ["koin_core", "koin_core_coroutines", "koin_sl4j", "koin_ktor"]


### PR DESCRIPTION
## What

Adopts the **Koin Kotlin compiler plugin** (`io.insert-koin.compiler.plugin` 1.0.2) and converts `:common`'s DI from the classic Koin DSL to the plugin DSL (`org.koin.plugin.module.dsl`), turning on **compile-time DI graph validation** (`compileSafety = true`) while keeping the centralized `module { }` layout — no annotations, nothing moves onto classes.

`singleOf(::X)` → `single<X>()` (auto-wired + graph-checked). Provider functions / `when` bodies use `create(::fn)`. Interface `bind`, `named()`, and dynamic closures stay classic.

## Status

**`compileSafety = true` on every target, including iOS / Kotlin-Native.**

| Target | `compileSafety = true` |
|---|---|
| Desktop compile | ✅ |
| Android (`compileAndroidMain`) | ✅ |
| Common metadata | ✅ |
| `desktopTest` (compile + **1404 tests**) | ✅ |
| **iOS / Kotlin-Native** (compile + test + framework link) | ✅ |

CI is green across `build`, `android-instrumented-tests`, `iOS compile & test`, and `iOS UI tests`.

## The iOS K/N clash and how it's handled

Under `compileSafety = true` the plugin emits a synthetic `dsl_single` hint function for **every** definition in a plugin-processed `module { }`, encoding the definition's `named()` qualifier as a value-parameter **name**. Kotlin/Native's `IdSignature` ignores parameter names, so multiple same-type qualified definitions collapse to a single signature and fail klib serialization (`SignatureClashDetector` `AssertionError`). Our three same-type qualified `CoroutineContext` dispatchers (`main`/`default`/`io`) hit this.

The fix keeps `compileSafety` on for iOS by moving just those three definitions out of the plugin's reach: they now live in a plugin-less `dispatcherModule()` in `:base` (which has `koin-core` but not the compiler plugin), included from `mainModule`. No hints are generated for them, so there's no clash, and the rest of the graph is still fully validated on iOS. This is safe because the dispatchers are only ever consumed via runtime `inject(named(...))`, never constructor auto-wiring, so nothing the plugin validates depends on them — and the `DISPATCHER_*` constants stay in `:common`, so there are **zero consumer changes**.

(A separate iOS issue — the full-graph A3 pass choking on the custom `ProjectDefScope` because `startKoin` lived in `:common` — was resolved by relocating iOS `startKoin` into a plugin-less `bootstrapKoin()` helper in `:base`.)

## Changes

- `libs.versions.toml`: koin compiler plugin 1.0.2 + `koin-annotations` (BOM-managed).
- `:common` applies the plugin; all of `mainModule` (root + `ProjectDefScope` block), `migratorModule`, and the android/desktop/ios `platformModule` + `exampleProjectModule` actuals converted to plugin DSL.
- `@Provided` on `SandboxFileAccess` (its Koin definition lives in the `desktop` app module — external to `:common`).
- `:base` gains koin-core + a `bootstrapKoin()` helper (iOS `initializeKoin` delegates to it) and a plugin-less `dispatcherModule()` holding the three qualified `CoroutineContext` dispatchers.
