### PR TITLE
Tell self-hosters when the server is not serving HTTPS

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_account_settings.xml
+++ b/common/src/commonMain/composeResources/values/strings_account_settings.xml
@@ -144,5 +144,6 @@
 	<string
 		name="server_error_connection_generic">Network error connecting to %1$s. Check your connection and try again.
 	</string>
+	<string name="server_error_tls">Could not make a secure connection to %1$s. Hammer only connects over HTTPS, so the server needs a valid TLS certificate of its own or a reverse proxy that provides one.</string>
 
 </resources>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
@@ -454,19 +454,28 @@ class AccountSettingsComponent(
 	}
 
 	companion object {
-		// regex to validate url with port number
-		private val urlWithPortRegex =
-			Regex("""^([a-z0-9]+\.)*([a-z0-9]+)(\.[a-z]+)(:[0-9]{1,5})?$""")
-		private val ipWithPortRegex = Regex("""^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?::\d+)?$""")
+		/** A host name or IPv4 address: dot-separated labels of letters, digits and inner hyphens. */
+		private val hostRegex =
+			Regex("""^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*$""")
 
 		fun validateUrl(url: String): Boolean {
-			return url.isNotBlank() && (urlWithPortRegex.matches(url) || ipWithPortRegex.matches(url))
+			if (url.isBlank()) return false
+
+			val host = url.substringBefore(':')
+			if (hostRegex.matches(host).not()) return false
+
+			if (url.contains(':')) {
+				val port = url.substringAfter(':').toIntOrNull() ?: return false
+				if (port !in 1..65535) return false
+			}
+
+			return true
 		}
 
 		fun cleanUpUrl(url: String): String {
 			var cleanUrl: String = url.trim()
-			cleanUrl = cleanUrl.removeSuffix("http://")
-			cleanUrl = cleanUrl.removeSuffix("https://")
+			cleanUrl = cleanUrl.removePrefix("http://")
+			cleanUrl = cleanUrl.removePrefix("https://")
 			cleanUrl = cleanUrl.removeSuffix("/")
 
 			return cleanUrl

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
@@ -16,6 +16,7 @@ import com.darkrockstudios.apps.hammer.server_error_connection_generic
 import com.darkrockstudios.apps.hammer.server_error_connection_timeout
 import com.darkrockstudios.apps.hammer.server_error_dns
 import com.darkrockstudios.apps.hammer.server_error_timeout
+import com.darkrockstudios.apps.hammer.server_error_tls
 import com.darkrockstudios.apps.hammer.sync_general_error
 import com.darkrockstudios.apps.hammer.sync_unauthorized
 import io.github.aakira.napier.Napier
@@ -151,17 +152,30 @@ abstract class Api(
 				)
 			)
 		} catch (e: IOException) {
-			// Generic network error (connection refused, SSL errors, etc.)
-			Napier.e("Network Error", e)
-			Result.failure(
-				HttpFailureException(
-					statusCode = outerResponse?.status ?: HttpStatusCode.RequestTimeout,
-					error = HttpResponseError(
-						error = e.message ?: "Network Error",
-						displayMessage = strRes.get(Res.string.server_error_connection_generic, path),
+			if (e.isTlsFailure()) {
+				Napier.e("TLS Error", e)
+				Result.failure(
+					HttpFailureException(
+						statusCode = outerResponse?.status ?: HttpStatusCode.BadGateway,
+						error = HttpResponseError(
+							error = e.message ?: "TLS Error",
+							displayMessage = strRes.get(Res.string.server_error_tls, server.url),
+						)
 					)
 				)
-			)
+			} else {
+				// Generic network error (connection refused, etc.)
+				Napier.e("Network Error", e)
+				Result.failure(
+					HttpFailureException(
+						statusCode = outerResponse?.status ?: HttpStatusCode.RequestTimeout,
+						error = HttpResponseError(
+							error = e.message ?: "Network Error",
+							displayMessage = strRes.get(Res.string.server_error_connection_generic, path),
+						)
+					)
+				)
+			}
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/TlsFailure.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/TlsFailure.kt
@@ -1,0 +1,13 @@
+package com.darkrockstudios.apps.hammer.common.server
+
+/**
+ * True when this throwable, or anything it wraps, is a TLS handshake or certificate failure.
+ *
+ * Clients only ever speak HTTPS, so this is what a server reachable only over plain HTTP looks
+ * like from the client side, and it needs a different message than a generic network error.
+ */
+expect fun Throwable.isTlsFailure(): Boolean
+
+/** Walks the `cause` chain, bounded so a self-referential or cyclic cause cannot spin forever. */
+internal fun Throwable.causeChain(): Sequence<Throwable> =
+	generateSequence(this) { throwable -> throwable.cause?.takeIf { it !== throwable } }.take(16)

--- a/common/src/desktopTest/kotlin/components/projectselection/ServerUrlValidationTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/ServerUrlValidationTest.kt
@@ -1,0 +1,91 @@
+package components.projectselection
+
+import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettingsComponent.Companion.cleanUpUrl
+import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettingsComponent.Companion.validateUrl
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ServerUrlValidationTest {
+
+	@Test
+	fun `a pasted http scheme is stripped`() {
+		assertEquals("192.168.1.50:8080", cleanUpUrl("http://192.168.1.50:8080"))
+	}
+
+	@Test
+	fun `a pasted https scheme is stripped`() {
+		assertEquals("hammer.example.com", cleanUpUrl("https://hammer.example.com"))
+	}
+
+	@Test
+	fun `surrounding whitespace and a trailing slash are stripped`() {
+		assertEquals("hammer.example.com", cleanUpUrl("  https://hammer.example.com/  "))
+	}
+
+	@Test
+	fun `a url with no scheme is left alone`() {
+		assertEquals("hammer.ink", cleanUpUrl("hammer.ink"))
+	}
+
+	@Test
+	fun `a cleaned pasted url validates`() {
+		assertTrue(validateUrl(cleanUpUrl("http://192.168.1.50:8080")))
+	}
+
+	@Test
+	fun `a domain with a port validates`() {
+		assertTrue(validateUrl("hammer.example.com:8080"))
+	}
+
+	@Test
+	fun `a bare lan hostname validates`() {
+		assertTrue(validateUrl("homeserver:8080"))
+	}
+
+	@Test
+	fun `a hostname with a hyphen validates`() {
+		assertTrue(validateUrl("home-server.lan:8080"))
+	}
+
+	@Test
+	fun `a mixed case hostname validates`() {
+		assertTrue(validateUrl("Hammer.Example.com"))
+	}
+
+	@Test
+	fun `an ip address validates`() {
+		assertTrue(validateUrl("192.168.1.50"))
+	}
+
+	@Test
+	fun `a blank url does not validate`() {
+		assertFalse(validateUrl("   "))
+	}
+
+	@Test
+	fun `a url still carrying its scheme does not validate`() {
+		assertFalse(validateUrl("http://hammer.example.com"))
+	}
+
+	@Test
+	fun `a url with a path does not validate`() {
+		assertFalse(validateUrl("hammer.example.com/sync"))
+	}
+
+	@Test
+	fun `a non numeric port does not validate`() {
+		assertFalse(validateUrl("hammer.example.com:port"))
+	}
+
+	@Test
+	fun `a port beyond the valid range does not validate`() {
+		assertFalse(validateUrl("hammer.example.com:99999"))
+	}
+
+	@Test
+	fun `a host with a trailing hyphen does not validate`() {
+		assertFalse(validateUrl("hammer-.example.com"))
+	}
+}

--- a/common/src/desktopTest/kotlin/server/ApiTlsFailureTest.kt
+++ b/common/src/desktopTest/kotlin/server/ApiTlsFailureTest.kt
@@ -1,0 +1,112 @@
+package server
+
+import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
+import com.darkrockstudios.apps.hammer.common.server.ServerAccountApi
+import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
+import com.darkrockstudios.apps.hammer.common.util.StrRes
+import com.darkrockstudios.apps.hammer.server_error_connection_generic
+import com.darkrockstudios.apps.hammer.server_error_tls
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.jetbrains.compose.resources.StringResource
+import org.junit.jupiter.api.BeforeEach
+import org.koin.dsl.module
+import utils.BaseTest
+import java.net.ConnectException
+import javax.net.ssl.SSLHandshakeException
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * A server reachable only over plain HTTP fails the client's TLS handshake, which needs to read as
+ * "this server isn't serving HTTPS" rather than as a generic connectivity problem.
+ */
+class ApiTlsFailureTest : BaseTest() {
+
+	private lateinit var globalSettingsStore: GlobalSettingsStore
+	private lateinit var strRes: RecordingStrRes
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+
+		strRes = RecordingStrRes()
+		globalSettingsStore = mockk(relaxed = true)
+		every { globalSettingsStore.serverSettings } returns ServerSettings(
+			url = "homeserver:8080",
+			email = "user@example.com",
+			userId = -1L,
+			bearerToken = null,
+			refreshToken = null,
+		)
+
+		setupKoin(
+			module {
+				single { DeviceLocaleResolver() }
+			}
+		)
+	}
+
+	private fun createApi(failure: Throwable): ServerAccountApi {
+		val client = HttpClient(MockEngine { throw failure }) {
+			install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+		}
+		return ServerAccountApi(client, globalSettingsStore, strRes)
+	}
+
+	@Test
+	fun `a handshake failure reports the server is not serving https`() = runTest {
+		val api = createApi(SSLHandshakeException("Remote host terminated the handshake"))
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertIs<HttpFailureException>(result.exceptionOrNull())
+		assertTrue(strRes.requested.contains(Res.string.server_error_tls))
+	}
+
+	@Test
+	fun `a wrapped handshake failure is still recognised`() = runTest {
+		val api = createApi(
+			java.io.IOException("request failed", SSLHandshakeException("unable to find valid certification path"))
+		)
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertIs<HttpFailureException>(result.exceptionOrNull())
+		assertTrue(strRes.requested.contains(Res.string.server_error_tls))
+	}
+
+	@Test
+	fun `an ordinary connection failure keeps the generic message`() = runTest {
+		val api = createApi(ConnectException("Connection refused"))
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertIs<HttpFailureException>(result.exceptionOrNull())
+		assertTrue(strRes.requested.contains(Res.string.server_error_connection_generic))
+	}
+}
+
+private class RecordingStrRes : StrRes {
+	val requested = mutableListOf<StringResource>()
+
+	override suspend fun get(str: StringResource): String {
+		requested += str
+		return "test"
+	}
+
+	override suspend fun get(str: StringResource, vararg args: Any): String {
+		requested += str
+		return "test"
+	}
+}

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/server/TlsFailure.ios.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/server/TlsFailure.ios.kt
@@ -1,0 +1,12 @@
+package com.darkrockstudios.apps.hammer.common.server
+
+/**
+ * NSURLSession surfaces TLS problems as an `NSError` whose localized description names the
+ * failure, which is all the Darwin engine carries through into the exception message.
+ */
+private val TLS_MARKERS = listOf("ssl", "tls", "certificate", "secure connection")
+
+actual fun Throwable.isTlsFailure(): Boolean = causeChain().any { throwable ->
+	val text = "${throwable::class.simpleName.orEmpty()} ${throwable.message.orEmpty()}"
+	TLS_MARKERS.any { marker -> text.contains(marker, ignoreCase = true) }
+}

--- a/common/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/common/server/TlsFailure.jvm.kt
+++ b/common/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/common/server/TlsFailure.jvm.kt
@@ -1,0 +1,5 @@
+package com.darkrockstudios.apps.hammer.common.server
+
+import javax.net.ssl.SSLException
+
+actual fun Throwable.isTlsFailure(): Boolean = causeChain().any { it is SSLException }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       # Loopback by default: this connector is plain HTTP, and published ports
       # bypass host firewall rules. Set HAMMER_HTTP_BIND=0.0.0.0 only if nothing
       # untrusted can reach the host. HAMMER_HTTP_PORT moves the host-side port.
+      #
+      # Clients only speak HTTPS and will not connect to this port. Terminate TLS
+      # at a reverse proxy in front of it, or configure sslCert and publish 443.
       - "${HAMMER_HTTP_BIND:-127.0.0.1}:${HAMMER_HTTP_PORT:-8080}:8080"
 
     # Uncomment alongside the postgres service below.

--- a/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
+++ b/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
@@ -32,8 +32,14 @@ docker run -d --name hammer-server \
   ghcr.io/darkrock-studios/hammer-editor/server:latest
 ```
 
-Then **download a client and create an account**. The first account created
-becomes the admin account.
+That gets the server running, but **a client cannot talk to it yet**. Hammer
+clients only speak HTTPS, and the container serves plain HTTP, so put TLS in
+front of it first: see [Networking](#networking) below. A client pointed at the
+cleartext port fails its TLS handshake and reports that it could not make a
+secure connection.
+
+Once TLS is in place, **download a client and create an account**. The first
+account created becomes the admin account.
 
 ## Networking
 
@@ -54,6 +60,18 @@ To change the host-side binding or port:
 ```bash
 HAMMER_HTTP_BIND=0.0.0.0 HAMMER_HTTP_PORT=8090 docker compose up -d
 ```
+
+### A client that will not connect
+
+If a client reports that it could not make a secure connection, it reached the
+cleartext port and got no TLS. Add a reverse proxy or a certificate as above.
+
+The server log is misleading here. A client's TLS handshake is rejected by the
+HTTP parser before any route runs, so nothing about it appears in the
+application log. What you will see instead are `UnsupportedProtocolVersionException`
+entries from your own browser or `curl` hitting `/api/...`, since only Hammer
+clients send the `X-Hammer-Protocol-Version` header. Those are unrelated to the
+client's failure.
 
 ### Do not set `bindHosts`
 

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -53,7 +53,10 @@ The Hammer server is a Java application that runs on Windows, Linux, and macOS.
 4. Run the server (_see platform-specific instructions below_)
 5. If everything worked, you should be able to access your server at your server's IP or at the host name you set in your config file and DNS configuration, such as:
    `http://example.com`
-6. **IMPORTANT!** You must now download one of the clients and create an account on the server. The first account
+6. **Set up HTTPS before going any further.** Clients only speak `https` and will not connect to a
+   plain HTTP server, so it needs either its own certificate or a reverse proxy holding one. See
+   [Setting up SSL](#setting-up-ssl-required-for-direct-connections).
+7. **IMPORTANT!** You must now download one of the clients and create an account on the server. The first account
    created will be the admin account.
 
 ## Network binding


### PR DESCRIPTION
Fixes #790.

## The bug

Clients are HTTPS-only (#743), but the Docker image serves plain HTTP, so a client pointed at a self-hosted container fails its TLS handshake. `Api.makeRequest` caught the `SSLHandshakeException` in its generic `IOException` arm and showed *"Network error connecting to /api/account/create. Check your connection and try again."* Nothing named TLS.

The reporter went looking in the server log instead, and found `UnsupportedProtocolVersionException` on `GET /api/account/create`. That is a red herring: the client only ever POSTs there, always sends `X-Hammer-Protocol-Version`, and a TLS ClientHello is rejected by Jetty's HTTP parser before `CallSetup` runs, so a real client handshake never produces a log line at all. Those entries were their own browser and curl.

## Changes

**TLS failures get their own message.** New `Throwable.isTlsFailure()` (expect/actual: `SSLException` in the cause chain on JVM, message markers on iOS where NSURLSession carries nothing else through), and `Api.makeRequest` splits its `IOException` arm on it. The new message names HTTPS and the certificate / reverse-proxy requirement.

**Server URL entry fixes**, hit by the same self-hoster:
- `cleanUpUrl` stripped the scheme with `removeSuffix` instead of `removePrefix`, so a pasted `http://192.168.1.50:8080` was never stripped and failed validation.
- `validateUrl` required a dotted TLD (rejecting bare LAN hostnames like `homeserver:8080`), was lowercase-only, and admitted 5-digit ports above 65535 that would crash the unguarded `.toInt()` in `url()`. Replaced with a host-label regex plus a numeric port range check.

Neither function had any test.

**Docs.** The Docker quick start now says a client cannot connect until TLS is in front, before "download a client", and a new troubleshooting section explains why the server log is misleading here. Same gate added to the Java-executable steps in `HOW-TO-RUN-A-SERVER.md`, plus a note on the `ports` line in `docker-compose.yml`.

## Tests

- `ServerUrlValidationTest` (16 cases) failed 8 against the old code, all pass now.
- `ApiTlsFailureTest` covers a bare handshake failure, a wrapped one, and an ordinary `ConnectException` that must keep the generic message, so neither branch can pass vacuously.
- Full `:common:desktopTest` green; `:common:compileAndroidMain`, `:common:compileIosMainKotlinMetadata`, `:composeUi:compileKotlinDesktop`, `:desktop:compileKotlinJvm` all build.

## Not addressed

A client still cannot talk to a plain-HTTP server. This makes the failure legible, not survivable, which keeps the intent of #743 intact.
