### PR TITLE
Fix Mac App Store publish hanging forever on build processing

### DIFF
--- a/.github/scripts/discord-release-message.sh
+++ b/.github/scripts/discord-release-message.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Builds the Discord announcement `content` for a release and prints it to
+# stdout. Shared by the automated notify job (publish-release.yml) and the
+# manual announcer (announce-release.yml) so the token catalog, message format,
+# and length handling live in exactly one place and can't drift apart.
+#
+# Required env:
+#   TAG           - the release tag (may carry a +suffix for subset releases)
+#   RELEASE_NAME  - release title
+#   RELEASE_URL   - release html_url
+#   RELEASE_BODY  - release body / changelog
+set -euo pipefail
+
+# Tokens → human display names for the Discord audience. Keep in sync with the
+# Platform token catalog; this is the single source for release messaging.
+to_display() {
+  case "$1" in
+    google-play)   echo "Google Play" ;;
+    fdroid)        echo "F-Droid" ;;
+    snap)          echo "Snap" ;;
+    ms-store)      echo "MS Store" ;;
+    mac-app-store) echo "Mac App Store" ;;
+    ios-app-store) echo "iOS App Store" ;;
+    server)        echo "Server" ;;
+    *)             echo "$1" ;;
+  esac
+}
+
+# Subset releases carry a +token(+token…) suffix; name them in a header line.
+header=""
+if [[ "${TAG:-}" == *+* ]]; then
+  pretty=""
+  for token in $(echo "${TAG#*+}" | tr '+' ' '); do
+    display="$(to_display "$token")"
+    if [ -z "$pretty" ]; then pretty="$display"; else pretty="$pretty, $display"; fi
+  done
+  header="🔧 Patch release — ${pretty} only"$'\n'
+fi
+
+content="$(printf '%s**New release:** %s\n**Download Here:** %s\n\n**Changelog:**\n%s' \
+  "$header" "${RELEASE_NAME:-}" "${RELEASE_URL:-}" "${RELEASE_BODY:-}")"
+
+# Discord caps webhook content at 2000 characters. Trim by Unicode codepoint
+# with jq (locale-independent, and never splits a multibyte character) rather
+# than eating a 400 from the API.
+printf '%s' "$content" | jq -Rrs 'if length > 2000 then .[0:1997] + "..." else . end'

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -1,0 +1,72 @@
+name: Announce Release
+# Manually post a release's Discord announcement. The automated `notify` job in
+# publish-release.yml is skipped whenever the publish run is cancelled or a
+# store job fails (its `if: !cancelled() && !failure()` gate). This lets you
+# send the announcement after the fact — for a given tag — without re-running
+# the publish jobs (which would re-upload to every store).
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to announce (e.g. v3.7.0)'
+        type: string
+        required: true
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Send Discord announcement
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # Tokens → human display names for the Discord audience. Mirrors the
+          # scope header in publish-release.yml so patch releases read the same.
+          to_display() {
+            case "$1" in
+              google-play)   echo "Google Play" ;;
+              fdroid)        echo "F-Droid" ;;
+              snap)          echo "Snap" ;;
+              ms-store)      echo "MS Store" ;;
+              mac-app-store) echo "Mac App Store" ;;
+              ios-app-store) echo "iOS App Store" ;;
+              server)        echo "Server" ;;
+              *)             echo "$1" ;;
+            esac
+          }
+
+          header=""
+          if [[ "$TAG" == *+* ]]; then
+            pretty=""
+            for token in $(echo "${TAG#*+}" | tr '+' ' '); do
+              display=$(to_display "$token")
+              if [ -z "$pretty" ]; then pretty="$display"; else pretty="$pretty, $display"; fi
+            done
+            header="🔧 Patch release — ${pretty} only"$'\n'
+          fi
+
+          # Pull the release metadata for the tag (name/body/url) so the message
+          # matches the automated one, which templates off the release payload.
+          release_json=$(gh api "repos/$REPO/releases/tags/$TAG")
+          name=$(echo "$release_json" | jq -r '.name // .tag_name')
+          url=$(echo "$release_json" | jq -r '.html_url')
+          body=$(echo "$release_json" | jq -r '.body // ""')
+
+          content=$(printf '%s**New release:** %s\n**Download Here:** %s\n\n**Changelog:**\n%s' \
+            "$header" "$name" "$url" "$body")
+
+          # Discord caps webhook content at 2000 chars; trim the changelog if a
+          # long body would push us over, rather than eating a 400 from Discord.
+          if [ "${#content}" -gt 2000 ]; then
+            content="${content:0:1997}..."
+          fi
+
+          jq -n --arg content "$content" '{content: $content}' \
+            | curl -fsSL -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -18,6 +18,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
       - name: Send Discord announcement
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
@@ -27,46 +30,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Tokens → human display names for the Discord audience. Mirrors the
-          # scope header in publish-release.yml so patch releases read the same.
-          to_display() {
-            case "$1" in
-              google-play)   echo "Google Play" ;;
-              fdroid)        echo "F-Droid" ;;
-              snap)          echo "Snap" ;;
-              ms-store)      echo "MS Store" ;;
-              mac-app-store) echo "Mac App Store" ;;
-              ios-app-store) echo "iOS App Store" ;;
-              server)        echo "Server" ;;
-              *)             echo "$1" ;;
-            esac
-          }
+          # `gh release view` takes the tag as an argument and encodes it for us,
+          # so tags carrying a '+' subset suffix resolve correctly.
+          release_json="$(gh release view "$TAG" --repo "$REPO" --json name,tagName,body,url)"
+          RELEASE_NAME="$(echo "$release_json" | jq -r 'if (.name // "") == "" then .tagName else .name end')"
+          RELEASE_URL="$(echo "$release_json" | jq -r '.url')"
+          RELEASE_BODY="$(echo "$release_json" | jq -r '.body // ""')"
+          export RELEASE_NAME RELEASE_URL RELEASE_BODY
 
