### PR TITLE
Add optional Terms of Service gate for account creation

### DIFF
--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/Http.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/Http.kt
@@ -12,3 +12,6 @@ const val HEADER_ORIGINAL_HASH = "X-Original-Hash"
 const val HEADER_ENTITY_TYPE = "X-Entity-Type"
 
 const val API_ROUTE_PREFIX = "api"
+
+/** HTTP 451: account creation is gated on accepting the server's Terms of Service. */
+const val HTTP_STATUS_TERMS_OF_SERVICE = 451

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/TermsOfServiceChallenge.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/TermsOfServiceChallenge.kt
@@ -1,0 +1,10 @@
+package com.darkrockstudios.apps.hammer.base.http
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermsOfServiceChallenge(
+	val text: String,
+	/** SHA-256 hex of the terms of service text, echoed back on acceptance */
+	val version: String,
+)

--- a/common/src/commonMain/composeResources/values/strings_account_settings.xml
+++ b/common/src/commonMain/composeResources/values/strings_account_settings.xml
@@ -148,6 +148,12 @@
 		name="settings_server_setup_toast_failure_unknown">Server setup failed. Please check your connection and try again.
 	</string>
 
+	<!-- Terms of Service -->
+	<string name="settings_server_tos_title">Terms of Service</string>
+	<string name="settings_server_tos_accept">Accept</string>
+	<string name="settings_server_tos_decline">Decline</string>
+	<string name="settings_server_tos_declined">You must accept the Terms of Service to create an account.</string>
+
 	<!-- Network Errors -->
 	<string
 		name="server_error_connection_timeout">Could not connect to server. Make sure the server is running and the address is correct.

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettings.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.common.components.projectselection.accou
 
 import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.value.Value
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
 import com.darkrockstudios.apps.hammer.common.components.ComponentToaster
 import com.darkrockstudios.apps.hammer.common.components.projectselection.ProjectSelection
 import com.darkrockstudios.apps.hammer.common.components.spellchecksettings.SpellCheckSettings
@@ -28,6 +29,9 @@ interface AccountSettings : ComponentToaster {
 		create: Boolean,
 		removeLocalContent: Boolean
 	)
+
+	fun acceptTos()
+	fun declineTos()
 
 	suspend fun authTest(): Boolean
 	fun removeServer()
