### PR TITLE
Add self-contained static-analysis CI gate (custom Semgrep rules + gitleaks)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,11 +79,21 @@ jobs:
           python-version: '3.12'
       - name: Install Semgrep
         run: pip install semgrep
-      # TODO(gating): report-only for now. This surfaces the existing baseline without failing
-      # the build; once the baseline is triaged (fixed or `// nosemgrep`-suppressed) add `--error`
-      # so an unsuppressed finding blocks the PR. Honors existing `// nosemgrep` comments.
-      - name: Run Semgrep
-        run: semgrep scan --config p/kotlin --config p/secrets --metrics off
+      # Self-contained code-pattern rules under .semgrep/ (no registry fetch, no account).
+      # Honors `// nosemgrep` comments. TODO(gating): add `--error` once the baseline is clean.
+      - name: Run Semgrep (custom rules)
+        run: semgrep scan --config .semgrep --metrics off
+      - name: Install gitleaks
+        run: |
+          version=$(curl -sSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep -oP '"tag_name": "v\K[^"]+')
+          echo "gitleaks version: $version"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      # Report-only for now (--exit-code 0): surfaces the secrets baseline (test fixtures, the
+      # dev keystore password, etc.) so it can be allowlisted in .gitleaks.toml before gating.
+      - name: Run gitleaks (report only)
+        run: gitleaks dir . --no-banner --redact --exit-code 0
 
   android-instrumented-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,14 +90,19 @@ jobs:
           curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin gitleaks
           gitleaks version
-      # Report-only for now (--exit-code 0): surfaces the secrets baseline (test fixtures, the
-      # dev keystore password, etc.) so it can be allowlisted in .gitleaks.toml before gating.
-      - name: Run gitleaks (report only)
+      # Fails the build on any committed secret. Known test fixtures are allowlisted in
+      # .gitleaks.toml; the JSON report is parsed so failures list rule + file:line.
+      - name: Run gitleaks
         run: |
-          gitleaks dir . --no-banner --redact --exit-code 0 \
-            --report-format json --report-path gitleaks-report.json
-          echo "=== gitleaks findings (rule  file:line) ==="
-          python3 -c "import json; [print(f\"{x['RuleID']}  {x['File']}:{x['StartLine']}\") for x in json.load(open('gitleaks-report.json'))]"
+          gitleaks dir . --config .gitleaks.toml --no-banner --redact \
+            --report-format json --report-path gitleaks-report.json --exit-code 2 || true
+          count=$(python3 -c "import json; print(len(json.load(open('gitleaks-report.json'))))")
+          if [ "$count" -gt 0 ]; then
+            echo "::error::gitleaks found $count secret(s):"
+            python3 -c "import json; [print(f\"  {x['RuleID']}  {x['File']}:{x['StartLine']}\") for x in json.load(open('gitleaks-report.json'))]"
+            exit 1
+          fi
+          echo "gitleaks: no leaks"
 
   android-instrumented-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,16 +78,18 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install Semgrep
-        run: pip install semgrep
+        run: pip install semgrep==1.170.0
       # Self-contained code-pattern rules under .semgrep/ (no registry fetch, no account).
       # Honors `// nosemgrep` comments. `--error` makes an unsuppressed finding fail the build.
       - name: Run Semgrep (custom rules)
         run: semgrep scan --config .semgrep --error --metrics off
+      # Pinned for reproducibility — a tool auto-update must never spontaneously fail an
+      # unrelated PR's gate. Bump deliberately to pick up new secret-detection rules.
       - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
         run: |
-          version=$(curl -sSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep -oP '"tag_name": "v\K[^"]+')
-          echo "gitleaks version: $version"
-          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" \
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin gitleaks
           gitleaks version
       # Fails the build on any committed secret. Known test fixtures are allowlisted in

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,9 @@ jobs:
       - name: Install Semgrep
         run: pip install semgrep
       # Self-contained code-pattern rules under .semgrep/ (no registry fetch, no account).
-      # Honors `// nosemgrep` comments. TODO(gating): add `--error` once the baseline is clean.
+      # Honors `// nosemgrep` comments. `--error` makes an unsuppressed finding fail the build.
       - name: Run Semgrep (custom rules)
-        run: semgrep scan --config .semgrep --metrics off
+        run: semgrep scan --config .semgrep --error --metrics off
       - name: Install gitleaks
         run: |
           version=$(curl -sSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep -oP '"tag_name": "v\K[^"]+')
@@ -93,7 +93,11 @@ jobs:
       # Report-only for now (--exit-code 0): surfaces the secrets baseline (test fixtures, the
       # dev keystore password, etc.) so it can be allowlisted in .gitleaks.toml before gating.
       - name: Run gitleaks (report only)