-          header=""
-          if [[ "$TAG" == *+* ]]; then
-            pretty=""
-            for token in $(echo "${TAG#*+}" | tr '+' ' '); do
-              display=$(to_display "$token")
-              if [ -z "$pretty" ]; then pretty="$display"; else pretty="$pretty, $display"; fi
-            done
-            header="🔧 Patch release — ${pretty} only"$'\n'
-          fi
-
-          # Pull the release metadata for the tag (name/body/url) so the message
-          # matches the automated one, which templates off the release payload.
-          release_json=$(gh api "repos/$REPO/releases/tags/$TAG")
-          name=$(echo "$release_json" | jq -r '.name // .tag_name')
-          url=$(echo "$release_json" | jq -r '.html_url')
-          body=$(echo "$release_json" | jq -r '.body // ""')
-
-          content=$(printf '%s**New release:** %s\n**Download Here:** %s\n\n**Changelog:**\n%s' \
-            "$header" "$name" "$url" "$body")
-
-          # Discord caps webhook content at 2000 chars; trim the changelog if a
-          # long body would push us over, rather than eating a 400 from Discord.
-          if [ "${#content}" -gt 2000 ]; then
-            content="${content:0:1997}..."
-          fi
-
+          content="$(bash .github/scripts/discord-release-message.sh)"
           jq -n --arg content "$content" '{content: $content}' \
             | curl -fsSL -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"

--- a/.github/workflows/publish-ios-app-store.yml
+++ b/.github/workflows/publish-ios-app-store.yml
@@ -18,6 +18,10 @@ on:
 jobs:
   publish-ios-app-store:
     runs-on: macos-latest
+    # Backstop against a hung publish holding an expensive macOS runner for the
+    # 6h default. A healthy release fits well within this; the fastlane build
+    # processing wait is bounded tighter still.
+    timeout-minutes: 120
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish-mac-app-store.yml
+++ b/.github/workflows/publish-mac-app-store.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   publish-mac-app-store:
     runs-on: macos-latest
+    # Backstop against a hung publish holding an expensive macOS runner for the
+    # 6h default. A healthy release (build + upload + processing + submit) fits
+    # well within this; the fastlane processing wait is bounded tighter still.
+    timeout-minutes: 120
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish-mac-app-store.yml
+++ b/.github/workflows/publish-mac-app-store.yml
@@ -1,6 +1,18 @@
 name: Publish — Mac App Store
 on:
   workflow_dispatch:
+    inputs:
+      lane:
+        description: 'Fastlane lane to run'
+        type: choice
+        default: desktop_release
+        options:
+          - desktop_release
+          - desktop_submit
+      build_number:
+        description: 'desktop_submit only: build to submit (defaults to latest processed)'
+        type: string
+        required: false
   workflow_call:
 
 jobs:
