### PR TITLE
Warn in the import preview when a scene is too large

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values/strings_project_home.xml
@@ -123,6 +123,10 @@
 	<string name="project_home_import_preview_empty">Nothing to import</string>
 	<string name="project_home_import_preview_reading">Reading your manuscript</string>
 	<string name="project_home_import_preview_count">Will create %1$d scene(s)</string>
+	<string name="project_home_import_large_scene_label">Large scene</string>
+	<string name="project_home_import_large_scene_one">One scene holds %1$s words, so chapter detection probably missed your chapter titles. Try another detection setting.</string>
+	<string name="project_home_import_large_scene_many">%1$d scenes hold %2$s words or more, so chapter detection probably missed some chapter titles. Try another detection setting.</string>
+	<string name="project_home_import_scene_word_count">%1$s W</string>
 	<string name="project_home_import_cancel">Cancel</string>
 	<string name="project_home_import_execute">Import</string>
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/StoryImporter.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/StoryImporter.kt
@@ -2,7 +2,12 @@ package com.darkrockstudios.apps.hammer.common.data.importer
 
 import com.darkrockstudios.apps.hammer.common.data.ImportFormat
 import com.darkrockstudios.apps.hammer.common.data.ImportOptions
+import com.darkrockstudios.apps.hammer.common.data.projectstatistics.countWords
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+/** Above this, a scene reads as a failed chapter split rather than a long chapter. */
+const val LARGE_SCENE_WORD_COUNT = 10_000
 
 interface StoryImporter {
 	val format: ImportFormat
@@ -29,6 +34,17 @@ data class ImportPreview(
 				is PreviewItem.Group -> item.scenes.size
 			}
 		}
+
+	/** Scenes at or over [LARGE_SCENE_WORD_COUNT], in document order. */
+	val oversizedScenes: List<PreviewItem.Scene>
+		get() = buildList {
+			items.forEach { item ->
+				when (item) {
+					is PreviewItem.Scene -> if (item.isOversized) add(item)
+					is PreviewItem.Group -> item.scenes.filterTo(this) { it.isOversized }
+				}
+			}
+		}
 }
 
 @Serializable
