### PR TITLE
Fix release jobs failing with 403 by granting contents:write

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -143,6 +143,8 @@ jobs:
   linux:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -252,6 +254,8 @@ jobs:
   macos:
     needs: tests
     runs-on: macos-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -335,6 +339,8 @@ jobs:
   server:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -395,6 +401,8 @@ jobs:
   android:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -568,6 +576,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ windows, linux, macos, android, server, snap, flatpak ]
     if: success()
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The linux, macos, server, android, and set-release-body jobs in the
release workflow were missing a `permissions: contents: write` block.
With the repository's default read-only GITHUB_TOKEN, the
ncipollo/release-action step in those jobs failed with
"Error 403: Resource not accessible by integration" when trying to
create/update the release.

The windows, snap, and flatpak jobs already declared this permission
and succeeded, which is why only some jobs failed. Add the same block
to the remaining jobs so every release-creating job can write to the
release.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HtaZqYaJ1xDUJJLKvFG3jJ