### PR TITLE
Configurable disk cache directory

### DIFF
--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -54,7 +54,8 @@ card — enable `richLinkPreviews`:
 richLinkPreviews = true
 ```
 
-Generated images are disk-cached under `~/hammer_data/cache/og/` and pruned automatically.
+Generated images are disk-cached and pruned automatically; see [Disk cache](#disk-cache) for where
+they live and how to move them.
 
 **Requirement:** rendering the text uses headless AWT, which needs native font libraries installed.
 On Debian/Ubuntu:
@@ -126,7 +127,7 @@ candidate for a scratch volume:
 [cache]
 # Defaults shown. Omit this whole block to accept them.
 directory = "/var/tmp/hammer-cache"   # default: <data dir>/cache
-maxSizeMb = 200                       # per cache, oldest entries evicted first
+maxSizeMb = 200                       # per cache, oldest entries evicted first (max 1048576)
 ```
 
 A relative `directory` is resolved against the config file's own directory. The path must be

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -113,6 +113,29 @@ start again.
 
 To rehearse the migration against a copy of production before flipping the live config, run with `--migrate-dry-run`: it does everything except commit and rename.
 
+## Disk cache
+
+The server caches two regenerable things on disk: rendered story HTML and the OpenGraph share
+images used for rich link previews. By default they live in `~/hammer_data/cache/`, one
+subdirectory per cache.
+
+Nothing in there is durable data — deleting it costs a re-render, never content — so it is a good
+candidate for a scratch volume:
+
+```toml
+[cache]
+# Defaults shown. Omit this whole block to accept them.
+directory = "/var/tmp/hammer-cache"   # default: <data dir>/cache
+maxSizeMb = 200                       # per cache, oldest entries evicted first
+```
+
+A relative `directory` is resolved against the config file's own directory. The path must be
+creatable and writable at startup, or the server aborts rather than silently running with the
+caches disabled.
+
+Only publicly readable stories are ever written to the HTML cache, so a password-protected
+story's prose never lands on the cache volume.
+
 ## Encryption at rest
 
 Content encryption at rest is **optional** — a fresh server stores in plaintext and

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -22,6 +22,7 @@ import com.darkrockstudios.apps.hammer.plugins.configureSecurity
 import com.darkrockstudios.apps.hammer.plugins.configureSerialization
 import com.darkrockstudios.apps.hammer.secret.KeyringCodec
 import com.darkrockstudios.apps.hammer.utilities.DevSelfSignedCert
+import com.darkrockstudios.apps.hammer.utilities.cacheRoot
 import com.darkrockstudios.apps.hammer.utilities.configureDiskCachePruneJob
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import com.darkrockstudios.apps.hammer.utilities.loadPemAsKeyStore
@@ -42,6 +43,7 @@ import io.ktor.util.logging.KtorSimpleLogger
 import kotlinx.coroutines.runBlocking
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
+import okio.IOException
 import okio.Path
 import okio.Path.Companion.toPath
 import org.koin.core.module.Module