@@ -64,6 +68,7 @@ interface AccountSettings : ComponentToaster {
 		@Transient val serverPassword: String? = null,
 		@Transient val serverError: String? = null,
 		@Transient val serverWorking: Boolean = false,
+		@Transient val tosChallenge: TermsOfServiceChallenge? = null,
 		val syncAutomaticSync: Boolean,
 		val syncAutomaticBackups: Boolean,
 		val syncAutoCloseDialog: Boolean,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
@@ -20,11 +20,11 @@ import com.darkrockstudios.apps.hammer.common.components.spellchecksettings.Spel
 import com.darkrockstudios.apps.hammer.common.components.spellchecksettings.SpellCheckSettingsComponent
 import com.darkrockstudios.apps.hammer.common.data.ExampleProjectRepository
 import com.darkrockstudios.apps.hammer.common.data.account.AccountUseCase
+import com.darkrockstudios.apps.hammer.common.data.account.ServerSetupResult
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.InitialProjectScreen
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.UiTheme
-import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
 import com.darkrockstudios.apps.hammer.common.util.StrRes
@@ -39,6 +39,7 @@ import com.darkrockstudios.apps.hammer.server_setup_error_password_too_short
 import com.darkrockstudios.apps.hammer.settings_server_setup_toast_failure
 import com.darkrockstudios.apps.hammer.settings_server_setup_toast_failure_unknown
 import com.darkrockstudios.apps.hammer.settings_server_setup_toast_success
+import com.darkrockstudios.apps.hammer.settings_server_tos_declined
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -73,6 +74,7 @@ class AccountSettingsComponent(
 		)
 
 	private var serverSetupJob: Job? = null
+	private var pendingServerSetup: PendingServerSetup? = null
 
 	override val platformSettings: PlatformSettings by inject { parametersOf(componentContext) }
 	override val spellCheckSettings: SpellCheckSettings = SpellCheckSettingsComponent(componentContext)
@@ -176,11 +178,17 @@ class AccountSettingsComponent(
 	override fun cancelServerSetup() {
 		cancelSetupJob()
 		cleanUpServerSetup()
+		// A pending setup means setupServer already persisted provisional settings; drop them.
+		if (pendingServerSetup != null) {
+			globalSettingsStore.deleteServerSettings()
+		}
+		pendingServerSetup = null
 		_state.getAndUpdate {
 			it.copy(
 				serverSetup = false,
 				serverError = null,
 				serverWorking = false,
+				tosChallenge = null,
 			)
 		}
 	}
@@ -331,12 +339,61 @@ class AccountSettingsComponent(
 				removeLocalContent()
 			}
 
-			val result = accountUseCase.setupServer(ssl, cleanUrl, email.trim(), password, create)
+			val pending = PendingServerSetup(ssl, cleanUrl, email.trim(), password, create)
+			pendingServerSetup = pending
+			performServerSetup(pending, acceptedTosVersion = null)
+		}
+	}
+
+	override fun acceptTos() {
+		val pending = pendingServerSetup ?: return
+		val version = _state.value.tosChallenge?.version ?: return
+
+		cancelSetupJob()
+		serverSetupJob = scope.launch {
 			withContext(mainDispatcher) {
-				if (isSuccess(result)) {
+				_state.getAndUpdate {
+					it.copy(
+						tosChallenge = null,
+						serverError = null,
+						serverWorking = true,
+					)
+				}
+			}
+			performServerSetup(pending, acceptedTosVersion = version)
+		}
+	}
+
+	override fun declineTos() {
+		pendingServerSetup = null
+		// setupServer persisted provisional settings for the retry; declining discards them.
+		globalSettingsStore.deleteServerSettings()
+		_state.getAndUpdate {
+			it.copy(
+				tosChallenge = null,
+				serverSetup = false,
+				serverWorking = false,
+			)
+		}
+		showToast(scope, Res.string.settings_server_tos_declined)
+	}
+
+	private suspend fun performServerSetup(pending: PendingServerSetup, acceptedTosVersion: String?) {
+		val result = accountUseCase.setupServer(
+			ssl = pending.ssl,
+			url = pending.url,
+			email = pending.email,
+			password = pending.password,
+			create = pending.create,
+			acceptedTosVersion = acceptedTosVersion,
+		)
+		withContext(mainDispatcher) {
+			when (result) {
+				is ServerSetupResult.Success -> {
+					pendingServerSetup = null
 					// A freshly created account holds no projects, so any serverProjectId from a
 					// previous server is stale and would make sync skip re-creating the project.
-					if (create) {
+					if (pending.create) {
 						clearAllProjectIds()
 					}
 					cleanUpServerSetup()
@@ -347,7 +404,21 @@ class AccountSettingsComponent(
 						)
 					}
 					showToast(Res.string.settings_server_setup_toast_success)
-				} else {
+				}
+
+				is ServerSetupResult.TermsRequired -> {
+					// Replace the setup dialog with the terms dialog so they don't stack.
+					_state.getAndUpdate {
+						it.copy(
+							tosChallenge = result.challenge,
+							serverSetup = false,
+							serverWorking = false,
+						)
+					}
+				}
+
+				is ServerSetupResult.Failure -> {
+					pendingServerSetup = null
 					val message = result.displayMessage?.text(strRes)
 						?: strRes.get(Res.string.settings_server_setup_toast_failure_unknown)
 					_state.getAndUpdate {
@@ -412,6 +483,14 @@ class AccountSettingsComponent(
 		}
 	}
 }
+
+private data class PendingServerSetup(
+	val ssl: Boolean,
+	val url: String,
+	val email: String,
+	val password: String,
+	val create: Boolean,
+)
 
 @Serializable
 data object BackupManagerConfig

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/account/AccountUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/account/AccountUseCase.kt
@@ -1,14 +1,16 @@
 package com.darkrockstudios.apps.hammer.common.data.account
 
 import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
 import com.darkrockstudios.apps.hammer.base.http.Token
-import com.darkrockstudios.apps.hammer.common.data.CResult
+import com.darkrockstudios.apps.hammer.common.data.Msg
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.toMsg
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.updateCredentials
 import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
 import com.darkrockstudios.apps.hammer.common.server.ServerAccountApi
+import com.darkrockstudios.apps.hammer.common.server.TermsOfServiceRequiredException
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.server_setup_error_unknown
 import io.ktor.client.*
@@ -25,8 +27,9 @@ class AccountUseCase(
 		url: String,
 		email: String,
 		password: String,
-		create: Boolean
-	): CResult<Unit> {
+		create: Boolean,
+		acceptedTosVersion: String? = null,
+	): ServerSetupResult {
 		val installId = globalSettingsStore.ensureInstallId()
 		val newSettings = ServerSettings(
 			userId = -1,
@@ -44,6 +47,7 @@ class AccountUseCase(
 				email = email,
 				password = password,
 				installId = installId,
+				acceptedTosVersion = acceptedTosVersion,
 			)
 		} else {
 			accountApi.login(
@@ -66,23 +70,31 @@ class AccountUseCase(
 			httpClient.updateCredentials(bearerTokens)
 			globalSettingsStore.updateServerSettings(authedSettings)
 
-			CResult.success()
+			ServerSetupResult.Success
 		} else {
-			globalSettingsStore.deleteServerSettings()
+			val exception = result.exceptionOrNull()
+			if (exception is TermsOfServiceRequiredException) {
+				// Keep the provisional server settings so accepting the terms can retry the request.
+				ServerSetupResult.TermsRequired(exception.challenge)
+			} else {
+				globalSettingsStore.deleteServerSettings()
 
-			val exception = result.exceptionOrNull() as? HttpFailureException
-			val displayMessage = exception?.error?.displayMessage
-				?: strRes.get(Res.string.server_setup_error_unknown)
+				val httpFailure = exception as? HttpFailureException
+				val displayMessage = httpFailure?.error?.displayMessage?.toMsg()
+					?: strRes.get(Res.string.server_setup_error_unknown).toMsg()
 
-			CResult.failure(
-				error = exception?.error?.error ?: "Unknown error",
-				displayMessage = displayMessage.toMsg(),
-				exception = exception
-			)
+				ServerSetupResult.Failure(displayMessage = displayMessage, exception = exception)
+			}
 		}
 	}
 
 	suspend fun testAuth(): Boolean {
 		return accountApi.testAuth().isSuccess
 	}
+}
+
+sealed interface ServerSetupResult {
+	data object Success : ServerSetupResult
+	data class TermsRequired(val challenge: TermsOfServiceChallenge) : ServerSetupResult
+	data class Failure(val displayMessage: Msg?, val exception: Throwable?) : ServerSetupResult
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
@@ -35,6 +35,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
+import io.ktor.serialization.ContentConvertException
 import io.ktor.util.network.UnresolvedAddressException
 import kotlinx.coroutines.withContext
 import okio.IOException
@@ -324,6 +325,21 @@ class TermsOfServiceRequiredException(
 
 typealias FailureHandler = suspend (HttpResponse) -> Throwable
 
+private suspend fun unparseableErrorBody(
+	status: HttpStatusCode,
+	strRes: StrRes,
+	cause: Throwable,
+): HttpFailureException {
+	Napier.w("Error response body unable to be parsed", cause)
+	return HttpFailureException(
+		statusCode = status,
+		error = HttpResponseError(
+			error = "Unhandled error body",
+			displayMessage = strRes.get(Res.string.sync_general_error),
+		)
+	)
+}
+
 suspend fun defaultFailureHandler(response: HttpResponse, strRes: StrRes): Throwable {
 	return when(response.status) {
 		HttpStatusCode.Unauthorized -> {
@@ -343,14 +359,9 @@ suspend fun defaultFailureHandler(response: HttpResponse, strRes: StrRes): Throw
 					error = error
 				)
 			} catch (e: NoTransformationFoundException) {
-				Napier.w("Error response body unable to be parsed", e)
-				HttpFailureException(
-					statusCode = response.status,
-					error = HttpResponseError(
-						error = "Unhandled error body",
-						displayMessage = strRes.get(Res.string.sync_general_error),
-					)
-				)
+				unparseableErrorBody(response.status, strRes, e)
+			} catch (e: ContentConvertException) {
+				unparseableErrorBody(response.status, strRes, e)
 			}
 		}
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
 import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
 import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.protocolmismatch.ProtocolMismatchRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectIoDispatcher
@@ -45,6 +46,9 @@ abstract class Api(
 	private val globalSettingsStore: GlobalSettingsStore,
 	private val strRes: StrRes,
 ) : KoinComponent {
+
+	protected suspend fun defaultFailure(response: HttpResponse): Throwable =
+		defaultFailureHandler(response, strRes)
 	protected val userId: Long?
 		get() = globalSettingsStore.serverSettings?.userId
 
@@ -312,6 +316,11 @@ class HttpFailureException(
 ) : Exception("HTTP $statusCode ${error.error}: ${error.displayMessage}") {
 	override fun toString() = message ?: super.toString()
 }
+
+/** The server requires the given Terms of Service to be accepted before an account can be created. */
+class TermsOfServiceRequiredException(
+	val challenge: TermsOfServiceChallenge
+) : Exception("Terms of service acceptance required (version ${challenge.version})")
 
 typealias FailureHandler = suspend (HttpResponse) -> Throwable
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerAccountApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerAccountApi.kt
@@ -1,5 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.server
 
+import com.darkrockstudios.apps.hammer.base.http.HTTP_STATUS_TERMS_OF_SERVICE
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
 import com.darkrockstudios.apps.hammer.base.http.Token
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.util.StrRes
@@ -7,7 +9,9 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
+import kotlinx.serialization.SerializationException
 
 class ServerAccountApi(
 	httpClient: HttpClient,
@@ -19,18 +23,39 @@ class ServerAccountApi(
 		email: String,
 		password: String,
 		installId: String,
+		acceptedTosVersion: String? = null,
 	): Result<Token> {
-		return post("/api/account/create", parse = { it.body() }) {
+		return post(
+			"/api/account/create",
+			parse = { it.body() },
+			failureHandler = { response -> createAccountFailure(response) },
+		) {
 			setBody(
 				FormDataContent(
 					Parameters.build {
 						append("email", email)
 						append("password", password)
 						append("installId", installId)
+						acceptedTosVersion?.let { append("acceptedTosVersion", it) }
 					}
 				)
 			)
 		}
+	}
+
+	private suspend fun createAccountFailure(response: HttpResponse): Throwable {
+		if (response.status.value == HTTP_STATUS_TERMS_OF_SERVICE) {
+			val challenge = try {
+				response.body<TermsOfServiceChallenge>()
+			} catch (e: NoTransformationFoundException) {
+				null
+			} catch (e: SerializationException) {
+				// A 451 with a malformed/empty body falls through to the default failure.
+				null
+			}
+			if (challenge != null) return TermsOfServiceRequiredException(challenge)
+		}
+		return defaultFailure(response)
 	}
 
 	suspend fun login(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerAccountApi.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/ServerAccountApi.kt
@@ -11,7 +11,7 @@ import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import kotlinx.serialization.SerializationException
+import io.ktor.serialization.ContentConvertException
 
 class ServerAccountApi(
 	httpClient: HttpClient,
@@ -49,7 +49,7 @@ class ServerAccountApi(
 				response.body<TermsOfServiceChallenge>()
 			} catch (e: NoTransformationFoundException) {
 				null
-			} catch (e: SerializationException) {
+			} catch (e: ContentConvertException) {
 				// A 451 with a malformed/empty body falls through to the default failure.
 				null
 			}

--- a/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
@@ -3,12 +3,13 @@ package components.projectselection
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
 import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettingsComponent
 import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.PlatformSettings
-import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ExampleProjectRepository
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.account.AccountUseCase
+import com.darkrockstudios.apps.hammer.common.data.account.ServerSetupResult
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
@@ -17,9 +18,13 @@ import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRe
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -124,9 +129,10 @@ class AccountSettingsComponentTest : BaseTest() {
 				any(),
 				any(),
 				any(),
+				any(),
 				any()
 			)
-		} returns CResult.success()
+		} returns ServerSetupResult.Success
 
 		val component = newComponent()
 		component.setupServer(
@@ -153,9 +159,10 @@ class AccountSettingsComponentTest : BaseTest() {
 				any(),
 				any(),
 				any(),
+				any(),
 				any()
 			)
-		} returns CResult.success()
+		} returns ServerSetupResult.Success
 
 		val component = newComponent()
 		component.setupServer(
@@ -169,5 +176,66 @@ class AccountSettingsComponentTest : BaseTest() {
 		advanceUntilIdle()
 
 		verify(exactly = 0) { projectsRepository.removeProjectId(any()) }
+	}
+
+	@Test
+	fun `Terms of service challenge is surfaced and acceptance retries the request`() = runTest {
+		every { projectsRepository.getProjects() } returns emptyList()
+		coEvery {
+			accountUseCase.setupServer(any(), any(), any(), any(), any(), null)
+		} returns ServerSetupResult.TermsRequired(TermsOfServiceChallenge(text = "Legal text", version = "v1"))
+		coEvery {
+			accountUseCase.setupServer(any(), any(), any(), any(), any(), "v1")
+		} returns ServerSetupResult.Success
+
+		val component = newComponent()
+		component.setupServer(
+			ssl = true,
+			url = "example.com",
+			email = "writer@example.com",
+			password = "Password1!",
+			create = true,
+			removeLocalContent = false,
+		)
+		advanceUntilIdle()
+
+		assertEquals("Legal text", component.state.value.tosChallenge?.text)
+		assertEquals("v1", component.state.value.tosChallenge?.version)
+		assertFalse(component.state.value.serverWorking)
+
+		component.acceptTos()
+		advanceUntilIdle()
+
+		assertNull(component.state.value.tosChallenge)
+		assertFalse(component.state.value.serverSetup)
+		coVerify { accountUseCase.setupServer(any(), any(), any(), any(), any(), "v1") }
+	}
+
+	@Test
+	fun `Declining terms of service clears the challenge without creating an account`() = runTest {
+		coEvery {
+			accountUseCase.setupServer(any(), any(), any(), any(), any(), null)
+		} returns ServerSetupResult.TermsRequired(TermsOfServiceChallenge(text = "Legal text", version = "v1"))
+
+		val component = newComponent()
+		component.setupServer(
+			ssl = true,
+			url = "example.com",
+			email = "writer@example.com",
+			password = "Password1!",
+			create = true,
+			removeLocalContent = false,
+		)
+		advanceUntilIdle()
+		assertNotNull(component.state.value.tosChallenge)
+
+		component.declineTos()
+		advanceUntilIdle()
+
+		assertNull(component.state.value.tosChallenge)
+		// Declining discards the provisional server settings setupServer persisted for the retry.
+		verify { globalSettingsStore.deleteServerSettings() }
+		// Only the initial challenge attempt ran; declining never resubmits.
+		coVerify(exactly = 1) { accountUseCase.setupServer(any(), any(), any(), any(), any(), any()) }
 	}
 }

--- a/common/src/desktopTest/kotlin/server/ServerAccountApiTest.kt
+++ b/common/src/desktopTest/kotlin/server/ServerAccountApiTest.kt
@@ -1,0 +1,117 @@
+package server
+
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
+import com.darkrockstudios.apps.hammer.common.server.ServerAccountApi
+import com.darkrockstudios.apps.hammer.common.server.TermsOfServiceRequiredException
+import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.koin.dsl.module
+import utils.BaseTest
+import utils.TestStrRes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ServerAccountApiTest : BaseTest() {
+
+	private lateinit var globalSettingsStore: GlobalSettingsStore
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+
+		globalSettingsStore = mockk(relaxed = true)
+		every { globalSettingsStore.serverSettings } returns ServerSettings(
+			ssl = false,
+			url = "example.com",
+			email = "user@example.com",
+			userId = -1L,
+			bearerToken = null,
+			refreshToken = null,
+		)
+
+		setupKoin(
+			module {
+				single { DeviceLocaleResolver() }
+			}
+		)
+	}
+
+	private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+
+	private fun createApi(engine: MockEngine): ServerAccountApi {
+		val client = HttpClient(engine) {
+			install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+		}
+		return ServerAccountApi(client, globalSettingsStore, TestStrRes())
+	}
+
+	@Test
+	fun `a successful create returns the token`() = runTest {
+		val engine = MockEngine {
+			respond(
+				content = """{"userId":1,"auth":"auth-token","refresh":"refresh-token"}""",
+				status = HttpStatusCode.Created,
+				headers = jsonHeaders,
+			)
+		}
+		val api = createApi(engine)
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertTrue(result.isSuccess)
+		assertEquals("auth-token", result.getOrThrow().auth)
+	}
+
+	@Test
+	fun `a 451 with a challenge body fails with a terms-of-service exception`() = runTest {
+		val challenge = TermsOfServiceChallenge(text = "Be excellent to each other", version = "v1")
+		val engine = MockEngine {
+			respond(
+				content = """{"text":"${challenge.text}","version":"${challenge.version}"}""",
+				status = HttpStatusCode.fromValue(451),
+				headers = jsonHeaders,
+			)
+		}
+		val api = createApi(engine)
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertTrue(result.isFailure)
+		val exception = assertIs<TermsOfServiceRequiredException>(result.exceptionOrNull())
+		assertEquals(challenge, exception.challenge)
+	}
+
+	@Test
+	fun `a 451 with a malformed body falls through to the default failure`() = runTest {
+		val engine = MockEngine {
+			respond(
+				content = "not a challenge",
+				status = HttpStatusCode.fromValue(451),
+				headers = jsonHeaders,
+			)
+		}
+		val api = createApi(engine)
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertTrue(result.isFailure)
+		assertIs<HttpFailureException>(result.exceptionOrNull())
+	}
+}

--- a/common/src/desktopTest/kotlin/usecases/AccountUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/AccountUseCaseTest.kt
@@ -1,15 +1,16 @@
 package usecases
 
 import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
 import com.darkrockstudios.apps.hammer.base.http.Token
 import com.darkrockstudios.apps.hammer.common.data.ClientMessage
 import com.darkrockstudios.apps.hammer.common.data.account.AccountUseCase
+import com.darkrockstudios.apps.hammer.common.data.account.ServerSetupResult
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
-import com.darkrockstudios.apps.hammer.common.data.isFailure
-import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.updateCredentials
 import com.darkrockstudios.apps.hammer.common.server.ServerAccountApi
+import com.darkrockstudios.apps.hammer.common.server.TermsOfServiceRequiredException
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.server_setup_error_unknown
 import io.ktor.client.*
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.Test
 import utils.BaseTest
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 class AccountUseCaseTest : BaseTest() {
 
@@ -89,9 +89,9 @@ class AccountUseCaseTest : BaseTest() {
 			password = "password",
 			create = true
 		)
-		assertTrue(isSuccess(result))
+		assertIs<ServerSetupResult.Success>(result)
 
-		coVerify { accountApi.createAccount(settings.email, "password", "test-uuid") }
+		coVerify { accountApi.createAccount(settings.email, "password", "test-uuid", null) }
 		coVerify(exactly = 0) { accountApi.login(any(), any(), any()) }
 
 		assertEquals(token.auth, bearerTokenSlot.captured.accessToken)
@@ -129,6 +129,7 @@ class AccountUseCaseTest : BaseTest() {
 			accountApi.createAccount(
 				any(),
 				any(),
+				any(),
 				any()
 			)
 		} returns Result.failure(IOException())
@@ -144,16 +145,61 @@ class AccountUseCaseTest : BaseTest() {
 			password = "password",
 			create = true
 		)
-		assertTrue(isFailure(result))
-		assertEquals("Unknown error", result.error)
+		val failure = assertIs<ServerSetupResult.Failure>(result)
 		// Non-HTTP failures fall back to the localized unknown-error message.
-		val displayMessage = assertIs<ClientMessage.Literal>(result.displayMessage)
+		val displayMessage = assertIs<ClientMessage.Literal>(failure.displayMessage)
 		assertEquals("Unknown error message", displayMessage.text())
 
-		coVerify { accountApi.createAccount(any(), any(), any()) }
+		coVerify { accountApi.createAccount(any(), any(), any(), any()) }
 		coVerify(exactly = 0) { accountApi.login(any(), any(), any()) }
 		coVerify(exactly = 0) { httpClient.updateCredentials(any()) }
 		coVerify { globalSettingsStore.deleteServerSettings() }
+	}
+
+	@Test
+	fun `Create account requiring terms of service`() = runTest {
+		val challenge = TermsOfServiceChallenge(text = "Be excellent to each other", version = "v1")
+		coEvery {
+			accountApi.createAccount(any(), any(), any(), acceptedTosVersion = null)
+		} returns Result.failure(TermsOfServiceRequiredException(challenge))
+
+		val usecase = createSut()
+
+		val result = usecase.setupServer(
+			ssl = false,
+			url = "hammer.ink",
+			email = "test@example.com",
+			password = "password",
+			create = true,
+		)
+
+		val termsRequired = assertIs<ServerSetupResult.TermsRequired>(result)
+		assertEquals(challenge, termsRequired.challenge)
+		// The provisional server settings must survive so accepting the terms can retry.
+		coVerify(exactly = 0) { globalSettingsStore.deleteServerSettings() }
+	}
+
+	@Test
+	fun `Accepting terms of service resubmits with the accepted version`() = runTest {
+		val token = Token(1, "test-auth", "test-refresh")
+		coEvery {
+			accountApi.createAccount(any(), any(), any(), acceptedTosVersion = "v1")
+		} returns Result.success(token)
+		every { httpClient.updateCredentials(any()) } just Runs
+
+		val usecase = createSut()
+
+		val result = usecase.setupServer(
+			ssl = false,
+			url = "hammer.ink",
+			email = "test@example.com",
+			password = "password",
+			create = true,
+			acceptedTosVersion = "v1",
+		)
+
+		assertIs<ServerSetupResult.Success>(result)
+		coVerify { accountApi.createAccount("test@example.com", "password", "test-uuid", "v1") }
 	}
 
 	@Test
@@ -186,9 +232,9 @@ class AccountUseCaseTest : BaseTest() {
 			password = "password",
 			create = false
 		)
-		assertTrue(isSuccess(result))
+		assertIs<ServerSetupResult.Success>(result)
 
-		coVerify(exactly = 0) { accountApi.createAccount(any(), any(), any()) }
+		coVerify(exactly = 0) { accountApi.createAccount(any(), any(), any(), any()) }
 		coVerify { accountApi.login(settings.email, "password", "test-uuid") }
 
 		assertEquals(token.auth, bearerTokenSlot.captured.accessToken)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSettingsUi.kt
@@ -120,6 +120,7 @@ fun ServerSettingsUi(
 
 	Toaster(component, rootSnackbar)
 	ServerSetupDialog(component, scope)
+	TermsOfServiceDialog(component)
 
 	if (showHelpDialog) {
 		ServerSetupHelpDialog(onDismiss = { showHelpDialog = false })

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/TermsOfServiceDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/TermsOfServiceDialog.kt
@@ -1,0 +1,143 @@
+package com.darkrockstudios.apps.hammer.common.projectselection.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettings
+import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialogContainer
+import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMasthead
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
+import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.settings_server_tos_accept
+import com.darkrockstudios.apps.hammer.settings_server_tos_decline
+import com.darkrockstudios.apps.hammer.settings_server_tos_title
+
+private val DialogMaxWidth = 540.dp
+private val DialogMaxHeight = 760.dp
+
+@Composable
+fun TermsOfServiceDialog(component: AccountSettings) {
+	val state by component.state.subscribeAsState()
+	val challenge = state.tosChallenge
+
+	if (challenge != null) {
+		AnimatedDialogContainer(
+			isOpen = true,
+			onDismissRequest = { component.declineTos() },
+			onClosed = {},
+			properties = DialogProperties(
+				dismissOnBackPress = true,
+				dismissOnClickOutside = false,
+				usePlatformDefaultWidth = false,
+			),
+		) {
+			TermsOfServiceDialogContent(
+				text = challenge.text,
+				working = state.serverWorking,
+				onAccept = { component.acceptTos() },
+				onDecline = { component.declineTos() },
+				modifier = Modifier.predictiveBackTransform(),
+			)
+		}
+	}
+}
+
+/**
+ * The static chrome of [TermsOfServiceDialog] without the [AnimatedDialogContainer] wrapper, so it
+ * can be rendered directly in a `@Preview` where the enter animation can't advance.
+ */
+@Composable
+fun TermsOfServiceDialogContent(
+	text: String,
+	working: Boolean,
+	onAccept: () -> Unit,
+	onDecline: () -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	Surface(
+		modifier = modifier
+			.padding(Ui.Padding.XL)
+			.widthIn(max = DialogMaxWidth)
+			.heightIn(max = DialogMaxHeight)
+			.fillMaxWidth()
+			.fillMaxHeight(0.9f),
+		shape = RectangleShape,
+		color = MaterialTheme.colorScheme.surface,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+		border = BorderStroke(
+			width = Dp.Hairline,
+			color = MaterialTheme.colorScheme.outlineVariant,
+		),
+	) {
+		Column(modifier = Modifier.fillMaxWidth()) {
+			HdMasthead(
+				section = "TERMS OF SERVICE",
+				trailing = { HdMastheadAction(label = "× DECLINE", onClick = onDecline) },
+			)
+			HdFolioDivider()
+
+			Column(
+				modifier = Modifier
+					.weight(1f)
+					.fillMaxWidth()
+					.verticalScroll(rememberScrollState())
+					.padding(
+						start = Ui.Padding.XL,
+						end = Ui.Padding.XL,
+						top = Ui.Padding.L,
+						bottom = Ui.Padding.L,
+					),
+				verticalArrangement = Arrangement.spacedBy(Ui.Padding.L),
+			) {
+				Text(
+					text = Res.string.settings_server_tos_title.get(),
+					style = MaterialTheme.typography.headlineSmall,
+					color = MaterialTheme.colorScheme.onSurface,
+				)
+
+				Text(
+					text = text,
+					style = MaterialTheme.typography.bodyMedium,
+					color = MaterialTheme.colorScheme.onSurfaceVariant,
+				)
+			}
+
+			HdFolioDivider()
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.L),
+				horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
+			) {
+				HdHairlineButton(
+					label = Res.string.settings_server_tos_decline.get(),
+					onClick = onDecline,
+					enabled = !working,
+				)
+				Spacer(modifier = Modifier.weight(1f))
+				HdHairlineButton(
+					label = Res.string.settings_server_tos_accept.get(),
+					onClick = onAccept,
+					enabled = !working,
+					emphasised = true,
+				)
+			}
+		}
+	}
+}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/TermsOfServiceDialog.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/TermsOfServiceDialog.Preview.kt
@@ -1,0 +1,41 @@
+package com.darkrockstudios.apps.hammer.common.preview
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.projectselection.settings.TermsOfServiceDialogContent
+
+private const val SAMPLE_TOS =
+	"By creating an account on this server you agree to use it responsibly. " +
+		"Do not upload unlawful content. The server is provided as-is with no warranty, " +
+		"and the administrator may remove accounts that abuse the service.\n\n" +
+		"Your projects are stored so they can be synchronized across your devices. " +
+		"You remain the owner of everything you write."
+
+@Preview(widthDp = 560, heightDp = 640)
+@Composable
+fun TermsOfServiceDialogPreview() {
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, true) {
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.background(MaterialTheme.colorScheme.background),
+				contentAlignment = Alignment.Center,
+			) {
+				TermsOfServiceDialogContent(
+					text = SAMPLE_TOS,
+					working = false,
+					onAccept = {},
+					onDecline = {},
+				)
+			}
+		}
+	}
+}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
@@ -66,6 +66,9 @@ internal fun accountSettingsComponent(state: AccountSettings.State = defaultAcco
 		) {
 		}
 
+		override fun acceptTos() {}
+		override fun declineTos() {}
+
 		override suspend fun authTest() = true
 		override fun removeServer() {}
 		override suspend fun setAutomaticBackups(value: Boolean) {}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -178,20 +178,34 @@ internal fun resolveServerConfig(
 	configPath: String?,
 	fileSystem: FileSystem = FileSystem.SYSTEM,
 ): ServerConfig {
-	val config = if (configPath != null) {
-		loadConfig(fileSystem, configPath.toPath())
+	val configFile: Path? = if (configPath != null) {
+		configPath.toPath()
 	} else {
 		val defaultConfig = getRootDataDirectory(fileSystem) / DEFAULT_CONFIG_FILE_NAME
 		if (fileSystem.exists(defaultConfig)) {
 			configLogger.info("Loading config from default location: $defaultConfig")
-			loadConfig(fileSystem, defaultConfig)
+			defaultConfig
 		} else {
-			ServerConfig()
+			null
 		}
 	}
 
-	validateTermsOfService(config, fileSystem)
-	return config
+	val config = configFile?.let { loadConfig(fileSystem, it) } ?: ServerConfig()
+
+	val resolved = resolveTermsOfServicePath(config, configFile?.parent)
+	validateTermsOfService(resolved, fileSystem)
+	return resolved
+}
+
+/**
+ * A relative [ServerConfig.termsOfService] is resolved against the config file's own directory, so
+ * a bare `tos.txt` sitting next to `config.toml` is found regardless of the server's working
+ * directory. Absolute paths are left untouched.
+ */
+private fun resolveTermsOfServicePath(config: ServerConfig, configDir: Path?): ServerConfig {
+	val tosPath = config.termsOfService?.toPath() ?: return config
+	if (tosPath.isAbsolute || configDir == null) return config
+	return config.copy(termsOfService = configDir.resolve(tosPath).toString())
 }
 
 /**

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -178,14 +178,36 @@ internal fun resolveServerConfig(
 	configPath: String?,
 	fileSystem: FileSystem = FileSystem.SYSTEM,
 ): ServerConfig {
-	if (configPath != null) return loadConfig(fileSystem, configPath.toPath())
-
-	val defaultConfig = getRootDataDirectory(fileSystem) / DEFAULT_CONFIG_FILE_NAME
-	return if (fileSystem.exists(defaultConfig)) {
-		configLogger.info("Loading config from default location: $defaultConfig")
-		loadConfig(fileSystem, defaultConfig)
+	val config = if (configPath != null) {
+		loadConfig(fileSystem, configPath.toPath())
 	} else {
-		ServerConfig()
+		val defaultConfig = getRootDataDirectory(fileSystem) / DEFAULT_CONFIG_FILE_NAME
+		if (fileSystem.exists(defaultConfig)) {
+			configLogger.info("Loading config from default location: $defaultConfig")
+			loadConfig(fileSystem, defaultConfig)
+		} else {
+			ServerConfig()
+		}
+	}
+
+	validateTermsOfService(config, fileSystem)
+	return config
+}
+
+/**
+ * A configured [ServerConfig.termsOfService] must resolve to a readable, non-blank file. Aborting
+ * startup on a bad path keeps a misconfiguration from silently disabling the terms-of-service gate.
+ */
+private fun validateTermsOfService(config: ServerConfig, fileSystem: FileSystem) {
+	val tosPath = config.termsOfService ?: return
+	val path = tosPath.toPath()
+
+	val metadata = fileSystem.metadataOrNull(path)
+	check(metadata?.isRegularFile == true) {
+		"termsOfService is set to \"$tosPath\" but no readable file exists there."
+	}
+	check(fileSystem.read(path) { readUtf8() }.isNotBlank()) {
+		"termsOfService file \"$tosPath\" is empty; provide the terms text or remove the setting."
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -28,6 +28,11 @@ data class ServerConfig(
 	val publicUrl: String? = null,
 	val sslCert: SslCertConfig? = null,
 	val patreonEnabled: Boolean? = null,
+	/**
+	 * Path to a plaintext file whose contents are presented as a Terms of Service that
+	 * users must accept before an account is created. Null/absent disables the requirement.
+	 */
+	val termsOfService: String? = null,
 	val emailProvider: String? = null,
 	val communityEnabled: Boolean = false,
 	val storage: StorageConfig = StorageConfig(),

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -31,6 +31,8 @@ data class ServerConfig(
 	/**
 	 * Path to a plaintext file whose contents are presented as a Terms of Service that
 	 * users must accept before an account is created. Null/absent disables the requirement.
+	 * A relative path is resolved against the config file's own directory, so `tos.txt` finds
+	 * a file sitting next to `config.toml`. A configured path that can't be read aborts startup.
 	 */
 	val termsOfService: String? = null,
 	val emailProvider: String? = null,

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountRoutes.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.account
 
+import com.darkrockstudios.apps.hammer.base.http.HTTP_STATUS_TERMS_OF_SERVICE
 import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
 import com.darkrockstudios.apps.hammer.base.http.INVALID_USER_ID
 import com.darkrockstudios.apps.hammer.monitoring.MonitoringState
@@ -40,17 +41,28 @@ private fun Route.createAccount() {
 		val email = formParameters["email"].toString()
 		val password = formParameters["password"].toString()
 		val installId = formParameters["installId"].toString()
+		val acceptedTosVersion = formParameters["acceptedTosVersion"]
 
-		val result = accountsComponent.createAccount(email = email, installId = installId, password = password)
-		if (isSuccess(result)) {
-			val token = result.data
-			call.respond(HttpStatusCode.Created, token)
-		} else {
-			val response = HttpResponseError(
-				error = "Failed to create account",
-				displayMessage = result.displayMessageText(call, R("api_error_unknown"))
+		val result = accountsComponent.createAccount(
+			email = email,
+			installId = installId,
+			password = password,
+			acceptedTosVersion = acceptedTosVersion,
+		)
+		when (result) {
+			is CreateAccountResult.Success -> call.respond(HttpStatusCode.Created, result.token)
+			is CreateAccountResult.TermsRequired -> call.respond(
+				status = HttpStatusCode(HTTP_STATUS_TERMS_OF_SERVICE, "Unavailable For Legal Reasons"),
+				message = result.challenge,
 			)
-			call.respond(status = HttpStatusCode.Conflict, response)
+
+			is CreateAccountResult.Failure -> {
+				val response = HttpResponseError(
+					error = "Failed to create account",
+					displayMessage = result.failure.displayMessageText(call, R("api_error_unknown"))
+				)
+				call.respond(status = HttpStatusCode.Conflict, response)
+			}
 		}
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsComponent.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsComponent.kt
@@ -5,6 +5,7 @@ import com.darkrockstudios.apps.hammer.ServerConfig
 import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.admin.WhiteListRepository
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
 import com.darkrockstudios.apps.hammer.base.http.Token
 import com.darkrockstudios.apps.hammer.patreon.PatreonConfig
 import com.darkrockstudios.apps.hammer.projects.ProjectsRepository
@@ -18,25 +19,35 @@ class AccountsComponent(
 	private val whiteListRepository: WhiteListRepository,
 	private val projectsRepository: ProjectsRepository,
 	private val configRepository: ConfigRepository,
+	private val termsOfServiceRepository: TermsOfServiceRepository,
 	private val serverConfig: ServerConfig,
 ) {
 	suspend fun createAccount(
 		email: String,
 		installId: String,
-		password: String
-	): ServerResult<Token> {
+		password: String,
+		acceptedTosVersion: String? = null,
+	): CreateAccountResult {
 		// If we dont have users, skip whitelist check
 		if (accountsRepository.hasUsers() && checkIfWhiteListRejected(email)) {
-			return whiteListRejectedFailure()
+			return CreateAccountResult.Failure(whiteListRejectedFailure())
+		}
+
+		// A single read closes the enforce/accept race: if a challenge exists and the submitted
+		// version doesn't match it, the account is never created.
+		val challenge = termsOfServiceRepository.challenge()
+		if (challenge != null && acceptedTosVersion != challenge.version) {
+			return CreateAccountResult.TermsRequired(challenge)
 		}
 
 		val result = accountsRepository.createAccount(email, installId, password)
-		if (isSuccess(result)) {
+		return if (isSuccess(result)) {
 			val token = result.data
 			projectsRepository.createUserData(token.userId)
+			CreateAccountResult.Success(token)
+		} else {
+			CreateAccountResult.Failure(result as ServerResult.Failure<Token>)
 		}
-
-		return result
 	}
 
 	suspend fun login(email: String, password: String, installId: String): SResult<Token> {
@@ -84,7 +95,7 @@ class AccountsComponent(
 		return if (config.enabled && config.patreonUrl.isNotBlank()) config else null
 	}
 
-	private suspend fun whiteListRejectedFailure(): SResult<Token> {
+	private suspend fun whiteListRejectedFailure(): ServerResult.Failure<Token> {
 		val patreonConfig = getActivePatreonConfig()
 		return if (patreonConfig != null) {
 			val amount = "%.2f".format(patreonConfig.minimumAmountCents / 100.0)
@@ -99,4 +110,10 @@ class AccountsComponent(
 			)
 		}
 	}
+}
+
+sealed interface CreateAccountResult {
+	data class Success(val token: Token) : CreateAccountResult
+	data class TermsRequired(val challenge: TermsOfServiceChallenge) : CreateAccountResult
+	data class Failure(val failure: ServerResult.Failure<Token>) : CreateAccountResult
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/TermsOfServiceRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/TermsOfServiceRepository.kt
@@ -1,0 +1,58 @@
+package com.darkrockstudios.apps.hammer.account
+
+import com.darkrockstudios.apps.hammer.ServerConfig
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.security.MessageDigest
+
+/**
+ * Serves the optional Terms of Service that new accounts must accept. When
+ * [ServerConfig.termsOfService] points at a readable, non-blank file, [challenge] returns the
+ * current terms and account creation is gated on accepting its version; otherwise it returns null.
+ */
+class TermsOfServiceRepository(
+	serverConfig: ServerConfig,
+	private val fileSystem: FileSystem,
+) {
+	private val path = serverConfig.termsOfService?.toPath()
+
+	private var cached: Cached? = null
+
+	@Synchronized
+	fun challenge(): TermsOfServiceChallenge? {
+		val path = path ?: return null
+
+		val metadata = fileSystem.metadataOrNull(path) ?: return null
+		if (!metadata.isRegularFile) return null
+
+		val cached = cached
+		if (cached != null && cached.matches(metadata.size, metadata.lastModifiedAtMillis)) {
+			return cached.challenge
+		}
+
+		val text = fileSystem.read(path) { readUtf8() }
+		if (text.isBlank()) {
+			this.cached = null
+			return null
+		}
+
+		val challenge = TermsOfServiceChallenge(text = text, version = hash(text))
+		this.cached = Cached(metadata.size, metadata.lastModifiedAtMillis, challenge)
+		return challenge
+	}
+
+	private fun hash(text: String): String =
+		MessageDigest.getInstance("SHA-256")
+			.digest(text.encodeToByteArray())
+			.joinToString("") { "%02x".format(it) }
+
+	private class Cached(
+		val size: Long?,
+		val lastModifiedAtMillis: Long?,
+		val challenge: TermsOfServiceChallenge,
+	) {
+		fun matches(size: Long?, lastModifiedAtMillis: Long?): Boolean =
+			this.size == size && this.lastModifiedAtMillis == lastModifiedAtMillis
+	}
+}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/TermsOfServiceRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/TermsOfServiceRepository.kt
@@ -10,6 +10,9 @@ import java.security.MessageDigest
  * Serves the optional Terms of Service that new accounts must accept. When
  * [ServerConfig.termsOfService] points at a readable, non-blank file, [challenge] returns the
  * current terms and account creation is gated on accepting its version; otherwise it returns null.
+ *
+ * A configured-but-missing path is rejected at startup (see validateTermsOfService in Application),
+ * so [challenge] only returns null here when no path is configured.
  */
 class TermsOfServiceRepository(
 	serverConfig: ServerConfig,

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
@@ -123,6 +123,7 @@ fun mainModule(
 	singleOf(::PublishedStoryReaderDao)
 
 	singleOf(::AccountsRepository)
+	singleOf(::TermsOfServiceRepository)
 	singleOf(::ProjectsRepository)
 	singleOf(::ProjectEntityRepository)
 	singleOf(::ProjectAccessRepository)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
@@ -26,6 +26,17 @@ class ServerConfigTest {
 	}
 
 	@Test
+	fun `termsOfService defaults to null`() {
+		assertEquals(null, parse("").termsOfService)
+	}
+
+	@Test
+	fun `termsOfService parses a file path`() {
+		val config = parse("""termsOfService = "/srv/hammer/tos.txt"""")
+		assertEquals("/srv/hammer/tos.txt", config.termsOfService)
+	}
+
+	@Test
 	fun `resolve falls back to defaults when no config file present`() {
 		val fs = FakeFileSystem()
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
@@ -3,9 +3,12 @@ package com.darkrockstudios.apps.hammer
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import net.peanuuutz.tomlkt.Toml
 import okio.Path
+import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class ServerConfigTest {
 
@@ -65,6 +68,42 @@ class ServerConfigTest {
 		val config = resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
 
 		assertEquals(1234, config.port)
+	}
+
+	@Test
+	fun `resolve aborts when termsOfService points at a missing file`() {
+		val fs = FakeFileSystem()
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		writeConfig(fs, explicit, """termsOfService = "/data/tos.txt"""")
+
+		val error = assertFailsWith<IllegalStateException> {
+			resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+		}
+		assertTrue(error.message.orEmpty().contains("/data/tos.txt"))
+	}
+
+	@Test
+	fun `resolve aborts when termsOfService file is blank`() {
+		val fs = FakeFileSystem()
+		writeConfig(fs, "/data/tos.txt".toPath(), "   \n ")
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		writeConfig(fs, explicit, """termsOfService = "/data/tos.txt"""")
+
+		assertFailsWith<IllegalStateException> {
+			resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+		}
+	}
+
+	@Test
+	fun `resolve succeeds when termsOfService file exists and is non-blank`() {
+		val fs = FakeFileSystem()
+		writeConfig(fs, "/data/tos.txt".toPath(), "Be excellent to each other")
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		writeConfig(fs, explicit, """termsOfService = "/data/tos.txt"""")
+
+		val config = resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+
+		assertEquals("/data/tos.txt", config.termsOfService)
 	}
 
 	private fun writeConfig(fs: FakeFileSystem, path: Path, contents: String) {

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
@@ -106,6 +106,19 @@ class ServerConfigTest {
 		assertEquals("/data/tos.txt", config.termsOfService)
 	}
 
+	@Test
+	fun `a relative termsOfService is resolved next to the config file`() {
+		val fs = FakeFileSystem()
+		val configDir = getRootDataDirectory(fs)
+		writeConfig(fs, configDir / "tos.txt", "Be excellent to each other")
+		val explicit = configDir / "custom.toml"
+		writeConfig(fs, explicit, """termsOfService = "tos.txt"""")
+
+		val config = resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+
+		assertEquals((configDir / "tos.txt").toString(), config.termsOfService)
+	}
+
 	private fun writeConfig(fs: FakeFileSystem, path: Path, contents: String) {
 		path.parent?.let { fs.createDirectories(it) }
 		fs.write(path) { writeUtf8(contents) }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/AccountRoutesTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/AccountRoutesTest.kt
@@ -194,6 +194,81 @@ class AccountRoutesTest : BaseTest() {
 		}
 	}
 
+	@Test
+	fun `Account - Create - Terms of service challenge`() = testApplication {
+		val challenge = TermsOfServiceChallenge(text = "Be excellent to each other", version = "v1")
+		coEvery {
+			accountsComponent.createAccount(any(), any(), any(), acceptedTosVersion = null)
+		} returns CreateAccountResult.TermsRequired(challenge)
+
+		application {
+			setupKtorTestKoin(this@AccountRoutesTest, testModule)
+
+			configureSerialization()
+			configureLocalization()
+			configureSecurity()
+			configureRouting()
+		}
+
+		createClient {
+			install(ContentNegotiation) {
+				json(json)
+			}
+		}
+
+		makeCreateCall(acceptedTosVersion = null).apply {
+			assertEquals(HTTP_STATUS_TERMS_OF_SERVICE, status.value)
+			val body = json.decodeFromString<TermsOfServiceChallenge>(bodyAsText())
+			assertEquals(challenge, body)
+		}
+	}
+
+	@Test
+	fun `Account - Create - Accepted terms succeeds`() = testApplication {
+		val expectedToken = Token(userId = 0L, auth = "access", refresh = "refresh")
+		coEvery {
+			accountsComponent.createAccount(any(), any(), any(), acceptedTosVersion = "v1")
+		} returns CreateAccountResult.Success(expectedToken)
+
+		application {
+			setupKtorTestKoin(this@AccountRoutesTest, testModule)
+
+			configureSerialization()
+			configureLocalization()
+			configureSecurity()
+			configureRouting()
+		}
+
+		createClient {
+			install(ContentNegotiation) {
+				json(json)
+			}
+		}
+
+		makeCreateCall(acceptedTosVersion = "v1").apply {
+			assertEquals(HttpStatusCode.Created, status)
+			val body = json.decodeFromString<Token>(bodyAsText())
+			assertEquals(expectedToken.auth, body.auth)
+		}
+	}
+
+	private suspend fun ApplicationTestBuilder.makeCreateCall(acceptedTosVersion: String?): HttpResponse =
+		client.post("/api/account/create") {
+			header(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION)
+			header(HEADER_CLIENT_VERSION, BuildMetadata.APP_VERSION)
+			header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+			setBody(
+				FormDataContent(
+					Parameters.build {
+						append("email", "test@test.com")
+						append("password", "qweasdZXC123")
+						append("installId", INSTALL_ID)
+						acceptedTosVersion?.let { append("acceptedTosVersion", it) }
+					}
+				)
+			)
+		}
+
 	private suspend fun ApplicationTestBuilder.makeRefreshCall(userId: Long, mockRefreshToken: String): HttpResponse =
 		client.post("/api/account/refresh_token/$userId") {
 			header(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/AccountsComponentCreateAccountTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/AccountsComponentCreateAccountTest.kt
@@ -3,14 +3,15 @@ package com.darkrockstudios.apps.hammer.account
 import com.darkrockstudios.apps.hammer.ServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.admin.WhiteListRepository
+import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
 import com.darkrockstudios.apps.hammer.base.http.Token
 import com.darkrockstudios.apps.hammer.projects.ProjectsRepository
 import com.darkrockstudios.apps.hammer.utilities.SResult
-import com.darkrockstudios.apps.hammer.utilities.isFailure
-import com.darkrockstudios.apps.hammer.utilities.isSuccess
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.verify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -32,6 +33,9 @@ class AccountsComponentCreateAccountTest {
 	@MockK
 	private lateinit var configRepository: ConfigRepository
 
+	@MockK
+	private lateinit var termsOfServiceRepository: TermsOfServiceRepository
+
 	private val serverConfig = ServerConfig()
 
 	private val validEmail = "test@test.com"
@@ -43,9 +47,19 @@ class AccountsComponentCreateAccountTest {
 		refresh = "abc"
 	)
 
+	private fun component() = AccountsComponent(
+		accountsRepository,
+		whiteListRepository,
+		projectsRepository,
+		configRepository,
+		termsOfServiceRepository,
+		serverConfig
+	)
+
 	@BeforeEach
 	fun begin() {
 		MockKAnnotations.init(this, relaxUnitFun = true)
+		every { termsOfServiceRepository.challenge() } returns null
 	}
 
 	@Test
@@ -61,21 +75,14 @@ class AccountsComponentCreateAccountTest {
 			)
 		} returns SResult.success(token)
 
-		val comp = AccountsComponent(
-			accountsRepository,
-			whiteListRepository,
-			projectsRepository,
-			configRepository,
-			serverConfig
-		)
-		val result = comp.createAccount(
+		val result = component().createAccount(
 			email = validEmail,
 			installId = installId,
 			password = validPassword,
 		)
 
-		assertTrue(isSuccess(result))
-		assertEquals(token, result.data)
+		assertTrue(result is CreateAccountResult.Success)
+		assertEquals(token, result.token)
 
 		coVerify(exactly = 0) { whiteListRepository.useWhiteList() }
 		coVerify(exactly = 0) { whiteListRepository.isOnWhiteList(any()) }
@@ -96,21 +103,14 @@ class AccountsComponentCreateAccountTest {
 			)
 		} returns SResult.success(token)
 
-		val comp = AccountsComponent(
-			accountsRepository,
-			whiteListRepository,
-			projectsRepository,
-			configRepository,
-			serverConfig
-		)
-		val result = comp.createAccount(
+		val result = component().createAccount(
 			email = validEmail,
 			installId = installId,
 			password = validPassword,
 		)
 
-		assertTrue(isSuccess(result))
-		assertEquals(token, result.data)
+		assertTrue(result is CreateAccountResult.Success)
+		assertEquals(token, result.token)
 
 		coVerify { projectsRepository.createUserData(token.userId) }
 	}
@@ -129,20 +129,13 @@ class AccountsComponentCreateAccountTest {
 			)
 		} returns SResult.success(token)
 
-		val comp = AccountsComponent(
-			accountsRepository,
-			whiteListRepository,
-			projectsRepository,
-			configRepository,
-			serverConfig
-		)
-		val result = comp.createAccount(
+		val result = component().createAccount(
 			email = validEmail,
 			installId = installId,
 			password = validPassword,
 		)
 
-		assertTrue(isFailure(result))
+		assertTrue(result is CreateAccountResult.Failure)
 		// A whitelist rejection must short-circuit: no account row, no user data.
 		coVerify(exactly = 0) { accountsRepository.createAccount(any(), any(), any()) }
 		coVerify(exactly = 0) { projectsRepository.createUserData(any()) }
@@ -162,21 +155,102 @@ class AccountsComponentCreateAccountTest {
 			)
 		} returns SResult.success(token)
 
-		val comp = AccountsComponent(
-			accountsRepository,
-			whiteListRepository,
-			projectsRepository,
-			configRepository,
-			serverConfig
-		)
-		val result = comp.createAccount(
+		val result = component().createAccount(
 			email = validEmail,
 			installId = installId,
 			password = validPassword,
 		)
 
-		assertTrue(isSuccess(result))
-		assertEquals(token, result.data)
+		assertTrue(result is CreateAccountResult.Success)
+		assertEquals(token, result.token)
 		coVerify { projectsRepository.createUserData(token.userId) }
+	}
+
+	@Test
+	fun `Create Account - TOS enforced, no acceptance - challenges`() = runTest {
+		val challenge = TermsOfServiceChallenge(text = "Be excellent to each other", version = "v1")
+		coEvery { accountsRepository.hasUsers() } returns true
+		coEvery { accountsRepository.findAccount(any()) } returns null
+		coEvery { whiteListRepository.useWhiteList() } returns false
+		every { termsOfServiceRepository.challenge() } returns challenge
+
+		val result = component().createAccount(
+			email = validEmail,
+			installId = installId,
+			password = validPassword,
+		)
+
+		assertTrue(result is CreateAccountResult.TermsRequired)
+		assertEquals(challenge, result.challenge)
+		// No account is created until the terms are accepted.
+		coVerify(exactly = 0) { accountsRepository.createAccount(any(), any(), any()) }
+		coVerify(exactly = 0) { projectsRepository.createUserData(any()) }
+	}
+
+	@Test
+	fun `Create Account - TOS enforced, stale acceptance - challenges`() = runTest {
+		val challenge = TermsOfServiceChallenge(text = "Be excellent to each other", version = "v2")
+		coEvery { accountsRepository.hasUsers() } returns true
+		coEvery { accountsRepository.findAccount(any()) } returns null
+		coEvery { whiteListRepository.useWhiteList() } returns false
+		every { termsOfServiceRepository.challenge() } returns challenge
+
+		val result = component().createAccount(
+			email = validEmail,
+			installId = installId,
+			password = validPassword,
+			acceptedTosVersion = "v1",
+		)
+
+		assertTrue(result is CreateAccountResult.TermsRequired)
+		assertEquals(challenge, result.challenge)
+		coVerify(exactly = 0) { accountsRepository.createAccount(any(), any(), any()) }
+	}
+
+	@Test
+	fun `Create Account - TOS enforced, correct acceptance - succeeds`() = runTest {
+		val challenge = TermsOfServiceChallenge(text = "Be excellent to each other", version = "v1")
+		coEvery { accountsRepository.hasUsers() } returns true
+		coEvery { accountsRepository.findAccount(any()) } returns null
+		coEvery { whiteListRepository.useWhiteList() } returns false
+		every { termsOfServiceRepository.challenge() } returns challenge
+		coEvery {
+			accountsRepository.createAccount(
+				email = validEmail,
+				installId = installId,
+				password = validPassword
+			)
+		} returns SResult.success(token)
+
+		val result = component().createAccount(
+			email = validEmail,
+			installId = installId,
+			password = validPassword,
+			acceptedTosVersion = "v1",
+		)
+
+		assertTrue(result is CreateAccountResult.Success)
+		assertEquals(token, result.token)
+		coVerify { projectsRepository.createUserData(token.userId) }
+	}
+
+	@Test
+	fun `Create Account - Whitelist rejection precedes TOS challenge`() = runTest {
+		coEvery { accountsRepository.hasUsers() } returns true
+		coEvery { accountsRepository.findAccount(any()) } returns null
+		coEvery { whiteListRepository.useWhiteList() } returns true
+		coEvery { whiteListRepository.isOnWhiteList(validEmail) } returns false
+		every { termsOfServiceRepository.challenge() } returns
+			TermsOfServiceChallenge(text = "Be excellent to each other", version = "v1")
+
+		val result = component().createAccount(
+			email = validEmail,
+			installId = installId,
+			password = validPassword,
+		)
+
+		// Whitelist is checked first, so non-whitelisted emails never see the TOS.
+		assertTrue(result is CreateAccountResult.Failure)
+		verify(exactly = 0) { termsOfServiceRepository.challenge() }
 	}
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/AccountsComponentLoginTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/AccountsComponentLoginTest.kt
@@ -34,6 +34,9 @@ class AccountsComponentLoginTest {
 	@MockK
 	private lateinit var configRepository: ConfigRepository
 
+	@MockK
+	private lateinit var termsOfServiceRepository: TermsOfServiceRepository
+
 	private val serverConfig = ServerConfig()
 
 	private val validEmail = "test@test.com"
@@ -80,6 +83,7 @@ class AccountsComponentLoginTest {
 			whiteListRepository,
 			projectsRepository,
 			configRepository,
+			termsOfServiceRepository,
 			serverConfig
 		)
 		val result = comp.login(validEmail, validPassword, installId)
@@ -106,6 +110,7 @@ class AccountsComponentLoginTest {
 			whiteListRepository,
 			projectsRepository,
 			configRepository,
+			termsOfServiceRepository,
 			serverConfig
 		)
 		val result = comp.login(validEmail, validPassword, installId)
@@ -132,6 +137,7 @@ class AccountsComponentLoginTest {
 			whiteListRepository,
 			projectsRepository,
 			configRepository,
+			termsOfServiceRepository,
 			serverConfig
 		)
 		val result = comp.login(validEmail, validPassword, installId)
@@ -158,6 +164,7 @@ class AccountsComponentLoginTest {
 			whiteListRepository,
 			projectsRepository,
 			configRepository,
+			termsOfServiceRepository,
 			serverConfig
 		)
 		val result = comp.login(validEmail, validPassword, installId)
@@ -177,6 +184,7 @@ class AccountsComponentLoginTest {
 			whiteListRepository,
 			projectsRepository,
 			configRepository,
+			termsOfServiceRepository,
 			serverConfig
 		)
 
@@ -202,6 +210,7 @@ class AccountsComponentLoginTest {
 			whiteListRepository,
 			projectsRepository,
 			configRepository,
+			termsOfServiceRepository,
 			serverConfig
 		)
 		val result = comp.login(validEmail, validPassword, installId)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/TermsOfServiceRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/TermsOfServiceRepositoryTest.kt
@@ -1,0 +1,81 @@
+package com.darkrockstudios.apps.hammer.account
+
+import com.darkrockstudios.apps.hammer.ServerConfig
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TermsOfServiceRepositoryTest {
+
+	private val path = "/data/tos.txt".toPath()
+
+	private fun repository(fs: FakeFileSystem, tosPath: String? = path.toString()) =
+		TermsOfServiceRepository(ServerConfig(termsOfService = tosPath), fs)
+
+	private fun FakeFileSystem.writeFile(path: Path, contents: String) {
+		path.parent?.let { createDirectories(it) }
+		write(path) { writeUtf8(contents) }
+	}
+
+	@Test
+	fun `no configured path means no terms`() {
+		val repo = repository(FakeFileSystem(), tosPath = null)
+		assertNull(repo.challenge())
+	}
+
+	@Test
+	fun `a missing file means no terms`() {
+		val repo = repository(FakeFileSystem())
+		assertNull(repo.challenge())
+	}
+
+	@Test
+	fun `a blank file means no terms`() {
+		val fs = FakeFileSystem()
+		fs.writeFile(path, "   \n\t ")
+		val repo = repository(fs)
+		assertNull(repo.challenge())
+	}
+
+	@Test
+	fun `a populated file is served as the challenge text with a hex version`() {
+		val fs = FakeFileSystem()
+		fs.writeFile(path, "Be excellent to each other")
+		val repo = repository(fs)
+
+		val challenge = assertNotNull(repo.challenge())
+		assertEquals("Be excellent to each other", challenge.text)
+		assertEquals(64, challenge.version.length)
+		assertTrue(challenge.version.all { it in "0123456789abcdef" })
+	}
+
+	@Test
+	fun `the version is stable for identical content`() {
+		val fs = FakeFileSystem()
+		fs.writeFile(path, "Be excellent to each other")
+		val repo = repository(fs)
+
+		assertEquals(repo.challenge()?.version, repo.challenge()?.version)
+	}
+
+	@Test
+	fun `different content yields a different version`() {
+		val fs = FakeFileSystem()
+
+		fs.writeFile(path, "Terms version one")
+		val first = repository(fs).challenge()?.version
+
+		fs.delete(path)
+		fs.writeFile(path, "Terms version two, which is longer")
+		val second = repository(fs).challenge()?.version
+
+		assertNotNull(first)
+		assertNotNull(second)
+		assertTrue(first != second)
+	}
+}


### PR DESCRIPTION
## Context

hammer.ink self-hosters need an **optional**, off-by-default way to require users to agree to a Terms of Service before a sync account is created. Existing servers must be unaffected with zero config.

## How it works

- **Config**: an undocumented `termsOfService` field in `ServerConfig` (TOML) — a path to a plaintext file. Absent/null ⇒ disabled. When set to a readable, non-blank file, the file's contents *are* the TOS, hashed (SHA-256) into a version string.
- **Handshake**: the client POSTs `create` as usual. If a TOS is configured and the submitted acceptance version doesn't match the current one, the server responds **451 Unavailable For Legal Reasons** with a `TermsOfServiceChallenge(text, version)` body. The client shows a scrollable dialog; **Accept** resubmits `create` with `acceptedTosVersion`, **Decline** discards the provisional server settings and shows a snackbar.
- **Scope**: account creation only. Login/refresh unchanged.
- **Audit**: gate-only, no DB migration — an account only exists once its owner accepted the TOS current at signup.

The gate sits *after* the whitelist check, so non-whitelisted emails never see the TOS. The server reads the TOS file once per create (cached on file metadata) and compares against a single `challenge()` read, closing the enforce/accept race.

## Key files

- Shared: `base/.../http/TermsOfServiceChallenge.kt`, `Http.kt` (451 constant)
- Server: `ServerConfig.kt`, `account/TermsOfServiceRepository.kt`, `account/AccountsComponent.kt` (`CreateAccountResult`), `account/AccountRoutes.kt`
- Client: `server/ServerAccountApi.kt` + `Api.kt` (`TermsOfServiceRequiredException`), `data/account/AccountUseCase.kt` (`ServerSetupResult`), `components/.../AccountSettingsComponent.kt`
- UI: `composeUi/.../settings/TermsOfServiceDialog.kt` (+ `@Preview`)

## Testing

- Server: `AccountsComponentCreateAccountTest` (disabled → success; no/stale/correct acceptance; whitelist precedes TOS), `AccountRoutesTest` (451 + body; accepted → 201), `ServerConfigTest` (parse).
- Client: `AccountUseCaseTest` (451 → `TermsRequired`, accept resubmits with version, provisional settings preserved), `AccountSettingsComponentTest` (challenge surfaced, accept retries, decline clears + deletes provisional settings).
- UI: rendered the `TermsOfServiceDialog` preview.
- Full `:server:test` and `:common:desktopTest` pass locally.

A high-effort code review ran against the diff; all confirmed findings were fixed (orphaned settings on abandon, malformed-451 handling, stacked dialogs, TOCTOU gate bypass, duplicate payload types).