### PR TITLE
Retry the focus tap in the iOS UI test type() helper

### DIFF
--- a/ios/iosUITests/HammerUITest.swift
+++ b/ios/iosUITests/HammerUITest.swift
@@ -189,15 +189,24 @@ class HammerUITest: XCTestCase {
     /// keyboard focus". Tapping focuses the Compose field (raising the keyboard); typing on the
     /// *application* then routes to whatever Compose has focused — the reliable path for
     /// Compose-on-iOS text entry.
+    ///
+    /// The focus tap is a best-effort coordinate tap and can be silently dropped (see `tapUntil`),
+    /// so re-focus on a short sub-timeout until the keyboard rises rather than betting the whole
+    /// test on one tap. If a hardware keyboard is "connected" on the simulator the software one
+    /// stays hidden and typing fails outright — the run script disables that (see ios/scripts).
     func type(_ text: String, into tag: String, timeout: TimeInterval = HammerUITest.defaultTimeout,
               file: StaticString = #file, line: UInt = #line) {
-        tapToFocus(waitFor(tag, timeout: timeout, file: file, line: line))
-        // The software keyboard must be up for typing to route to the focused Compose field.
-        // If a hardware keyboard is "connected" on the simulator it stays hidden and typeText
-        // fails with "no keyboard focus" — the run script disables that (see ios/scripts).
-        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 10),
-                      "Software keyboard never appeared after focusing \(tag)", file: file, line: line)
-        app.typeText(text)
+        let field = waitFor(tag, timeout: timeout, file: file, line: line)
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            tapToFocus(field)
+            if app.keyboards.firstMatch.waitForExistence(timeout: 3) {
+                app.typeText(text)
+                return
+            }
+        } while Date() < deadline
+        XCTFail("Software keyboard never appeared after focusing \(tag) within \(timeout)s",
+                file: file, line: line)
     }
 
     /// Type into a Compose rich-text editor (the scene body) and retry until the edit lands.


### PR DESCRIPTION
## Problem

`NotesWorkflowUITests.testCreateNoteThenSeeItListed()` failed CI on #756 with:

```
ios/iosUITests/NotesWorkflowUITests.swift:14: error: XCTAssertTrue failed -
Software keyboard never appeared after focusing create-project-name
```

Line 14 is `createAndOpenProject(...)`, the project-creation preamble — the notes flow never ran. Unrelated to that PR's changes.

## Cause

`HammerUITest.type()` was the only input helper without a retry loop: one blind `tapToFocus` coordinate tap, then one hard 10s wait for the keyboard. A dropped Compose coordinate tap — the failure mode already documented on `tapUntil` and worked around in `tapUntilGone` and `typeIntoEditor` — leaves the field unfocused, so the keyboard never rises and the test fails outright.

## Fix

Re-focus on a short sub-timeout until the keyboard appears, returning as soon as the text is typed and only failing after the full timeout. Mirrors the existing `typeIntoEditor` loop. The assertion isn't weakened — a genuinely stuck keyboard (e.g. a simulator hardware keyboard still connected) still fails.

## Verification

Swift can't be built on this machine (Windows), so this rides on the `iOS UI tests` CI job. Watch that all 4 tests pass.