### PR TITLE
Fix literal ** and _ around RTF-imported emphasis

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/RtfStoryImporter.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/RtfStoryImporter.kt
@@ -157,7 +157,9 @@ class RtfStoryImporter : StoryImporter {
 	/**
 	 * Walks the body destinations of an RTF document, emitting one [RtfParagraph] per `\par`. Tracks
 	 * group-scoped character formatting (bold/italic/font size) and paragraph properties (outline
-	 * level), wrapping bold/italic runs in Markdown the way the library's own converter does.
+	 * level), wrapping bold/italic runs in Markdown. Delimiters hug the emphasized text: RTF writers
+	 * routinely put the surrounding spaces inside the run, and CommonMark rejects emphasis with
+	 * whitespace immediately inside the markers.
 	 */
 	private class RtfParagraphCollector : com.darkrockstudios.libs.rtfparserkmp.parser.RtfListener {
 		val paragraphs = mutableListOf<RtfParagraph>()
@@ -195,9 +197,8 @@ class RtfStoryImporter : StoryImporter {
 
 		override fun processString(string: String) {
 			if (!isBodyDestination()) return
-			openEmphasis()
 			plain.append(string)
-			markdown.append(escape(string))
+			appendMarkdown(string)
 			for (ch in string) {
 				if (ch.isWhitespace()) continue
 				totalChars++
@@ -241,7 +242,7 @@ class RtfStoryImporter : StoryImporter {
 
 		private fun endParagraph() {
 			closeEmphasis()
-			val md = markdown.toString().trim()
+			val md = escapeOrderedListMarkers(markdown.toString().trim())
 			val text = plain.toString().trim()
 			val dominantSize = sizeCounts.maxByOrNull { it.value }?.key
 			val mostlyBold = totalChars > 0 && boldChars.toDouble() / totalChars >= BOLD_RATIO
@@ -287,6 +288,21 @@ class RtfStoryImporter : StoryImporter {
 			Marker.ITALIC -> italic
 		}
 
+		/**
+		 * Opens pending emphasis at the first non-whitespace character, so a run's leading whitespace
+		 * stays outside the delimiters and an all-whitespace run opens nothing.
+		 */
+		private fun appendMarkdown(text: String) {
+			val firstVisible = text.indexOfFirst { !it.isWhitespace() }
+			if (firstVisible < 0) {
+				markdown.append(text)
+				return
+			}
+			markdown.append(text.substring(0, firstVisible))
+			openEmphasis()
+			markdown.append(escape(text.substring(firstVisible)))
+		}
+
 		private fun openEmphasis() {
 			if (bold && Marker.BOLD !in openMarkers) {
 				markdown.append(Marker.BOLD.text)
@@ -298,27 +314,35 @@ class RtfStoryImporter : StoryImporter {
 			}
 		}
 
+		/**
+		 * Closes every marker down to the shallowest inactive one. Still-active markers come off the
+		 * stack too and are reopened by [openEmphasis] at the next non-whitespace character.
+		 */
 		private fun closeDisabledMarkers() {
 			val deepestDisabled = openMarkers.indexOfFirst { !isActive(it) }
 			if (deepestDisabled < 0) return
-			val reopen = ArrayDeque<Marker>()
 			while (openMarkers.size > deepestDisabled) {
-				val top = openMarkers.removeLast()
-				markdown.append(top.text)
-				if (isActive(top)) reopen.addLast(top)
-			}
-			while (reopen.isNotEmpty()) {
-				val m = reopen.removeLast()
-				markdown.append(m.text)
-				openMarkers.addLast(m)
+				closeMarker(openMarkers.removeLast())
 			}
 		}
 
 		private fun closeEmphasis() {
 			while (openMarkers.isNotEmpty()) {
-				markdown.append(openMarkers.removeLast().text)
+				closeMarker(openMarkers.removeLast())
 			}
 		}
+
+		/** Emits [marker] ahead of any trailing whitespace, keeping the delimiter against the text. */
+		private fun closeMarker(marker: Marker) {
+			markdown.insert(markdown.length - trailingWhitespaceLength(), marker.text)
+		}
+
+		private fun trailingWhitespaceLength(): Int =
+			markdown.length - (markdown.indexOfLast { !it.isWhitespace() } + 1)
+
+		/** Keeps an imported paragraph that starts with "1." from parsing as an ordered list. */
+		private fun escapeOrderedListMarkers(text: String): String =
+			text.replace(ORDERED_LIST_MARKER, "$1\\\\.")
 
 		private fun escape(text: String): String {
 			val out = StringBuilder(text.length)
@@ -333,12 +357,15 @@ class RtfStoryImporter : StoryImporter {
 
 		private enum class Marker(val text: String) {
 			BOLD("**"),
-			ITALIC("_"),
+			ITALIC("*"),
 		}
 
 		private companion object {
 			const val BOLD_RATIO = 0.8
-			val MARKDOWN_SPECIAL = "\\`*_{}[]<>#".toSet()
+
+			/** Mirrors `MARKDOWN_SPECIAL_CHARS` in ComposeTextEditor's Markdown escaper. */
+			val MARKDOWN_SPECIAL = "\\`*_{}[]()<>#+-!|".toSet()
+			val ORDERED_LIST_MARKER = Regex("^(\\d+)\\.", RegexOption.MULTILINE)
 		}
 	}
 }

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/RtfStoryImporterTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/RtfStoryImporterTest.kt
@@ -2,6 +2,9 @@ package com.darkrockstudios.apps.hammer.common.data.importer
 
 import com.darkrockstudios.apps.hammer.common.data.ImportOptions
 import com.darkrockstudios.apps.hammer.common.data.RtfSplitStrategy
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.MarkdownParser
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -28,6 +31,16 @@ class RtfStoryImporterTest {
 			createChapterGroups = groups,
 		),
 	)
+
+	/** Imports [body] as one unsplit scene, so assertions see the paragraph Markdown verbatim. */
+	private fun singleScene(body: String): PreviewItem.Scene =
+		preview(body, strategy = RtfSplitStrategy.SingleScene).items[0] as PreviewItem.Scene
+
+	private fun renderHtml(markdown: String): String {
+		val flavour = GFMFlavourDescriptor()
+		val parsed = MarkdownParser(flavour).buildMarkdownTreeFromString(markdown)
+		return HtmlGenerator(markdown, parsed, flavour).generateHtml()
+	}
 
 	@Test
 	fun `Formatting splits chapters by outline level into groups and scenes`() {
@@ -109,6 +122,106 @@ class RtfStoryImporterTest {
 
 		val scene = result.items[0] as PreviewItem.Scene
 		assertTrue(scene.markdown.contains("**strong**"), "Expected bold markdown, was: ${scene.markdown}")
+	}
+
+	@Test
+	fun `Bold run whose whitespace is inside the run keeps the delimiters tight`() {
+		val scene = singleScene("""\fs24 A\b  strong \b0 word.\par""")
+
+		assertEquals("A **strong** word.", scene.markdown)
+	}
+
+	@Test
+	fun `Bold run with trailing space before the paragraph end keeps the delimiters tight`() {
+		val scene = singleScene("""\fs24 She said \b run \b0\par""")
+
+		assertEquals("She said **run**", scene.markdown)
+	}
+
+	@Test
+	fun `Emphasis run of only whitespace emits no delimiters`() {
+		val scene = singleScene("""\fs24 word\b  \b0 next.\par""")
+
+		assertEquals("word next.", scene.markdown)
+	}
+
+	@Test
+	fun `Bold spanning a tab keeps the delimiters against the text`() {
+		val scene = singleScene("""\fs24 A\b  strong\tab\tab\b0 word.\par""")
+
+		assertEquals("A **strong**\t\tword.", scene.markdown)
+	}
+
+	@Test
+	fun `Bold ended by a group close keeps the delimiters tight`() {
+		val scene = singleScene("""\fs24 A {\b strong }word.\par""")
+
+		assertEquals("A **strong** word.", scene.markdown)
+	}
+
+	@Test
+	fun `Emphasis is closed at a hard line break`() {
+		val scene = singleScene("""\fs24 \b first\line second \b0 last.\par""")
+
+		assertEquals("**first**  \n**second** last.", scene.markdown)
+	}
+
+	@Test
+	fun `Overlapping bold and italic runs stay balanced`() {
+		val scene = singleScene("""\fs24 \i one \b two \i0 three \b0 four.\par""")
+
+		assertEquals("*one **two*** **three** four.", scene.markdown)
+	}
+
+	@Test
+	fun `Italic uses asterisks so intra-word emphasis renders`() {
+		val scene = singleScene("""\fs24 foo\i bar\i0 baz.\par""")
+
+		assertEquals("foo*bar*baz.", scene.markdown)
+	}
+
+	@Test
+	fun `Nested bold and italic close inside the trailing whitespace`() {
+		val scene = singleScene("""\fs24 A \b\i very loud \i0\b0 word.\par""")
+
+		assertEquals("A ***very loud*** word.", scene.markdown)
+	}
+
+	@Test
+	fun `Emphasis that ends with the paragraph is still closed`() {
+		val scene = singleScene("""\fs24 He was \i gone\par""")
+
+		assertEquals("He was *gone*", scene.markdown)
+	}
+
+	@Test
+	fun `A paragraph starting with a dash is escaped instead of importing as a list`() {
+		val scene = singleScene("""\fs24 - a spoken line.\par""")
+
+		assertEquals("\\- a spoken line.", scene.markdown)
+	}
+
+	@Test
+	fun `A paragraph starting with a number is escaped instead of importing as a list`() {
+		val scene = singleScene("""\fs24 1. Never speak of it.\par""")
+
+		assertEquals("1\\. Never speak of it.", scene.markdown)
+	}
+
+	@Test
+	fun `Markdown special characters in prose are escaped`() {
+		val scene = singleScene("""\fs24 Wait! (really) 1+1 a|b\par""")
+
+		assertEquals("Wait\\! \\(really\\) 1\\+1 a\\|b", scene.markdown)
+	}
+
+	@Test
+	fun `Emphasis with whitespace inside the run renders as emphasis`() {
+		val scene = singleScene("""\fs24 She said \b run \b0 and\i then\i0 fled.\par""")
+
+		val html = renderHtml(scene.markdown)
+		assertTrue(html.contains("<strong>run</strong>"), "Expected bold to render, was: $html")
+		assertTrue(html.contains("<em>then</em>"), "Expected italics to render, was: $html")
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #803

## Problem

`RtfStoryImporter` opened and closed Markdown emphasis delimiters at the exact character boundaries of an RTF formatting run. RTF writers routinely include the surrounding spaces inside the run (`\b Chapter One \b0`), which produced `** Chapter One **`. CommonMark rejects emphasis with whitespace immediately inside the delimiters, so the editor rendered the asterisks as literal text.

Italics had a second failure mode: the collector emitted `_`, and CommonMark does not allow intra-word `_` emphasis, so an italic run starting or ending mid-word left both underscores visible.

## Changes

- Emphasis delimiters now hug the text. A run's leading whitespace stays outside the opening marker (openings are deferred to the first non-whitespace character) and closing markers are inserted ahead of any trailing whitespace. A run made only of whitespace opens nothing.
- `closeDisabledMarkers` no longer re-emits still-active markers eagerly; they come off the stack and are reopened lazily at the next non-whitespace character, which keeps the deferral rule uniform for overlapping bold/italic runs.
- Italics emit `*` instead of `_`.
- `escape()` now mirrors ComposeTextEditor's `MARKDOWN_SPECIAL_CHARS` (adds `+ - ! ( ) |`) and, like the editor's escaper, escapes ordered-list markers at line starts. A paragraph beginning with `- ` or `1. ` no longer imports as a list.

## Tests

Written first and confirmed failing against the old behavior. Sixteen new cases in `RtfStoryImporterTest` cover whitespace inside a run, whitespace-only runs, run-ends at a tab / group close / hard line break / paragraph end, nested and overlapping bold+italic, intra-word italics, the widened escape set, and one case that runs the imported Markdown through the Markdown parser and asserts `<strong>`/`<em>` actually appear.

`./gradlew desktopTest` is green.
