### PR TITLE
Render the privacy policy page as Markdown

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PrivacyPolicyPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PrivacyPolicyPage.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.frontend
 
 import com.darkrockstudios.apps.hammer.account.PrivacyPolicyRepository
+import com.darkrockstudios.apps.hammer.utilities.MarkdownService
 import io.ktor.http.*
 import io.ktor.server.mustache.*
 import io.ktor.server.response.*
@@ -9,16 +10,18 @@ import org.koin.ktor.ext.inject
 
 fun Route.privacyPolicyPage() {
 	val privacyPolicyRepository: PrivacyPolicyRepository by inject()
+	val markdownService: MarkdownService by inject()
 	route("/privacy") {
 		get {
-			val text = privacyPolicyRepository.text()
-			if (text == null) {
+			val markdown = privacyPolicyRepository.text()
+			if (markdown == null) {
 				call.respond(HttpStatusCode.NotFound)
 				return@get
 			}
 
 			val model = call.withDefaults()
-			model["privacyText"] = text
+			model["page_stylesheet"] = "/assets/css/about.css"
+			model["privacyHtml"] = markdownService.markdownToSafeHtml(markdown)
 
 			call.respond(MustacheContent("privacy.mustache", model))
 		}

--- a/server/src/main/resources/templates/privacy.mustache
+++ b/server/src/main/resources/templates/privacy.mustache
@@ -9,7 +9,9 @@
 		</div>
 
 		<section class="paper-section">
-			<div class="legal-text">{{privacyText}}</div>
+			<div class="about-content">
+				{{{privacyHtml}}}
+			</div>
 		</section>
 	</div>
 </main>


### PR DESCRIPTION
## Summary

Follow-up to #744: the `/privacy` page now renders its configured source as **Markdown** instead of escaped plaintext, matching the About page.

- `PrivacyPolicyPage.kt` runs the configured text through `MarkdownService.markdownToSafeHtml(...)` and passes the sanitized HTML to the template.
- `privacy.mustache` renders it raw (`{{{privacyHtml}}}`) inside the shared `.about-content` wrapper and loads `about.css`, so headings/lists/links/blockquotes/code/tables pick up the existing "Writer's Desk" styling used by About, author bios, and the dashboard.

Terms stays plaintext on purpose — its text is the content-hashed acceptance-gate copy.

## Testing

- `:server:compileKotlin` + full `:server:test` suite pass locally.
- App-boot tests (`ApplicationTest`, `AccountRoutesTest`) pass — the added lazy `MarkdownService` inject doesn't affect route registration.
- Held to the same coverage bar as the About page, which renders Markdown the same way and has no dedicated render test (route tests mock `MarkdownService`).
