### PR TITLE
Fix ineffective nosemgrep SQL-injection suppression in migrator

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/migration/SqliteToPostgresMigrator.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/migration/SqliteToPostgresMigrator.kt
@@ -139,8 +139,9 @@ class SqliteToPostgresMigrator(
 		bind: PreparedStatement.(T) -> Unit,
 	): Int {
 		if (rows.isEmpty()) return 0
-		// nosemgrep: kotlin_inject_rule-SqlInjection -- sql is always a compile-time
-		// INSERT string from the copy* methods in this file; no user input reaches it.
+		// sql is always a compile-time INSERT string from the copy* methods in this file;
+		// no user input reaches it.
+		// nosemgrep: kotlin_inject_rule-SqlInjection
 		conn.prepareStatement(sql).use { ps ->
 			var batched = 0
 			for (r in rows) {


### PR DESCRIPTION
## What

The `nosemgrep` suppression on `SqliteToPostgresMigrator.copyTable` was positioned so it suppresses nothing. The directive was on the first of two comment lines, with the justification prose on the line directly above the flagged `conn.prepareStatement(sql)` call:

```kotlin
// nosemgrep: kotlin_inject_rule-SqlInjection -- sql is always a compile-time
// INSERT string from the copy* methods in this file; no user input reaches it.
conn.prepareStatement(sql).use { ps ->
```

Semgrep only honors a `nosemgrep` directive on the flagged line itself or the single line immediately above it. With the justification sandwiched in between, the directive is out of range. Reordered so the directive sits directly above the statement.

## Why it went unnoticed

- GitHub Actions runs no Semgrep/detekt/lint step — only Gradle build/test jobs. It never sees this.
- Codacy (which does run Semgrep, out of band) gates only *new* issues in a PR diff, so a pre-existing broken suppression is treated as baseline and never blocks.

The finding itself is a false positive: `sql` is always a compile-time `INSERT … VALUES (?, …)` literal from the `copy*` methods, with every value bound via placeholders — no user input reaches it. Nothing behavioral changes; this only makes the suppression actually work so the next edit to that line doesn't spuriously block on a "new critical".

Note: the `kotlin_inject_rule-SqlInjection` rule-id is carried over from the original comment and couldn't be verified against a live scan from the dev environment.