@@ -39,7 +55,12 @@ sealed interface PreviewItem {
 	data class Scene(
 		override val name: String,
 		val markdown: String,
-	) : PreviewItem
+	) : PreviewItem {
+		@Transient
+		val wordCount: Int = countWords(markdown)
+
+		val isOversized: Boolean get() = wordCount >= LARGE_SCENE_WORD_COUNT
+	}
 
 	@Serializable
 	data class Group(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/WordCount.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/WordCount.kt
@@ -1,8 +1,16 @@
 package com.darkrockstudios.apps.hammer.common.data.projectstatistics
 
-private val whitespaceRun = Regex("""\s+""")
-
+/** Counts runs of non-whitespace. Single pass: a whole manuscript is one string, not a word list. */
 fun countWords(text: String): Int {
-	val trimmed = text.trim()
-	return if (trimmed.isEmpty()) 0 else trimmed.split(whitespaceRun).size
+	var count = 0
+	var inWord = false
+	for (char in text) {
+		if (char.isWhitespace()) {
+			inWord = false
+		} else if (!inWord) {
+			inWord = true
+			count++
+		}
+	}
+	return count
 }

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/OversizedSceneWarningTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/importer/OversizedSceneWarningTest.kt
@@ -1,0 +1,147 @@
+package com.darkrockstudios.apps.hammer.common.data.importer
+
+import com.darkrockstudios.apps.hammer.common.data.ImportOptions
+import com.darkrockstudios.apps.hammer.common.data.MarkdownSplitStrategy
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OversizedSceneWarningTest {
+
+	private val importer = MarkdownStoryImporter()
+
+	private fun words(count: Int): String = "word ".repeat(count)
+
+	private fun preview(
+		content: String,
+		groups: Boolean = false,
+		strategy: MarkdownSplitStrategy = MarkdownSplitStrategy.H1,
+	) = importer.preview(
+		sourceName = "story",
+		content = content.encodeToByteArray(),
+		options = ImportOptions(markdownSplitStrategy = strategy, createChapterGroups = groups),
+	)
+
+	@Test
+	fun `A whole manuscript collapsed into one scene is flagged`() {
+		val result = preview(words(LARGE_SCENE_WORD_COUNT + 500))
+
+		assertEquals(1, result.totalScenes)
+		val flagged = result.oversizedScenes.single()
+		assertEquals(LARGE_SCENE_WORD_COUNT + 500, flagged.wordCount)
+	}
+
+	@Test
+	fun `Chapters that split correctly are not flagged`() {
+		val md = (1..5).joinToString("\n") { "# Chapter $it\n${words(2_000)}" }
+
+		val result = preview(md)
+
+		assertEquals(5, result.totalScenes)
+		assertTrue(result.oversizedScenes.isEmpty())
+	}
+
+	@Test
+	fun `A scene exactly at the threshold is flagged`() {
+		val result = preview(words(LARGE_SCENE_WORD_COUNT))
+
+		assertEquals(LARGE_SCENE_WORD_COUNT, result.oversizedScenes.single().wordCount)
+	}
+
+	@Test
+	fun `A scene one word under the threshold is not flagged`() {
+		val result = preview(words(LARGE_SCENE_WORD_COUNT - 1))
+
+		assertTrue(result.oversizedScenes.isEmpty())
+	}
+
+	@Test
+	fun `Only the oversized chapter of a mixed import is flagged`() {
+		val md = buildString {
+			appendLine("# Chapter One")
+			appendLine(words(500))
+			appendLine("# Chapter Two")
+			appendLine(words(LARGE_SCENE_WORD_COUNT + 1))
+			appendLine("# Chapter Three")
+			appendLine(words(500))
+		}
+
+		val result = preview(md)
+
+		assertEquals(3, result.totalScenes)
+		assertEquals(listOf("Chapter Two"), result.oversizedScenes.map { it.name })
+	}
+
+	@Test
+	fun `An oversized scene nested in a chapter group is flagged`() {
+		val md = "# Chapter One\n${words(LARGE_SCENE_WORD_COUNT + 1)}"
+
+		val result = preview(md, groups = true)
+
+		assertTrue(result.items.single() is PreviewItem.Group)
+		assertEquals(listOf("Chapter One"), result.oversizedScenes.map { it.name })
+	}
+
+	@Test
+	fun `An empty preview flags nothing`() {
+		assertTrue(preview("").oversizedScenes.isEmpty())
+	}
+
+	@Test
+	fun `Scenes split by Setext headings carry their word count`() {
+		val md = """
+			Chapter One
+			===========
+
+			${words(500)}
+
+			Chapter Two
+			===========
+
+			${words(LARGE_SCENE_WORD_COUNT + 1)}
+		""".trimIndent()
+
+		val result = preview(md, strategy = MarkdownSplitStrategy.Auto)
+
+		assertEquals(2, result.totalScenes)
+		assertEquals(listOf("Chapter Two"), result.oversizedScenes.map { it.name })
+	}
+
+	@Test
+	fun `A Setext title with no chapters collapses to one flagged scene`() {
+		val md = "The Long Walk Home\n==================\n\n${words(LARGE_SCENE_WORD_COUNT + 1)}"
+
+		val result = preview(md, strategy = MarkdownSplitStrategy.Auto)
+
+		assertEquals(LARGE_SCENE_WORD_COUNT + 1, result.oversizedScenes.single().wordCount)
+	}
+
+	@Test
+	fun `Scenes split by a bold chapter title carry their word count`() {
+		val md = (1..4).joinToString("\n") { "**Chapter $it**\n${words(3_000)}" } +
+			"\n**Chapter Five**\n${words(LARGE_SCENE_WORD_COUNT + 1)}"
+
+		val result = preview(md, strategy = MarkdownSplitStrategy.Auto)
+
+		assertEquals(listOf("Chapter Five"), result.oversizedScenes.map { it.name })
+	}
+
+	@Test
+	fun `Scenes split by the chapter pattern carry their word count`() {
+		val md = "Chapter One\n${words(500)}\nChapter Two\n${words(LARGE_SCENE_WORD_COUNT + 1)}"
+
+		val result = preview(md, strategy = MarkdownSplitStrategy.Pattern)
+
+		assertEquals(listOf("Chapter Two"), result.oversizedScenes.map { it.name })
+	}
+
+	@Test
+	fun `Word count is derived on decode rather than carried in the serialized form`() {
+		val decoded = Json.decodeFromString<PreviewItem.Scene>(
+			"""{"name":"Chapter One","markdown":"one two three"}""",
+		)
+
+		assertEquals(3, decoded.wordCount)
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/projectstatistics/WordCountTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectstatistics/WordCountTest.kt
@@ -46,4 +46,9 @@ class WordCountTest {
 	fun `mixed whitespace runs collapse to single separator`() {
 		assertEquals(3, countWords("one \t two\n\n three"))
 	}
+
+	@Test
+	fun `a non-breaking space separates words`() {
+		assertEquals(2, countWords("hello world"))
+	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
@@ -235,6 +235,11 @@ The handwriting of the system. Reach for these instead of styling
   `LocalHammerColors`.
 - **[`HdDailyGoalProgress`](HdDailyGoalProgress.kt)** — daily-goal
   pair with thin progress bar.
+- **[`HdWarningNotice`](HdWarningNotice.kt)** — amber hairline callout:
+  `HdWarnGlyph` + mono label over a body message. For a condition the
+  user should see before acting on it, where an error dialog would be
+  too much and silence too little. Non-blocking by design — the action
+  it warns about stays available.
 
 ### Buttons & inputs
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdWarningNotice.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdWarningNotice.kt
@@ -1,0 +1,59 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
+
+/**
+ * Amber hairline callout: mono [label] over a body [message].
+ *
+ * ```
+ *   ┌──────────────────────────────┐
+ *   │ [!]  LABEL                   │
+ *   │      Message body.           │
+ *   └──────────────────────────────┘
+ * ```
+ *
+ * Non-blocking, unlike an error: the action it warns about stays available.
+ */
+@Composable
+fun HdWarningNotice(
+	label: String,
+	message: String,
+	modifier: Modifier = Modifier,
+) {
+	val amber = LocalHammerColors.current.warning
+	Row(
+		modifier = modifier
+			.fillMaxWidth()
+			.border(width = Dp.Hairline, color = amber, shape = RectangleShape)
+			.padding(horizontal = 10.dp, vertical = 8.dp),
+		horizontalArrangement = Arrangement.spacedBy(10.dp),
+		verticalAlignment = Alignment.Top,
+	) {
+		HdWarnGlyph(size = 16.dp)
+		Column(
+			modifier = Modifier.weight(1f),
+			verticalArrangement = Arrangement.spacedBy(4.dp),
+		) {
+			HdMonoLabel(text = label, color = amber)
+			Text(
+				text = message,
+				style = MaterialTheme.typography.bodySmall,
+				color = MaterialTheme.colorScheme.onSurface,
+			)
+		}
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdowneditor/MarkdownEditField.kt
@@ -51,8 +51,11 @@ fun MarkdownEditField(
 	val spellCheckRepository = rememberKoinInject<SpellCheckRepository>()
 	val platformSpellChecker by spellCheckRepository.dictionaryFlow.collectAsState(initial = null)
 
+	// rememberSpellCheckState re-scans the whole document whenever this instance changes identity.
+	val editorSpellChecker = remember(platformSpellChecker) { platformSpellChecker.toEditorSpellChecker() }
+
 	val textEditorState = rememberSpellCheckState(
-		spellChecker = platformSpellChecker.toEditorSpellChecker(),
+		spellChecker = editorSpellChecker,
 		initialText = null,
 		// The repository only emits a dictionary while spell checking is globally enabled,
 		// so a null checker also means "disabled" — clear decorations rather than keep checking.

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportStoryDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ImportStoryDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
@@ -22,12 +23,15 @@ import com.darkrockstudios.apps.hammer.common.compose.NameKind
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.rememberNameValidation
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
+import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
 import com.darkrockstudios.apps.hammer.common.data.ImportFormat
 import com.darkrockstudios.apps.hammer.common.data.ImportOptions
 import com.darkrockstudios.apps.hammer.common.data.MarkdownSplitStrategy
 import com.darkrockstudios.apps.hammer.common.data.RtfSplitStrategy
 import com.darkrockstudios.apps.hammer.common.data.importer.ImportPreview
+import com.darkrockstudios.apps.hammer.common.data.importer.LARGE_SCENE_WORD_COUNT
 import com.darkrockstudios.apps.hammer.common.data.importer.PreviewItem
+import com.darkrockstudios.apps.hammer.common.util.formatDecimalSeparator
 import org.jetbrains.compose.resources.StringResource
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 
@@ -289,6 +293,9 @@ private fun ImportPreviewPane(
 			}
 		}
 		Spacer(modifier = Modifier.height(Ui.Padding.S))
+		if (!isParsing) {
+			LargeSceneWarning(remember(preview) { preview.oversizedScenes })
+		}
 		Box(
 			modifier = Modifier
 				.fillMaxWidth()
@@ -326,10 +333,9 @@ private fun ImportPreviewPane(
 				val rows = remember(preview) { preview.toRows() }
 				LazyColumn(contentPadding = PaddingValues(Ui.Padding.M)) {
 					items(rows) { row ->
-						if (row.isGroup) {
-							PreviewGroupRow(row.name)
-						} else {
-							PreviewSceneRow(row.name, indented = row.indented)
+						when (row) {
+							is PreviewRow.Group -> PreviewGroupRow(row.name)
+							is PreviewRow.Scene -> PreviewSceneRow(row)
 						}
 					}
 				}
@@ -338,16 +344,42 @@ private fun ImportPreviewPane(
 	}
 }
 
+/** Amber notice when the import would produce a scene over [LARGE_SCENE_WORD_COUNT]. Never blocks the import. */
+@Composable
+private fun LargeSceneWarning(oversized: List<PreviewItem.Scene>) {
+	if (oversized.isEmpty()) return
+
+	val message = if (oversized.size == 1) {
+		Res.string.project_home_import_large_scene_one.get(
+			oversized.first().wordCount.formatDecimalSeparator(),
+		)
+	} else {
+		Res.string.project_home_import_large_scene_many.get(
+			oversized.size,
+			oversized.minOf { it.wordCount }.formatDecimalSeparator(),
+		)
+	}
+
+	HdWarningNotice(
+		label = Res.string.project_home_import_large_scene_label.get(),
+		message = message,
+	)
+	Spacer(modifier = Modifier.height(Ui.Padding.S))
+}
+
 /** One flat row of the preview tree: a group header, or a scene at top level or inside a group. */
-private class PreviewRow(val name: String, val isGroup: Boolean, val indented: Boolean)
+private sealed interface PreviewRow {
+	class Group(val name: String) : PreviewRow
+	class Scene(val item: PreviewItem.Scene, val indented: Boolean) : PreviewRow
+}
 
 private fun ImportPreview.toRows(): List<PreviewRow> = buildList {
 	items.forEach { item ->
 		when (item) {
-			is PreviewItem.Scene -> add(PreviewRow(item.name, isGroup = false, indented = false))
+			is PreviewItem.Scene -> add(PreviewRow.Scene(item, indented = false))
 			is PreviewItem.Group -> {
-				add(PreviewRow(item.name, isGroup = true, indented = false))
-				item.scenes.forEach { add(PreviewRow(it.name, isGroup = false, indented = true)) }
+				add(PreviewRow.Group(item.name))
+				item.scenes.forEach { add(PreviewRow.Scene(it, indented = true)) }
 			}
 		}
 	}
@@ -375,25 +407,41 @@ private fun PreviewGroupRow(name: String) {
 }
 
 @Composable
-private fun PreviewSceneRow(name: String, indented: Boolean) {
+private fun PreviewSceneRow(row: PreviewRow.Scene) {
+	val oversized = row.item.isOversized
 	Row(
 		modifier = Modifier
 			.fillMaxWidth()
-			.padding(start = if (indented) Ui.Padding.L else 0.dp, top = 2.dp, bottom = 2.dp),
+			.padding(start = if (row.indented) Ui.Padding.L else 0.dp, top = 2.dp, bottom = 2.dp),
 		verticalAlignment = Alignment.CenterVertically,
 	) {
+		val amber = LocalHammerColors.current.warning
 		Icon(
 			Icons.AutoMirrored.Filled.Article,
 			contentDescription = null,
-			tint = MaterialTheme.colorScheme.onSurfaceVariant,
+			tint = if (oversized) amber else MaterialTheme.colorScheme.onSurfaceVariant,
 			modifier = Modifier.size(18.dp),
 		)
 		Spacer(modifier = Modifier.width(Ui.Padding.S))
 		Text(
-			name,
+			row.item.name,
 			style = MaterialTheme.typography.bodyMedium,
 			color = MaterialTheme.colorScheme.onSurface,
+			maxLines = 1,
+			overflow = TextOverflow.Ellipsis,
+			modifier = Modifier.weight(1f),
 		)
+		if (oversized) {
+			Spacer(modifier = Modifier.width(Ui.Padding.S))
+			HdMonoLabel(
+				text = Res.string.project_home_import_scene_word_count.get(
+					row.item.wordCount.formatDecimalSeparator(),
+				),
+				color = amber,
+				maxLines = 1,
+				softWrap = false,
+			)
+		}
 	}
 }
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
@@ -64,9 +64,12 @@ fun FocusModeUi(component: FocusMode) {
 	val editorSpellChecker = remember(state.spellChecker) {
 		state.spellChecker.toEditorSpellChecker()
 	}
+	// Only read once, but unremembered it rebuilds the whole document's AnnotatedString on the UI
+	// thread every recomposition, and the buffer republishes every 500ms while typing.
+	val initialEditorContent = remember { getInitialEditorContent(state.sceneBuffer?.content, markdownConfig) }
 	val textEditorState = rememberSpellCheckState(
 		spellChecker = editorSpellChecker,
-		initialText = getInitialEditorContent(state.sceneBuffer?.content, markdownConfig),
+		initialText = initialEditorContent,
 		enableSpellChecking = state.spellCheckingEnabled,
 	)
 	val markdownExtension = remember { textEditorState.withMarkdown(markdownConfig) }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -90,9 +90,12 @@ fun SceneEditorUi(
 	val editorSpellChecker = remember(state.spellChecker) {
 		state.spellChecker.toEditorSpellChecker()
 	}
+	// Only read once, but unremembered it rebuilds the whole document's AnnotatedString on the UI
+	// thread every recomposition, and the buffer republishes every 500ms while typing.
+	val initialEditorContent = remember { getInitialEditorContent(state.sceneBuffer?.content, markdownConfig) }
 	val textEditorState = rememberSpellCheckState(
 		spellChecker = editorSpellChecker,
-		initialText = getInitialEditorContent(state.sceneBuffer?.content, markdownConfig),
+		initialText = initialEditorContent,
 		enableSpellChecking = state.spellCheckingEnabled,
 		spellCheckMode = SpellCheckMode.Word,
 	)

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ImportStoryDialog.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ImportStoryDialog.Preview.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -71,6 +72,41 @@ fun ImportStoryDialogMarkdownPatternPreview() {
 				ImportStoryContent(
 					projectName = "Alice In Wonderland 2",
 					options = ImportOptions(markdownSplitStrategy = MarkdownSplitStrategy.Pattern),
+					preview = preview,
+					isParsing = false,
+					onProjectNameChange = {},
+					onCancel = {},
+					onOptionsChange = {},
+					onConfirm = {},
+				)
+			}
+		}
+	}
+}
+
+/** Chapter detection found nothing, so the whole manuscript landed in one scene. */
+@Preview(widthDp = 640, heightDp = 760)
+@Composable
+fun ImportStoryDialogLargeScenePreview() {
+	val preview = remember {
+		ImportPreview(
+			items = listOf(
+				PreviewItem.Scene(name = "Chapter One", markdown = "A normal opening chapter."),
+				PreviewItem.Scene(name = "The Long Walk Home", markdown = "word ".repeat(54_300)),
+			),
+		)
+	}
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, true) {
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.background(MaterialTheme.colorScheme.background),
+				contentAlignment = Alignment.Center,
+			) {
+				ImportStoryContent(
+					projectName = "The Long Walk Home",
+					options = ImportOptions(),
 					preview = preview,
 					isParsing = false,
 					onProjectNameChange = {},


### PR DESCRIPTION
Part of #805.

When Markdown chapter detection finds nothing (#804), the whole manuscript lands in one scene. Today the first sign of that is the editor locking up, after the import has already been committed. This is the guard rail half: the preview says so before you press Import.

## Guard rail

`PreviewItem.Scene` now carries its word count, and `ImportPreview.oversizedScenes` lists the scenes at or over the threshold. The preview pane shows an amber notice above the list, and each offending row is tinted and stamped with its real count (`54,300 W`).

The import stays enabled. One huge scene is a legitimate thing to want, so this warns rather than gates.

### Why 10,000 words

A novel chapter runs 3,000 to 5,000 words; the longest chapters in published novels reach roughly 20,000. A whole manuscript starts around 50,000. 10,000 clears almost every real chapter, so it does not nag, and sits far below any whole book, so it always fires on the collapse case this issue is about.

#563 reports trouble from about 1,200 words up, but a threshold that low would fire on ordinary chapters and train people to ignore it. The number is a single `const` (`LARGE_SCENE_WORD_COUNT`) if it needs moving.

## Editor performance (partial)

I profiled the large-document path. The dominant costs live in ComposeTextEditor and are **not** touched here; that analysis goes on the issue. Three main-thread wastes were fixable on the Hammer side and are included:

- **`SceneEditorUi` / `FocusModeUi`** passed `getInitialEditorContent(...)` to `rememberSpellCheckState` as an unremembered argument. `rememberTextEditorState` documents that it only consumes `initialText` on first composition, but Kotlin still evaluates the argument on every recomposition, and once a scene is loaded that call rebuilds the whole document's `AnnotatedString` on the UI thread. The scene buffer republishes every 500 ms while typing, so this ran constantly. Now remembered: strictly less work, no behaviour change.
- **`MarkdownEditField`** built a fresh `PlatformEditorSpellChecker` every recomposition. That type has no `equals`, so it re-keyed the library's full-rescan `LaunchedEffect` each time and re-ran a whole-document spell check. `rememberSpellCheckState`'s own KDoc warns about exactly this, and the scene editor already did it correctly; this brings the notes / timeline / encyclopedia editors in line.
- **`countWords`** materialised a `List<String>` of every word just to take its size. On a 120k-word scene that is a large transient allocation, and the guard rail now calls it once per imported scene. Replaced with a single pass. Behaviour is covered by the existing `WordCountTest`, plus a new case pinning non-breaking-space handling.

These reduce wasted work but do not make a 100k-word scene usable on their own. The remaining fixes are in ComposeTextEditor: every edit re-measures and re-lays out the entire document rather than an affected range, and spell check applies rich spans one at a time with a full relayout each.

## Design system

`HdWarningNotice` is new: amber hairline border, `HdWarnGlyph`, mono label over a body line. There was no existing notice / callout / banner atom in `designsystem/`; the closest was a private `ExperimentalNotice` inlined in `SpellCheckSettingsUi`, which is a borderless inline italic run on an unrelated screen. Added to the `DESIGN_README` catalogue.

## Testing

`OversizedSceneWarningTest` covers the collapse case, correctly split chapters, both sides of the threshold boundary, mixed imports, scenes nested in chapter groups, and that the word count survives a serialization round-trip without entering the JSON shape. Written first and confirmed failing before the implementation.

`./gradlew desktopTest` is green. `ImportStoryDialogLargeScenePreview` renders the warning state; the other two import previews are unchanged.

## Note

#807 also touches `ImportStoryDialog.kt` and `ImportStoryDialog.Preview.kt`, so whichever merges second will need a rebase.
