### PR TITLE
Harden flaky iOS scene-editor UI test with tap-retry helpers

### DIFF
--- a/ios/iosUITests/HammerUITest.swift
+++ b/ios/iosUITests/HammerUITest.swift
@@ -99,15 +99,6 @@ class HammerUITest: XCTestCase {
         return el
     }
 
-    /// Assert an element disappears (e.g. the save affordance vanishing after a successful save).
-    func waitUntilGone(_ tag: String, timeout: TimeInterval = HammerUITest.defaultTimeout,
-                       file: StaticString = #file, line: UInt = #line) {
-        let gone = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"),
-                                             object: element(tag))
-        XCTAssertEqual(XCTWaiter().wait(for: [gone], timeout: timeout), .completed,
-                       "Element still present after \(timeout)s: \(tag)", file: file, line: line)
-    }
-
     // MARK: - Interaction
 
     /// Tap a Compose element by its center point. Compose renders to a single surface, so most
@@ -120,6 +111,26 @@ class HammerUITest: XCTestCase {
         app.coordinate(withNormalizedOffset: .zero)
             .withOffset(CGVector(dx: frame.midX, dy: frame.midY))
             .tap()
+    }
+
+    /// Tap a Compose element by its center and re-tap on a short sub-timeout until `reaction`
+    /// becomes true. `tapCenter` synthesizes a best-effort *coordinate* tap onto Compose's single
+    /// surface, and an individual tap can be silently dropped (mid-relayout, under simulator load,
+    /// or while the software-keyboard geometry is shifting). A lone tap followed by one long wait is
+    /// the classic XCUITest flake — a single dropped tap costs the entire timeout and fails the
+    /// test — so re-tapping until the app demonstrably reacts converges instead. `reaction` is
+    /// checked first, so an already-satisfied state never taps and a tap that *did* land isn't
+    /// double-fired into a toggle.
+    func tapUntil(_ element: XCUIElement, until reaction: () -> Bool,
+                  timeout: TimeInterval = HammerUITest.defaultTimeout,
+                  file: StaticString = #file, line: UInt = #line) {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if reaction() { return }
+            tapCenter(element)
+            if poll(reaction, timeout: 3) { return }
+        } while Date() < deadline
+        XCTFail("App never reacted after re-tapping for \(timeout)s", file: file, line: line)
     }
 
     /// Tap near a field's top-leading edge to focus it. For multiline Compose editors (scene text,