@@ -82,10 +94,20 @@ jobs:
           printf '%s' "$API_KEY_P8" > desktop/secrets/AuthKey_F8BSZ7LC8Q.p8
 
       - name: Publish to App Store 🍎
-        # Builds, uploads, waits for processing, submits for review, and
-        # auto-releases on approval. Waiting for build processing can hold the
-        # runner for several minutes before the submit step.
-        run: bundle exec fastlane mac desktop_release
+        # desktop_release builds, uploads, waits for processing, submits for
+        # review, and auto-releases on approval. desktop_submit skips the build
+        # and submits an already-uploaded, already-processed build — use it to
+        # finish a stuck submit without a rebuild. workflow_call (the release
+        # orchestrator) has no inputs, so it falls back to desktop_release.
+        env:
+          LANE: ${{ inputs.lane || 'desktop_release' }}
+          SUBMIT_BUILD_NUMBER: ${{ inputs.build_number }}
+        run: |
+          if [ "$LANE" = "desktop_submit" ] && [ -n "$SUBMIT_BUILD_NUMBER" ]; then
+            bundle exec fastlane mac desktop_submit build_number:"$SUBMIT_BUILD_NUMBER"
+          else
+            bundle exec fastlane mac "$LANE"
+          fi
 
       - name: Upload Gradle problems report on failure
         if: failure()

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -53,51 +53,22 @@ jobs:
     if: ${{ !cancelled() && !contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Compute scope header
-        id: scope
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-        run: |
-          # Tokens → human display names for the Discord audience.
-          to_display() {
-            case "$1" in
-              google-play)   echo "Google Play" ;;
-              fdroid)        echo "F-Droid" ;;
-              snap)          echo "Snap" ;;
-              ms-store)      echo "MS Store" ;;
-              mac-app-store) echo "Mac App Store" ;;
-              ios-app-store) echo "iOS App Store" ;;
-              server)        echo "Server" ;;
-              *)             echo "$1" ;;
-            esac
-          }
-
-          # Emitted as a multi-line $GITHUB_OUTPUT (heredoc) so the trailing
-          # newline survives YAML parsing and reaches Discord as a real line
-          # break. Single-line `echo "header=...\\n"` would arrive as a
-          # literal backslash-n because the substitution happens after YAML
-          # has already finished interpreting escape sequences.
-          if [[ "$TAG" == *+* ]]; then
-            PRETTY=""
-            for token in $(echo "${TAG#*+}" | tr '+' ' '); do
-              display=$(to_display "$token")
-              if [ -z "$PRETTY" ]; then PRETTY="$display"; else PRETTY="$PRETTY, $display"; fi
-            done
-            {
-              echo "header<<HEADER_EOF"
-              echo "🔧 Patch release — ${PRETTY} only"
-              echo "HEADER_EOF"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "header<<HEADER_EOF"
-              echo "HEADER_EOF"
-            } >> "$GITHUB_OUTPUT"
-          fi
+      - name: Checkout code
+        uses: actions/checkout@v7
 
       - name: Discord notification
+        # Message is built by the shared script so its token catalog, format,
+        # and length handling stay identical to the manual announcer
+        # (announce-release.yml). Untrusted release fields are passed via env,
+        # never interpolated into the run script.
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # 0.4.0
-        with:
-          args: "${{ steps.scope.outputs.header }}**New release:** {{ EVENT_PAYLOAD.release.name }}\n**Download Here:** {{ EVENT_PAYLOAD.release.html_url }}\n\n**Changelog:**\n{{ EVENT_PAYLOAD.release.body }}"
+          TAG: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
+          content="$(bash .github/scripts/discord-release-message.sh)"
+          jq -n --arg content "$content" '{content: $content}' \
+            | curl -fsSL -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -101,22 +101,40 @@ end
 platform :mac do
   desc "Build a sandboxed .pkg and upload to TestFlight only (beta; does not submit for review)."
   lane :desktop_testflight do
-    desktop_build_and_upload(wait: false)
+    desktop_build_and_upload
   end
 
-  desc "Full Mac App Store release: build, upload, wait for processing, submit for review, auto-release on approval."
+  desc "Full Mac App Store release: build, upload, submit for review, auto-release on approval."
   lane :desktop_release do
