### PR TITLE
Stop the E2E teardown racing the project-scope flush

### DIFF
--- a/android/src/androidTest/kotlin/EditorTestHarness.kt
+++ b/android/src/androidTest/kotlin/EditorTestHarness.kt
@@ -15,6 +15,7 @@ import com.darkrockstudios.apps.hammer.common.data.ClientResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import org.koin.java.KoinJavaComponent.getKoin
+import java.io.IOException
 
 /**
  * Shared helpers for editor instrumented tests: seed a project through the real Koin graph,
@@ -43,8 +44,37 @@ object EditorTestHarness {
 		scenario.onActivity { it.finish() }
 		InstrumentationRegistry.getInstrumentation().waitForIdleSync()
 		scenario.close()
-		repository().deleteProject(projectDef)
+		deleteProjectWhenSettled(projectDef)
 	}
+
+	/**
+	 * Delete the project directory, tolerating writes that are still landing.
+	 *
+	 * finish() and waitForIdleSync() only drain the main thread, but the project-scope close
+	 * flushes scene buffers on IO coroutines after that. A straggler write can land between
+	 * deleteRecursively emptying the directory and removing it, so the final rmdir fails with
+	 * "failed to delete <project dir>". Each retry deletes whatever reappeared, so this
+	 * converges as soon as the flushes stop.
+	 */
+	fun deleteProjectWhenSettled(projectDef: ProjectDef, timeoutMillis: Long = 15_000L) {
+		val deadline = SystemClock.uptimeMillis() + timeoutMillis
+		var lastFailure: IOException? = null
+		while (SystemClock.uptimeMillis() < deadline) {
+			try {
+				repository().deleteProject(projectDef)
+				return
+			} catch (e: IOException) {
+				lastFailure = e
+				SystemClock.sleep(DELETE_RETRY_INTERVAL_MS)
+			}
+		}
+		throw AssertionError(
+			"Project directory was still being written to ${timeoutMillis}ms after teardown began",
+			lastFailure,
+		)
+	}
+
+	private const val DELETE_RETRY_INTERVAL_MS = 100L
 }
 
 /** Matches nodes whose testTag starts with [prefix] - for list items keyed by an unknown id. */

--- a/android/src/androidTest/kotlin/ProjectLifecycleTest.kt
+++ b/android/src/androidTest/kotlin/ProjectLifecycleTest.kt
@@ -89,6 +89,6 @@ class ProjectLifecycleTest {
 	@After
 	fun deleteCreatedProject() {
 		val repository = getKoin().get<ProjectsRepository>()
-		repository.deleteProject(repository.getProjectDefinition(projectName))
+		EditorTestHarness.deleteProjectWhenSettled(repository.getProjectDefinition(projectName))
 	}
 }


### PR DESCRIPTION
Fixes the intermittent instrumented-test failure:

```
java.io.IOException: failed to delete
  /data/user/0/com.darkrockstudios.apps.hammer.android.dev/files/HammerProjects/E2E Smoke ...
  at okio.JvmSystemFileSystem.delete(JvmSystemFileSystem.kt:137)
```

## Cause

`EditorTestHarness.teardown` finishes the activity, calls `waitForIdleSync()`, then deletes
the project directory. But `waitForIdleSync()` only drains the **main thread**, while the
Koin project-scope close flushes scene buffers on IO coroutines afterwards.

So `deleteRecursively` empties the directory, a straggler write lands, and the final
directory removal fails with `ENOTEMPTY`. The error naming the *directory* rather than a
file is the tell: the children were deleted successfully, then something reappeared.

The existing `finish()` + `waitForIdleSync()` mitigation cannot close this, because there
is no signal to await for that scope close.

## Fix

Retry the delete until the flushes stop. Each attempt removes whatever reappeared, so it
converges as soon as writing ceases, normally on the first retry. It still fails loudly
after 15 seconds rather than masking a genuine leak.

`ProjectLifecycleTest` had its own inline delete and now uses the same helper, so all nine
E2E tests share one teardown path.

## Not just one test

This has been failing on `develop`, not only on feature branches, and across different
tests:

- run 30301880977: `ProjectLifecycleTest.createProjectThenOpenIt`
- run 30281793496 (on `develop`): `SceneEditorWorkflowTest.editSceneTextThenSave`

Same error both times, which is what pointed at the shared harness rather than any
individual test.

## Verification

Run locally against an emulator:

- the two previously-failing tests: 2/2 passed
- the full instrumented suite: 10/10 passed

Worth being straight about the limits: the race did not reproduce locally, so these runs
prove no regression rather than proving the flake is gone. The retry path may not have
been exercised at all. CI over time is the real confirmation.

## Related, not addressed here

`ProjectsRepository.deleteProject` does not catch this `IOException` either, so a user
deleting a project moments after closing it could hit the same race in the app. That is a
separate question about what the UI should do on a partial delete, and changing production
behaviour to cure a test flake seemed like the wrong order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqEGDLYm5ZoLiFNEJY7QpE
