### PR TITLE
Make clients HTTPS-only; add dev self-signed cert support

### DIFF
--- a/android/src/fdroid/AndroidManifest.xml
+++ b/android/src/fdroid/AndroidManifest.xml
@@ -37,8 +37,7 @@
 		android:label="@string/app_name"
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:supportsRtl="true"
-		android:theme="@style/Theme.Hammer"
-		android:networkSecurityConfig="@xml/network_security_config">
+		android:theme="@style/Theme.Hammer">
 
 		<activity
 			android:name=".ProjectSelectActivity"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
 		android:label="@string/app_name"
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:supportsRtl="true"
-		android:theme="@style/Theme.Hammer"
-		android:networkSecurityConfig="@xml/network_security_config">
+		android:theme="@style/Theme.Hammer">
 
 		<activity
 			android:name=".ProjectSelectActivity"

--- a/android/src/main/res/xml/network_security_config.xml
+++ b/android/src/main/res/xml/network_security_config.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-	Self-hosted sync servers are configured by the user at runtime and may be plain HTTP
-	(ServerSettings.ssl = false), so cleartext must stay permitted. From Android 17 (API 37)
-	the usesCleartextTraffic manifest flag is ignored without this config.
--->
-<network-security-config>
-	<base-config cleartextTrafficPermitted="true" />
-</network-security-config>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettings.kt
@@ -22,7 +22,6 @@ interface AccountSettings : ComponentToaster {
 	fun beginSetupServer()
 	fun cancelServerSetup()
 	fun setupServer(
-		ssl: Boolean,
 		url: String,
 		email: String,
 		password: String,
@@ -42,7 +41,6 @@ interface AccountSettings : ComponentToaster {
 	suspend fun setMaxBackups(value: Int): Boolean
 	fun reauthenticate()
 	fun updateServerUrl(url: String)
-	fun updateServerSsl(ssl: Boolean)
 	fun updateServerEmail(email: String)
 	fun updateServerPassword(password: String)
 
@@ -56,12 +54,10 @@ interface AccountSettings : ComponentToaster {
 		val location: ProjectSelection.Locations = ProjectSelection.Locations.Projects,
 		val uiTheme: UiTheme,
 		val currentUserId: Long? = null,
-		val currentSsl: Boolean? = null,
 		val currentUrl: String? = null,
 		val currentEmail: String? = null,
 		val serverSetup: Boolean = false,
 		val serverIsLoggedIn: Boolean = false,
-		val serverSsl: Boolean = true,
 		val serverUrl: String? = null,
 		val serverEmail: String? = null,
 		// Never persist the password to disk; drop stale error/working state on restore.

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
@@ -125,7 +125,6 @@ class AccountSettingsComponent(
 					_state.getAndUpdate {
 						it.copy(
 							currentUserId = settings?.userId,
-							currentSsl = settings?.ssl,
 							currentUrl = settings?.url,
 							currentEmail = settings?.email,
 							serverIsLoggedIn = settings?.bearerToken?.isNotBlank() == true,
@@ -169,7 +168,6 @@ class AccountSettingsComponent(
 				serverSetup = true,
 				serverUrl = it.currentUrl,
 				serverEmail = it.currentEmail,
-				serverSsl = it.currentSsl ?: true,
 				serverPassword = null,
 			)
 		}
@@ -196,7 +194,6 @@ class AccountSettingsComponent(
 	private fun cleanUpServerSetup() {
 		_state.getAndUpdate {
 			it.copy(
-				serverSsl = true,
 				serverUrl = null,
 				serverEmail = null,
 				serverPassword = null,
@@ -260,7 +257,6 @@ class AccountSettingsComponent(
 		_state.getAndUpdate {
 			it.copy(
 				serverSetup = true,
-				serverSsl = state.value.currentSsl ?: true,
 				serverUrl = state.value.currentUrl,
 				serverEmail = state.value.currentEmail,
 			)
@@ -269,10 +265,6 @@ class AccountSettingsComponent(
 
 	override fun updateServerUrl(url: String) {
 		_state.getAndUpdate { it.copy(serverUrl = url) }
-	}
-
-	override fun updateServerSsl(ssl: Boolean) {
-		_state.getAndUpdate { it.copy(serverSsl = ssl) }
 	}
 
 	override fun updateServerEmail(email: String) {
@@ -292,7 +284,6 @@ class AccountSettingsComponent(
 	}
 
 	override fun setupServer(
-		ssl: Boolean,
 		url: String,
 		email: String,
 		password: String,
@@ -339,7 +330,7 @@ class AccountSettingsComponent(
 				removeLocalContent()
 			}
 
-			val pending = PendingServerSetup(ssl, cleanUrl, email.trim(), password, create)
+			val pending = PendingServerSetup(cleanUrl, email.trim(), password, create)
 			pendingServerSetup = pending
 			performServerSetup(pending, acceptedTosVersion = null)
 		}
@@ -380,7 +371,6 @@ class AccountSettingsComponent(
 
 	private suspend fun performServerSetup(pending: PendingServerSetup, acceptedTosVersion: String?) {
 		val result = accountUseCase.setupServer(
-			ssl = pending.ssl,
 			url = pending.url,
 			email = pending.email,
 			password = pending.password,
@@ -485,7 +475,6 @@ class AccountSettingsComponent(
 }
 
 private data class PendingServerSetup(
-	val ssl: Boolean,
 	val url: String,
 	val email: String,
 	val password: String,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/account/AccountUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/account/AccountUseCase.kt
@@ -23,7 +23,6 @@ class AccountUseCase(
 	private val strRes: StrRes,
 ) {
 	suspend fun setupServer(
-		ssl: Boolean,
 		url: String,
 		email: String,
 		password: String,
@@ -33,7 +32,6 @@ class AccountUseCase(
 		val installId = globalSettingsStore.ensureInstallId()
 		val newSettings = ServerSettings(
 			userId = -1,
-			ssl = ssl,
 			url = url,
 			email = email,
 			bearerToken = null,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/ServerSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/ServerSettings.kt
@@ -5,7 +5,9 @@ import net.peanuuutz.tomlkt.TomlLiteralString
 
 @Serializable
 data class ServerSettings(
-	val ssl: Boolean,
+	// Clients always talk HTTPS; only test harnesses pointing at a plain-HTTP in-process
+	// server construct this with ssl = false.
+	val ssl: Boolean = true,
 	@TomlLiteralString
 	val url: String,
 	@TomlLiteralString

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/PersistedServerSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/datasource/PersistedServerSettings.kt
@@ -7,10 +7,12 @@ import net.peanuuutz.tomlkt.TomlLiteralString
 /**
  * Tokenless persisted form of [ServerSettings] written to the per-workspace
  * `server.json`. The secret token fields live in [AuthTokenStore] instead.
+ *
+ * Note the absence of an `ssl` field: clients are HTTPS-only, so a legacy `ssl` key
+ * in an existing `server.json` is ignored on load and every restored connection is HTTPS.
  */
 @Serializable
 data class PersistedServerSettings(
-	val ssl: Boolean,
 	@TomlLiteralString
 	val url: String,
 	@TomlLiteralString
@@ -19,14 +21,13 @@ data class PersistedServerSettings(
 )
 
 fun ServerSettings.toPersisted(): PersistedServerSettings = PersistedServerSettings(
-	ssl = ssl,
 	url = url,
 	email = email,
 	userId = userId,
 )
 
 fun PersistedServerSettings.toServerSettings(tokens: AuthTokens?): ServerSettings = ServerSettings(
-	ssl = ssl,
+	ssl = true,
 	url = url,
 	email = email,
 	userId = userId,

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/getHttpPlatformEngine.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/getHttpPlatformEngine.kt
@@ -71,7 +71,7 @@ private fun loopbackTrustingSslContext(): SSLContext {
 
 		override fun getAcceptedIssuers(): Array<X509Certificate> = default.acceptedIssuers
 	}
-	return SSLContext.getInstance("TLS").apply {
+	return SSLContext.getInstance("TLSv1.3").apply {
 		init(null, arrayOf(trustManager), SecureRandom())
 	}
 }

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/getHttpPlatformEngine.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/getHttpPlatformEngine.kt
@@ -1,14 +1,88 @@
 package com.darkrockstudios.apps.hammer.common.dependencyinjection
 
+import com.darkrockstudios.apps.hammer.common.getInDevelopmentMode
 import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.java.*
 import io.ktor.client.plugins.compression.*
+import java.net.InetAddress
+import java.net.Socket
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedTrustManager
 
-actual fun getHttpPlatformEngine(): HttpClientEngineFactory<*> = Java
+actual fun getHttpPlatformEngine(): HttpClientEngineFactory<*> =
+	if (getInDevelopmentMode()) DevLoopbackTrustJava else Java
+
 actual fun <T : HttpClientEngineConfig> HttpClientConfig<T>.installCompression() {
 	install(ContentEncoding) {
 		gzip()
 		deflate()
 	}
+}
+
+/**
+ * Dev-only engine that accepts a self-signed certificate ONLY from a loopback peer, so the desktop
+ * client can reach a `--dev` server's auto-generated cert on localhost. Connections to any
+ * non-loopback host still go through the platform's full certificate and hostname validation, so a
+ * `--dev` build pointed at a real remote server is not exposed to a man-in-the-middle. Selected only
+ * when [getInDevelopmentMode] is true; release builds always use plain [Java].
+ */
+private object DevLoopbackTrustJava : HttpClientEngineFactory<JavaHttpConfig> {
+	override fun create(block: JavaHttpConfig.() -> Unit): HttpClientEngine =
+		Java.create {
+			block()
+			config {
+				sslContext(loopbackTrustingSslContext())
+			}
+		}
+}
+
+private fun loopbackTrustingSslContext(): SSLContext {
+	val default = platformTrustManager()
+	val trustManager = object : X509ExtendedTrustManager() {
+		override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?, socket: Socket?) {
+			if (socket?.inetAddress?.isLoopbackAddress == true) return
+			default.checkServerTrusted(chain, authType, socket)
+		}
+
+		override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?, engine: SSLEngine?) {
+			if (isLoopbackHost(engine?.peerHost)) return
+			default.checkServerTrusted(chain, authType, engine)
+		}
+
+		override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+			// No peer host available in this overload; fall back to real validation.
+			default.checkServerTrusted(chain, authType)
+		}
+
+		override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?, socket: Socket?) =
+			default.checkClientTrusted(chain, authType, socket)
+
+		override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?, engine: SSLEngine?) =
+			default.checkClientTrusted(chain, authType, engine)
+
+		override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) =
+			default.checkClientTrusted(chain, authType)
+
+		override fun getAcceptedIssuers(): Array<X509Certificate> = default.acceptedIssuers
+	}
+	return SSLContext.getInstance("TLS").apply {
+		init(null, arrayOf(trustManager), SecureRandom())
+	}
+}
+
+private fun isLoopbackHost(host: String?): Boolean {
+	if (host.isNullOrBlank()) return false
+	return runCatching { InetAddress.getByName(host).isLoopbackAddress }.getOrDefault(false)
+}
+
+private fun platformTrustManager(): X509ExtendedTrustManager {
+	val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+	factory.init(null as KeyStore?)
+	return factory.trustManagers.filterIsInstance<X509ExtendedTrustManager>().first()
 }

--- a/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
@@ -129,14 +129,12 @@ class AccountSettingsComponentTest : BaseTest() {
 				any(),
 				any(),
 				any(),
-				any(),
 				any()
 			)
 		} returns ServerSetupResult.Success
 
 		val component = newComponent()
 		component.setupServer(
-			ssl = true,
 			url = "example.com",
 			email = "writer@example.com",
 			password = "Password1!",
@@ -159,14 +157,12 @@ class AccountSettingsComponentTest : BaseTest() {
 				any(),
 				any(),
 				any(),
-				any(),
 				any()
 			)
 		} returns ServerSetupResult.Success
 
 		val component = newComponent()
 		component.setupServer(
-			ssl = true,
 			url = "example.com",
 			email = "writer@example.com",
 			password = "Password1!",
@@ -182,15 +178,14 @@ class AccountSettingsComponentTest : BaseTest() {
 	fun `Terms of service challenge is surfaced and acceptance retries the request`() = runTest {
 		every { projectsRepository.getProjects() } returns emptyList()
 		coEvery {
-			accountUseCase.setupServer(any(), any(), any(), any(), any(), null)
+			accountUseCase.setupServer(any(), any(), any(), any(), null)
 		} returns ServerSetupResult.TermsRequired(TermsOfServiceChallenge(text = "Legal text", version = "v1"))
 		coEvery {
-			accountUseCase.setupServer(any(), any(), any(), any(), any(), "v1")
+			accountUseCase.setupServer(any(), any(), any(), any(), "v1")
 		} returns ServerSetupResult.Success
 
 		val component = newComponent()
 		component.setupServer(
-			ssl = true,
 			url = "example.com",
 			email = "writer@example.com",
 			password = "Password1!",
@@ -208,18 +203,17 @@ class AccountSettingsComponentTest : BaseTest() {
 
 		assertNull(component.state.value.tosChallenge)
 		assertFalse(component.state.value.serverSetup)
-		coVerify { accountUseCase.setupServer(any(), any(), any(), any(), any(), "v1") }
+		coVerify { accountUseCase.setupServer(any(), any(), any(), any(), "v1") }
 	}
 
 	@Test
 	fun `Declining terms of service clears the challenge without creating an account`() = runTest {
 		coEvery {
-			accountUseCase.setupServer(any(), any(), any(), any(), any(), null)
+			accountUseCase.setupServer(any(), any(), any(), any(), null)
 		} returns ServerSetupResult.TermsRequired(TermsOfServiceChallenge(text = "Legal text", version = "v1"))
 
 		val component = newComponent()
 		component.setupServer(
-			ssl = true,
 			url = "example.com",
 			email = "writer@example.com",
 			password = "Password1!",
@@ -236,6 +230,6 @@ class AccountSettingsComponentTest : BaseTest() {
 		// Declining discards the provisional server settings setupServer persisted for the retry.
 		verify { globalSettingsStore.deleteServerSettings() }
 		// Only the initial challenge attempt ran; declining never resubmits.
-		coVerify(exactly = 1) { accountUseCase.setupServer(any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 1) { accountUseCase.setupServer(any(), any(), any(), any(), any()) }
 	}
 }

--- a/common/src/desktopTest/kotlin/usecases/AccountUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/AccountUseCaseTest.kt
@@ -63,7 +63,6 @@ class AccountUseCaseTest : BaseTest() {
 	fun `Create account successfully`() = runTest {
 		val token = Token(1, "test-auth", "test-refresh")
 		val settings = ServerSettings(
-			ssl = false,
 			url = "hammer.ink",
 			email = "test@example.com",
 			userId = 1,
@@ -83,7 +82,6 @@ class AccountUseCaseTest : BaseTest() {
 		val usecase = createSut()
 
 		val result = usecase.setupServer(
-			ssl = false,
 			url = settings.url,
 			email = settings.email,
 			password = "password",
@@ -117,7 +115,6 @@ class AccountUseCaseTest : BaseTest() {
 	fun `Create account failure`() = runTest {
 		val token = Token(1, "test-auth", "test-refresh")
 		val settings = ServerSettings(
-			ssl = false,
 			url = "hammer.ink",
 			email = "test@example.com",
 			userId = 1,
@@ -139,7 +136,6 @@ class AccountUseCaseTest : BaseTest() {
 		val usecase = createSut()
 
 		val result = usecase.setupServer(
-			ssl = false,
 			url = settings.url,
 			email = settings.email,
 			password = "password",
@@ -166,7 +162,6 @@ class AccountUseCaseTest : BaseTest() {
 		val usecase = createSut()
 
 		val result = usecase.setupServer(
-			ssl = false,
 			url = "hammer.ink",
 			email = "test@example.com",
 			password = "password",
@@ -190,7 +185,6 @@ class AccountUseCaseTest : BaseTest() {
 		val usecase = createSut()
 
 		val result = usecase.setupServer(
-			ssl = false,
 			url = "hammer.ink",
 			email = "test@example.com",
 			password = "password",
@@ -206,7 +200,6 @@ class AccountUseCaseTest : BaseTest() {
 	fun `Login account successfully`() = runTest {
 		val token = Token(1, "test-auth", "test-refresh")
 		val settings = ServerSettings(
-			ssl = false,
 			url = "hammer.ink",
 			email = "test@example.com",
 			userId = 1,
@@ -226,7 +219,6 @@ class AccountUseCaseTest : BaseTest() {
 		val usecase = createSut()
 
 		val result = usecase.setupServer(
-			ssl = false,
 			url = settings.url,
 			email = settings.email,
 			password = "password",

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSetupDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSetupDialog.kt
@@ -126,18 +126,6 @@ fun ServerSetupDialogContent(
 					),
 				verticalArrangement = Arrangement.spacedBy(Ui.Padding.L),
 			) {
-				HdHairlineSegmentedPicker(
-					options = listOf(false, true),
-					selected = state.serverSsl,
-					onSelect = { ssl ->
-						if (!state.serverWorking && !existingServer) {
-							component.updateServerSsl(ssl)
-						}
-					},
-					label = { ssl -> if (ssl) "HTTPS" else "HTTP" },
-					title = "PROTOCOL",
-				)
-
 				HdHairlineField(
 					label = "URL",
 					value = state.serverUrl ?: "",
@@ -207,7 +195,6 @@ fun ServerSetupDialogContent(
 						confirmDeleteLocal = false
 					} else {
 						component.setupServer(
-							ssl = state.serverSsl,
 							url = state.serverUrl ?: "",
 							email = state.serverEmail ?: "",
 							password = state.serverPassword ?: "",
@@ -223,7 +210,6 @@ fun ServerSetupDialogContent(
 	confirmDeleteLocal?.let { create ->
 		fun setupServer(create: Boolean, removeLocal: Boolean) {
 			component.setupServer(
-				ssl = state.serverSsl,
 				url = state.serverUrl ?: "",
 				email = state.serverEmail ?: "",
 				password = state.serverPassword ?: "",

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/AccountSettingsUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/AccountSettingsUi.Preview.kt
@@ -32,7 +32,6 @@ internal fun ScreenAccountSettingsUiTabletPreview() {
 			serverIsLoggedIn = true,
 			currentEmail = "admin@example.com",
 			currentUrl = "https://hammer-server.com",
-			currentSsl = true,
 			serverWorking = false,
 		)
 	)
@@ -54,7 +53,6 @@ internal fun ScreenAccountSettingsUiServerConfiguredPreview() {
 			serverIsLoggedIn = true,
 			currentEmail = "admin@example.com",
 			currentUrl = "https://hammer-server.com",
-			currentSsl = true,
 			serverWorking = false,
 		)
 	)

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
@@ -57,7 +57,6 @@ internal fun accountSettingsComponent(state: AccountSettings.State = defaultAcco
 		override fun beginSetupServer() {}
 		override fun cancelServerSetup() {}
 		override fun setupServer(
-			ssl: Boolean,
 			url: String,
 			email: String,
 			password: String,
@@ -77,7 +76,6 @@ internal fun accountSettingsComponent(state: AccountSettings.State = defaultAcco
 		override suspend fun setMaxBackups(value: Int) = true
 		override fun reauthenticate() {}
 		override fun updateServerUrl(url: String) {}
-		override fun updateServerSsl(ssl: Boolean) {}
 		override fun updateServerEmail(email: String) {}
 		override fun updateServerPassword(password: String) {}
 		override val spellCheckSettings: SpellCheckSettings

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -199,9 +199,12 @@ Run the server:
 ./run.sh
 ```
 
-## Setting up SSL (optional)
+## Setting up SSL (required for direct connections)
 
-_This step is optional but strongly recommended._
+**Hammer clients only speak `https`.** A client will never connect over plain HTTP, so a
+server that clients reach **directly** must terminate TLS. The only deployment that can run
+Hammer on plain HTTP is one sitting **behind a reverse proxy** — the proxy holds the
+certificate and forwards plain HTTP to Hammer on the same host.
 
 There are two ways to serve Hammer over `https`. Pick **one**:
 
@@ -211,6 +214,9 @@ There are two ways to serve Hammer over `https`. Pick **one**:
   Hammer. Preferred if you run other services on the same host. If you go this route,
   **skip the rest of this section** and follow
   [Reverse Proxy using Nginx](#reverse-proxy-using-nginx) instead.
+
+> The plain HTTP connector (`port`, default 8080) still exists solely for the reverse-proxy
+> case. Do not expose it directly to clients — they won't use it.
 
 If you want Hammer to terminate SSL itself, you'll first need to edit your server config file and
 add these lines:
@@ -222,13 +228,29 @@ forceHttps = true # Optional, defualts to true
 
 ### Getting an SSL Certificate
 
-#### Self-signed certs are not supported
+#### Self-signed certs are not supported in production
 
-Don't use a self-signed certificate. The mobile clients trust only the system CA store — Android
-won't trust user-added or self-signed CAs by default, and iOS rejects them too — so they'll fail the
-TLS handshake with no way to override it. Use a real certificate from **Let's Encrypt** below (or
-put
-Hammer behind a reverse proxy that holds one).
+Don't use a self-signed certificate for a real deployment. The mobile clients trust only the
+system CA store — Android won't trust user-added or self-signed CAs by default, and iOS rejects
+them too — so they'll fail the TLS handshake with no way to override it. The desktop client also
+rejects self-signed certs outside development mode. Use a real certificate from **Let's Encrypt**
+below (or put Hammer behind a reverse proxy that holds one).
+
+#### Development: automatic self-signed cert
+
+When you run the server with `--dev` and **no** `sslCert` configured, Hammer generates a
+self-signed certificate on first boot and serves it, persisting the keystore to
+`hammer_data/dev-selfsigned.jks` so it stays stable across restarts. To avoid the privileged
+port 443 (which needs root on Linux/macOS), the dev connector listens on **8443** by default;
+set `sslPort` to override. Point the client at `localhost:8443` or `127.0.0.1:8443`.
+
+The desktop client run with `--dev` trusts this self-signed cert, but **only for loopback hosts**
+(localhost / 127.0.0.1) — a `--dev` client talking to any other host still does full certificate
+and hostname validation, so pointing a dev build at a real server is not silently insecure.
+
+This path never activates without `--dev`; a production server with no `sslCert` serves plain HTTP
+only (for the reverse-proxy case). Mobile clients still won't trust the self-signed cert, so
+develop the mobile clients against a real certificate or a reverse proxy.
 
 #### Let's Encrypt
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -20,6 +20,7 @@ import com.darkrockstudios.apps.hammer.plugins.configureRouting
 import com.darkrockstudios.apps.hammer.plugins.configureSecurity
 import com.darkrockstudios.apps.hammer.plugins.configureSerialization
 import com.darkrockstudios.apps.hammer.secret.KeyringCodec
+import com.darkrockstudios.apps.hammer.utilities.DevSelfSignedCert
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import com.darkrockstudios.apps.hammer.utilities.loadPemAsKeyStore
 import com.github.ajalt.clikt.core.CliktCommand
@@ -242,7 +243,7 @@ private fun startServer(config: ServerConfig, devMode: Boolean, logLevel: Level?
 	embeddedServer(
 		Jetty,
 		configure = {
-			configureServer(config)
+			configureServer(config, devMode)
 		},
 		module = {
 			appMain(config, logLevel = logLevel)
@@ -251,10 +252,13 @@ private fun startServer(config: ServerConfig, devMode: Boolean, logLevel: Level?
 }
 
 private fun JettyApplicationEngineBase.Configuration.configureServer(
-	config: ServerConfig
+	config: ServerConfig,
+	devMode: Boolean,
 ) {
 	require(config.bindHosts.isNotEmpty()) { "bindHosts must list at least one address" }
 
+	// The plain connector stays so reverse-proxy deployments can forward plain HTTP to Hammer;
+	// clients themselves are HTTPS-only and talk TLS to the proxy.
 	config.bindHosts.forEach { bindHost ->
 		connector {
 			port = config.port
@@ -262,30 +266,64 @@ private fun JettyApplicationEngineBase.Configuration.configureServer(
 		}
 	}
 
-	config.sslCert?.apply {
-		require(validate()) { "SSL config must have either keystore (path + storePassword) or PEM files (certChainPath + privateKeyPath)" }
+	val sslCert = config.sslCert
+	if (sslCert != null) {
+		require(sslCert.validate()) { "SSL config must have either keystore (path + storePassword) or PEM files (certChainPath + privateKeyPath)" }
 
-		val keyStore = getKeyStore(this)
-		val alias = if (usePem()) "server" else (keyAlias ?: "")
-		val storePass = if (usePem()) "" else (storePassword ?: "")
-		val keyPass = if (usePem()) "" else (keyPassword ?: "")
+		val keyStore = getKeyStore(sslCert)
+		val alias = if (sslCert.usePem()) "server" else (sslCert.keyAlias ?: "")
+		val storePass = if (sslCert.usePem()) "" else (sslCert.storePassword ?: "")
+		val keyPass = if (sslCert.usePem()) "" else (sslCert.keyPassword ?: "")
+		val keyStorePath = if (!sslCert.usePem() && sslCert.path != null) File(sslCert.path) else null
 
-		config.bindHosts.forEach { bindHost ->
-			sslConnector(
-				keyStore = keyStore,
-				keyAlias = alias,
-				keyStorePassword = { storePass.toCharArray() },
-				privateKeyPassword = { keyPass.toCharArray() }
-			) {
-				if (!usePem() && path != null) {
-					this.keyStorePath = File(path)
-				}
-				host = bindHost
-				port = config.sslPort
-			}
+		bindSslConnectors(config, keyStore, alias, storePass, keyPass, config.sslPort, keyStorePath)
+	} else if (devMode) {
+		configureDevTlsConnector(config)
+	}
+}
+
+/**
+ * Binds a TLS connector backed by an auto-generated self-signed cert, for the dev loop where
+ * no real certificate is configured. Never reached in production: absent an [ServerConfig.sslCert]
+ * a production server serves plain HTTP only (the reverse-proxy deployment shape).
+ */
+private fun JettyApplicationEngineBase.Configuration.configureDevTlsConnector(config: ServerConfig) {
+	val dev = DevSelfSignedCert.getOrCreate()
+	// 443 is privileged on Linux/macOS; when the operator hasn't overridden the default, fall back
+	// to a non-privileged port so the dev server boots without root.
+	val port = if (config.sslPort == ServerConfig.DEFAULT_SSL_PORT) DEV_TLS_FALLBACK_PORT else config.sslPort
+	configLogger.warn(
+		"Dev mode: no sslCert configured, serving a self-signed certificate on port $port " +
+			"(keystore: ${dev.path}). Clients must trust it — the desktop --dev client does so automatically."
+	)
+	bindSslConnectors(config, dev.keyStore, dev.alias, dev.password, dev.password, port, keyStorePath = null)
+}
+
+/** Binds one TLS connector per bind host, sharing the same keystore-backed configuration. */
+private fun JettyApplicationEngineBase.Configuration.bindSslConnectors(
+	config: ServerConfig,
+	keyStore: KeyStore,
+	alias: String,
+	storePassword: String,
+	keyPassword: String,
+	sslPort: Int,
+	keyStorePath: File?,
+) {
+	config.bindHosts.forEach { bindHost ->
+		sslConnector(
+			keyStore = keyStore,
+			keyAlias = alias,
+			keyStorePassword = { storePassword.toCharArray() },
+			privateKeyPassword = { keyPassword.toCharArray() },
+		) {
+			if (keyStorePath != null) this.keyStorePath = keyStorePath
+			host = bindHost
+			port = sslPort
 		}
 	}
 }
+
+private const val DEV_TLS_FALLBACK_PORT = 8443
 
 internal fun getKeyStore(sslConfig: SslCertConfig): KeyStore {
 	return if (sslConfig.usePem()) {

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -19,7 +19,7 @@ data class ServerConfig(
 	 */
 	val bindHosts: List<String> = listOf("0.0.0.0"),
 	val port: Int = 8080,
-	val sslPort: Int = 443,
+	val sslPort: Int = DEFAULT_SSL_PORT,
 	/**
 	 * The externally visible base URL (e.g. "https://hammer.example.com"), used for
 	 * links placed in emails. Set this when running behind a reverse proxy; otherwise
@@ -45,6 +45,10 @@ data class ServerConfig(
 	@Transient
 	val emailProviderType: EmailProvider? = emailProvider?.let { provider ->
 		EmailProvider.entries.find { it.name.equals(provider, ignoreCase = true) }
+	}
+
+	companion object {
+		const val DEFAULT_SSL_PORT = 443
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/DevSelfSignedCert.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/DevSelfSignedCert.kt
@@ -16,6 +16,9 @@ import java.security.KeyStore
  */
 object DevSelfSignedCert {
 	private const val ALIAS = "server"
+
+	// nosemgrep: generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password -- not a
+	// secret; guards a throwaway self-signed keystore generated locally in dev mode.
 	private const val PASSWORD = "hammer-dev"
 	private const val FILE_NAME = "dev-selfsigned.jks"
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/DevSelfSignedCert.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/DevSelfSignedCert.kt
@@ -17,8 +17,8 @@ import java.security.KeyStore
 object DevSelfSignedCert {
 	private const val ALIAS = "server"
 
-	// nosemgrep: generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password -- not a
-	// secret; guards a throwaway self-signed keystore generated locally in dev mode.
+	// Not a secret; guards a throwaway self-signed keystore generated locally in dev mode.
+	// nosemgrep: generic.secrets.gitleaks.hashicorp-tf-password.hashicorp-tf-password
 	private const val PASSWORD = "hammer-dev"
 	private const val FILE_NAME = "dev-selfsigned.jks"
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/DevSelfSignedCert.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/DevSelfSignedCert.kt
@@ -1,0 +1,63 @@
+package com.darkrockstudios.apps.hammer.utilities
+
+import io.ktor.network.tls.certificates.buildKeyStore
+import io.ktor.network.tls.certificates.saveToFile
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import java.io.File
+import java.security.KeyStore
+
+/**
+ * A self-signed keystore used only when the server runs in `--dev` mode with no `sslCert`
+ * configured. It lets the direct-connection dev loop (desktop client → local server, no
+ * reverse proxy) speak HTTPS without provisioning a real certificate. The desktop `--dev`
+ * client trusts it automatically; it is never used by a production build.
+ */
+object DevSelfSignedCert {
+	private const val ALIAS = "server"
+	private const val PASSWORD = "hammer-dev"
+	private const val FILE_NAME = "dev-selfsigned.jks"
+
+	/**
+	 * Loads the persisted dev keystore, generating and saving one on first run. Persisting it
+	 * keeps the certificate (and its fingerprint) stable across restarts instead of minting a
+	 * fresh one every boot.
+	 */
+	fun getOrCreate(fileSystem: FileSystem = FileSystem.SYSTEM): DevKeyStore {
+		val path: Path = getRootDataDirectory(fileSystem) / FILE_NAME
+		return getOrCreate(File(path.toString()))
+	}
+
+	/** Testable core: reads or writes the keystore at an explicit [keyStoreFile]. */
+	internal fun getOrCreate(keyStoreFile: File): DevKeyStore {
+		val keyStore = if (keyStoreFile.exists()) {
+			KeyStore.getInstance(keyStoreFile, PASSWORD.toCharArray())
+		} else {
+			val generated = buildKeyStore {
+				certificate(ALIAS) {
+					password = PASSWORD
+					domains = listOf("localhost", "127.0.0.1", "0.0.0.0")
+					daysValid = 3650
+				}
+			}
+			keyStoreFile.parentFile?.mkdirs()
+			generated.saveToFile(keyStoreFile, PASSWORD)
+			generated
+		}
+
+		return DevKeyStore(
+			keyStore = keyStore,
+			alias = ALIAS,
+			password = PASSWORD,
+			path = keyStoreFile.path.toPath(),
+		)
+	}
+}
+
+data class DevKeyStore(
+	val keyStore: KeyStore,
+	val alias: String,
+	val password: String,
+	val path: Path,
+)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/DevSelfSignedCertTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/DevSelfSignedCertTest.kt
@@ -1,0 +1,42 @@
+package com.darkrockstudios.apps.hammer.utilities
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.security.cert.X509Certificate
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DevSelfSignedCertTest {
+
+	@TempDir
+	lateinit var tempDir: File
+
+	@Test
+	fun `generates a keystore holding the server key entry`() {
+		val file = File(tempDir, "dev.jks")
+
+		val dev = DevSelfSignedCert.getOrCreate(file)
+
+		assertTrue(file.exists(), "keystore should be persisted to disk")
+		assertTrue(dev.keyStore.isKeyEntry(dev.alias), "keystore should hold the server key entry")
+		val cert = dev.keyStore.getCertificate(dev.alias) as X509Certificate
+		assertNotNull(cert)
+		// A self-signed cert's issuer equals its subject.
+		assertEquals(cert.subjectX500Principal, cert.issuerX500Principal)
+	}
+
+	@Test
+	fun `reuses the persisted keystore instead of regenerating`() {
+		val file = File(tempDir, "dev.jks")
+
+		val first = DevSelfSignedCert.getOrCreate(file)
+		val second = DevSelfSignedCert.getOrCreate(file)
+
+		val firstCert = first.keyStore.getCertificate(first.alias) as X509Certificate
+		val secondCert = second.keyStore.getCertificate(second.alias) as X509Certificate
+		// Same persisted cert on the second call — the fingerprint stays stable across restarts.
+		assertEquals(firstCert, secondCert)
+	}
+}


### PR DESCRIPTION
## Summary

Grows the sync stack up to HTTPS-only clients, and gives the direct-connection dev loop a zero-config self-signed cert.

### Client — HTTPS only
- Removed the HTTP/HTTPS protocol picker from the server-setup dialog and all `ssl` plumbing through `AccountSettings`, `AccountSettingsComponent`, and `AccountUseCase`.
- Persisted server settings now always resolve to HTTPS: dropped the `ssl` field from `PersistedServerSettings`, so an existing `server.json` with `ssl=false` is silently upgraded on load.
- `ServerSettings.ssl` is kept (defaulting `true`) **only** as an internal seam for the plain-HTTP integration-test server.

### Android — no cleartext
- Deleted the permissive `network_security_config.xml` and its manifest references (main + fdroid). Android's secure default now blocks plaintext traffic. (Also closes the open F-3 cleartext finding from the client security audit.)

### Server + dev cert
- The plain HTTP connector **stays** for reverse-proxy deployments (Nginx terminates TLS → forwards plain HTTP). A cert is only needed when clients connect directly.
- New `DevSelfSignedCert`: in `--dev` with no `sslCert` configured, the server generates & persists a self-signed keystore (`hammer_data/dev-selfsigned.jks`) and serves TLS on a **non-privileged port (8443 by default)** so it boots without root on Linux/macOS.
- The desktop `--dev` client trusts that cert **for loopback hosts only** — a dev build pointed at a real remote server still gets full certificate + hostname validation.
- Rewrote the SSL section of `HOW-TO-RUN-A-SERVER.md`.

## Migration note
Existing self-hosters running plain HTTP will need a cert or a reverse proxy — their client now speaks HTTPS only. This is the intended consequence of dropping HTTP.

## Testing
- `:server:compileKotlin`, `:common`/`:composeUi` desktop compile: clean
- `AccountUseCaseTest`, `AccountSettingsComponentTest`, `ServerSettingsDatasourceTest`, `AccountReauthUseCaseTest`: pass
- New `DevSelfSignedCertTest` + existing `SslCertTest`: pass