-    build_number = desktop_build_and_upload(wait: true)
+    build_number = desktop_build_and_upload
     desktop_submit(build_number: build_number)
   end
 
-  desc "Submit an already-processed TestFlight build for review + auto-release. build_number defaults to latest."
+  desc "Submit an already-uploaded build for review + auto-release. build_number defaults to the latest uploaded."
   lane :desktop_submit do |options|
+    api_key = appstore_api_key
+
+    # deliver only skips its build-processing wait when handed an explicit build
+    # number — it then selects that build directly. A nil/"latest" build number
+    # sends deliver into FastlaneCore::BuildWatcher, which hangs forever on macOS
+    # (the App Store Connect API never reports a macOS build's processingState as
+    # complete). So always resolve a concrete build number ourselves.
+    build_number = options[:build_number]
+    if build_number.nil? || build_number.to_s.empty?
+      build_number = latest_testflight_build_number(
+        api_key: api_key,
+        app_identifier: "com.darkrockstudios.apps.hammer",
+        platform: "osx",
+        initial_build_number: 0,
+      ).to_s
+    end
+
     params = {
-      api_key: appstore_api_key,
+      api_key: api_key,
       app_identifier: "com.darkrockstudios.apps.hammer",
       platform: "osx",
       app_version: app_marketing_version,
+      build_number: build_number,
       skip_binary_upload: true,
       skip_screenshots: true,
       metadata_path: "fastlane/metadata/osx",
@@ -125,14 +143,17 @@ platform :mac do
       run_precheck_before_submit: false,
       force: true,
     }
-    params[:build_number] = options[:build_number] if options[:build_number]
-    deliver_with_retry(params)
+    # In the release flow this runs right after upload, so the build can take a
+    # few minutes to become queryable/submittable — retry generously. deliver
+    # returns as soon as it succeeds, and submission_landed? guards false
+    # negatives; the retry budget stays well under the job's timeout-minutes.
+    deliver_with_retry(params, attempts: 30)
   end
 
   # Build number is the latest in TestFlight + 1 — per-platform, always above
   # what's shipped, and self-correcting on re-runs. Set BUILD_NUMBER to override.
   # Returns the build number so the release lane can submit that exact build.
-  private_lane :desktop_build_and_upload do |options|
+  private_lane :desktop_build_and_upload do
     api_key = appstore_api_key
 
     build_number = ENV["BUILD_NUMBER"]
@@ -153,19 +174,19 @@ platform :mac do
     UI.user_error!("Build produced no .pkg") unless pkg_path
     UI.message("Uploading #{pkg_path}")
 
-    # When releasing we must wait for App Store Connect to finish processing the
-    # build before deliver can attach it to the version and submit it. Bound that
-    # wait: macOS processing is routinely slower/flakier than iOS, and the wait
-    # loop is otherwise unbounded — a stuck build hangs the runner until the job's
-    # 6h ceiling. On timeout the lane fails fast; re-run `desktop_submit` once the
-    # build finishes processing to submit it without rebuilding.
+    # Do NOT wait for App Store Connect to "finish processing" the build: macOS
+    # builds' processingState never reliably flips to VALID via the App Store
+    # Connect API, so fastlane's BuildWatcher polls "Waiting for App Store Connect
+    # to finish processing…" forever even though the upload succeeded and the
+    # build is usable. desktop_release submits by explicit build number, and
+    # deliver's select_build looks that up directly (no processing poll) — so
+    # there is nothing to wait for here.
     upload_to_testflight(
       api_key: api_key,
       app_identifier: "com.darkrockstudios.apps.hammer",
       app_platform: "osx",
       pkg: pkg_path,
-      skip_waiting_for_build_processing: !options[:wait],
-      wait_processing_timeout_duration: 5400,
+      skip_waiting_for_build_processing: true,
     )
 
     build_number

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -270,17 +270,16 @@ platform :ios do
     )
 
     # When releasing we must wait for App Store Connect to finish processing the
