### PR TITLE
Bind e2e test server to an ephemeral port to fix flakiness

### DIFF
--- a/integrationTests/build.gradle.kts
+++ b/integrationTests/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
 	useJUnitPlatform()
-	// EndToEndTest binds port 54321; only one server at a time.
+	// These tests share JVM-global state (Koin GlobalContext, Dispatchers.setMain),
+	// so they must run one at a time.
 	maxParallelForks = 1
 }

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/HeadlessClient.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/HeadlessClient.kt
@@ -23,7 +23,7 @@ import org.koin.mp.KoinPlatform.getKoin
  *
  * Each instance:
  *   - creates a local project on the real filesystem (Okio `FileSystem.SYSTEM`),
- *   - writes [ServerSettings] pointing at `127.0.0.1:54321` with the test's bearer token,
+ *   - writes [ServerSettings] pointing at the in-process server's port with the test's bearer token,
  *   - opens the project's Koin scope so the full sync pipeline is resolvable.
  *
  * The on-disk state under [projectPath] is what tests assert against.

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
@@ -50,7 +50,7 @@ import kotlin.uuid.Uuid
 
 /**
  * Base class for round-trip sync integration tests. Spins up a real Jetty server
- * on `127.0.0.1:54321` (via [EndToEndTest]) and a real client Koin context with
+ * on an OS-assigned port (via [EndToEndTest]) and a real client Koin context with
  * production wiring.
  *
  * Both server and client share `EndToEndTest`'s [okio.fakefilesystem.FakeFileSystem]
@@ -247,7 +247,7 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 	 */
 	protected fun makeServerSettings(): ServerSettings = ServerSettings(
 		ssl = false,
-		url = "127.0.0.1:$TEST_PORT",
+		url = "127.0.0.1:$serverPort",
 		email = account.email,
 		userId = userId,
 		bearerToken = authToken.auth,

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
@@ -18,6 +18,7 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.engine.*
 import io.ktor.server.jetty.jakarta.*
+import kotlinx.coroutines.runBlocking
 import okio.FileSystem
 import okio.fakefilesystem.FakeFileSystem
 import org.junit.jupiter.api.AfterEach
@@ -28,17 +29,16 @@ import kotlin.io.encoding.Base64
 
 /**
  * Base class for End to End Tests.
- * This will start up and tear down a server running on
- * port 54321, and writing to a FakeFileSystem.
+ * This will start up and tear down a server on an ephemeral port (assigned by
+ * the OS at bind time), and writing to a FakeFileSystem. Binding to a fixed port
+ * made the suite flaky: back-to-back tests reuse the same JVM and a server whose
+ * socket hadn't fully released yet could collide with the next test's bind.
  */
 abstract class EndToEndTest {
 
-	companion object {
-		const val TEST_PORT = 54321
-	}
-
 	protected lateinit var fileSystem: FakeFileSystem
 	private lateinit var server: ApplicationEngine
+	private var serverPort: Int = 0
 	private lateinit var client: HttpClient
 	private lateinit var testDatabase: SqliteTestDatabase
 	private lateinit var base64: Base64
@@ -92,11 +92,14 @@ abstract class EndToEndTest {
 		server.stop(1000, 3000)
 	}
 
-	protected fun route(path: String): String = "http://127.0.0.1:$TEST_PORT/$path"
+	protected fun route(path: String): String = "http://127.0.0.1:$serverPort/$path"
 	protected fun api(path: String): String = route("api/$path")
 
 	fun doStartServer() {
 		server = startServer()
+		// port = 0 bound an OS-assigned port; read back what we actually got so
+		// the client connects to the right place.
+		serverPort = runBlocking { server.resolvedConnectors().first().port }
 	}
 
 	private fun startServer(): ApplicationEngine {
@@ -112,7 +115,7 @@ abstract class EndToEndTest {
 
 		val server = embeddedServer(
 			Jetty,
-			port = TEST_PORT,
+			port = 0,
 			host = "0.0.0.0",
 			module = {
 				appMain(config, testModule)

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
@@ -38,7 +38,10 @@ abstract class EndToEndTest {
 
 	protected lateinit var fileSystem: FakeFileSystem
 	private lateinit var server: ApplicationEngine
-	private var serverPort: Int = 0
+
+	/** The OS-assigned port the server bound to; valid after [doStartServer]. */
+	protected var serverPort: Int = 0
+		private set
 	private lateinit var client: HttpClient
 	private lateinit var testDatabase: SqliteTestDatabase
 	private lateinit var base64: Base64


### PR DESCRIPTION
## Problem

`EndToEndTest` bound every test's server to a **fixed port (54321)**. The whole server suite shares one JVM and boots/tears down a full Jetty server per test with a 1s/3s stop grace, so a stopped server whose socket hadn't fully released could collide with the next test's bind. This surfaced as an unrelated single test failing intermittently with a non-200 — e.g. `ReviewPageTest > review page falls back to English for untranslated locales` failing the `assertEquals(HttpStatusCode.OK, …)` on runs like [this logback-bump PR](https://github.com/Darkrock-Studios/hammer-editor/actions/runs/29223212133/job/87706176807), whose only change was a one-line dependency bump.

## Fix

Bind `port = 0` so the OS assigns a free port, then read the actual port back via `resolvedConnectors()` after start so the client targets the right place. The change is fully contained in `EndToEndTest` — no subclass hardcoded the port — so the now-unused `TEST_PORT` constant is removed.

## Verification

Full e2e suite (62 tests) passes with 0 failures / 0 errors, including the previously-flaky locale-fallback test.