### PR TITLE
Rename SqliteTestDatabase to SharedPostgresTestDatabase

### DIFF
--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/RoundTripTestBase.kt
@@ -228,9 +228,10 @@ abstract class RoundTripTestBase : EndToEndTest(), KoinTest {
 			// and rejects the pre-seeded auth token).
 			single<FileSystem> { sharedFileSystem }
 
-			// FakeFileSystem is not thread-safe, so bind IO and Default to the same single-threaded
-			// dispatcher as Main: this serializes all client-side filesystem work and keeps
-			// concurrent opens from corrupting its open-file list.
+			// Bind IO and Default to the same single-threaded dispatcher as Main so client-side work
+			// runs in a deterministic order. Test bodies still drive the pipeline from the JUnit
+			// thread via runBlocking, so this alone doesn't serialize filesystem access — the shared
+			// fake is wrapped in a SynchronizedFileSystem for that.
 			single<CoroutineContext>(named(DISPATCHER_MAIN)) { mainDispatcher }
 			single<CoroutineContext>(named(DISPATCHER_IO)) { mainDispatcher }
 			single<CoroutineContext>(named(DISPATCHER_DEFAULT)) { mainDispatcher }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -156,7 +156,7 @@ dependencies {
 	testImplementation(libs.testcontainers.junit.jupiter)
 
 	// testFixtures exposes the reusable E2E harness (EndToEndTest, E2eTestData,
-	// SqliteTestDatabase) to both :server's own tests and the :integrationTests module.
+	// SharedPostgresTestDatabase) to both :server's own tests and the :integrationTests module.
 	testFixturesApi(project(":base"))
 	testFixturesApi(libs.bundles.ktor.client)
 	testFixturesApi(libs.ktor.serialization.kotlinx.json)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/AdminComponentTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/AdminComponentTest.kt
@@ -2,7 +2,7 @@ package com.darkrockstudios.apps.hammer.admin
 
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
 import com.darkrockstudios.apps.hammer.database.WhiteListDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utilities.isFailure
 import com.darkrockstudios.apps.hammer.utilities.isSuccess
 import com.darkrockstudios.apps.hammer.utils.BaseTest
@@ -19,7 +19,7 @@ import kotlin.time.Duration.Companion.days
 
 class AdminComponentTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var whiteListDao: WhiteListDao
 	private lateinit var whiteListRepository: WhiteListRepository
 	private lateinit var clock: TestClock
@@ -28,7 +28,7 @@ class AdminComponentTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		whiteListDao = WhiteListDao(db)
 		clock = TestClock(Clock.System)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/ConfigRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/ConfigRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.admin
 
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 
 class ConfigRepositoryTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var dao: ServerConfigDao
 
 	private val MAX_UPLOAD_SIZE = ServerConfigKey.int("max_upload_size_mb", 10)
@@ -23,7 +23,7 @@ class ConfigRepositoryTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		dao = ServerConfigDao(db)
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/WhiteListRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/WhiteListRepositoryTest.kt
@@ -2,7 +2,7 @@ package com.darkrockstudios.apps.hammer.admin
 
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
 import com.darkrockstudios.apps.hammer.database.WhiteListDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import com.darkrockstudios.apps.hammer.utils.TestClock
 import kotlinx.coroutines.test.runTest
@@ -18,7 +18,7 @@ import kotlin.time.Instant
 
 class WhiteListRepositoryTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var whiteListDao: WhiteListDao
 	private lateinit var configDao: ServerConfigDao
 	private lateinit var configRepository: ConfigRepository
@@ -28,7 +28,7 @@ class WhiteListRepositoryTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		whiteListDao = WhiteListDao(db)
 		configDao = ServerConfigDao(db)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/WhitelistExpiryJobTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/WhitelistExpiryJobTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.database.AccountDao
 import com.darkrockstudios.apps.hammer.database.AuthTokenDao
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
 import com.darkrockstudios.apps.hammer.database.WhiteListDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utilities.TokenHasher
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import com.darkrockstudios.apps.hammer.utils.TestClock
@@ -25,7 +25,7 @@ import kotlin.time.Duration.Companion.days
 
 class WhitelistExpiryJobTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var whiteListDao: WhiteListDao
 	private lateinit var accountDao: AccountDao
 	private lateinit var authTokenDao: AuthTokenDao
@@ -38,7 +38,7 @@ class WhitelistExpiryJobTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		whiteListDao = WhiteListDao(db)
 		accountDao = AccountDao(db)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/database/AuthTokenDaoTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/database/AuthTokenDaoTest.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.database
 
 import com.darkrockstudios.apps.hammer.base.http.Token
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -13,13 +13,13 @@ import kotlin.time.Duration.Companion.days
 
 class AuthTokenDaoTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var dao: AuthTokenDao
 
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		dao = AuthTokenDao(db)
 		setupKoin()

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/database/ProjectAccessDaoTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/database/ProjectAccessDaoTest.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.database
 
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -11,7 +11,7 @@ import kotlin.test.assertTrue
 
 class ProjectAccessDaoTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var dao: ProjectAccessDao
 
 	private val attackerProjectId = 100L
@@ -20,7 +20,7 @@ class ProjectAccessDaoTest : BaseTest() {
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		dao = ProjectAccessDao(db)
 		setupKoin()

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/util/TestDataSet1.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/util/TestDataSet1.kt
@@ -23,7 +23,7 @@ object TestDataSet1 {
 		userId = 1,
 	)
 
-	fun createFullDataset(database: SqliteTestDatabase, contentEncryptor: ContentEncryptor) {
+	fun createFullDataset(database: SharedPostgresTestDatabase, contentEncryptor: ContentEncryptor) {
 		createAccount(account1, database)
 		createProject(project1, database)
 
@@ -61,7 +61,7 @@ object TestDataSet1 {
 		add(7)
 	}
 
-	fun createEmptyDataset(database: SqliteTestDatabase) {
+	fun createEmptyDataset(database: SharedPostgresTestDatabase) {
 		createAccount(account1, database)
 		createProject(project1, database)
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/util/TestDataSetWithReferences.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/util/TestDataSetWithReferences.kt
@@ -34,7 +34,7 @@ object TestDataSetWithReferences {
 
 	val entities: List<ApiProjectEntity> = listOf(sceneWithRefs, entryWithAliases)
 
-	fun createFullDataset(database: SqliteTestDatabase, contentEncryptor: ContentEncryptor) {
+	fun createFullDataset(database: SharedPostgresTestDatabase, contentEncryptor: ContentEncryptor) {
 		createAccount(TestDataSet1.account1, database)
 		createProject(TestDataSet1.project1, database)
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/email/MailgunEmailServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/email/MailgunEmailServiceTest.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.email
 import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -13,7 +13,7 @@ import kotlin.test.assertTrue
 
 class MailgunEmailServiceTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var dao: ServerConfigDao
 	private lateinit var configRepository: ConfigRepository
 
@@ -21,7 +21,7 @@ class MailgunEmailServiceTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		dao = ServerConfigDao(db)
 		configRepository = ConfigRepository(dao)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/email/PostmarkEmailServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/email/PostmarkEmailServiceTest.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.email
 import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -13,7 +13,7 @@ import kotlin.test.assertTrue
 
 class PostmarkEmailServiceTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var dao: ServerConfigDao
 	private lateinit var configRepository: ConfigRepository
 
@@ -21,7 +21,7 @@ class PostmarkEmailServiceTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		dao = ServerConfigDao(db)
 		configRepository = ConfigRepository(dao)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/email/SendGridEmailServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/email/SendGridEmailServiceTest.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.email
 import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -13,7 +13,7 @@ import kotlin.test.assertTrue
 
 class SendGridEmailServiceTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var dao: ServerConfigDao
 	private lateinit var configRepository: ConfigRepository
 
@@ -21,7 +21,7 @@ class SendGridEmailServiceTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		dao = ServerConfigDao(db)
 		configRepository = ConfigRepository(dao)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/encryption/EncryptionBootstrapTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/encryption/EncryptionBootstrapTest.kt
@@ -5,7 +5,7 @@ import com.darkrockstudios.apps.hammer.EncryptionMode
 import com.darkrockstudios.apps.hammer.ServerConfig
 import com.darkrockstudios.apps.hammer.database.AccountDao
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.secret.Keyring
 import com.darkrockstudios.apps.hammer.secret.KeyringCodec
 import com.darkrockstudios.apps.hammer.secret.KeyringManager
@@ -25,7 +25,7 @@ import kotlin.test.assertNotEquals
 
 class EncryptionBootstrapTest : BaseTest() {
 
-	private lateinit var testDatabase: SqliteTestDatabase
+	private lateinit var testDatabase: SharedPostgresTestDatabase
 	private lateinit var configDao: ServerConfigDao
 	private lateinit var convergence: EncryptionConvergence
 	private lateinit var contentEncryptors: ContentEncryptors
@@ -40,7 +40,7 @@ class EncryptionBootstrapTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 		setupKoin()
-		testDatabase = SqliteTestDatabase()
+		testDatabase = SharedPostgresTestDatabase()
 		testDatabase.initialize()
 
 		val keyProvider = SimpleFileBasedAesGcmKeyProvider(Base64.Default)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/encryption/EncryptionConvergenceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/encryption/EncryptionConvergenceTest.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.encryption
 
 import com.darkrockstudios.apps.hammer.database.AccountDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -13,7 +13,7 @@ import kotlin.test.assertFailsWith
 
 class EncryptionConvergenceTest : BaseTest() {
 
-	private lateinit var testDatabase: SqliteTestDatabase
+	private lateinit var testDatabase: SharedPostgresTestDatabase
 	private lateinit var base64: Base64
 	private lateinit var secureRandom: SecureRandom
 	private lateinit var keyProvider: SimpleFileBasedAesGcmKeyProvider
@@ -34,7 +34,7 @@ class EncryptionConvergenceTest : BaseTest() {
 		secureRandom = SecureRandom()
 		setupKoin()
 
-		testDatabase = SqliteTestDatabase()
+		testDatabase = SharedPostgresTestDatabase()
 		testDatabase.initialize()
 
 		keyProvider = SimpleFileBasedAesGcmKeyProvider(base64)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/encryption/EncryptionModeGuardTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/encryption/EncryptionModeGuardTest.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.encryption
 
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -8,12 +8,12 @@ import kotlin.test.assertEquals
 
 class EncryptionModeGuardTest : BaseTest() {
 
-	private lateinit var testDatabase: SqliteTestDatabase
+	private lateinit var testDatabase: SharedPostgresTestDatabase
 
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		testDatabase = SqliteTestDatabase()
+		testDatabase = SharedPostgresTestDatabase()
 		testDatabase.initialize()
 	}
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/StatusPagesErrorRecordingTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/StatusPagesErrorRecordingTest.kt
@@ -2,7 +2,7 @@ package com.darkrockstudios.apps.hammer.frontend
 
 import com.darkrockstudios.apps.hammer.database.ErrorLogDao
 import com.darkrockstudios.apps.hammer.dependencyinjection.DISPATCHER_IO
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.monitoring.ErrorRepository
 import com.darkrockstudios.apps.hammer.monitoring.MonitoringState
 import io.ktor.client.request.get
@@ -44,7 +44,7 @@ class StatusPagesErrorRecordingTest {
 				single<CoroutineContext>(named(DISPATCHER_IO)) { Dispatchers.IO }
 			})
 		}
-		val db = SqliteTestDatabase()
+		val db = SharedPostgresTestDatabase()
 		db.initialize()
 		errorRepository = ErrorRepository(ErrorLogDao(db), clock)
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MetricsRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MetricsRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.monitoring
 
 import com.darkrockstudios.apps.hammer.database.ApiMetricDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -15,12 +15,12 @@ import kotlin.time.Instant
 
 class MetricsRepositoryTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		setupKoin()
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringAlertTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringAlertTest.kt
@@ -8,7 +8,7 @@ import com.darkrockstudios.apps.hammer.database.LoginAttemptDao
 import com.darkrockstudios.apps.hammer.database.PublishedStoryReaderDao
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
 import com.darkrockstudios.apps.hammer.database.UserActivityDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.email.EmailResult
 import com.darkrockstudios.apps.hammer.email.EmailService
 import com.darkrockstudios.apps.hammer.utils.BaseTest
@@ -23,7 +23,7 @@ import kotlin.time.Instant
 
 class MonitoringAlertTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 
 	private val fixedNow = Instant.parse("2026-01-15T12:00:00Z")
 	private val clock = object : Clock {
@@ -43,7 +43,7 @@ class MonitoringAlertTest : BaseTest() {
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		setupKoin()
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringConfigTest.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.monitoring
 import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -14,14 +14,14 @@ import kotlin.test.assertTrue
 
 class MonitoringConfigTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var dao: ServerConfigDao
 
 	@BeforeEach
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		dao = ServerConfigDao(db)
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringDaoTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringDaoTest.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.monitoring
 import com.darkrockstudios.apps.hammer.database.ApiMetricDao
 import com.darkrockstudios.apps.hammer.database.ErrorLogDao
 import com.darkrockstudios.apps.hammer.database.LoginAttemptDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -27,12 +27,12 @@ import kotlin.time.Instant
  */
 class MonitoringDaoTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		setupKoin()
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringIgnoreRouteTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringIgnoreRouteTest.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.monitoring
 import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.frontend.adminMonitoringPages
 import com.darkrockstudios.apps.hammer.project.ProjectSynchronizationSession
 import com.darkrockstudios.apps.hammer.projects.ProjectsSynchronizationSession
@@ -34,13 +34,13 @@ class MonitoringIgnoreRouteTest : BaseTest() {
 		override fun now() = fixedNow
 	}
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var configRepository: ConfigRepository
 
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		setupKoin()
 		configRepository = ConfigRepository(ServerConfigDao(db))

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringMaintenanceJobLifecycleTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringMaintenanceJobLifecycleTest.kt
@@ -11,7 +11,7 @@ import com.darkrockstudios.apps.hammer.database.UserActivityDao
 import com.darkrockstudios.apps.hammer.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.dependencyinjection.DISPATCHER_IO
 import com.darkrockstudios.apps.hammer.dependencyinjection.DISPATCHER_MAIN
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.email.EmailResult
 import com.darkrockstudios.apps.hammer.email.EmailService
 import kotlinx.coroutines.CoroutineScope
@@ -44,7 +44,7 @@ import kotlin.time.Instant
  */
 class MonitoringMaintenanceJobLifecycleTest {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 
 	@BeforeEach
 	fun setup() {
@@ -58,7 +58,7 @@ class MonitoringMaintenanceJobLifecycleTest {
 				}
 			)
 		}
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 	}
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityAlertEmailTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityAlertEmailTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.database.PublishedStoryReaderDao
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
 import com.darkrockstudios.apps.hammer.database.UserActivityDao
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.email.EmailResult
 import com.darkrockstudios.apps.hammer.email.EmailService
 import com.darkrockstudios.apps.hammer.utils.BaseTest
@@ -23,7 +23,7 @@ import kotlin.test.assertTrue
 
 class SecurityAlertEmailTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 
 	private var nowValue = Instant.parse("2026-01-15T12:00:00Z")
 	private val clock = object : Clock {
@@ -43,7 +43,7 @@ class SecurityAlertEmailTest : BaseTest() {
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		setupKoin()
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/StoryReaderTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/StoryReaderTest.kt
@@ -1,7 +1,7 @@
 package com.darkrockstudios.apps.hammer.monitoring
 
 import com.darkrockstudios.apps.hammer.database.PublishedStoryReaderDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -20,7 +20,7 @@ import kotlin.time.Instant
  */
 class StoryReaderTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 
 	private val baseNow = Instant.parse("2026-01-15T12:00:00Z")
 	private var clockNow = baseNow
@@ -29,7 +29,7 @@ class StoryReaderTest : BaseTest() {
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		clockNow = baseNow
 		setupKoin()

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/UserActivityTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/UserActivityTest.kt
@@ -9,7 +9,7 @@ import com.darkrockstudios.apps.hammer.database.LoginAttemptDao
 import com.darkrockstudios.apps.hammer.database.PublishedStoryReaderDao
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
 import com.darkrockstudios.apps.hammer.database.UserActivityDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.email.EmailResult
 import com.darkrockstudios.apps.hammer.email.EmailService
 import com.darkrockstudios.apps.hammer.utils.BaseTest
@@ -30,7 +30,7 @@ import kotlin.time.Instant
  */
 class UserActivityTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 
 	private val now = Instant.parse("2026-01-15T12:00:00Z")
 	private val clock = object : Clock { override fun now() = now }
@@ -38,7 +38,7 @@ class UserActivityTest : BaseTest() {
 	@BeforeEach
 	override fun setup() {
 		super.setup()
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		setupKoin()
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/patreon/PatreonSyncServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/patreon/PatreonSyncServiceTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.admin.WhiteListRepository
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
 import com.darkrockstudios.apps.hammer.database.WhiteListDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import com.darkrockstudios.apps.hammer.utils.TestClock
 import io.mockk.coEvery
@@ -26,7 +26,7 @@ import kotlin.time.Instant
 
 class PatreonSyncServiceTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var whiteListDao: WhiteListDao
 	private lateinit var configDao: ServerConfigDao
 	private lateinit var configRepository: ConfigRepository
@@ -40,7 +40,7 @@ class PatreonSyncServiceTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		whiteListDao = WhiteListDao(db)
 		configDao = ServerConfigDao(db)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/patreon/PatreonWebhookHandlerTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/patreon/PatreonWebhookHandlerTest.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.patreon
 import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.database.ServerConfigDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -18,7 +18,7 @@ import kotlin.test.assertTrue
 
 class PatreonWebhookHandlerTest : BaseTest() {
 
-	private lateinit var db: SqliteTestDatabase
+	private lateinit var db: SharedPostgresTestDatabase
 	private lateinit var configDao: ServerConfigDao
 	private lateinit var configRepository: ConfigRepository
 	private lateinit var patreonApiClient: PatreonApiClient
@@ -29,7 +29,7 @@ class PatreonWebhookHandlerTest : BaseTest() {
 	override fun setup() {
 		super.setup()
 
-		db = SqliteTestDatabase()
+		db = SharedPostgresTestDatabase()
 		db.initialize()
 		configDao = ServerConfigDao(db)
 		configRepository = ConfigRepository(configDao)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/datasource/ProjectEntityDatabaseDatasourceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/datasource/ProjectEntityDatabaseDatasourceTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.apps.hammer.base.http.ApiSceneType
 import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.base.http.createTokenBase64
 import com.darkrockstudios.apps.hammer.database.*
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.encryption.AesGcmContentEncryptor
 import com.darkrockstudios.apps.hammer.encryption.ContentEncryptor
 import com.darkrockstudios.apps.hammer.encryption.ContentEncryptorRegistry
@@ -40,7 +40,7 @@ import kotlin.time.Instant
 class ProjectEntityDatabaseDatasourceTest : BaseTest() {
 
 	private lateinit var fileSystem: FakeFileSystem
-	private lateinit var testDatabase: SqliteTestDatabase
+	private lateinit var testDatabase: SharedPostgresTestDatabase
 	private lateinit var json: Json
 	private lateinit var clock: TestClock
 	private lateinit var contentEncryptor: ContentEncryptor
@@ -76,7 +76,7 @@ class ProjectEntityDatabaseDatasourceTest : BaseTest() {
 		encryptorRegistry = ContentEncryptorRegistry(listOf(contentEncryptor, plaintextEncryptor))
 		cipherSecretGenerator = SecureTokenGenerator(AccountsRepository.CIPHER_SALT_LENGTH, base64)
 
-		testDatabase = SqliteTestDatabase()
+		testDatabase = SharedPostgresTestDatabase()
 		testDatabase.initialize()
 
 		setupKoin()
@@ -588,7 +588,7 @@ class ProjectEntityDatabaseDatasourceTest : BaseTest() {
 		return entity
 	}
 
-	private fun setupAccount(testDatabase: SqliteTestDatabase) {
+	private fun setupAccount(testDatabase: SharedPostgresTestDatabase) {
 		testDatabase.serverDatabase.accountQueries.createAccount(
 			email = "test@test.com",
 			password_hash = "hash",
@@ -597,7 +597,7 @@ class ProjectEntityDatabaseDatasourceTest : BaseTest() {
 		)
 	}
 
-	private fun setupEntities(testDatabase: SqliteTestDatabase, encryptor: ContentEncryptor) {
+	private fun setupEntities(testDatabase: SharedPostgresTestDatabase, encryptor: ContentEncryptor) {
 		setupAccount(testDatabase)
 
 		testDatabase.serverDatabase.projectQueries.insertProject(
@@ -631,7 +631,7 @@ class ProjectEntityDatabaseDatasourceTest : BaseTest() {
 	}
 
 	private fun insertEntity(
-		testDatabase: SqliteTestDatabase,
+		testDatabase: SharedPostgresTestDatabase,
 		id: Long,
 		type: ApiProjectEntity.Type,
 		encryptor: ContentEncryptor
@@ -650,7 +650,7 @@ class ProjectEntityDatabaseDatasourceTest : BaseTest() {
 		)
 	}
 
-	private fun insertDeletedEntity(testDatabase: SqliteTestDatabase, id: Long) {
+	private fun insertDeletedEntity(testDatabase: SharedPostgresTestDatabase, id: Long) {
 		testDatabase.serverDatabase.deletedEntityQueries.markEntityDeleted(
 			userId = 1,
 			projectId = 1,

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/repository/ServerProjectDataRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/repository/ServerProjectDataRepositoryTest.kt
@@ -10,7 +10,7 @@ import com.darkrockstudios.apps.hammer.base.http.projectdata.WordCountGoal
 import com.darkrockstudios.apps.hammer.base.http.synchronizer.ProjectDataHasher
 import com.darkrockstudios.apps.hammer.database.ProjectDao
 import com.darkrockstudios.apps.hammer.database.ProjectDataDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.project.ProjectDataSaveResult
 import com.darkrockstudios.apps.hammer.project.ProjectDefinition
 import com.darkrockstudios.apps.hammer.project.ProjectNotFound
@@ -35,7 +35,7 @@ import kotlin.time.Instant
 
 class ServerProjectDataRepositoryTest : BaseTest() {
 
-	private lateinit var testDatabase: SqliteTestDatabase
+	private lateinit var testDatabase: SharedPostgresTestDatabase
 	private lateinit var repository: ServerProjectDataRepository
 
 	private val json = createJsonSerializer()
@@ -61,7 +61,7 @@ class ServerProjectDataRepositoryTest : BaseTest() {
 		super.setup()
 		setupKoin()
 
-		testDatabase = SqliteTestDatabase()
+		testDatabase = SharedPostgresTestDatabase()
 		testDatabase.initialize()
 
 		seedAccountAndProject()

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/repository/ServerWritingActivityRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/project/repository/ServerWritingActivityRepositoryTest.kt
@@ -8,7 +8,7 @@ import com.darkrockstudios.apps.hammer.base.http.writingactivity.DeviceLog
 import com.darkrockstudios.apps.hammer.base.http.writingactivity.WritingSession
 import com.darkrockstudios.apps.hammer.database.ProjectDao
 import com.darkrockstudios.apps.hammer.database.WritingActivityDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.project.ProjectDefinition
 import com.darkrockstudios.apps.hammer.project.ProjectNotFound
 import com.darkrockstudios.apps.hammer.project.ServerWritingActivityRepository
@@ -25,7 +25,7 @@ import kotlin.time.Instant
 
 class ServerWritingActivityRepositoryTest : BaseTest() {
 
-	private lateinit var testDatabase: SqliteTestDatabase
+	private lateinit var testDatabase: SharedPostgresTestDatabase
 	private lateinit var repository: ServerWritingActivityRepository
 
 	private val userId = 1L
@@ -37,7 +37,7 @@ class ServerWritingActivityRepositoryTest : BaseTest() {
 		super.setup()
 		setupKoin()
 
-		testDatabase = SqliteTestDatabase()
+		testDatabase = SharedPostgresTestDatabase()
 		testDatabase.initialize()
 
 		seedAccountAndProject()

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/datasource/ProjectsDatabaseDatasourceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/datasource/ProjectsDatabaseDatasourceTest.kt
@@ -6,7 +6,7 @@ import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.base.http.createTokenBase64
 import com.darkrockstudios.apps.hammer.database.ProjectDao
 import com.darkrockstudios.apps.hammer.database.ProjectsDao
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.project.ProjectDefinition
 import com.darkrockstudios.apps.hammer.projects.ProjectsDatabaseDatasource
 import com.darkrockstudios.apps.hammer.projects.ProjectsSyncData
@@ -28,7 +28,7 @@ import kotlin.uuid.Uuid
 
 class ProjectsDatabaseDatasourceTest : BaseTest() {
 
-	private lateinit var testDatabase: SqliteTestDatabase
+	private lateinit var testDatabase: SharedPostgresTestDatabase
 	private lateinit var json: Json
 	private lateinit var clock: TestClock
 	private lateinit var cipherSecretGenerator: SecureTokenGenerator
@@ -42,7 +42,7 @@ class ProjectsDatabaseDatasourceTest : BaseTest() {
 		base64 = createTokenBase64()
 		cipherSecretGenerator = SecureTokenGenerator(AccountsRepository.CIPHER_SALT_LENGTH, base64)
 
-		testDatabase = SqliteTestDatabase()
+		testDatabase = SharedPostgresTestDatabase()
 		testDatabase.initialize()
 
 		setupKoin()

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utils/FileResourcesUtils.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utils/FileResourcesUtils.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.utils
 
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import okio.Path
 import okio.Path.Companion.toOkioPath
 import okio.fakefilesystem.FakeFileSystem
@@ -73,7 +73,7 @@ object FileResourcesUtils {
 		}
 	}
 
-	suspend fun setupDatabase(from: Path, database: SqliteTestDatabase) {
+	suspend fun setupDatabase(from: Path, database: SharedPostgresTestDatabase) {
 		val clazz = FileResourcesUtils::class.java
 		val dbFiles = getResourceFiles(clazz, from.toString())
 			.filter { it.name.endsWith(".sql") }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utils/FileResourcesUtils.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utils/FileResourcesUtils.kt
@@ -3,7 +3,7 @@ package com.darkrockstudios.apps.hammer.utils
 import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import okio.Path
 import okio.Path.Companion.toOkioPath
-import okio.fakefilesystem.FakeFileSystem
+import okio.FileSystem
 import java.io.File
 import java.io.IOException
 
@@ -36,7 +36,7 @@ object FileResourcesUtils {
 	fun copyResourceFolderToFakeFileSystem(
 		from: Path,
 		to: Path,
-		ffs: FakeFileSystem,
+		ffs: FileSystem,
 		filterBlackList: List<String> = listOf(".gitkeep", ".sql"),
 		includeFromDir: Boolean = true
 	) {

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utils/TestServerUtils.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utils/TestServerUtils.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.utils
 
-import com.darkrockstudios.apps.hammer.e2e.util.SqliteTestDatabase
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
 import com.darkrockstudios.apps.hammer.projects.ProjectsFileSystemDatasource
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import okio.Path
@@ -23,7 +23,7 @@ fun getUserDataDirectory(ffs: FakeFileSystem): Path {
 suspend fun createTestServer(
 	serverName: String,
 	ffs: FakeFileSystem,
-	testDatabase: SqliteTestDatabase
+	testDatabase: SharedPostgresTestDatabase
 ) {
 	val rootDir = getRootDataDirectory(ffs)
 	ffs.createDirectories(rootDir)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utils/TestServerUtils.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utils/TestServerUtils.kt
@@ -5,14 +5,14 @@ import com.darkrockstudios.apps.hammer.projects.ProjectsFileSystemDatasource
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import okio.Path
 import okio.Path.Companion.toPath
-import okio.fakefilesystem.FakeFileSystem
+import okio.FileSystem
 
 const val SERVER_EMPTY_NO_WHITELIST = "EmptyServerNoWhitelist"
 const val SERVER_EMPTY_YES_WHITELIST = "EmptyServerYesWhitelist"
 const val SERVER_CONFIG_ONE = "ServerConfigOne"
 const val TEST_SERVER_1 = "Test Server 1"
 
-fun getUserDataDirectory(ffs: FakeFileSystem): Path {
+fun getUserDataDirectory(ffs: FileSystem): Path {
 	val rootDir = ProjectsFileSystemDatasource.getRootDirectory(ffs)
 	return rootDir
 }
@@ -22,7 +22,7 @@ fun getUserDataDirectory(ffs: FakeFileSystem): Path {
  */
 suspend fun createTestServer(
 	serverName: String,
-	ffs: FakeFileSystem,
+	ffs: FileSystem,
 	testDatabase: SharedPostgresTestDatabase
 ) {
 	val rootDir = getRootDataDirectory(ffs)

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/E2eTestData.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/E2eTestData.kt
@@ -32,7 +32,7 @@ object E2eTestData {
 	val b64 = createTokenBase64()
 	val cipherSecretGenerator = SecureTokenGenerator(AccountsRepository.CIPHER_SALT_LENGTH, b64)
 
-	fun createAccount(account: TestAccount, database: SqliteTestDatabase) {
+	fun createAccount(account: TestAccount, database: SharedPostgresTestDatabase) {
 		database.serverDatabase.accountQueries.createAccount(
 			email = account.email,
 			password_hash = account.passwordHash,
@@ -43,7 +43,7 @@ object E2eTestData {
 
 	fun createProject(
 		project: TestProject,
-		database: SqliteTestDatabase,
+		database: SharedPostgresTestDatabase,
 	) {
 		database.serverDatabase.projectQueries.createProject(
 			userId = project.userId,
@@ -56,7 +56,7 @@ object E2eTestData {
 	fun addDeletedProject(
 		userId: Long,
 		uuid: Uuid,
-		database: SqliteTestDatabase
+		database: SharedPostgresTestDatabase
 	) {
 		database.serverDatabase.deletedProjectQueries.addDeletedProject(
 			userId = userId,
@@ -69,7 +69,7 @@ object E2eTestData {
 		userId: Long,
 		installId: String,
 		expires: Instant = Clock.System.now() + 30.days,
-		database: SqliteTestDatabase,
+		database: SharedPostgresTestDatabase,
 		tokenHasher: TokenHasher,
 	): Token {
 		val plainAuthToken = tokenGenerator.generateToken()
@@ -97,7 +97,7 @@ object E2eTestData {
 		userId: Long,
 		projectId: Long,
 		entity: ApiProjectEntity,
-		testDatabase: SqliteTestDatabase,
+		testDatabase: SharedPostgresTestDatabase,
 		contentEncryptor: ContentEncryptor,
 	) {
 		val cipherSecret = testDatabase.serverDatabase.accountQueries
@@ -123,7 +123,7 @@ object E2eTestData {
 		id: Long,
 		userId: Long,
 		projectId: Long,
-		testDatabase: SqliteTestDatabase,
+		testDatabase: SharedPostgresTestDatabase,
 	) {
 		testDatabase.serverDatabase.deletedEntityQueries.markEntityDeleted(
 			userId = userId,

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
@@ -56,7 +56,7 @@ abstract class EndToEndTest {
 	protected var serverPort: Int = 0
 		private set
 	private lateinit var client: HttpClient
-	private lateinit var testDatabase: SqliteTestDatabase
+	private lateinit var testDatabase: SharedPostgresTestDatabase
 	private lateinit var base64: Base64
 	private lateinit var contentEncryptor: AesGcmContentEncryptor
 	private lateinit var tokenHasher: TokenHasher
@@ -90,7 +90,7 @@ abstract class EndToEndTest {
 			SimpleFileBasedAesGcmKeyProvider(base64),
 			secureRandom,
 		)
-		testDatabase = SqliteTestDatabase()
+		testDatabase = SharedPostgresTestDatabase()
 		testDatabase.initialize()
 
 		client = HttpClient {

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/EndToEndTest.kt
@@ -42,7 +42,12 @@ import kotlin.io.encoding.Base64
  */
 abstract class EndToEndTest {
 
-	protected lateinit var fileSystem: FakeFileSystem
+	/**
+	 * Storage for both the server under test and anything the test drives against it. Wrapped in
+	 * [SynchronizedFileSystem] because the underlying fake is shared across the test thread, the
+	 * server's Jetty threads and any client the test spins up, and it is not thread-safe.
+	 */
+	protected lateinit var fileSystem: FileSystem
 	private lateinit var server: EmbeddedServer<*, *>
 	private val taskRegistry = RecurringTaskRegistry()
 
@@ -68,7 +73,7 @@ abstract class EndToEndTest {
 
 	@BeforeEach
 	open fun setup() {
-		fileSystem = FakeFileSystem()
+		fileSystem = SynchronizedFileSystem(FakeFileSystem())
 		base64 = createTokenBase64()
 		val secureRandom = SecureRandom()
 		val serverSecretManager = ServerSecretManager(fileSystem, secureRandom)

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/SharedPostgresTestDatabase.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/SharedPostgresTestDatabase.kt
@@ -13,8 +13,13 @@ import java.time.Duration
  * Test database backed by a single, process-wide Zonky embedded Postgres
  * shared across every test in the JVM. The schema is created once for the
  * whole JVM; each instance just truncates the user tables to start clean.
+ *
+ * That truncate is the only isolation boundary, so it holds only while nothing
+ * else writes. Anything a test starts that can write on its own schedule — a
+ * background job, a detached coroutine — must be shut down before the test ends,
+ * or it will corrupt whichever test is running when it next fires.
  */
-class SqliteTestDatabase : Database {
+class SharedPostgresTestDatabase : Database {
 	private lateinit var _driver: SqlDriver
 	private lateinit var _serverDatabase: ServerDatabase
 	private var initialized = false
@@ -40,7 +45,7 @@ class SqliteTestDatabase : Database {
 
 	override fun close() {
 		// No-op. The shared embedded postgres outlives any single
-		// SqliteTestDatabase; it is shut down by SharedTestPostgres's JVM hook.
+		// SharedPostgresTestDatabase; it is shut down by SharedTestPostgres's JVM hook.
 	}
 }
 

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/SynchronizedFileSystem.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/SynchronizedFileSystem.kt
@@ -1,0 +1,93 @@
+package com.darkrockstudios.apps.hammer.e2e.util
+
+import okio.Buffer
+import okio.FileHandle
+import okio.FileMetadata
+import okio.FileSystem
+import okio.ForwardingFileSystem
+import okio.Path
+import okio.Sink
+import okio.Source
+import okio.Timeout
+
+/**
+ * Serializes every access to a [FileSystem] that more than one thread can touch.
+ *
+ * [okio.fakefilesystem.FakeFileSystem] is not thread-safe: it tracks open files in a plain
+ * `ArrayList`, so an open on one thread while another iterates that list throws
+ * `ConcurrentModificationException`. In an end-to-end test the fake is shared by the test thread,
+ * the client's dispatcher threads and the server's Jetty threads, and that collision surfaces as a
+ * failed sync in whichever test is unlucky.
+ *
+ * The lock covers the returned [Source], [Sink] and [FileHandle] too — the fake mutates its open-file
+ * list when those close, not only when they open.
+ */
+class SynchronizedFileSystem(delegate: FileSystem) : ForwardingFileSystem(delegate) {
+
+	private val lock = Any()
+
+	override fun canonicalize(path: Path): Path = synchronized(lock) { super.canonicalize(path) }
+
+	override fun metadataOrNull(path: Path): FileMetadata? = synchronized(lock) { super.metadataOrNull(path) }
+
+	override fun list(dir: Path): List<Path> = synchronized(lock) { super.list(dir) }
+
+	override fun listOrNull(dir: Path): List<Path>? = synchronized(lock) { super.listOrNull(dir) }
+
+	override fun openReadOnly(file: Path): FileHandle =
+		synchronized(lock) { LockedFileHandle(super.openReadOnly(file), readWrite = false) }
+
+	override fun openReadWrite(file: Path, mustCreate: Boolean, mustExist: Boolean): FileHandle =
+		synchronized(lock) {
+			LockedFileHandle(super.openReadWrite(file, mustCreate, mustExist), readWrite = true)
+		}
+
+	override fun source(file: Path): Source = synchronized(lock) { LockedSource(super.source(file)) }
+
+	override fun sink(file: Path, mustCreate: Boolean): Sink =
+		synchronized(lock) { LockedSink(super.sink(file, mustCreate)) }
+
+	override fun appendingSink(file: Path, mustExist: Boolean): Sink =
+		synchronized(lock) { LockedSink(super.appendingSink(file, mustExist)) }
+
+	override fun createDirectory(dir: Path, mustCreate: Boolean) =
+		synchronized(lock) { super.createDirectory(dir, mustCreate) }
+
+	override fun atomicMove(source: Path, target: Path) = synchronized(lock) { super.atomicMove(source, target) }
+
+	override fun delete(path: Path, mustExist: Boolean) = synchronized(lock) { super.delete(path, mustExist) }
+
+	override fun createSymlink(source: Path, target: Path) = synchronized(lock) { super.createSymlink(source, target) }
+
+	private inner class LockedSource(private val delegate: Source) : Source {
+		override fun read(sink: Buffer, byteCount: Long): Long = synchronized(lock) { delegate.read(sink, byteCount) }
+		override fun timeout(): Timeout = delegate.timeout()
+		override fun close() = synchronized(lock) { delegate.close() }
+	}
+
+	private inner class LockedSink(private val delegate: Sink) : Sink {
+		override fun write(source: Buffer, byteCount: Long) = synchronized(lock) { delegate.write(source, byteCount) }
+		override fun flush() = synchronized(lock) { delegate.flush() }
+		override fun timeout(): Timeout = delegate.timeout()
+		override fun close() = synchronized(lock) { delegate.close() }
+	}
+
+	private inner class LockedFileHandle(
+		private val delegate: FileHandle,
+		readWrite: Boolean,
+	) : FileHandle(readWrite) {
+		override fun protectedSize(): Long = synchronized(lock) { delegate.size() }
+
+		override fun protectedRead(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int): Int =
+			synchronized(lock) { delegate.read(fileOffset, array, arrayOffset, byteCount) }
+
+		override fun protectedWrite(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int) =
+			synchronized(lock) { delegate.write(fileOffset, array, arrayOffset, byteCount) }
+
+		override fun protectedFlush() = synchronized(lock) { delegate.flush() }
+
+		override fun protectedResize(size: Long) = synchronized(lock) { delegate.resize(size) }
+
+		override fun protectedClose() = synchronized(lock) { delegate.close() }
+	}
+}


### PR DESCRIPTION
Follow-up to #765. Pure rename, no behaviour change.

The class is backed by a Zonky embedded Postgres, not SQLite. Worse than being wrong, the name gave no hint that an instance is a handle onto *one process-wide database shared by every test in the JVM*, whose only isolation is a `TRUNCATE` in `initialize()`. That misreading is part of why the leaked-background-job bug fixed in #765 stayed hidden.

- `SqliteTestDatabase` → `SharedPostgresTestDatabase`, file renamed to match (35 files, plus one stale comment in `server/build.gradle.kts`).
- KDoc now states the hazard directly: the truncate is the only isolation boundary, so anything that can write on its own schedule must be shut down before a test ends.

## Verification

- `./gradlew :server:test` — 967 tests, 0 failures.
- `./gradlew :integrationTests:compileTestKotlin` — green (that module consumes these testFixtures).