@@ -195,9 +197,18 @@ internal fun resolveServerConfig(
 
 	val config = configFile?.let { loadConfig(fileSystem, it) } ?: ServerConfig()
 
-	val resolved = resolveConfigFilePaths(config, configFile?.parent)
+	val resolved = resolveCacheDirectory(resolveConfigFilePaths(config, configFile?.parent), configFile?.parent)
 	validateConfigFiles(resolved, fileSystem)
+	resolved.cache.validate()
+	validateCacheDirectory(resolved.cache, fileSystem)
 	return resolved
+}
+
+/** [CacheConfig.directory] follows the same relative-to-the-config-file rule as the file settings. */
+private fun resolveCacheDirectory(config: ServerConfig, configDir: Path?): ServerConfig {
+	val path = config.cache.directory?.toPath() ?: return config
+	if (path.isAbsolute || configDir == null) return config
+	return config.copy(cache = config.cache.copy(directory = configDir.resolve(path).toString()))
 }
 
 /**
@@ -244,6 +255,26 @@ private fun validateConfigFiles(config: ServerConfig, fileSystem: FileSystem) {
 		check(fileSystem.read(path) { readUtf8() }.isNotBlank()) {
 			"${setting.name} file \"$raw\" is empty; provide the text or remove the setting."
 		}
+	}
+}
+
+/**
+ * A configured cache directory must be creatable and writable. The caches treat every IO failure as
+ * a miss, so an unusable directory would otherwise leave the server quietly re-rendering every page
+ * — a config mistake that presents as Hammer being slow.
+ */
+private fun validateCacheDirectory(config: CacheConfig, fileSystem: FileSystem) {
+	if (config.directory == null) return
+
+	val root = cacheRoot(config, fileSystem)
+	val probe = root / ".write-probe"
+	try {
+		fileSystem.createDirectories(root)
+		fileSystem.write(probe) { writeUtf8("hammer") }
+	} catch (e: IOException) {
+		error("cache.directory \"${config.directory}\" is not writable: ${e.message}")
+	} finally {
+		runCatching { fileSystem.delete(probe, mustExist = false) }
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -22,7 +22,8 @@ import com.darkrockstudios.apps.hammer.plugins.configureSecurity
 import com.darkrockstudios.apps.hammer.plugins.configureSerialization
 import com.darkrockstudios.apps.hammer.secret.KeyringCodec
 import com.darkrockstudios.apps.hammer.utilities.DevSelfSignedCert
-import com.darkrockstudios.apps.hammer.utilities.cacheRoot
+import com.darkrockstudios.apps.hammer.utilities.DiskCache
+import com.darkrockstudios.apps.hammer.utilities.cacheDirectory
 import com.darkrockstudios.apps.hammer.utilities.configureDiskCachePruneJob
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import com.darkrockstudios.apps.hammer.utilities.loadPemAsKeyStore
@@ -196,10 +197,12 @@ internal fun resolveServerConfig(
 	}
 
 	val config = configFile?.let { loadConfig(fileSystem, it) } ?: ServerConfig()
+	// Validated before resolution: a blank directory resolves to the config file's own directory,
+	// which would look valid and quietly put the caches next to the database.
+	config.cache.validate()
 
 	val resolved = resolveCacheDirectory(resolveConfigFilePaths(config, configFile?.parent), configFile?.parent)
 	validateConfigFiles(resolved, fileSystem)
-	resolved.cache.validate()
 	validateCacheDirectory(resolved.cache, fileSystem)
 	return resolved
 }
@@ -266,15 +269,19 @@ private fun validateConfigFiles(config: ServerConfig, fileSystem: FileSystem) {
 private fun validateCacheDirectory(config: CacheConfig, fileSystem: FileSystem) {
 	if (config.directory == null) return
 
-	val root = cacheRoot(config, fileSystem)
-	val probe = root / ".write-probe"
-	try {
-		fileSystem.createDirectories(root)
-		fileSystem.write(probe) { writeUtf8("hammer") }
-	} catch (e: IOException) {
-		error("cache.directory \"${config.directory}\" is not writable: ${e.message}")
-	} finally {
-		runCatching { fileSystem.delete(probe, mustExist = false) }
+	// Probed per cache rather than on the root alone: a writable root can still hold a
+	// subdirectory left behind by another user, which is where the entries actually go.
+	for (cache in DiskCache.entries) {
+		val directory = cacheDirectory(config, fileSystem, cache)
+		val probe = directory / ".write-probe"
+		try {
+			fileSystem.createDirectories(directory)
+			fileSystem.write(probe) { writeUtf8("hammer") }
+		} catch (e: IOException) {
+			error("cache.directory \"${config.directory}\" is not writable: $directory (${e.message})")
+		} finally {
+			runCatching { fileSystem.delete(probe, mustExist = false) }
+		}
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -53,6 +53,7 @@ data class ServerConfig(
 	val emailProvider: String? = null,
 	val communityEnabled: Boolean = false,
 	val storage: StorageConfig = StorageConfig(),
+	val cache: CacheConfig = CacheConfig(),
 	val analytics: AnalyticsConfig = AnalyticsConfig(),
 	val encryption: EncryptionConfig = EncryptionConfig(),
 	val secret: SecretConfig = SecretConfig(),
@@ -229,6 +230,31 @@ data class StorageConfig(
 		if (type == StorageMode.REMOTE) {
 			require(remote != null) { "storage.type=remote requires storage.remote config block" }
 		}
+	}
+}
+
+/**
+ * The regenerable disk caches: rendered story HTML and OpenGraph share cards. Nothing here is
+ * durable data — losing the whole directory costs a re-render, so it belongs on whatever volume
+ * has room for churn rather than alongside the database.
+ */
+@Serializable
+data class CacheConfig(
+	/**
+	 * Where the caches live, one subdirectory per cache. Defaults to `cache/` under the server's
+	 * data directory. Point it at a scratch volume (e.g. "/var/tmp/hammer-cache") to keep the churn
+	 * off the data partition. A relative path is resolved against the config file's own directory.
+	 */
+	val directory: String? = null,
+	/** Size bound for each cache, enforced by evicting least-recently-used entries. */
+	val maxSizeMb: Long = 200,
+) {
+	@Transient
+	val maxSizeBytes: Long = maxSizeMb * 1024 * 1024
+
+	fun validate() {
+		directory?.let { require(it.isNotBlank()) { "cache.directory must not be blank" } }
+		require(maxSizeMb > 0) { "cache.maxSizeMb must be positive, was $maxSizeMb" }
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -254,7 +254,15 @@ data class CacheConfig(
 
 	fun validate() {
 		directory?.let { require(it.isNotBlank()) { "cache.directory must not be blank" } }
-		require(maxSizeMb > 0) { "cache.maxSizeMb must be positive, was $maxSizeMb" }
+		// Upper bound as well as lower: a value given in bytes by mistake would overflow the
+		// conversion to a negative cap, which only surfaces as a failure to build the cache.
+		require(maxSizeMb in 1..MAX_SIZE_MB) {
+			"cache.maxSizeMb must be between 1 and $MAX_SIZE_MB, was $maxSizeMb"
+		}
+	}
+
+	private companion object {
+		const val MAX_SIZE_MB = 1024L * 1024
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
@@ -203,8 +203,14 @@ fun mainModule(
 	single<TokenMaintenanceJob>()
 	single<WhitelistExpiryJob>()
 	single<OgImageRenderer>()
-	single { OgImageService(get(), get(), cacheDirectory(get(), "og")) }
-	single { StoryRenderCache(get(), cacheDirectory(get(), "story-html")) }
+	single {
+		val cacheConfig = get<ServerConfig>().cache
+		OgImageService(get(), get(), cacheDirectory(cacheConfig, get(), "og"), cacheConfig.maxSizeBytes)
+	}
+	single {
+		val cacheConfig = get<ServerConfig>().cache
+		StoryRenderCache(get(), cacheDirectory(cacheConfig, get(), "story-html"), cacheConfig.maxSizeBytes)
+	}
 	single<TouchableFileSystem> { SystemTouchableFileSystem() }
 	single { DiskCachePruneJob(listOf(get<OgImageService>(), get<StoryRenderCache>()), get()) }
 	// Explicit ctor: renderCache defaults to null, which the constructor DSL would honor over injection.

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
@@ -100,6 +100,7 @@ import com.darkrockstudios.apps.hammer.story.StoryExportService
 import com.darkrockstudios.apps.hammer.story.StoryRenderCache
 import com.darkrockstudios.apps.hammer.storyideas.ServerIdeasRepository
 import com.darkrockstudios.apps.hammer.syncsessionmanager.SyncSessionManager
+import com.darkrockstudios.apps.hammer.utilities.DiskCache
 import com.darkrockstudios.apps.hammer.utilities.DiskCachePruneJob
 import com.darkrockstudios.apps.hammer.utilities.MarkdownService
 import com.darkrockstudios.apps.hammer.utilities.ServerSecretManager
@@ -205,11 +206,20 @@ fun mainModule(
 	single<OgImageRenderer>()
 	single {
 		val cacheConfig = get<ServerConfig>().cache
-		OgImageService(get(), get(), cacheDirectory(cacheConfig, get(), "og"), cacheConfig.maxSizeBytes)
+		OgImageService(
+			get(),
+			get(),
+			cacheDirectory(cacheConfig, get(), DiskCache.OG_IMAGES),
+			cacheConfig.maxSizeBytes,
+		)
 	}
 	single {
 		val cacheConfig = get<ServerConfig>().cache
-		StoryRenderCache(get(), cacheDirectory(cacheConfig, get(), "story-html"), cacheConfig.maxSizeBytes)
+		StoryRenderCache(
+			get(),
+			cacheDirectory(cacheConfig, get(), DiskCache.STORY_HTML),
+			cacheConfig.maxSizeBytes,
+		)
 	}
 	single<TouchableFileSystem> { SystemTouchableFileSystem() }
 	single { DiskCachePruneJob(listOf(get<OgImageService>(), get<StoryRenderCache>()), get()) }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/og/OgImageService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/og/OgImageService.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.frontend.og
 
+import com.darkrockstudios.apps.hammer.CacheConfig
 import com.darkrockstudios.apps.hammer.utilities.LruDiskCache
 import com.darkrockstudios.apps.hammer.utilities.PrunableCache
 import com.darkrockstudios.apps.hammer.utilities.TouchableFileSystem
@@ -17,7 +18,7 @@ class OgImageService(
 	private val renderer: OgImageRenderer,
 	fileSystem: TouchableFileSystem,
 	cacheDirectory: Path,
-	maxCacheBytes: Long = DEFAULT_MAX_BYTES,
+	maxCacheBytes: Long = CacheConfig().maxSizeBytes,
 ) : PrunableCache {
 	private val cache = LruDiskCache(fileSystem, cacheDirectory, maxCacheBytes)
 
@@ -42,6 +43,5 @@ class OgImageService(
 
 	private companion object {
 		const val TEMPLATE_VERSION = "v1"
-		const val DEFAULT_MAX_BYTES = 200L * 1024 * 1024
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.story
 
+import com.darkrockstudios.apps.hammer.CacheConfig
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.EntityHash
 import com.darkrockstudios.apps.hammer.utilities.LruDiskCache
@@ -22,7 +23,7 @@ import kotlin.time.Duration
 class StoryRenderCache(
 	fileSystem: TouchableFileSystem,
 	cacheDirectory: Path,
-	maxCacheBytes: Long = DEFAULT_MAX_BYTES,
+	maxCacheBytes: Long = CacheConfig().maxSizeBytes,
 ) : PrunableCache {
 	private val cache = LruDiskCache(fileSystem, cacheDirectory, maxCacheBytes)
 	private val json = Json { ignoreUnknownKeys = true }
@@ -75,7 +76,6 @@ class StoryRenderCache(
 
 	companion object {
 		private const val RENDER_VERSION = "v1"
-		private const val DEFAULT_MAX_BYTES = 200L * 1024 * 1024
 
 		/**
 		 * Everything a render of this story depends on, collapsed to a string: the title heading

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/PrunableCache.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/PrunableCache.kt
@@ -1,7 +1,9 @@
 package com.darkrockstudios.apps.hammer.utilities
 
+import com.darkrockstudios.apps.hammer.CacheConfig
 import okio.FileSystem
 import okio.Path
+import okio.Path.Companion.toPath
 import kotlin.time.Duration
 
 /** A disk cache that can reclaim entries older than a given age. */
@@ -10,6 +12,14 @@ fun interface PrunableCache {
 	fun prune(maxAge: Duration)
 }
 
-/** Where the regenerable disk cache named [name] lives, under the server's data directory. */
-fun cacheDirectory(fileSystem: FileSystem, name: String): Path =
-	getRootDataDirectory(fileSystem) / "cache" / name
+/**
+ * Where the regenerable disk cache named [name] lives: under [CacheConfig.directory] when the
+ * operator configured one, otherwise `cache/` in the server's data directory.
+ */
+fun cacheDirectory(config: CacheConfig, fileSystem: FileSystem, name: String): Path =
+	cacheRoot(config, fileSystem) / name
+
+fun cacheRoot(config: CacheConfig, fileSystem: FileSystem): Path =
+	config.directory?.toPath() ?: (getRootDataDirectory(fileSystem) / DEFAULT_CACHE_DIR_NAME)
+
+private const val DEFAULT_CACHE_DIR_NAME = "cache"

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/PrunableCache.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/PrunableCache.kt
@@ -12,13 +12,20 @@ fun interface PrunableCache {
 	fun prune(maxAge: Duration)
 }
 
-/**
- * Where the regenerable disk cache named [name] lives: under [CacheConfig.directory] when the
- * operator configured one, otherwise `cache/` in the server's data directory.
- */
-fun cacheDirectory(config: CacheConfig, fileSystem: FileSystem, name: String): Path =
-	cacheRoot(config, fileSystem) / name
+/** The regenerable disk caches, each in its own subdirectory of the cache root. */
+enum class DiskCache(val dirName: String) {
+	OG_IMAGES("og"),
+	STORY_HTML("story-html"),
+}
 
+/**
+ * Where [cache] stores its entries: under [CacheConfig.directory] when the operator configured
+ * one, otherwise `cache/` in the server's data directory.
+ */
+fun cacheDirectory(config: CacheConfig, fileSystem: FileSystem, cache: DiskCache): Path =
+	cacheRoot(config, fileSystem) / cache.dirName
+
+/** The directory holding every cache's subdirectory. */
 fun cacheRoot(config: CacheConfig, fileSystem: FileSystem): Path =
 	config.directory?.toPath() ?: (getRootDataDirectory(fileSystem) / DEFAULT_CACHE_DIR_NAME)
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer
 
+import com.darkrockstudios.apps.hammer.utilities.cacheDirectory
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import net.peanuuutz.tomlkt.Toml
 import okio.Path
@@ -177,6 +178,113 @@ class ServerConfigTest {
 		val config = resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
 
 		assertEquals((configDir / "privacy.txt").toString(), config.privacyPolicy)
+	}
+
+	@Test
+	fun `cache defaults to a directory under the data directory`() {
+		val fs = FakeFileSystem()
+
+		val config = parse("")
+
+		assertEquals(null, config.cache.directory)
+		assertEquals(getRootDataDirectory(fs) / "cache" / "og", cacheDirectory(config.cache, fs, "og"))
+	}
+
+	@Test
+	fun `a configured cache directory holds each named cache`() {
+		val fs = FakeFileSystem()
+
+		val config = parse(
+			"""
+			[cache]
+			directory = "/var/tmp/hammer-cache"
+			""".trimIndent()
+		)
+
+		assertEquals("/var/tmp/hammer-cache/story-html".toPath(), cacheDirectory(config.cache, fs, "story-html"))
+	}
+
+	@Test
+	fun `maxSizeMb bounds each cache in bytes`() {
+		val config = parse(
+			"""
+			[cache]
+			maxSizeMb = 50
+			""".trimIndent()
+		)
+
+		assertEquals(50L * 1024 * 1024, config.cache.maxSizeBytes)
+	}
+
+	@Test
+	fun `a relative cache directory is resolved next to the config file`() {
+		val fs = FakeFileSystem()
+		val configDir = getRootDataDirectory(fs)
+		val explicit = configDir / "custom.toml"
+		writeConfig(
+			fs, explicit,
+			"""
+			[cache]
+			directory = "scratch"
+			""".trimIndent()
+		)
+
+		val config = resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+
+		assertEquals((configDir / "scratch").toString(), config.cache.directory)
+	}
+
+	@Test
+	fun `resolve creates a configured cache directory`() {
+		val fs = FakeFileSystem()
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		writeConfig(
+			fs, explicit,
+			"""
+			[cache]
+			directory = "/var/tmp/hammer-cache"
+			""".trimIndent()
+		)
+
+		resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+
+		assertTrue(fs.metadataOrNull("/var/tmp/hammer-cache".toPath())?.isDirectory == true)
+	}
+
+	@Test
+	fun `resolve aborts when the cache directory cannot be written`() {
+		val fs = FakeFileSystem()
+		writeConfig(fs, "/var/tmp/occupied".toPath(), "not a directory")
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		writeConfig(
+			fs, explicit,
+			"""
+			[cache]
+			directory = "/var/tmp/occupied"
+			""".trimIndent()
+		)
+
+		val error = assertFailsWith<IllegalStateException> {
+			resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+		}
+		assertTrue(error.message.orEmpty().contains("/var/tmp/occupied"))
+	}
+
+	@Test
+	fun `resolve aborts when maxSizeMb is not positive`() {
+		val fs = FakeFileSystem()
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		writeConfig(
+			fs, explicit,
+			"""
+			[cache]
+			maxSizeMb = 0
+			""".trimIndent()
+		)
+
+		assertFailsWith<IllegalArgumentException> {
+			resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+		}
 	}
 
 	private fun writeConfig(fs: FakeFileSystem, path: Path, contents: String) {

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer
 
+import com.darkrockstudios.apps.hammer.utilities.DiskCache
 import com.darkrockstudios.apps.hammer.utilities.cacheDirectory
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import net.peanuuutz.tomlkt.Toml
@@ -187,7 +188,7 @@ class ServerConfigTest {
 		val config = parse("")
 
 		assertEquals(null, config.cache.directory)
-		assertEquals(getRootDataDirectory(fs) / "cache" / "og", cacheDirectory(config.cache, fs, "og"))
+		assertEquals(getRootDataDirectory(fs) / "cache" / "og", cacheDirectory(config.cache, fs, DiskCache.OG_IMAGES))
 	}
 
 	@Test
@@ -201,7 +202,7 @@ class ServerConfigTest {
 			""".trimIndent()
 		)
 
-		assertEquals("/var/tmp/hammer-cache/story-html".toPath(), cacheDirectory(config.cache, fs, "story-html"))
+		assertEquals("/var/tmp/hammer-cache/story-html".toPath(), cacheDirectory(config.cache, fs, DiskCache.STORY_HTML))
 	}
 
 	@Test
@@ -248,7 +249,66 @@ class ServerConfigTest {
 
 		resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
 
-		assertTrue(fs.metadataOrNull("/var/tmp/hammer-cache".toPath())?.isDirectory == true)
+		DiskCache.entries.forEach { cache ->
+			val directory = "/var/tmp/hammer-cache".toPath() / cache.dirName
+			assertTrue(fs.metadataOrNull(directory)?.isDirectory == true, "$directory should exist")
+		}
+	}
+
+	@Test
+	fun `resolve aborts when a single cache subdirectory is unusable`() {
+		val fs = FakeFileSystem()
+		// The root is a perfectly good directory; only one cache's subdirectory is occupied.
+		fs.createDirectories("/var/tmp/hammer-cache".toPath())
+		writeConfig(fs, "/var/tmp/hammer-cache/og".toPath(), "not a directory")
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		writeConfig(
+			fs, explicit,
+			"""
+			[cache]
+			directory = "/var/tmp/hammer-cache"
+			""".trimIndent()
+		)
+
+		val error = assertFailsWith<IllegalStateException> {
+			resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+		}
+		assertTrue(error.message.orEmpty().contains("og"), "the failing cache should be named")
+	}
+
+	@Test
+	fun `resolve aborts when the cache directory is blank`() {
+		val fs = FakeFileSystem()
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		writeConfig(
+			fs, explicit,
+			"""
+			[cache]
+			directory = ""
+			""".trimIndent()
+		)
+
+		// A blank directory must not be quietly resolved into the config file's own directory.
+		assertFailsWith<IllegalArgumentException> {
+			resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+		}
+	}
+
+	@Test
+	fun `resolve aborts when the cache directory is only whitespace`() {
+		val fs = FakeFileSystem()
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		writeConfig(
+			fs, explicit,
+			"""
+			[cache]
+			directory = "   "
+			""".trimIndent()
+		)
+
+		assertFailsWith<IllegalArgumentException> {
+			resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+		}
 	}
 
 	@Test
@@ -279,6 +339,24 @@ class ServerConfigTest {
 			"""
 			[cache]
 			maxSizeMb = 0
+			""".trimIndent()
+		)
+
+		assertFailsWith<IllegalArgumentException> {
+			resolveServerConfig(configPath = explicit.toString(), fileSystem = fs)
+		}
+	}
+
+	@Test
+	fun `resolve aborts when maxSizeMb would overflow the byte conversion`() {
+		val fs = FakeFileSystem()
+		val explicit = getRootDataDirectory(fs) / "custom.toml"
+		// A size given in bytes by mistake; positive, but it overflows Long once scaled to bytes.
+		writeConfig(
+			fs, explicit,
+			"""
+			[cache]
+			maxSizeMb = 9000000000000
 			""".trimIndent()
 		)
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/PublicStoryPageTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/PublicStoryPageTest.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.e2e
 
 import com.darkrockstudios.apps.hammer.e2e.util.E2eTestData
 import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
+import com.darkrockstudios.apps.hammer.utilities.DiskCache
 import com.darkrockstudios.apps.hammer.e2e.util.TestAccount
 import com.darkrockstudios.apps.hammer.e2e.util.TestProject
 import com.darkrockstudios.apps.hammer.frontend.utils.ProjectName
@@ -117,7 +118,7 @@ class PublicStoryPageTest : EndToEndTest() {
 
 		client().get(storyPath())
 
-		assertEquals(1, cachedFiles("story-html").size, "a public render should be cached")
+		assertEquals(1, cachedFiles(DiskCache.STORY_HTML).size, "a public render should be cached")
 	}
 
 	@Test
@@ -134,7 +135,7 @@ class PublicStoryPageTest : EndToEndTest() {
 		// in a plaintext cache file.
 		assertEquals(
 			emptyList(),
-			cachedFiles("story-html"),
+			cachedFiles(DiskCache.STORY_HTML),
 			"a private share must leave no rendered prose on disk"
 		)
 	}
@@ -147,6 +148,6 @@ class PublicStoryPageTest : EndToEndTest() {
 		val response = client().get(storyPath())
 
 		assertEquals(HttpStatusCode.NotFound, response.status)
-		assertEquals(emptyList(), cachedFiles("story-html"))
+		assertEquals(emptyList(), cachedFiles(DiskCache.STORY_HTML))
 	}
 }

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
@@ -1,6 +1,5 @@
 package com.darkrockstudios.apps.hammer.e2e.util
 
-import com.darkrockstudios.apps.hammer.CacheConfig
 import com.darkrockstudios.apps.hammer.EncryptionConfig
 import com.darkrockstudios.apps.hammer.EncryptionMode
 import com.darkrockstudios.apps.hammer.ServerConfig
@@ -16,6 +15,7 @@ import com.darkrockstudios.apps.hammer.utilities.FakeTouchableFileSystem
 import com.darkrockstudios.apps.hammer.utilities.ServerSecretManager
 import com.darkrockstudios.apps.hammer.utilities.TokenHasher
 import com.darkrockstudios.apps.hammer.utilities.TouchableFileSystem
+import com.darkrockstudios.apps.hammer.utilities.DiskCache
 import com.darkrockstudios.apps.hammer.utilities.cacheDirectory
 import io.ktor.client.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -43,6 +43,12 @@ abstract class EndToEndTest {
 
 	protected lateinit var fileSystem: FakeFileSystem
 	private lateinit var server: ApplicationEngine
+
+	/**
+	 * The config the server under test runs on. These tests exercise the AES-at-rest path with a
+	 * known secret, so pin it explicitly rather than riding the plaintext default.
+	 */
+	protected open val serverConfig = ServerConfig(encryption = EncryptionConfig(EncryptionMode.AES))
 
 	/** The OS-assigned port the server bound to; valid after [doStartServer]. */
 	protected var serverPort: Int = 0
@@ -100,9 +106,9 @@ abstract class EndToEndTest {
 		server.stop(1000, 3000)
 	}
 
-	/** Files a named disk cache wrote during this test, e.g. `cachedFiles("story-html")`. */
-	protected fun cachedFiles(name: String): List<Path> =
-		fileSystem.listOrNull(cacheDirectory(CacheConfig(), fileSystem, name)).orEmpty()
+	/** Files [cache] wrote during this test, read from wherever [serverConfig] puts it. */
+	protected fun cachedFiles(cache: DiskCache): List<Path> =
+		fileSystem.listOrNull(cacheDirectory(serverConfig.cache, fileSystem, cache)).orEmpty()
 
 	protected fun route(path: String): String = "http://127.0.0.1:$serverPort/$path"
 	protected fun api(path: String): String = route("api/$path")
@@ -123,16 +129,12 @@ abstract class EndToEndTest {
 			single<TouchableFileSystem> { FakeTouchableFileSystem(fileSystem) }
 		}
 
-		// These tests exercise the AES-at-rest path with a known secret, so pin it
-		// explicitly rather than riding the plaintext default.
-		val config = ServerConfig(encryption = EncryptionConfig(EncryptionMode.AES))
-
 		val server = embeddedServer(
 			Jetty,
 			port = 0,
 			host = "0.0.0.0",
 			module = {
-				appMain(config, testModule)
+				appMain(serverConfig, testModule)
 			}
 		)
 		server.start()

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.e2e.util
 
+import com.darkrockstudios.apps.hammer.CacheConfig
 import com.darkrockstudios.apps.hammer.EncryptionConfig
 import com.darkrockstudios.apps.hammer.EncryptionMode
 import com.darkrockstudios.apps.hammer.ServerConfig
@@ -101,7 +102,7 @@ abstract class EndToEndTest {
 
 	/** Files a named disk cache wrote during this test, e.g. `cachedFiles("story-html")`. */
 	protected fun cachedFiles(name: String): List<Path> =
-		fileSystem.listOrNull(cacheDirectory(fileSystem, name)).orEmpty()
+		fileSystem.listOrNull(cacheDirectory(CacheConfig(), fileSystem, name)).orEmpty()
 
 	protected fun route(path: String): String = "http://127.0.0.1:$serverPort/$path"
 	protected fun api(path: String): String = route("api/$path")


### PR DESCRIPTION
The OG card and rendered story HTML caches wrote to `hammer_data/cache/` with no way to move them. That directory is pure churn — every entry is regenerable — so an operator should be able to put it on a scratch volume instead of the data partition.

A new `[cache]` block does that:

```toml
[cache]
directory = "/var/tmp/hammer-cache"   # default: <data dir>/cache
maxSizeMb = 200                       # per cache, LRU eviction
```

Each cache keeps its own subdirectory under the root (`og/`, `story-html/`), so the layout is unchanged apart from where the root sits. Omitting the block reproduces today's behavior exactly.

`directory` follows the same relative-path rule as `termsOfService` and `privacyPolicy`: a relative value resolves against the config file's own directory. At startup the resolved path is created and write-probed, and an unusable one aborts the boot. Without that check the failure mode is silent — the caches treat every IO error as a miss, so a typo'd or read-only path leaves the server re-rendering every page and looking like Hammer is just slow.

`maxSizeMb` replaces the hard-coded 200 MB per-cache bound, which matters once the caches live on a small partition.

## Testing

Seven new cases in `ServerConfigTest` cover the default location, a configured root, relative resolution, the byte conversion, directory creation, an unwritable path aborting, and a non-positive size aborting. `ServerConfigTest`, `LruDiskCacheTest`, `OgImageRoutesTest`, `StoryRendererServiceTest`, `ApplicationTest`, and the e2e suites pass (129 tests).

## Docs

New "Disk cache" section in `docs/HOW-TO-RUN-A-SERVER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
