### PR TITLE
Fix flaky iOS scene-editor save UI test

### DIFF
--- a/ios/iosUITests/HammerUITest.swift
+++ b/ios/iosUITests/HammerUITest.swift
@@ -164,21 +164,40 @@ class HammerUITest: XCTestCase {
     /// The save button lives in the top bar, and right after the edit that surfaces it its
     /// accessibility frame can be briefly *stale* — reported up under the status bar (a dead pixel)
     /// before the layout settles. A blind coordinate tap there does nothing, and repeatedly tapping
-    /// that dead spot can even scroll/navigate the app away. So only tap when the button is actually
-    /// hittable (settled), using a hit-tested `tap()` that re-resolves its real position; otherwise
-    /// wait for it to settle. Re-tap until it's gone, which also covers a dropped tap or a late IME
-    /// keystroke re-dirtying the buffer right after a save.
+    /// that dead spot can even scroll/navigate the app away. So never tap the stale frame: tap only
+    /// once the button has *settled*.
+    ///
+    /// `isHittable` is the fast settled-signal and the preferred path (a hit-tested `tap()`
+    /// re-resolves the real position). But under simulator/CI load it can never flip true within the
+    /// timeout, which would leave a purely-`isHittable`-gated loop waiting out the whole budget
+    /// without ever tapping. So fall back to a coordinate `tapCenter` once the frame is demonstrably
+    /// settled by geometry — fully below the status bar (ruling out the dead-pixel position) and
+    /// stable across two samples. Re-tap until it's gone, which also covers a dropped tap or a late
+    /// IME keystroke re-dirtying the buffer right after a save.
     func tapUntilGone(_ tag: String, timeout: TimeInterval = HammerUITest.defaultTimeout,
                       file: StaticString = #file, line: UInt = #line) {
         let el = waitFor(tag, timeout: timeout, file: file, line: line)
         let deadline = Date().addingTimeInterval(timeout)
+        var lastFrame = CGRect.null
         repeat {
             if !el.exists { return }
             if el.isHittable {
                 el.tap()
                 if poll({ !el.exists }, timeout: 3) { return }
             } else {
-                _ = poll({ el.isHittable || !el.exists }, timeout: 1)
+                // Geometry fallback for when `isHittable` never settles under load. A settled top-bar
+                // button sits fully below the status bar and holds a stable frame; the transient
+                // dead-pixel frame reads under the status bar and is discarded here.
+                let frame = el.frame
+                let statusBarMaxY = app.statusBars.firstMatch.frame.maxY
+                let settled = frame.height > 0 && frame.minY >= statusBarMaxY && frame == lastFrame
+                lastFrame = frame
+                if settled {
+                    tapCenter(el)
+                    if poll({ !el.exists }, timeout: 3) { return }
+                } else {
+                    _ = poll({ el.isHittable || !el.exists }, timeout: 0.5)
+                }
             }
         } while Date() < deadline
         XCTFail("Element still present after \(timeout)s: \(tag)", file: file, line: line)


### PR DESCRIPTION
## Problem

`SceneEditorWorkflowUITests.testEditSceneTextThenSave` flakes in CI (e.g. [run 30298567282](https://github.com/Darkrock-Studios/hammer-editor/actions/runs/30298567282)) with:

```
SceneEditorWorkflowUITests.swift:41: error: -[iosUITests.SceneEditorWorkflowUITests testEditSceneTextThenSave] : failed - Element still present after 20.0s: scene-editor-save
```

The failure is the final `tapUntilGone(Tag.sceneEditorSave)`. The save button is rendered only while the scene buffer is dirty (`EditorTopBar.kt`), and tapping it saves + clears the dirty flag, removing the button. `tapUntilGone` (added in #741) taps **only when `el.isHittable`**. Under simulator/CI load the top-bar button's accessibility frame can never settle to hittable within the 20s budget, so the loop waits out the entire timeout in its `else` branch without ever tapping — the save never fires and the button stays present.

## Fix

Keep #741's proven `isHittable` hit-tested fast path, and add a **geometry fallback** for when `isHittable` never settles: once the button's frame is demonstrably settled — fully below the status bar (ruling out the transient "dead-pixel under the status bar" position that #741 guarded against) and stable across two samples — tap it via the repo's standard `tapCenter`. This guarantees a tap eventually lands even when `isHittable` never flips true, while preserving the dead-pixel/scroll-away protection.

## Testing

- `xcodebuild build-for-testing -scheme iosUITests` succeeds.
- Change is confined to the test helper `HammerUITest.swift`; no app code affected.