@@ -135,6 +146,27 @@ class HammerUITest: XCTestCase {
     func tap(_ tag: String, timeout: TimeInterval = HammerUITest.defaultTimeout,
              file: StaticString = #file, line: UInt = #line) {
         tapCenter(waitFor(tag, timeout: timeout, file: file, line: line))
+    }
+
+    /// Tap the element tagged `tag`, re-tapping until the element tagged `expect` appears — i.e.
+    /// until the tap has demonstrably registered (a menu opened, a screen navigated). Robust
+    /// against dropped/stale Compose taps; see `tapUntil(_:until:)`. Use when a tap's effect is a
+    /// *new* element surfacing.
+    func tap(_ tag: String, expecting expect: String, timeout: TimeInterval = HammerUITest.defaultTimeout,
+             file: StaticString = #file, line: UInt = #line) {
+        let el = waitFor(tag, timeout: timeout, file: file, line: line)
+        tapUntil(el, until: { self.element(expect).exists }, timeout: timeout, file: file, line: line)
+    }
+
+    /// Tap the element tagged `tag`, re-tapping until it disappears — e.g. the scene-editor save
+    /// affordance, which is rendered only while the buffer is dirty and so vanishes once the save
+    /// lands. A lone tap here is doubly flaky: the tap can be dropped, or a late IME keystroke can
+    /// re-dirty the buffer right after a save and bring the button back. Re-tapping converges on
+    /// both; see `tapUntil(_:until:)`.
+    func tapUntilGone(_ tag: String, timeout: TimeInterval = HammerUITest.defaultTimeout,
+                      file: StaticString = #file, line: UInt = #line) {
+        let el = waitFor(tag, timeout: timeout, file: file, line: line)
+        tapUntil(el, until: { !el.exists }, timeout: timeout, file: file, line: line)
     }
 
     /// Tap a tagged field and type into it. Compose text fields don't report per-element keyboard
@@ -208,22 +240,22 @@ class HammerUITest: XCTestCase {
         // FormField submits on the IME action; the keyboard return key triggers it.
         app.typeText("\n")
 
-        // The new project shows as a card on the list; tap the one we just made.
+        // The new project shows as a card on the list; tap the one we just made. openProjectCard
+        // re-taps until the project root's nav rail renders, so on return we're in the open project.
         openProjectCard(named: name, file: file, line: line)
-
-        // The project root renders its navigation rail once open.
-        waitFor(Tag.navHome, file: file, line: line)
         return name
     }
 
-    /// Tap the project card matching `name`, falling back to the first card if the label isn't
-    /// exposed (Compose may merge the card's text into the card node's label).
+    /// Tap the project card matching `name` to open it, falling back to the first card if the label
+    /// isn't exposed (Compose may merge the card's text into the card node's label). The card tap is
+    /// re-tried until the project root's nav rail renders — a single Compose coordinate tap can be
+    /// dropped, which would otherwise fail the whole test on one miss (see `tapUntil`).
     private func openProjectCard(named name: String, file: StaticString, line: UInt) {
         let cards = app.descendants(matching: .any).matching(identifier: Tag.projectCard)
         let named = cards.matching(NSPredicate(format: "label CONTAINS[c] %@", name)).firstMatch
         let card = named.waitForExistence(timeout: 5) ? named : cards.firstMatch
         XCTAssertTrue(card.waitForExistence(timeout: HammerUITest.defaultTimeout),
                       "No project card appeared for \(name)", file: file, line: line)
-        tapCenter(card)
+        tapUntil(card, until: { self.element(Tag.navHome).exists }, file: file, line: line)
     }
 }

--- a/ios/iosUITests/HammerUITest.swift
+++ b/ios/iosUITests/HammerUITest.swift
@@ -158,15 +158,30 @@ class HammerUITest: XCTestCase {
         tapUntil(el, until: { self.element(expect).exists }, timeout: timeout, file: file, line: line)
     }
 
-    /// Tap the element tagged `tag`, re-tapping until it disappears — e.g. the scene-editor save
-    /// affordance, which is rendered only while the buffer is dirty and so vanishes once the save
-    /// lands. A lone tap here is doubly flaky: the tap can be dropped, or a late IME keystroke can
-    /// re-dirty the buffer right after a save and bring the button back. Re-tapping converges on
-    /// both; see `tapUntil(_:until:)`.
+    /// Tap the element tagged `tag` until it disappears — e.g. the scene-editor save affordance,
+    /// which is rendered only while the buffer is dirty and so vanishes once the save lands.
+    ///
+    /// The save button lives in the top bar, and right after the edit that surfaces it its
+    /// accessibility frame can be briefly *stale* — reported up under the status bar (a dead pixel)
+    /// before the layout settles. A blind coordinate tap there does nothing, and repeatedly tapping
+    /// that dead spot can even scroll/navigate the app away. So only tap when the button is actually
+    /// hittable (settled), using a hit-tested `tap()` that re-resolves its real position; otherwise
+    /// wait for it to settle. Re-tap until it's gone, which also covers a dropped tap or a late IME
+    /// keystroke re-dirtying the buffer right after a save.
     func tapUntilGone(_ tag: String, timeout: TimeInterval = HammerUITest.defaultTimeout,
                       file: StaticString = #file, line: UInt = #line) {
         let el = waitFor(tag, timeout: timeout, file: file, line: line)
-        tapUntil(el, until: { !el.exists }, timeout: timeout, file: file, line: line)
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if !el.exists { return }
+            if el.isHittable {
+                el.tap()
+                if poll({ !el.exists }, timeout: 3) { return }
+            } else {
+                _ = poll({ el.isHittable || !el.exists }, timeout: 1)
+            }
+        } while Date() < deadline
+        XCTFail("Element still present after \(timeout)s: \(tag)", file: file, line: line)
     }
 
     /// Tap a tagged field and type into it. Compose text fields don't report per-element keyboard

