### PR TITLE
Enable Koin compile-time safety on the server

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -9,11 +9,17 @@ plugins {
 	alias(libs.plugins.kotlin.serialization)
 	alias(libs.plugins.sqldelight)
 	alias(libs.plugins.jetbrains.kover)
+	alias(libs.plugins.koin.compiler)
 	`java-test-fixtures`
 }
 
 group = "com.darkrockstudios.apps.hammer"
 version = libs.versions.app.get()
+
+koinCompiler {
+	compileSafety = true
+}
+
 application {
 	mainClass.set("com.darkrockstudios.apps.hammer.ApplicationKt")
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
@@ -59,11 +59,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.Json
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
-import org.koin.core.module.dsl.factoryOf
-import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.factory
+import org.koin.plugin.module.dsl.single
 import java.security.SecureRandom
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.encoding.Base64
@@ -83,7 +83,7 @@ fun mainModule(
 	single { logger }
 	single { com.darkrockstudios.apps.hammer.plugins.LoginRateLimitConfig() }
 
-	singleOf(::createJsonSerializer) bind Json::class
+	single { createJsonSerializer() } bind Json::class
 	single { Toml { ignoreUnknownKeys = true } } bind Toml::class
 	single { Clock.System } bind Clock::class
 	single { createTokenBase64() } bind Base64::class
@@ -99,71 +99,71 @@ fun mainModule(
 			)
 		}
 	}
-	singleOf(::AccountDao)
-	singleOf(::AuthTokenDao)
-	singleOf(::WhiteListDao)
-	singleOf(::StoryEntityDao)
-	singleOf(::ProjectsDao)
-	singleOf(::ProjectDao)
-	singleOf(::DeletedProjectDao)
-	singleOf(::DeletedEntityDao)
-	singleOf(::ServerConfigDao)
-	singleOf(::ProjectAccessDao)
-	singleOf(::PasswordResetTokenDao)
-	singleOf(::ReviewRequestDao)
-	singleOf(::ReviewSceneDao)
-	singleOf(::ReviewSuggestionDao)
-	singleOf(::WritingActivityDao)
-	singleOf(::ProjectDataDao)
-	singleOf(::StoryIdeaDao)
-	singleOf(::DeletedIdeaDao)
-	singleOf(::ApiMetricDao)
-	singleOf(::ErrorLogDao)
-	singleOf(::LoginAttemptDao)
-	singleOf(::UserActivityDao)
-	singleOf(::PublishedStoryReaderDao)
+	single<AccountDao>()
+	single<AuthTokenDao>()
+	single<WhiteListDao>()
+	single<StoryEntityDao>()
+	single<ProjectsDao>()
+	single<ProjectDao>()
+	single<DeletedProjectDao>()
+	single<DeletedEntityDao>()
+	single<ServerConfigDao>()
+	single<ProjectAccessDao>()
+	single<PasswordResetTokenDao>()
+	single<ReviewRequestDao>()
+	single<ReviewSceneDao>()
+	single<ReviewSuggestionDao>()
+	single<WritingActivityDao>()
+	single<ProjectDataDao>()
+	single<StoryIdeaDao>()
+	single<DeletedIdeaDao>()
+	single<ApiMetricDao>()
+	single<ErrorLogDao>()
+	single<LoginAttemptDao>()
+	single<UserActivityDao>()
+	single<PublishedStoryReaderDao>()
 
-	singleOf(::AccountsRepository)
-	singleOf(::TermsOfServiceRepository)
-	singleOf(::PrivacyPolicyRepository)
-	singleOf(::ProjectsRepository)
-	singleOf(::ProjectEntityRepository)
-	singleOf(::ProjectAccessRepository)
-	singleOf(::ServerWritingActivityRepository)
-	singleOf(::ServerProjectDataRepository)
+	single<AccountsRepository>()
+	single<TermsOfServiceRepository>()
+	single<PrivacyPolicyRepository>()
+	single<ProjectsRepository>()
+	single<ProjectEntityRepository>()
+	single<ProjectAccessRepository>()
+	single<ServerWritingActivityRepository>()
+	single<ServerProjectDataRepository>()
 	single { ServerIdeasRepository(get(), get(), get(), get(), get(), get(), get()) }
-	singleOf(::WhiteListRepository)
-	singleOf(::ConfigRepository)
-	singleOf(::MetricsRepository)
-	singleOf(::ErrorRepository)
-	singleOf(::SecurityRepository)
-	singleOf(::MetricsCollector)
-	singleOf(::UserActivityCollector)
-	singleOf(::UserActivityRepository)
+	single<WhiteListRepository>()
+	single<ConfigRepository>()
+	single<MetricsRepository>()
+	single<ErrorRepository>()
+	single<SecurityRepository>()
+	single<MetricsCollector>()
+	single<UserActivityCollector>()
+	single<UserActivityRepository>()
 	// Explicit ctor: maxPendingKeys has a default, but a constructor reference would
 	// make Koin try to inject the Int rather than honor it.
 	single { StoryReaderCollector(clock = get()) }
-	singleOf(::StoryReaderRepository)
+	single<StoryReaderRepository>()
 	single { MonitoringState() }
 	single { RecurringTaskRegistry() }