-        run: gitleaks dir . --no-banner --redact --exit-code 0
+        run: |
+          gitleaks dir . --no-banner --redact --exit-code 0 \
+            --report-format json --report-path gitleaks-report.json
+          echo "=== gitleaks findings (rule  file:line) ==="
+          python3 -c "import json; [print(f\"{x['RuleID']}  {x['File']}:{x['StartLine']}\") for x in json.load(open('gitleaks-report.json'))]"
 
   android-instrumented-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,22 @@ jobs:
             integrationTests/build/reports/tests/jvmTest/
             integrationTests/build/test-results/jvmTest/
 
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Semgrep
+        run: pip install semgrep
+      # TODO(gating): report-only for now. This surfaces the existing baseline without failing
+      # the build; once the baseline is triaged (fixed or `// nosemgrep`-suppressed) add `--error`
+      # so an unsuppressed finding blocks the PR. Honors existing `// nosemgrep` comments.
+      - name: Run Semgrep
+        run: semgrep scan --config p/kotlin --config p/secrets --metrics off
+
   android-instrumented-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# Gitleaks configuration. Extends the built-in ruleset (so all default secret rules run) and
+# allowlists known test fixtures that are not real credentials.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Fake credentials used only as test fixtures, not real secrets."
+regexes = [
+  # Shared fake password in the server account tests (a keyboard-walk, not a real key).
+  '''qweasdZXC123''',
+]

--- a/.semgrep/rules.yml
+++ b/.semgrep/rules.yml
@@ -1,0 +1,12 @@
+rules:
+  - id: hammer-raw-sql-to-prepared-statement
+    languages: [kotlin]
+    severity: WARNING
+    message: >-
+      prepareStatement() is called with a non-literal SQL string. Build the SQL from a
+      compile-time literal and bind every value with `?` placeholders. If the string is
+      provably constant (e.g. assembled only from literals in this file), suppress with a
+      `// nosemgrep: hammer-raw-sql-to-prepared-statement` line and a one-line justification.
+    patterns:
+      - pattern: $CONN.prepareStatement($SQL)
+      - pattern-not: $CONN.prepareStatement("...")

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/migration/MigrationParityChecker.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/migration/MigrationParityChecker.kt
@@ -35,6 +35,9 @@ object MigrationParityChecker {
 	}
 
 	private fun countPostgres(conn: Connection, table: String): Int =
+		// table is always a hardcoded name from the migrator's copy map, never user input;
+		// a table identifier cannot be bound as a `?` parameter.
+		// nosemgrep: hammer-raw-sql-to-prepared-statement
 		conn.prepareStatement("SELECT COUNT(*) FROM $table").executeQuery().use {
 			it.next(); it.getInt(1)
 		}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/migration/SqliteToPostgresMigrator.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/migration/SqliteToPostgresMigrator.kt
@@ -139,8 +139,9 @@ class SqliteToPostgresMigrator(
 		bind: PreparedStatement.(T) -> Unit,
 	): Int {
 		if (rows.isEmpty()) return 0
-		// nosemgrep: kotlin_inject_rule-SqlInjection -- sql is always a compile-time
-		// INSERT string from the copy* methods in this file; no user input reaches it.
+		// sql is always a compile-time INSERT string from the copy* methods in this file;
+		// no user input reaches it.
+		// nosemgrep: kotlin_inject_rule-SqlInjection,hammer-raw-sql-to-prepared-statement
 		conn.prepareStatement(sql).use { ps ->
 			var batched = 0
 			for (r in rows) {


### PR DESCRIPTION
## What

Adds a `static-analysis` job to Build CI that runs two **self-contained** scanners as a gate, plus fixes the migrator suppression that motivated this (supersedes #746):

- **Semgrep** against hand-written rules in `.semgrep/` (no registry fetch, no account). First rule: raw SQL passed to `prepareStatement`. Runs with `--error` — an unsuppressed match fails the build. Honors `// nosemgrep`.
- **gitleaks** for committed secrets — pinned release binary, no license/account. Fails on any leak; known test fixtures are allowlisted in `.gitleaks.toml`.

Both tool versions are pinned so a tool auto-update can't spontaneously fail an unrelated PR.

## Why not the community rulesets

The first attempt used Semgrep's `p/kotlin` + `p/secrets`. A CI run proved them near-empty anonymously: **10 Kotlin rules, and none matching the patterns that flagged our real findings** — those are Codacy-proprietary. The fuller registry needs a `semgrep login` token, re-introducing the out-of-band-platform dependency we're moving away from. Custom rules + gitleaks keep the gate in the load-bearing CI, self-contained, and targeted.

## Baseline triage (done)

The report-only passes surfaced and resolved the whole baseline:
- **Semgrep (2):** the migrator INSERT loop, and a `SELECT COUNT(*) FROM $table` parity check — both take internally-constructed SQL (table names from a hardcoded map), so both are false positives, suppressed with justified `// nosemgrep` lines.
- **gitleaks (3):** all the same fake test password `qweasdZXC123` in server account tests — allowlisted by exact string, so every other file (tests included) stays scanned.

Final gated run: Semgrep `0 findings`, gitleaks `no leaks`.

## Note for the reviewer

To make this a *blocking* check (not just a visible one), add `static-analysis` to the branch-protection required checks for `develop`.