### PR TITLE
Add sitemap.xml generation with robots.txt discovery

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -26,6 +26,7 @@ data class ServerConfig(
 	 * links are derived from each request's Host header.
 	 */
 	val publicUrl: String? = null,
+	val additionalSitemaps: List<String> = emptyList(),
 	val sslCert: SslCertConfig? = null,
 	val patreonEnabled: Boolean? = null,
 	/**

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -113,6 +113,7 @@ fun Route.frontend() {
 	}
 
 	robotsRoutes()
+	sitemapRoutes(serverConfig, accountsRepository, projectAccessRepository, configRepository)
 	setupPage(serverConfig)
 	homePage(whiteListRepository, configRepository, serverConfig, accountsRepository, projectAccessRepository)
 	aboutPage(configRepository, serverConfig, accountsRepository, projectAccessRepository, markdownService)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/RobotsRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/RobotsRoutes.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.frontend
 
+import com.darkrockstudios.apps.hammer.frontend.utils.publicBaseUrl
 import io.ktor.http.ContentType
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.header
@@ -124,7 +125,10 @@ internal fun buildRobotsTxt(sitemapUrl: String? = null): String {
 
 fun Route.robotsRoutes() {
 	get("/robots.txt") {
-		call.respondText(buildRobotsTxt(), ContentType.Text.Plain)
+		// Only advertise the sitemap when a public URL is configured — the line needs an
+		// absolute URL, and the request Host is untrusted (see publicBaseUrl).
+		val sitemapUrl = call.publicBaseUrl()?.let { "$it/sitemap.xml" }
+		call.respondText(buildRobotsTxt(sitemapUrl), ContentType.Text.Plain)
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/SitemapRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/SitemapRoutes.kt
@@ -1,0 +1,177 @@
+package com.darkrockstudios.apps.hammer.frontend
+
+import com.darkrockstudios.apps.hammer.ServerConfig
+import com.darkrockstudios.apps.hammer.account.AccountsRepository
+import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
+import com.darkrockstudios.apps.hammer.admin.ConfigRepository
+import com.darkrockstudios.apps.hammer.database.CommunityAuthor
+import com.darkrockstudios.apps.hammer.database.CommunityFeedStory
+import com.darkrockstudios.apps.hammer.frontend.utils.ProjectName
+import com.darkrockstudios.apps.hammer.frontend.utils.publicBaseUrl
+import com.darkrockstudios.apps.hammer.project.access.ProjectAccessRepository
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+
+/** One `<url>` in a sitemap urlset. [lastmod] is a preformatted W3C datetime, or null. */
+internal data class SitemapEntry(val loc: String, val lastmod: String? = null)
+
+/** The sitemap protocol caps a single file at 50,000 URLs / 50 MB. */
+private const val SITEMAP_MAX_URLS = 50_000
+private const val SITEMAP_FETCH_PAGE = 500
+
+/**
+ * Serves the site's sitemaps:
+ *  - `/sitemap.xml`         — a sitemap index over the content sitemap below.
+ *  - `/sitemap-content.xml` — a urlset of this server's own public pages: the enabled static
+ *                             marketing pages, plus community authors and published stories
+ *                             enumerated from the database at request time.
+ *
+ * Both require [ServerConfig.publicUrl] so `<loc>`s are absolute; without it they 404. The
+ * client-controlled request Host is deliberately not used as a fallback (see [publicBaseUrl]).
+ */
+fun Route.sitemapRoutes(
+	serverConfig: ServerConfig,
+	accountsRepository: AccountsRepository,
+	projectAccessRepository: ProjectAccessRepository,
+	configRepository: ConfigRepository,
+) {
+	get("/sitemap.xml") {
+		val base = call.publicBaseUrl() ?: run {
+			call.respond(HttpStatusCode.NotFound)
+			return@get
+		}
+		val children = buildList {
+			add("$base/sitemap-content.xml")
+			addAll(serverConfig.additionalSitemaps.map(String::trim).filter(::isHttpUrl))
+		}
+		call.respondText(buildSitemapIndexXml(children), ContentType.Application.Xml)
+	}
+
+	get("/sitemap-content.xml") {
+		val base = call.publicBaseUrl() ?: run {
+			call.respond(HttpStatusCode.NotFound)
+			return@get
+		}
+
+		val authors: List<CommunityAuthor>
+		val stories: List<CommunityFeedStory>
+		if (serverConfig.communityEnabled) {
+			authors = fetchAllCommunityAuthors(accountsRepository)
+			stories = fetchAllFeedStories(projectAccessRepository)
+		} else {
+			authors = emptyList()
+			stories = emptyList()
+		}
+
+		val entries = buildContentEntries(
+			baseUrl = base,
+			includeAbout = configRepository.get(AdminServerConfig.ABOUT_SERVER).isNotBlank(),
+			includeTerms = serverConfig.termsOfService != null,
+			includePrivacy = serverConfig.privacyPolicy != null,
+			communityEnabled = serverConfig.communityEnabled,
+			authors = authors,
+			stories = stories,
+		)
+		call.respondText(buildSitemapUrlsetXml(entries), ContentType.Application.Xml)
+	}
+}
+
+internal fun buildContentEntries(
+	baseUrl: String,
+	includeAbout: Boolean,
+	includeTerms: Boolean,
+	includePrivacy: Boolean,
+	communityEnabled: Boolean,
+	authors: List<CommunityAuthor>,
+	stories: List<CommunityFeedStory>,
+): List<SitemapEntry> {
+	val base = baseUrl.trimEnd('/')
+	val entries = mutableListOf<SitemapEntry>()
+	entries += SitemapEntry("$base/")
+	if (includeAbout) entries += SitemapEntry("$base/about")
+	if (includeTerms) entries += SitemapEntry("$base/terms")
+	if (includePrivacy) entries += SitemapEntry("$base/privacy")
+	if (communityEnabled) {
+		entries += SitemapEntry("$base/community/feed")
+		entries += SitemapEntry("$base/community/authors")
+	}
+	for (author in authors) {
+		entries += SitemapEntry("$base/a/${ProjectName.penNameForUrl(author.penName)}")
+	}
+	for (story in stories) {
+		val pen = ProjectName.penNameForUrl(story.penName)
+		val segment = ProjectName.projectSegment(story.projectName, story.projectUuid)
+		entries += SitemapEntry("$base/a/$pen/$segment", story.publishedAt.toString())
+	}
+	return if (entries.size > SITEMAP_MAX_URLS) entries.take(SITEMAP_MAX_URLS) else entries
+}
+
+internal fun buildSitemapIndexXml(sitemapLocs: List<String>): String {
+	val sb = StringBuilder()
+	sb.appendLine("""<?xml version="1.0" encoding="UTF-8"?>""")
+	sb.appendLine("""<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""")
+	for (loc in sitemapLocs) {
+		sb.appendLine("\t<sitemap><loc>${xmlEscape(loc)}</loc></sitemap>")
+	}
+	sb.appendLine("</sitemapindex>")
+	return sb.toString()
+}
+
+internal fun buildSitemapUrlsetXml(entries: List<SitemapEntry>): String {
+	val sb = StringBuilder()
+	sb.appendLine("""<?xml version="1.0" encoding="UTF-8"?>""")
+	sb.appendLine("""<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""")
+	for (entry in entries) {
+		sb.append("\t<url><loc>").append(xmlEscape(entry.loc)).append("</loc>")
+		if (entry.lastmod != null) {
+			sb.append("<lastmod>").append(xmlEscape(entry.lastmod)).append("</lastmod>")
+		}
+		sb.appendLine("</url>")
+	}
+	sb.appendLine("</urlset>")
+	return sb.toString()
+}
+
+private fun isHttpUrl(value: String): Boolean =
+	value.startsWith("http://") || value.startsWith("https://")
+
+private fun xmlEscape(value: String): String = buildString {
+	for (c in value) when (c) {
+		'&' -> append("&amp;")
+		'<' -> append("&lt;")
+		'>' -> append("&gt;")
+		'"' -> append("&quot;")
+		'\'' -> append("&apos;")
+		else -> append(c)
+	}
+}
+
+private suspend fun fetchAllCommunityAuthors(repo: AccountsRepository): List<CommunityAuthor> {
+	val total = repo.countCommunityAuthors()
+	val out = ArrayList<CommunityAuthor>()
+	var page = 0
+	while (out.size < total && out.size < SITEMAP_MAX_URLS) {
+		val batch = repo.getCommunityAuthors(page, SITEMAP_FETCH_PAGE)
+		if (batch.isEmpty()) break
+		out += batch
+		page++
+	}
+	return out
+}
+
+private suspend fun fetchAllFeedStories(repo: ProjectAccessRepository): List<CommunityFeedStory> {
+	val total = repo.countCommunityFeedStories()
+	val out = ArrayList<CommunityFeedStory>()
+	var page = 0
+	while (out.size < total && out.size < SITEMAP_MAX_URLS) {
+		val batch = repo.getCommunityFeedStories(page, SITEMAP_FETCH_PAGE)
+		if (batch.isEmpty()) break
+		out += batch
+		page++
+	}
+	return out
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/SitemapRoutesTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/SitemapRoutesTest.kt
@@ -1,0 +1,111 @@
+package com.darkrockstudios.apps.hammer.frontend
+
+import com.darkrockstudios.apps.hammer.ServerConfig
+import com.darkrockstudios.apps.hammer.database.CommunityAuthor
+import com.darkrockstudios.apps.hammer.database.CommunityFeedStory
+import com.darkrockstudios.apps.hammer.frontend.utils.ProjectName
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class SitemapRoutesTest {
+
+	private val published = Instant.parse("2026-01-02T03:04:05Z")
+
+	@Test
+	fun `the home page is always present`() {
+		val locs = buildContentEntries(
+			baseUrl = "https://hammer.example.com",
+			includeAbout = false, includeTerms = false, includePrivacy = false,
+			communityEnabled = false, authors = emptyList(), stories = emptyList(),
+		).map { it.loc }
+		assertEquals(listOf("https://hammer.example.com/"), locs)
+	}
+
+	@Test
+	fun `static pages appear only when enabled and a trailing slash is trimmed`() {
+		val locs = buildContentEntries(
+			baseUrl = "https://x.test/",
+			includeAbout = true, includeTerms = true, includePrivacy = true,
+			communityEnabled = false, authors = emptyList(), stories = emptyList(),
+		).map { it.loc }
+		assertEquals(
+			listOf("https://x.test/", "https://x.test/about", "https://x.test/terms", "https://x.test/privacy"),
+			locs,
+		)
+	}
+
+	@Test
+	fun `community authors and stories map to their public urls with lastmod`() {
+		val author = CommunityAuthor(id = 1, penName = "Jane Doe", bio = null, created = published)
+		val story = CommunityFeedStory(
+			projectUuid = "abc-123", projectName = "My Story", penName = "Jane Doe", publishedAt = published,
+		)
+		val entries = buildContentEntries(
+			baseUrl = "https://x.test",
+			includeAbout = false, includeTerms = false, includePrivacy = false,
+			communityEnabled = true, authors = listOf(author), stories = listOf(story),
+		)
+
+		val authorUrl = "https://x.test/a/${ProjectName.penNameForUrl("Jane Doe")}"
+		val storyUrl = "https://x.test/a/${ProjectName.penNameForUrl("Jane Doe")}/" +
+			ProjectName.projectSegment("My Story", "abc-123")
+
+		val locs = entries.map { it.loc }
+		assertContains(locs, "https://x.test/community/feed")
+		assertContains(locs, "https://x.test/community/authors")
+		assertContains(locs, authorUrl)
+		assertContains(locs, storyUrl)
+		assertEquals(published.toString(), entries.first { it.loc == storyUrl }.lastmod)
+	}
+
+	@Test
+	fun `community pages are omitted when community is disabled`() {
+		val locs = buildContentEntries(
+			baseUrl = "https://x.test",
+			includeAbout = false, includeTerms = false, includePrivacy = false,
+			communityEnabled = false, authors = emptyList(), stories = emptyList(),
+		).map { it.loc }
+		assertEquals(listOf("https://x.test/"), locs)
+	}
+
+	@Test
+	fun `urlset escapes ampersands and emits lastmod`() {
+		val xml = buildSitemapUrlsetXml(
+			listOf(
+				SitemapEntry("https://x.test/a?x=1&y=2"),
+				SitemapEntry("https://x.test/p", "2026-01-02T03:04:05Z"),
+			)
+		)
+		assertContains(xml, """<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""")
+		assertContains(xml, "https://x.test/a?x=1&amp;y=2")
+		assertContains(xml, "<lastmod>2026-01-02T03:04:05Z</lastmod>")
+	}
+
+	@Test
+	fun `index lists the content sitemap and any extras`() {
+		val xml = buildSitemapIndexXml(
+			listOf("https://x.test/sitemap-content.xml", "https://x.test/extra/sitemap.xml")
+		)
+		assertContains(xml, "<sitemapindex")
+		assertContains(xml, "<loc>https://x.test/sitemap-content.xml</loc>")
+		assertContains(xml, "<loc>https://x.test/extra/sitemap.xml</loc>")
+	}
+
+	@Test
+	fun `sitemap routes 404 when no public url is configured`() = testApplication {
+		application {
+			routing {
+				sitemapRoutes(ServerConfig(), mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
+			}
+		}
+		assertEquals(HttpStatusCode.NotFound, client.get("/sitemap.xml").status)
+		assertEquals(HttpStatusCode.NotFound, client.get("/sitemap-content.xml").status)
+	}
+}


### PR DESCRIPTION
## What

Adds sitemap generation so search engines can discover a Hammer instance's public content.

- **`GET /sitemap-content.xml`** — a `<urlset>` of the server's own public pages: the home page, the enabled static pages (`/about`, `/terms`, `/privacy`), and — when community is enabled — community author pages and publicly-published stories, enumerated from the database at request time. Publishing content never requires a code change.
- **`GET /sitemap.xml`** — a `<sitemapindex>` over the content sitemap.
- **`robots.txt`** now advertises `Sitemap: {publicUrl}/sitemap.xml` when `publicUrl` is configured (and nothing when it isn't).

## Behavior

Both sitemap routes require `publicUrl` to emit absolute `<loc>`s and return **404** without it — the client-controlled request `Host` is deliberately not used as a fallback, matching `publicBaseUrl` and avoiding host injection into generated links.

## Notes

- Only community-participant authors and publicly-published stories are listed, matching the existing per-page indexability rules (`applyRobotsTag`).
- Bounded by the sitemap protocol's 50,000-URL limit; content is enumerated per request (no caching yet).

## Testing

- New `SitemapRoutesTest` (7): URL generation, static-page gating, community author/story URL mapping + `lastmod`, XML escaping, the index, and the no-`publicUrl` 404.
- Existing `RobotsRoutesTest` still passes with the new `Sitemap:` line.