### PR TITLE
Stop e2e tests leaking background jobs into the shared test database

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/scheduling/RecurringTaskWiring.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/scheduling/RecurringTaskWiring.kt
@@ -3,26 +3,31 @@ package com.darkrockstudios.apps.hammer.scheduling
 import io.ktor.server.application.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import org.koin.ktor.ext.inject
 
 /**
- * Starts [task] on its own supervised scope, registers it with the
- * [RecurringTaskRegistry] so the admin dashboard can report its status, and
- * wires graceful shutdown: when the application stops, the in-flight tick is
- * allowed to finish before the scope is cancelled, so a tick can't outlive the
- * application and mutate state afterwards.
+ * Starts [task] on a supervised scope parented to the application's job,
+ * registers it with the [RecurringTaskRegistry] so the admin dashboard can
+ * report its status, and wires graceful shutdown: when the application stops,
+ * the in-flight tick is allowed to finish before the scope is cancelled, so a
+ * tick can't outlive the application and mutate state afterwards.
+ *
+ * The [ApplicationStopping] hook is the graceful path. Parenting the scope to
+ * the application job is the backstop: a caller that tears the application down
+ * without the lifecycle event still cannot leave the loop running.
  */
 fun Application.launchRecurringTask(task: RecurringTask) {
 	val registry: RecurringTaskRegistry by inject()
 	registry.register(task)
 
-	val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+	val scope = CoroutineScope(SupervisorJob(coroutineContext[Job]) + Dispatchers.Default)
 	task.start(scope)
 
-	environment.monitor.subscribe(ApplicationStopped) {
+	monitor.subscribe(ApplicationStopping) {
 		runBlocking { task.stop() }
 		scope.cancel()
 	}

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.base.http.createTokenBase64
 import com.darkrockstudios.apps.hammer.database.Database
 import com.darkrockstudios.apps.hammer.encryption.AesGcmContentEncryptor
 import com.darkrockstudios.apps.hammer.encryption.SimpleFileBasedAesGcmKeyProvider
+import com.darkrockstudios.apps.hammer.scheduling.RecurringTaskRegistry
 import com.darkrockstudios.apps.hammer.secret.FileSecretProvider
 import com.darkrockstudios.apps.hammer.secret.KeyringCodec
 import com.darkrockstudios.apps.hammer.secret.KeyringManager
@@ -42,7 +43,8 @@ import kotlin.io.encoding.Base64
 abstract class EndToEndTest {
 
 	protected lateinit var fileSystem: FakeFileSystem
-	private lateinit var server: ApplicationEngine
+	private lateinit var server: EmbeddedServer<*, *>
+	private val taskRegistry = RecurringTaskRegistry()
 
 	/**
 	 * The config the server under test runs on. These tests exercise the AES-at-rest path with a
@@ -103,7 +105,18 @@ abstract class EndToEndTest {
 		// Close the per-test HttpClient before stopping the server so its engine threads and
 		// connection pool don't accumulate across the suite (a leak that grows test-to-test).
 		runCatching { client.close() }
+		// Stop the EmbeddedServer, not its engine: only the former destroys the
+		// application, and that is what fires the lifecycle event the recurring
+		// background jobs shut down on.
 		server.stop(1000, 3000)
+
+		// A job that outlives its test keeps writing to the shared database and
+		// corrupts whichever test is running when it next ticks. Fail here, on
+		// the test that leaked it, rather than somewhere downstream.
+		val leaked = taskRegistry.statuses().filter { it.running }
+		check(leaked.isEmpty()) {
+			"Background jobs still running after server stop: ${leaked.joinToString { it.name }}"
+		}
 	}
 
 	/** Files [cache] wrote during this test, read from wherever [serverConfig] puts it. */
@@ -117,16 +130,18 @@ abstract class EndToEndTest {
 		server = startServer()
 		// port = 0 bound an OS-assigned port; read back what we actually got so
 		// the client connects to the right place.
-		serverPort = runBlocking { server.resolvedConnectors().first().port }
+		serverPort = runBlocking { server.engine.resolvedConnectors().first().port }
 	}
 
-	private fun startServer(): ApplicationEngine {
+	private fun startServer(): EmbeddedServer<*, *> {
 		// Override the default database
 		val testModule = org.koin.dsl.module {
 			single { testDatabase } bind Database::class
 			single { fileSystem } bind FileSystem::class
 			// The disk caches need to set modification times; this keeps them on the same fake.
 			single<TouchableFileSystem> { FakeTouchableFileSystem(fileSystem) }
+			// Held by the test so tearDown can see which jobs the app started.
+			single { taskRegistry }
 		}
 
 		val server = embeddedServer(
@@ -138,6 +153,6 @@ abstract class EndToEndTest {
 			}
 		)
 		server.start()
-		return server.engine
+		return server
 	}
 }


### PR DESCRIPTION
Fixes the intermittent `:server:test` failures on `develop` (e.g. `UserActivityTest > master switch off prevents collection and flush()`, and whole-class failures in `AccountsRepositoryTest` / `PasswordResetRepositoryTest`).

## Root cause

`EndToEndTest` held the Ktor `ApplicationEngine` and called `engine.stop(...)` in `tearDown`. In Ktor 3.5 only `EmbeddedServer.stop()` calls `destroyApplication()`, and that is the sole place `ApplicationStopping` / `ApplicationStopped` are raised — stopping the engine just closes the HTTP connector.

`launchRecurringTask` hangs its shutdown off that event and runs the loop on an unparented `CoroutineScope(SupervisorJob() + Dispatchers.Default)`. So every e2e test leaked four background jobs that kept running for the rest of the JVM, against the process-wide embedded Postgres that `SqliteTestDatabase` shares and isolates only by truncating in `@BeforeEach`.

A leaked `MonitoringMaintenanceJob` flushes `UserActivityCollector` into `user_activity` every 60s — that is the stray SYNC row breaking `assertEquals(0L, ...)`. `TokenMaintenanceJob` and `WhitelistExpiryJob` deleting rows explains the account/password-reset classes failing wholesale. Whichever test happens to be running when a leaked job ticks is the one that fails, which is why it reproduces only under a full suite run and flips with load.

## Fix

- `EndToEndTest` keeps the `EmbeddedServer` and stops that, so the lifecycle events actually fire.
- `launchRecurringTask` parents its scope to the application job and moves the graceful stop to `ApplicationStopping`, which fires *before* the app job is cancelled. The in-flight tick still drains cleanly, and the parenting is a structural backstop for any teardown that misses the event.
- `tearDown` asserts no `RecurringTask` survived the stop, so a future leak fails on the test that caused it rather than corrupting a downstream one.

No assertions were loosened and nothing was disabled or slept on.

## Verification

- Full `./gradlew :server:test`: **967 tests, 0 failures** (previously reproduced the failures).
- Guard is not vacuous: temporarily reverting `tearDown` to `server.engine.stop(...)` makes `TeapotTest` fail with `Background jobs still running after server stop: Disk cache prune job, Monitoring maintenance job, Token maintenance job, Whitelist expiry job` — the leak, and the guard catching it.

## Follow-up

`SqliteTestDatabase` is Postgres, not SQLite, and the name hides the process-wide sharing. Renaming it to `SharedPostgresTestDatabase` is a mechanical sweep over ~35 files; left out here to keep this diff reviewable.
