### PR TITLE
Add a bytecode guard for responds in value position

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ androidx-security-crypto = "1.1.0"
 glance = "1.2.0-rc01"
 androix-junit = "1.3.0"
 junit = "6.1.1"
+asm = "9.9.1"
 clikt = "5.1.0"
 kotlinx_atomicfu = "0.33.0"
 kotlinx_collections_immutable = "0.5.1"
@@ -153,6 +154,8 @@ material_kolor = { group = "com.materialkolor", name = "material-kolor", version
 jakarta-mail = { module = "com.sun.mail:jakarta.mail", version = "2.0.2" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androix-junit" }
 androidx-junit-ktx = { module = "androidx.test.ext:junit-ktx", version.ref = "androix-junit" }
+
+asm-tree = { module = "org.ow2.asm:asm-tree", version.ref = "asm" }
 
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -138,6 +138,7 @@ dependencies {
 	testImplementation(libs.mockk)
 	testImplementation(libs.koin.test)
 	testImplementation(libs.okio.fakefilesystem)
+	testImplementation(libs.asm.tree)
 	testImplementation(libs.bundles.junit.jupiter)
 	testRuntimeOnly(libs.junit.jupiter.engine)
 	testRuntimeOnly(libs.junit.platform.launcher)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/RespondInValuePositionTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/RespondInValuePositionTest.kt
@@ -1,0 +1,126 @@
+package com.darkrockstudios.apps.hammer.frontend.utils
+
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import org.junit.jupiter.api.Test
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.TypeInsnNode
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readBytes
+import kotlin.io.path.walk
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Ktor's `respond*` functions are tail-call suspend functions: they return the send pipeline's final
+ * subject (a `CompressedReadChannelResponse` once Compression has run) rather than Unit. A respond in
+ * *value position* — the last expression of an exhaustive `when` with no `else` inside a route
+ * handler — makes the compiler cast that subject to Unit, and the handler dies with a
+ * ClassCastException once the pipeline suspends.
+ *
+ * The shape is invisible in source review: adding an `else`, or wrapping in `if/else`, is safe, while
+ * a trailing `return@post` is not. So this scans the compiled route handlers instead, looking for the
+ * coercion the compiler emits (`throwOnFailure` on the resumed value, then `checkcast kotlin/Unit`).
+ *
+ * [unsafeFixtureRoutes] is a positive control. If a Kotlin upgrade changes this codegen, the detector
+ * stops firing on the fixture and this test fails rather than silently passing forever.
+ */
+class RespondInValuePositionTest {
+
+	private val mainClasses = Path.of("build/classes/kotlin/main")
+	private val testClasses = Path.of("build/classes/kotlin/test")
+
+	private companion object {
+		const val MIN_EXPECTED_HANDLERS = 40
+	}
+
+	@Test
+	fun `no route handler coerces a respond result to Unit`() {
+		assertTrue(mainClasses.exists(), "Compiled main classes not found at $mainClasses")
+
+		val handlers = routeHandlers(mainClasses)
+
+		// A floor on the denominator: if a Ktor change breaks the handler filter, the scan would find
+		// nothing to check and pass regardless of what the routes do.
+		assertTrue(
+			handlers.size >= MIN_EXPECTED_HANDLERS,
+			"Only found ${handlers.size} route handlers to scan, expected at least " +
+				"$MIN_EXPECTED_HANDLERS. The handler filter has probably stopped matching."
+		)
+
+		val offenders = handlers.filter { it.coercesResumedValueToUnit() }.map { it.name }.sorted()
+
+		assertEquals(
+			emptyList(), offenders,
+			"These route handlers respond from value position (exhaustive `when` with no `else`). " +
+				"Have the `when` yield a value and respond once after it."
+		)
+	}
+
+	@Test
+	fun `the detector still recognises the unsafe shape`() {
+		assertTrue(testClasses.exists(), "Compiled test classes not found at $testClasses")
+
+		val detected = routeHandlers(testClasses)
+			.filter { it.coercesResumedValueToUnit() }
+			.map { it.name }
+
+		assertTrue(
+			detected.any { it.contains("unsafeFixtureRoutes") },
+			"The detector no longer flags the known-unsafe fixture, so it can no longer protect the " +
+				"main source set. Kotlin's codegen for this shape has likely changed — re-derive the " +
+				"pattern from `javap -c` before trusting this test again. Flagged: $detected"
+		)
+	}
+
+	@OptIn(kotlin.io.path.ExperimentalPathApi::class)
+	private fun routeHandlers(root: Path): List<ClassNode> = root.walk()
+		.filter { it.isRegularFile() && it.toString().endsWith(".class") }
+		.map { ClassNode().also { node -> ClassReader(it.readBytes()).accept(node, 0) } }
+		.filter { it.isRouteHandler() }
+		.toList()
+
+	/** A `suspend RoutingContext.() -> Unit` lambda, i.e. the body of a `get`/`post`/... route. */
+	private fun ClassNode.isRouteHandler(): Boolean =
+		superName == "kotlin/coroutines/jvm/internal/SuspendLambda" &&
+			signature?.contains("io/ktor/server/routing/RoutingContext") == true
+
+	/**
+	 * Looks for the resumption sequence the compiler emits when a suspend call's result is used as a
+	 * Unit-typed value: `ResultKt.throwOnFailure(result)` followed by a `checkcast` of that same
+	 * result. A `checkcast kotlin/Unit` on a restored local (`getfield L$n`) is unrelated and benign.
+	 */
+	private fun ClassNode.coercesResumedValueToUnit(): Boolean = methods.any { method ->
+		val instructions = method.instructions.filter { it.opcode >= 0 }
+		instructions.withIndex().any { (index, insn) ->
+			insn is MethodInsnNode &&
+				insn.owner == "kotlin/ResultKt" &&
+				insn.name == "throwOnFailure" &&
+				instructions.drop(index + 1).take(2).any { next ->
+					next is TypeInsnNode && next.opcode == Opcodes.CHECKCAST && next.desc == "kotlin/Unit"
+				}
+		}
+	}
+}
+
+private enum class FixtureOutcome { Saved, Rejected }
+
+private fun pickOutcome() = FixtureOutcome.Saved
+
+/**
+ * Positive control for [RespondInValuePositionTest]: an exhaustive `when` with no `else` whose
+ * branches each end in a respond. Never registered on a real route — it exists to be compiled.
+ */
+internal fun Route.unsafeFixtureRoutes() {
+	post("/fixture") {
+		when (pickOutcome()) {
+			FixtureOutcome.Saved -> respondToast("saved")
+			FixtureOutcome.Rejected -> respondToast("rejected")
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #752, which fixed a `ClassCastException` caused by a Ktor respond sitting in value position. This adds the guard so the shape can't come back.

**Stacked on #752** — its base is that PR's branch, not `develop`, because the guard fails until the bio fix lands. GitHub will retarget it to `develop` automatically once #752 merges.

## Why a bytecode test

Ktor's `respond*` functions are tail-call suspend functions that return the send pipeline's subject rather than `Unit`. When such a call is the value of an exhaustive `when` inside a route handler, the compiler casts that subject to `Unit` and the handler dies once the pipeline suspends.

The hazard is invisible in source review, and the obvious fixes are silent no-ops:

| Shape in a route handler | Result |
|---|---|
| exhaustive enum `when`, no `else` | **unsafe** |
| `when` with `else` | safe |
| `if/else` | safe |
| single respond call | safe |
| exhaustive `when` + trailing `return@post` | **unsafe** |

`return Unit` and `run { }` are likewise no-ops — all of these were checked in bytecode, not assumed. Semgrep can't express exhaustiveness or last-expression position, so a source-level rule would flag the 25 safe toast call sites too. The compiled output is the only reliable signal.

## What the test does

`RespondInValuePositionTest` walks the compiled classes with ASM, selects route handlers (`SuspendLambda` with a `RoutingContext` signature — which excludes unrelated suspend lambdas like `RecurringTask.stop()` by construction rather than by allowlist), and flags the coercion sequence: `ResultKt.throwOnFailure` followed within two instructions by `checkcast kotlin/Unit`. A `checkcast kotlin/Unit` on a restored local is a different, benign thing and is not matched.

Two things stop it from rotting into a green light that checks nothing:

- **Positive control** — `unsafeFixtureRoutes` is written in the known-unsafe shape and the detector must keep flagging it. If a Kotlin upgrade changes this codegen, the test fails and points you at re-deriving the pattern from `javap -c`.
- **Coverage floor** — asserts at least 40 handlers were scanned; there are currently 118. A handler filter broken by a Ktor upgrade can't pass vacuously.

Verified by reverting the bio fix: the guard fails and names `DashboardPageKt$dashboardPage$1$1$6`.

Adds `org.ow2.asm:asm-tree` as an explicit test dependency rather than relying on the transitive copy that arrives via mockk. Runs inside the existing `:server:test` task; the scan is sub-second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)