### PR TITLE
Add operator-configurable extra nav links

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -204,6 +204,7 @@ internal fun resolveServerConfig(
 	val resolved = resolveCacheDirectory(resolveConfigFilePaths(config, configFile?.parent), configFile?.parent)
 	validateConfigFiles(resolved, fileSystem)
 	validateCacheDirectory(resolved.cache, fileSystem)
+	resolved.extraLinks.forEach { it.validate() }
 	return resolved
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -142,16 +142,12 @@ data class ExtraLink(
 		require(icon.isNotBlank()) { "extraLinks entry \"$title\" must have a non-blank icon" }
 
 		if (isExternal) {
-			val uri = try {
-				URI(url)
-			} catch (e: URISyntaxException) {
-				throw IllegalArgumentException("extraLinks entry \"$title\" has an invalid url: $url", e)
-			}
-			require(uri.host != null) { "extraLinks entry \"$title\" url is missing a host: $url" }
+			requireHttpUrl(url, "extraLinks entry \"$title\" url")
 		} else {
-			// A scheme-relative "//host" would leave the site despite looking local, and any other
-			// scheme (javascript:, data:) has no business in a nav href.
-			require(url.startsWith("/") && !url.startsWith("//")) {
+			// Browsers resolve both "//host" and "/\host" as protocol-relative, so either would
+			// leave the site despite looking local. Any other scheme (javascript:, data:) has no
+			// business in a nav href.
+			require(url.startsWith("/") && url.getOrNull(1) !in setOf('/', '\\')) {
 				"extraLinks entry \"$title\" url must be site-relative (start with \"/\") " +
 					"or an absolute http(s) URL: $url"
 			}
@@ -161,6 +157,27 @@ data class ExtraLink(
 
 /** Language tags compare case-insensitively and treat `pt_BR` and `pt-BR` as the same key. */
 private fun normalizeLanguageTag(tag: String): String = tag.replace('_', '-').lowercase()
+
+/**
+ * Requires [value] to be an absolute http(s) URL. With [bareOrigin], it must also carry no
+ * path, query, or fragment — a CSP `connect-src` entry emits verbatim into the header, and
+ * anything past the origin silently narrows what the browser allows.
+ */
+private fun requireHttpUrl(value: String, label: String, bareOrigin: Boolean = false) {
+	val uri = try {
+		URI(value)
+	} catch (e: URISyntaxException) {
+		throw IllegalArgumentException("$label is not a valid URL: $value", e)
+	}
+	require(uri.scheme?.lowercase() in setOf("http", "https") && uri.host != null) {
+		"$label must be an absolute http(s) URL: $value"
+	}
+	if (bareOrigin) {
+		require(uri.path.isNullOrEmpty() && uri.query == null && uri.fragment == null) {
+			"$label must be a bare origin (scheme://host[:port], no path): $value"
+		}
+	}
+}
 
 @Serializable(with = AnalyticsProviderType.Serializer::class)
 enum class AnalyticsProviderType(val serial: String) {
@@ -216,25 +233,7 @@ data class UmamiConfig(
 		require(websiteId.isNotBlank()) { "analytics.umami.websiteId must not be blank" }
 		require(scriptUrl.isNotBlank()) { "analytics.umami.scriptUrl must not be blank" }
 		requireHttpUrl(scriptUrl, "analytics.umami.scriptUrl")
-		// connect-src entries must be bare origins: a path/query/fragment would be emitted
-		// verbatim into the CSP header and silently narrow what the browser allows.
 		connectSrc.forEach { requireHttpUrl(it, "analytics.umami.connectSrc entry", bareOrigin = true) }
-	}
-
-	private fun requireHttpUrl(value: String, label: String, bareOrigin: Boolean = false) {
-		val uri = try {
-			URI(value)
-		} catch (e: URISyntaxException) {
-			throw IllegalArgumentException("$label is not a valid URL: $value", e)
-		}
-		require(uri.scheme?.lowercase() in setOf("http", "https") && uri.host != null) {
-			"$label must be an absolute http(s) URL: $value"
-		}
-		if (bareOrigin) {
-			require(uri.path.isNullOrEmpty() && uri.query == null && uri.fragment == null) {
-				"$label must be a bare origin (scheme://host[:port], no path): $value"
-			}
-		}
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import java.net.URI
 import java.net.URISyntaxException
+import java.util.Locale
 
 @Serializable
 data class ServerConfig(
@@ -52,6 +53,7 @@ data class ServerConfig(
 	val privacyPolicy: String? = null,
 	val emailProvider: String? = null,
 	val communityEnabled: Boolean = false,
+	val extraLinks: List<ExtraLink> = emptyList(),
 	val storage: StorageConfig = StorageConfig(),
 	val cache: CacheConfig = CacheConfig(),
 	val analytics: AnalyticsConfig = AnalyticsConfig(),
@@ -67,6 +69,98 @@ data class ServerConfig(
 		const val DEFAULT_SSL_PORT = 443
 	}
 }
+
+@Serializable(with = LinkPlacement.Serializer::class)
+enum class LinkPlacement(val serial: String) {
+	HEADER("header"),
+	FOOTER("footer"),
+	BOTH("both");
+
+	val inHeader: Boolean get() = this == HEADER || this == BOTH
+	val inFooter: Boolean get() = this == FOOTER || this == BOTH
+
+	object Serializer : CaseInsensitiveEnumSerializer<LinkPlacement>(
+		"LinkPlacement", entries.toTypedArray(), { it.serial }
+	)
+}
+
+/**
+ * An operator-defined nav link appended to the header and/or footer, for pointing a deployment at
+ * content that isn't part of Hammer itself. Each entry is a `[[extraLinks]]` block in `config.toml`:
+ *
+ * ```toml
+ * [[extraLinks]]
+ * url = "/blog"
+ * title = "Blog"
+ * translations = { de = "Blog", fr = "Blogue" }
+ * icon = "fa-solid fa-blog"
+ * placement = "header"
+ * ```
+ *
+ * [translations] is an inline table so each entry stays self-contained; the sub-table form
+ * (`[extraLinks.translations]`) binds to whichever `[[extraLinks]]` precedes it.
+ */
+@Serializable
+data class ExtraLink(
+	/** Site-relative (`/blog`) or an absolute http(s) URL. */
+	val url: String,
+	/** Label used when [translations] has no entry for the viewer's locale. */
+	val title: String,
+	/**
+	 * Labels keyed by language tag, matched against the full tag (`pt-BR`) then the bare
+	 * language (`pt`). Underscores are accepted, so a key copied from a bundle filename
+	 * (`pt_BR`) works as well as the canonical `pt-BR`.
+	 */
+	val translations: Map<String, String> = emptyMap(),
+	/** FontAwesome classes, e.g. `fa-solid fa-blog`. */
+	val icon: String = "fa-solid fa-link",
+	val placement: LinkPlacement = LinkPlacement.FOOTER,
+) {
+	val isExternal: Boolean
+		get() = url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true)
+
+	fun title(locale: Locale): String {
+		val exact = normalizeLanguageTag(locale.toLanguageTag())
+		val language = normalizeLanguageTag(locale.language)
+		return translations.entries.firstOrNull { normalizeLanguageTag(it.key) == exact }?.value
+			?: translations.entries.firstOrNull { normalizeLanguageTag(it.key) == language }?.value
+			?: title
+	}
+
+	fun validate() {
+		require(title.isNotBlank()) { "extraLinks entry with url \"$url\" must have a non-blank title" }
+		translations.forEach { (tag, label) ->
+			require(label.isNotBlank()) { "extraLinks entry \"$title\" has a blank title for locale \"$tag\"" }
+			// A key the JVM can't round-trip would never match a viewer's locale, so it would
+			// silently render the fallback title forever.
+			val normalized = normalizeLanguageTag(tag)
+			require(Locale.forLanguageTag(normalized).toLanguageTag().lowercase() == normalized) {
+				"extraLinks entry \"$title\" has an unusable locale key \"$tag\"; " +
+					"use a language tag like \"de\" or \"pt-BR\""
+			}
+		}
+		require(icon.isNotBlank()) { "extraLinks entry \"$title\" must have a non-blank icon" }
+
+		if (isExternal) {
+			val uri = try {
+				URI(url)
+			} catch (e: URISyntaxException) {
+				throw IllegalArgumentException("extraLinks entry \"$title\" has an invalid url: $url", e)
+			}
+			require(uri.host != null) { "extraLinks entry \"$title\" url is missing a host: $url" }
+		} else {
+			// A scheme-relative "//host" would leave the site despite looking local, and any other
+			// scheme (javascript:, data:) has no business in a nav href.
+			require(url.startsWith("/") && !url.startsWith("//")) {
+				"extraLinks entry \"$title\" url must be site-relative (start with \"/\") " +
+					"or an absolute http(s) URL: $url"
+			}
+		}
+	}
+}
+
+/** Language tags compare case-insensitively and treat `pt_BR` and `pt-BR` as the same key. */
+private fun normalizeLanguageTag(tag: String): String = tag.replace('_', '-').lowercase()
 
 @Serializable(with = AnalyticsProviderType.Serializer::class)
 enum class AnalyticsProviderType(val serial: String) {

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -18,7 +18,6 @@ import com.darkrockstudios.apps.hammer.frontend.data.UserSession
 import com.darkrockstudios.apps.hammer.frontend.og.OgImageService
 import com.darkrockstudios.apps.hammer.frontend.og.ogImageRoutes
 import com.darkrockstudios.apps.hammer.frontend.utils.canonicalUrl
-import com.darkrockstudios.apps.hammer.frontend.utils.getLocale
 import com.darkrockstudios.apps.hammer.frontend.utils.msg
 import com.darkrockstudios.apps.hammer.frontend.utils.withMessages
 import com.darkrockstudios.apps.hammer.monitoring.ActivityType
@@ -365,7 +364,9 @@ suspend fun ApplicationCall.withDefaults(data: Map<String, Any> = emptyMap()): M
 	model["hasTermsPage"] = hasTermsPage
 	model["hasPrivacyPage"] = hasPrivacyPage
 
-	val locale = getLocale()
+	// withMessages() already resolved the viewer's locale; re-resolving repeats its config
+	// lookup, which is an uncached query for a request with no cookie or Accept-Language.
+	val locale = (model["locale"] as? String)?.let(Locale::forLanguageTag) ?: Locale.ENGLISH
 	val footerExtraLinks = serverConfig.extraLinks.filter { it.placement.inFooter }.map { it.toModel(locale) }
 	model["headerExtraLinks"] = serverConfig.extraLinks.filter { it.placement.inHeader }.map { it.toModel(locale) }
 	model["footerExtraLinks"] = footerExtraLinks

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.frontend
 
+import com.darkrockstudios.apps.hammer.ExtraLink
 import com.darkrockstudios.apps.hammer.ServerConfig
 import com.darkrockstudios.apps.hammer.account.AccountsRepository
 import com.darkrockstudios.apps.hammer.account.BioService
@@ -17,6 +18,7 @@ import com.darkrockstudios.apps.hammer.frontend.data.UserSession
 import com.darkrockstudios.apps.hammer.frontend.og.OgImageService
 import com.darkrockstudios.apps.hammer.frontend.og.ogImageRoutes
 import com.darkrockstudios.apps.hammer.frontend.utils.canonicalUrl
+import com.darkrockstudios.apps.hammer.frontend.utils.getLocale
 import com.darkrockstudios.apps.hammer.frontend.utils.msg
 import com.darkrockstudios.apps.hammer.frontend.utils.withMessages
 import com.darkrockstudios.apps.hammer.monitoring.ActivityType
@@ -70,6 +72,7 @@ import org.koin.core.qualifier.named
 import org.koin.ktor.ext.get
 import org.koin.ktor.ext.inject
 import java.security.MessageDigest
+import java.util.Locale
 import kotlin.time.Duration.Companion.days
 
 fun Route.frontend() {
@@ -319,6 +322,13 @@ suspend fun sessionIsAuthorized(
 	}
 }
 
+private fun ExtraLink.toModel(locale: Locale): Map<String, Any> = mapOf(
+	"url" to url,
+	"icon" to icon,
+	"title" to title(locale),
+	"external" to isExternal,
+)
+
 fun MutableMap<String, Any>.addDefaults(): MutableMap<String, Any> {
 	this["version"] = BuildMetadata.APP_VERSION
 	return this
@@ -354,7 +364,12 @@ suspend fun ApplicationCall.withDefaults(data: Map<String, Any> = emptyMap()): M
 	model["hasAboutPage"] = hasAboutPage
 	model["hasTermsPage"] = hasTermsPage
 	model["hasPrivacyPage"] = hasPrivacyPage
-	model["hasFooterNav"] = hasAboutPage || hasTermsPage || hasPrivacyPage
+
+	val locale = getLocale()
+	val footerExtraLinks = serverConfig.extraLinks.filter { it.placement.inFooter }.map { it.toModel(locale) }
+	model["headerExtraLinks"] = serverConfig.extraLinks.filter { it.placement.inHeader }.map { it.toModel(locale) }
+	model["footerExtraLinks"] = footerExtraLinks
+	model["hasFooterNav"] = hasAboutPage || hasTermsPage || hasPrivacyPage || footerExtraLinks.isNotEmpty()
 
 	// Add Patreon link for footer if configured
 	if (serverConfig.patreonEnabled == true) {

--- a/server/src/main/resources/templates/footer.mustache
+++ b/server/src/main/resources/templates/footer.mustache
@@ -20,6 +20,12 @@
 						<span>{{msg.footer_privacy}}</span>
 					</a>
 				{{/hasPrivacyPage}}
+				{{#footerExtraLinks}}
+					<a href="{{url}}"{{#external}} target="_blank" rel="noopener noreferrer"{{/external}}>
+						<i class="{{icon}}"></i>
+						<span>{{title}}</span>
+					</a>
+				{{/footerExtraLinks}}
 			</nav>
 		{{/hasFooterNav}}
 		<div class="footer-social">

--- a/server/src/main/resources/templates/header.mustache
+++ b/server/src/main/resources/templates/header.mustache
@@ -89,6 +89,12 @@
 					<span class="header-nav__label">{{msg.header_nav_community}}</span>
 				</a>
 			{{/communityEnabled}}
+			{{#headerExtraLinks}}
+				<a href="{{url}}" class="header-nav__link" title="{{title}}"{{#external}} target="_blank" rel="noopener noreferrer"{{/external}}>
+					<i class="{{icon}}"></i>
+					<span class="header-nav__label">{{title}}</span>
+				</a>
+			{{/headerExtraLinks}}
 			{{#isLoggedIn}}
 				<a href="/dashboard" class="header-nav__link header-nav__link--primary"
 				   title="{{msg.header_nav_dashboard}}">

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ExtraLinkTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ExtraLinkTest.kt
@@ -1,0 +1,268 @@
+package com.darkrockstudios.apps.hammer
+
+import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
+import net.peanuuutz.tomlkt.Toml
+import okio.Path
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.Test
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ExtraLinkTest {
+
+	private val toml = Toml { ignoreUnknownKeys = true }
+
+	private fun parse(tomlString: String): ServerConfig =
+		toml.decodeFromString(ServerConfig.serializer(), tomlString)
+
+	@Test
+	fun `extraLinks defaults to empty`() {
+		assertEquals(emptyList(), parse("").extraLinks)
+	}
+
+	@Test
+	fun `an entry parses with defaults for icon and placement`() {
+		val config = parse(
+			"""
+			[[extraLinks]]
+			url = "/blog"
+			title = "Blog"
+			""".trimIndent()
+		)
+
+		val link = config.extraLinks.single()
+		assertEquals("/blog", link.url)
+		assertEquals("Blog", link.title)
+		assertEquals("fa-solid fa-link", link.icon)
+		assertEquals(LinkPlacement.FOOTER, link.placement)
+		assertEquals(emptyMap(), link.translations)
+	}
+
+	@Test
+	fun `placement parses case-insensitively`() {
+		val config = parse(
+			"""
+			[[extraLinks]]
+			url = "/blog"
+			title = "Blog"
+			placement = "Header"
+			""".trimIndent()
+		)
+
+		assertEquals(LinkPlacement.HEADER, config.extraLinks.single().placement)
+	}
+
+	@Test
+	fun `an inline translations table binds to its own entry`() {
+		val config = parse(
+			"""
+			[[extraLinks]]
+			url = "/blog"
+			title = "Blog"
+			translations = { fr = "Blogue" }
+
+			[[extraLinks]]
+			url = "/shop"
+			title = "Shop"
+			translations = { fr = "Boutique" }
+			""".trimIndent()
+		)
+
+		assertEquals(listOf("Blogue", "Boutique"), config.extraLinks.map { it.title(Locale.FRENCH) })
+	}
+
+	@Test
+	fun `multiple entries are split by placement`() {
+		val config = parse(
+			"""
+			[[extraLinks]]
+			url = "/blog"
+			title = "Blog"
+			placement = "header"
+
+			[[extraLinks]]
+			url = "/press"
+			title = "Press"
+			placement = "footer"
+
+			[[extraLinks]]
+			url = "/shop"
+			title = "Shop"
+			placement = "both"
+			""".trimIndent()
+		)
+
+		assertEquals(
+			listOf("Blog", "Shop"),
+			config.extraLinks.filter { it.placement.inHeader }.map { it.title },
+		)
+		assertEquals(
+			listOf("Press", "Shop"),
+			config.extraLinks.filter { it.placement.inFooter }.map { it.title },
+		)
+	}
+
+	@Test
+	fun `title prefers an exact language tag match`() {
+		val link = ExtraLink(
+			url = "/blog",
+			title = "Blog",
+			translations = mapOf("pt" to "Blogue de Portugal", "pt-BR" to "Blogue do Brasil"),
+		)
+
+		assertEquals("Blogue do Brasil", link.title(Locale.forLanguageTag("pt-BR")))
+	}
+
+	@Test
+	fun `title falls back to the language when the tag has no entry`() {
+		val link = ExtraLink(url = "/blog", title = "Blog", translations = mapOf("de" to "Tagebuch"))
+
+		assertEquals("Tagebuch", link.title(Locale.forLanguageTag("de-AT")))
+	}
+
+	@Test
+	fun `title falls back to the default for an unlisted locale`() {
+		val link = ExtraLink(url = "/blog", title = "Blog", translations = mapOf("fr" to "Blogue"))
+
+		assertEquals("Blog", link.title(Locale.forLanguageTag("uk")))
+	}
+
+	@Test
+	fun `an underscore locale key matches a hyphenated tag`() {
+		val link = ExtraLink(url = "/blog", title = "Blog", translations = mapOf("pt_BR" to "Blogue do Brasil"))
+
+		assertEquals("Blogue do Brasil", link.title(Locale.forLanguageTag("pt-BR")))
+	}
+
+	@Test
+	fun `a locale key matches regardless of case`() {
+		val link = ExtraLink(url = "/blog", title = "Blog", translations = mapOf("PT-br" to "Blogue do Brasil"))
+
+		assertEquals("Blogue do Brasil", link.title(Locale.forLanguageTag("pt-BR")))
+	}
+
+	@Test
+	fun `a hyphenated locale key survives the toml round trip`() {
+		val config = parse(
+			"""
+			[[extraLinks]]
+			url = "/blog"
+			title = "Blog"
+			translations = { pt-BR = "Blogue do Brasil" }
+			""".trimIndent()
+		)
+
+		assertEquals(
+			"Blogue do Brasil",
+			config.extraLinks.single().title(Locale.forLanguageTag("pt-BR")),
+		)
+	}
+
+	@Test
+	fun `resolve aborts on an unusable locale key`() {
+		val error = assertFailsWith<IllegalArgumentException> {
+			resolveWith(
+				"""
+				[[extraLinks]]
+				url = "/blog"
+				title = "Blog"
+				translations = { "not a locale" = "Blogue" }
+				"""
+			)
+		}
+		assertTrue(error.message.orEmpty().contains("not a locale"))
+	}
+
+	@Test
+	fun `an absolute http url is external`() {
+		assertTrue(ExtraLink(url = "https://blog.example.com", title = "Blog").isExternal)
+	}
+
+	@Test
+	fun `a site-relative url is not external`() {
+		assertFalse(ExtraLink(url = "/blog", title = "Blog").isExternal)
+	}
+
+	@Test
+	fun `resolve accepts a site-relative url`() {
+		val config = resolveWith(
+			"""
+			[[extraLinks]]
+			url = "/blog"
+			title = "Blog"
+			"""
+		)
+
+		assertEquals("/blog", config.extraLinks.single().url)
+	}
+
+	@Test
+	fun `resolve aborts on a scheme-relative url`() {
+		val error = assertFailsWith<IllegalArgumentException> {
+			resolveWith(
+				"""
+				[[extraLinks]]
+				url = "//evil.example.com"
+				title = "Blog"
+				"""
+			)
+		}
+		assertTrue(error.message.orEmpty().contains("//evil.example.com"))
+	}
+
+	@Test
+	fun `resolve aborts on a non-http scheme`() {
+		assertFailsWith<IllegalArgumentException> {
+			resolveWith(
+				"""
+				[[extraLinks]]
+				url = "javascript:alert(1)"
+				title = "Blog"
+				"""
+			)
+		}
+	}
+
+	@Test
+	fun `resolve aborts on a blank title`() {
+		assertFailsWith<IllegalArgumentException> {
+			resolveWith(
+				"""
+				[[extraLinks]]
+				url = "/blog"
+				title = "  "
+				"""
+			)
+		}
+	}
+
+	@Test
+	fun `resolve aborts on a blank localized title`() {
+		val error = assertFailsWith<IllegalArgumentException> {
+			resolveWith(
+				"""
+				[[extraLinks]]
+				url = "/blog"
+				title = "Blog"
+				translations = { fr = "" }
+				"""
+			)
+		}
+		assertTrue(error.message.orEmpty().contains("fr"))
+	}
+
+	private fun resolveWith(configToml: String): ServerConfig {
+		val fs = FakeFileSystem()
+		val path = getRootDataDirectory(fs) / DEFAULT_CONFIG_FILE_NAME
+		writeConfig(fs, path, configToml.trimIndent())
+		return resolveServerConfig(configPath = null, fileSystem = fs)
+	}
+
+	private fun writeConfig(fs: FakeFileSystem, path: Path, contents: String) {
+		path.parent?.let { fs.createDirectories(it) }
+		fs.write(path) { writeUtf8(contents) }
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ExtraLinkTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ExtraLinkTest.kt
@@ -214,6 +214,34 @@ class ExtraLinkTest {
 	}
 
 	@Test
+	fun `resolve aborts on a backslash protocol-relative url`() {
+		val error = assertFailsWith<IllegalArgumentException> {
+			resolveWith(
+				"""
+				[[extraLinks]]
+				url = "/\\evil.example.com"
+				title = "Blog"
+				"""
+			)
+		}
+		assertTrue(error.message.orEmpty().contains("must be site-relative"), error.message)
+		assertTrue(error.message.orEmpty().contains("evil.example.com"), error.message)
+	}
+
+	@Test
+	fun `resolve accepts the site root`() {
+		val config = resolveWith(
+			"""
+			[[extraLinks]]
+			url = "/"
+			title = "Home"
+			"""
+		)
+
+		assertEquals("/", config.extraLinks.single().url)
+	}
+
+	@Test
 	fun `resolve aborts on a non-http scheme`() {
 		assertFailsWith<IllegalArgumentException> {
 			resolveWith(

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/ExtraLinkRenderTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/ExtraLinkRenderTest.kt
@@ -3,6 +3,7 @@ package com.darkrockstudios.apps.hammer.frontend
 import com.github.mustachejava.DefaultMustacheFactory
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -72,13 +73,40 @@ class ExtraLinkRenderTest {
 		assertFalse(html.substringBefore("footer-social").contains("""target="_blank""""), html)
 	}
 
-	@Test
-	fun `no extra links renders no nav entries`() {
-		val header = render("header.mustache", mapOf("headerExtraLinks" to emptyList<Any>()))
-		val footer = render("footer.mustache", mapOf("footerExtraLinks" to emptyList<Any>()))
+	/** The nav between `<nav class="...">` and its `</nav>`, so link counts exclude social icons. */
+	private fun nav(html: String, cssClass: String): String =
+		html.substringAfter("""<nav class="$cssClass">""").substringBefore("</nav>")
 
-		assertFalse(header.contains("header-nav__link\" title=\"Blog"), header)
-		assertFalse(footer.contains("footer-nav"), footer)
+	@Test
+	fun `no extra links leaves the footer nav with only its built-in entries`() {
+		val html = render(
+			"footer.mustache",
+			mapOf("hasFooterNav" to true, "hasAboutPage" to true, "footerExtraLinks" to emptyList<Any>()),
+		)
+
+		val nav = nav(html, "footer-nav")
+		assertTrue(nav.contains("""href="/about""""), nav)
+		assertEquals(1, Regex("<a ").findAll(nav).count(), nav)
+	}
+
+	@Test
+	fun `an extra link adds exactly one footer nav entry`() {
+		val html = render(
+			"footer.mustache",
+			mapOf("hasFooterNav" to true, "hasAboutPage" to true, "footerExtraLinks" to listOf(link())),
+		)
+
+		val nav = nav(html, "footer-nav")
+		assertEquals(2, Regex("<a ").findAll(nav).count(), nav)
+	}
+
+	@Test
+	fun `no extra links leaves the header nav with only its built-in entries`() {
+		val html = render("header.mustache", mapOf("headerExtraLinks" to emptyList<Any>()))
+
+		val nav = nav(html, "header-nav\" id=\"header-nav")
+		assertTrue(nav.contains("""href="/login""""), nav)
+		assertEquals(1, Regex("<a ").findAll(nav).count(), nav)
 	}
 
 	@Test

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/ExtraLinkRenderTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/ExtraLinkRenderTest.kt
@@ -1,0 +1,96 @@
+package com.darkrockstudios.apps.hammer.frontend
+
+import com.github.mustachejava.DefaultMustacheFactory
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Renders the real header/footer partials so a mustache typo fails the build — an unknown section
+ * name renders as nothing rather than erroring, so a broken template looks exactly like a
+ * deployment that configured no extra links.
+ */
+class ExtraLinkRenderTest {
+
+	private val factory = DefaultMustacheFactory("templates")
+
+	private fun render(template: String, model: Map<String, Any>): String {
+		val writer = StringWriter()
+		factory.compile(template).execute(writer, model).flush()
+		return writer.toString()
+	}
+
+	private fun link(
+		url: String = "/blog",
+		title: String = "Blog",
+		icon: String = "fa-solid fa-blog",
+		external: Boolean = false,
+	) = mapOf("url" to url, "icon" to icon, "title" to title, "external" to external)
+
+	@Test
+	fun `header renders a configured extra link`() {
+		val html = render("header.mustache", mapOf("headerExtraLinks" to listOf(link())))
+
+		assertTrue(html.contains("""href="/blog""""), html)
+		assertTrue(html.contains("""class="fa-solid fa-blog""""), html)
+		assertTrue(html.contains("Blog"), html)
+	}
+
+	@Test
+	fun `footer renders a configured extra link`() {
+		val html = render(
+			"footer.mustache",
+			mapOf("hasFooterNav" to true, "footerExtraLinks" to listOf(link())),
+		)
+
+		assertTrue(html.contains("""href="/blog""""), html)
+		assertTrue(html.contains("""class="fa-solid fa-blog""""), html)
+	}
+
+	@Test
+	fun `an external link opens in a new tab with noopener`() {
+		val html = render(
+			"footer.mustache",
+			mapOf(
+				"hasFooterNav" to true,
+				"footerExtraLinks" to listOf(link(url = "https://blog.example.com", external = true)),
+			),
+		)
+
+		assertTrue(html.contains("""target="_blank""""), html)
+		assertTrue(html.contains("""rel="noopener noreferrer""""), html)
+	}
+
+	@Test
+	fun `a site-relative link stays in the tab`() {
+		val html = render(
+			"footer.mustache",
+			mapOf("hasFooterNav" to true, "footerExtraLinks" to listOf(link())),
+		)
+
+		assertFalse(html.substringBefore("footer-social").contains("""target="_blank""""), html)
+	}
+
+	@Test
+	fun `no extra links renders no nav entries`() {
+		val header = render("header.mustache", mapOf("headerExtraLinks" to emptyList<Any>()))
+		val footer = render("footer.mustache", mapOf("footerExtraLinks" to emptyList<Any>()))
+
+		assertFalse(header.contains("header-nav__link\" title=\"Blog"), header)
+		assertFalse(footer.contains("footer-nav"), footer)
+	}
+
+	@Test
+	fun `titles are html escaped`() {
+		val html = render(
+			"footer.mustache",
+			mapOf(
+				"hasFooterNav" to true,
+				"footerExtraLinks" to listOf(link(title = """<script>alert(1)</script>""")),
+			),
+		)
+
+		assertFalse(html.contains("<script>alert(1)</script>"), html)
+	}
+}


### PR DESCRIPTION
Adds an undocumented server config option for appending links to the header and/or footer, so a deployment can point at content that isn't part of Hammer itself (a blog, a shop, a press page).

## Config

```toml
[[extraLinks]]
url = "/blog"
title = "Blog"
translations = { de = "Blog", fr = "Blogue" }
icon = "fa-solid fa-blog"
placement = "header"   # header | footer | both
```

Every field except `url` and `title` has a default, and `extraLinks` defaults to empty — existing deployments are unaffected.

## Notes

- **Localization.** The message bundles are compiled into the jar, so an operator can't add a key for their own blog without a fork. `translations` takes per-locale labels inline instead. Resolution is exact tag (`pt-BR`) → bare language (`pt`) → the default `title`. Keys are separator- and case-insensitive, so `pt_BR` copied from a bundle filename works too.
- **Inline table on purpose.** The sub-table form `[extraLinks.translations]` binds to whichever `[[extraLinks]]` precedes it, so reordering blocks would silently reassign labels. Inline keeps each entry self-contained.
- **Validation aborts startup** on a blank title/icon, a non-http(s) scheme, a scheme-relative `//host`, or a locale key the JVM can't round-trip — the failure mode this guards against is a link that silently renders the fallback label forever.
- **Undocumented by request**, so `HOW-TO-RUN-A-SERVER.md` is untouched; the KDoc on `ExtraLink` carries the example.

## Tests

`ExtraLinkTest` covers TOML parsing, defaults, per-entry translation binding, the three-step title fallback, separator/case normalization, and each validation rejection.

`ExtraLinkRenderTest` compiles the real header/footer partials. An unknown Mustache section renders as *nothing* rather than erroring, so a typo'd `{{#footerExtraLinks}}` would be indistinguishable from a deployment with no links configured — these tests are what make that fail loudly. They also pin `rel="noopener noreferrer"` on external links and HTML escaping of titles.