-    # build before deliver can attach it to the version and submit it. Bound that
-    # wait so a stuck build fails fast instead of hanging the runner until the
-    # job's 6h ceiling. On timeout, re-run `ios_submit` once the build finishes
-    # processing to submit it without rebuilding.
+    # build before deliver can attach it to the version and submit it. Unlike
+    # macOS, iOS builds' processingState reliably completes, so this returns
+    # normally; the job's timeout-minutes caps any pathological stall without
+    # cutting off a legitimately slow processing run at a tighter deadline.
     upload_to_testflight(
       api_key: api_key,
       app_identifier: "com.darkrockstudios.apps.hammer.ios",
       app_platform: "ios",
       ipa: lane_context[SharedValues::IPA_OUTPUT_PATH],
       skip_waiting_for_build_processing: !options[:wait],
-      wait_processing_timeout_duration: 5400,
     )
 
     build_number

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -154,13 +154,18 @@ platform :mac do
     UI.message("Uploading #{pkg_path}")
 
     # When releasing we must wait for App Store Connect to finish processing the
-    # build before deliver can attach it to the version and submit it.
+    # build before deliver can attach it to the version and submit it. Bound that
+    # wait: macOS processing is routinely slower/flakier than iOS, and the wait
+    # loop is otherwise unbounded — a stuck build hangs the runner until the job's
+    # 6h ceiling. On timeout the lane fails fast; re-run `desktop_submit` once the
+    # build finishes processing to submit it without rebuilding.
     upload_to_testflight(
       api_key: api_key,
       app_identifier: "com.darkrockstudios.apps.hammer",
       app_platform: "osx",
       pkg: pkg_path,
       skip_waiting_for_build_processing: !options[:wait],
+      wait_processing_timeout_duration: 5400,
     )
 
     build_number
@@ -244,13 +249,17 @@ platform :ios do
     )
 
     # When releasing we must wait for App Store Connect to finish processing the
-    # build before deliver can attach it to the version and submit it.
+    # build before deliver can attach it to the version and submit it. Bound that
+    # wait so a stuck build fails fast instead of hanging the runner until the
+    # job's 6h ceiling. On timeout, re-run `ios_submit` once the build finishes
+    # processing to submit it without rebuilding.
     upload_to_testflight(
       api_key: api_key,
       app_identifier: "com.darkrockstudios.apps.hammer.ios",
       app_platform: "ios",
       ipa: lane_context[SharedValues::IPA_OUTPUT_PATH],
       skip_waiting_for_build_processing: !options[:wait],
+      wait_processing_timeout_duration: 5400,
     )
 
     build_number


### PR DESCRIPTION
## Problem

The Mac App Store publish job hangs indefinitely on `Publish to App Store`, spinning until Actions' 6h default kills the (10×-billed) macOS runner:

```
Waiting for App Store Connect to finish processing the new build (3.7.0 - 24) for MAC_OS
```

## Root cause

The release lane called `upload_to_testflight` with the build-processing wait enabled. That wait lives in `FastlaneCore::BuildWatcher`, which polls each build's `processingState` until it reads complete. For **macOS** builds the App Store Connect API never reliably reports `processingState` as `VALID`, so it polls forever — even though the upload succeeded and the build is usable (ASC emails "completed processing"). iOS is unaffected because its `processingState` does flip.

Crucially, deliver's `select_build` only avoids the same hang when handed an **explicit build number** (it then looks the build up directly); a `nil`/`"latest"` number routes it back into `BuildWatcher`.

## Fix

- **`fastlane/Fastfile` (mac):** `skip_waiting_for_build_processing: true` on the upload — never block on the perpetually-incomplete macOS processing state. `desktop_submit` always resolves a concrete build number so deliver takes the direct-lookup path and never re-enters `BuildWatcher`; the retry budget is widened for the release flow.
- **`timeout-minutes: 120`** on both App Store jobs as a hard cost backstop.
- **`desktop_submit` dispatch lane** on the Mac workflow (mirrors iOS) — submit an already-uploaded build without a rebuild.
- **`announce-release.yml`** + shared `.github/scripts/discord-release-message.sh` — post a release's Discord message for a given tag when the automated `notify` job was skipped (e.g. a cancelled run). `notify` now uses the same shared script, so the two can't drift.
- iOS keeps its working wait-based flow.

## Validation

Ran `desktop_submit build_number:24` against the stuck v3.7.0 build: deliver took the `Selecting existing build-number: 24` path and `Successfully submitted the app for review!` in ~26s — confirming the ASC submit API accepts a macOS build by number, so the stuck `processingState` only ever blocked fastlane's cosmetic wait, never the submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)