### PR TITLE
Stop the encyclopedia E2E test failing on a dropped tap

### DIFF
--- a/android/src/androidTest/kotlin/EditorTestHarness.kt
+++ b/android/src/androidTest/kotlin/EditorTestHarness.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
@@ -95,6 +96,39 @@ fun ComposeTestRule.navigateTo(navTag: String) {
 		onAllNodesWithTag(navTag).fetchSemanticsNodes().isNotEmpty()
 	}
 	onNodeWithTag(navTag).performClick()
+}
+
+/**
+ * Click the first node matching [matcher] and wait for [landed] to confirm the click took effect.
+ *
+ * A single injected tap is occasionally dropped before `clickable` resolves it into an onClick,
+ * which leaves the screen unchanged and reports no error. Re-inject until the expected outcome
+ * appears rather than trusting one injection.
+ */
+fun ComposeTestRule.clickUntil(
+	matcher: SemanticsMatcher,
+	timeoutMillis: Long = 10_000L,
+	landed: () -> Boolean,
+) {
+	val deadline = SystemClock.uptimeMillis() + timeoutMillis
+	while (true) {
+		// Only re-click while the target is still on screen; once it's gone the click did land and
+		// the screen is mid-change, so clicking again would hit whatever replaced it.
+		if (onAllNodes(matcher).fetchSemanticsNodes().isNotEmpty()) {
+			onAllNodes(matcher).onFirst().performClick()
+		}
+		try {
+			waitUntil(timeoutMillis = 1_000L) { landed() }
+			return
+		} catch (e: ComposeTimeoutException) {
+			if (SystemClock.uptimeMillis() >= deadline) {
+				throw AssertionError(
+					"Click on '${matcher.description}' never took effect within ${timeoutMillis}ms",
+					e,
+				)
+			}
+		}
+	}
 }
 
 /**

--- a/android/src/androidTest/kotlin/EncyclopediaWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/EncyclopediaWorkflowTest.kt
@@ -66,8 +66,7 @@ class EncyclopediaWorkflowTest {
 		composeRule.onAllNodes(hasTestTagPrefix("encyclopedia-entry-")).onFirst().assertIsDisplayed()
 
 		// Opening it leaves the browse list - the create FAB only shows there.
-		composeRule.onAllNodes(hasTestTagPrefix("encyclopedia-entry-")).onFirst().performClick()
-		composeRule.waitUntil(10_000) {
+		composeRule.clickUntil(hasTestTagPrefix("encyclopedia-entry-")) {
 			composeRule.onAllNodesWithTag(ENCYCLOPEDIA_CREATE_FAB_TAG).fetchSemanticsNodes().isEmpty()
 		}
 	}


### PR DESCRIPTION
`EncyclopediaWorkflowTest.createEntryThenOpenIt` intermittently times out at the last step, waiting for the create FAB to disappear after opening the new entry. The tap on the entry card never becomes an `onClick`, so the browse list never navigates.

### It is not a regression from the Markdown import work

The timing looks suggestive but does not hold up. `develop` is currently green (#815, all jobs). The test failed in five runs on 2026-08-01 — two on `develop` (#806, #807) and three on feature branches — and passed on the same code in others. The Markdown commits (`cace720c`, `94c3465b`, `3a85c461`) only touch `MarkdownStoryImporter`, `RtfStoryImporter` and `ImportStoryDialog`, none of which this test exercises.

It is also not the only flaky one. The same job has recently gone red on `TimelineWorkflowTest`, `SceneListWorkflowTest`, `SceneEditorWorkflowTest` (twice) and `ProjectLifecycleTest`. Encyclopedia is just the most frequent, and always at the same line.

### What is actually happening

It never failed on a host-GPU emulator across 50+ runs. Matching CI's `-gpu swiftshader_indirect` reproduced it at roughly one run in six, with the identical signature.

Probing on-device ruled out the obvious explanations:

- the card's centre resolves to the card's own clickable, not the type stamp or a tag chip;
- the outgoing create screen is gone ~700ms before the card appears, so it is not swallowing the tap;
- the card's bounds and content are stable from the frame it renders, so nothing relayouts under the tap.

The card is present, displayed and correctly positioned, and the tap simply does not resolve into a click. I could not isolate the exact micro-mechanism inside Compose's input path — that is the one loose end here.

### The fix

`clickUntil` re-injects the click until the expected outcome is observed, the same way the existing `typeIntoEditor` re-injects keystrokes for exactly this reason. It stops re-clicking once the matcher resolves to nothing, so a slow but successful navigation does not get a second click on the next screen. The assertion is unchanged: clicking the card must still open the entry.

### Verification

The retry path never runs in a green test, so I exercised it with a throwaway probe: the loop re-clicked and still succeeded across four rounds, and a click that never lands fails with a clear message instead of hanging. Then under the swiftshader emulator, 12/12 for this test and 3/3 for the full ten-test suite. The probes are deleted; the diff is two test files.

Given how low the failure rate is, local green is not proof — CI is the real check.

The other four tests use the same single-injection pattern and will keep flaking. I left them alone to keep this scoped, but the helper is here if we want them converted.
