### PR TITLE
Lowercase the sync server URL when cleaning it up

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
@@ -473,7 +473,7 @@ class AccountSettingsComponent(
 		}
 
 		fun cleanUpUrl(url: String): String {
-			var cleanUrl: String = url.trim()
+			var cleanUrl: String = url.trim().lowercase()
 			cleanUrl = cleanUrl.removePrefix("http://")
 			cleanUrl = cleanUrl.removePrefix("https://")
 			cleanUrl = cleanUrl.removeSuffix("/")

--- a/common/src/desktopTest/kotlin/components/projectselection/ServerUrlValidationTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/ServerUrlValidationTest.kt
@@ -30,6 +30,16 @@ class ServerUrlValidationTest {
 	}
 
 	@Test
+	fun `a mixed case host is lowercased`() {
+		assertEquals("hammer.example.com", cleanUpUrl("Hammer.Example.COM"))
+	}
+
+	@Test
+	fun `an uppercase scheme is stripped`() {
+		assertEquals("hammer.example.com", cleanUpUrl("HTTPS://Hammer.Example.com"))
+	}
+
+	@Test
 	fun `a cleaned pasted url validates`() {
 		assertTrue(validateUrl(cleanUpUrl("http://192.168.1.50:8080")))
 	}


### PR DESCRIPTION
Follow-up nit from #797. The bulk of that issue (hyphens, uppercase, bare hostnames, `removeSuffix` vs `removePrefix`) was already fixed in 5acba728; this picks up the one remaining item that was flagged as "consider" rather than required.

`cleanUpUrl` now lowercases the URL. Hostnames are case-insensitive and `validateUrl` already tolerates mixed case, but the cleaned value is what gets stored, so it should be normalized.

Lowercasing *before* the `removePrefix` calls rather than after fixes a second thing for free: `removePrefix` is case-sensitive, so `HTTPS://example.com` previously kept its scheme and then failed validation.

## Tests

Two cases added to `ServerUrlValidationTest`:

- `Hammer.Example.COM` -> `hammer.example.com`
- `HTTPS://Hammer.Example.com` -> `hammer.example.com`

All 81 tests in `components.projectselection.*` pass.

## Not included

`hostRegex` stays case-tolerant (`[A-Za-z0-9]`). `validateUrl` is public and independently tested with mixed-case input, so narrowing it to lowercase-only would silently couple it to `cleanUpUrl` having run first.

The other leftover nit from #797, capping label length at 63 chars, is still open.