--- a/ios/iosUITests/SceneEditorWorkflowUITests.swift
+++ b/ios/iosUITests/SceneEditorWorkflowUITests.swift
@@ -15,11 +15,12 @@ final class SceneEditorWorkflowUITests: HammerUITest {
     func testEditSceneTextThenSave() {
         createAndOpenProject(baseName: "iOS-Scene")
 
-        tap(Tag.navEditor)
+        tap(Tag.navEditor, expecting: Tag.sceneListAdd)
 
-        // Create a scene and open it.
-        tap(Tag.sceneListAdd)
-        tap(Tag.sceneListAddScene)
+        // Create a scene and open it. Each coordinate tap onto Compose can be dropped, so drive each
+        // step by the element its tap surfaces (the add menu, then the create-item dialog).
+        tap(Tag.sceneListAdd, expecting: Tag.sceneListAddScene)
+        tap(Tag.sceneListAddScene, expecting: Tag.createItemNameField)
 
         // The scene-name dialog auto-focuses, so typing + IME submit works.
         type("Opening", into: Tag.createItemNameField)
@@ -34,8 +35,9 @@ final class SceneEditorWorkflowUITests: HammerUITest {
             self.element(Tag.sceneEditorSave).exists
         }
 
-        // Saving clears the dirty buffer, so the save action disappears.
-        tap(Tag.sceneEditorSave)
-        waitUntilGone(Tag.sceneEditorSave)
+        // Saving clears the dirty buffer, so the save action disappears. Re-tap until it does: the
+        // coordinate tap can be dropped, or a late IME keystroke can re-dirty the buffer just after
+        // the save and bring the button back.
+        tapUntilGone(Tag.sceneEditorSave)
     }
 }


### PR DESCRIPTION
## Problem

`SceneEditorWorkflowUITests.testEditSceneTextThenSave` intermittently timed out — most visibly at the last line, waiting 20s for the save affordance to disappear:

```
Element still present after 20.0s: scene-editor-save
```

The UI is Compose Multiplatform, which renders to a single surface, so XCUITest taps are best-effort **coordinate** taps onto that surface (see `HammerUITest.tapCenter`). An individual tap can be silently dropped — mid-relayout, under simulator load, or while the software-keyboard geometry is still shifting. A lone tap followed by one long wait is the classic XCUITest flake: a single dropped tap costs the whole timeout and fails the test. (The save button also only renders while the buffer is dirty, so a late IME keystroke committing right after a save can re-dirty the buffer and bring the button back.)

This is a test-robustness issue, not a product regression — a genuine registered single tap saves reliably (verified by driving the flow), and the save button disappears and stays gone.

## Fix

Add a small retry primitive and route the flake-prone taps through it:

- **`tapUntil(element, until:)`** — re-taps on a short sub-timeout until the app demonstrably reacts, converging instead of eating the full timeout on one dropped tap. `reaction` is checked first, so an already-satisfied state never taps and a tap that *did* land isn't double-fired.
- **`tap(_:expecting:)`** — drives each scene-creation step by the element its tap surfaces (the add menu, then the create-item dialog).
- **`tapUntilGone(_:)`** — replaces the lone save tap + long wait; also covers the late-IME-keystroke re-dirty.
- **`openProjectCard`** — re-taps the card until the project root's nav rail renders (same dropped-tap resilience), keeping its existing name/`firstMatch` card selection.

## Validation

Ran the full `iosUITests` scheme on freshly-erased simulators across **6 consecutive runs — all four UI test classes passed every run** (LaunchSmoke, Notes, Project, SceneEditor). The pre-existing code flaked in a repeated loop of the target test; the updated code did not.

CI exercises this via the `iOS UI tests` job in `.github/workflows/build.yml`.