-	singleOf(::MonitoringMaintenanceJob)
-	singleOf(::TokenMaintenanceJob)
-	singleOf(::WhitelistExpiryJob)
-	singleOf(::StoryExportService)
-	singleOf(::PenNameService)
-	singleOf(::BioService)
-	singleOf(::PasswordResetRepository)
-	singleOf(::ReviewRepository)
+	single<MonitoringMaintenanceJob>()
+	single<TokenMaintenanceJob>()
+	single<WhitelistExpiryJob>()
+	single<StoryExportService>()
+	single<PenNameService>()
+	single<BioService>()
+	single<PasswordResetRepository>()
+	single<ReviewRepository>()
 
-	singleOf(::ServerSecretManager)
-	singleOf(::MarkdownService)
+	single<ServerSecretManager>()
+	single<MarkdownService>()
 	single { KeyringCodec(get(), get()) }
 	single<ServerSecretProvider> { buildSecretProvider(get<ServerConfig>().secret, get()) }
 	single {
 		KeyringManager(get(), get(), get(), KeyringManager.legacySecretPath())
 	}
-	singleOf(::SimpleFileBasedAesGcmKeyProvider) bind AesGcmKeyProvider::class
-	singleOf(::PlaintextContentEncryptor)
+	single<SimpleFileBasedAesGcmKeyProvider>() bind AesGcmKeyProvider::class
+	single<PlaintextContentEncryptor>()
 	single {
 		val keyProvider = get<AesGcmKeyProvider>()
 		val random = get<SecureRandom>()
@@ -178,7 +178,7 @@ fun mainModule(
 	}
 	single { EncryptionConvergence(get(), get(), get()) }
 	single { EncryptionBootstrap(get(), get(), get(), get(), get(), get()) }
-	singleOf(::TokenHasher)
+	single<TokenHasher>()
 
 	single<EmailService> {
 		val serverConfig = get<ServerConfig>()
@@ -191,24 +191,24 @@ fun mainModule(
 		}
 	}
 
-	factoryOf(::ProjectsDatabaseDatasource) bind ProjectsDatasource::class
+	factory<ProjectsDatabaseDatasource>() bind ProjectsDatasource::class
 	factory<ProjectEntityDatasource> {
 		ProjectEntityDatabaseDatasource(get(), get(), get(), get(), get(), get(), get(), get())
 	}
 
-	singleOf(::AdminComponent)
-	singleOf(::AccountsComponent)
+	single<AdminComponent>()
+	single<AccountsComponent>()
 
-	singleOf(::PatreonApiClient)
-	singleOf(::PatreonSyncService)
-	singleOf(::PatreonWebhookHandler)
-	singleOf(::PatreonPollingJob)
+	single<PatreonApiClient>()
+	single<PatreonSyncService>()
+	single<PatreonWebhookHandler>()
+	single<PatreonPollingJob>()
 
-	singleOf(::ServerSceneSynchronizer)
-	singleOf(::ServerNoteSynchronizer)
-	singleOf(::ServerTimelineSynchronizer)
-	singleOf(::ServerEncyclopediaSynchronizer)
-	singleOf(::ServerSceneDraftSynchronizer)
+	single<ServerSceneSynchronizer>()
+	single<ServerNoteSynchronizer>()
+	single<ServerTimelineSynchronizer>()
+	single<ServerEncyclopediaSynchronizer>()
+	single<ServerSceneDraftSynchronizer>()
 
 	single<SyncSessionManager<Long, ProjectsSynchronizationSession>>(named(PROJECTS_SYNC_MANAGER)) {
 		SyncSessionManager(get(), get())


### PR DESCRIPTION
Brings `:server` up to the same compile-time-safe Koin setup the client's `:common` module already uses: the DI graph is now verified at compile time instead of failing at runtime startup.

## Changes

- `server/build.gradle.kts`: apply `libs.plugins.koin.compiler` + `koinCompiler { compileSafety = true }`. No `koin-annotations` dependency needed — everything used here lives in `koin-core`.
- `mainModule.kt`: convert the constructor DSL to the plugin DSL — `singleOf(::X)` → `single<X>()`, `factoryOf(::X) bind Y::class` → `factory<X>() bind Y::class`, importing `org.koin.plugin.module.dsl.{single, factory}` (same imports `:common` uses).

## Why the DSL conversion is required

The plugin's indexer does not understand `singleOf` / `factoryOf` — the string does not appear anywhere in the compiler-plugin jar. Applying the plugin without converting the DSL fails the build with ~70 `KOIN-D002 Missing definition` errors, one per `singleOf`-declared type, while every hand-written `single { … }` resolves fine. `:common` was already clean because it had previously moved to `single<T>()`.

## Semantics

- `skipDefaultValues` defaults to true, so constructor params with default values now use the default rather than being injected. Every converted class was checked — none has a defaulted constructor param, so no behavior change. The existing `StoryReaderCollector` explicit-ctor comment remains accurate.
- `createJsonSerializer` is a top-level function, not a class, so it became `single { createJsonSerializer() } bind Json::class`.

## Verification

- `:server:compileKotlin`, `compileTestKotlin`, `compileTestFixturesKotlin`, `:integrationTests:compileTestKotlin` all build.
- Full `:server:test` suite passes.
- Negative test: deleting `single<MarkdownService>()` fails the build pointing at the two `inject<MarkdownService>()` call sites.

## Note

The plugin auto-detects `koinApplication { }` in `Application.kt` and auto-enables `strictSafety` on `:server`, so `compileKotlin` is never up-to-date or cacheable (it logs this at build time). Server compiles in ~12s so it is left on; `strictSafety = false` in the `koinCompiler` block is the override if it becomes a CI cost.