### PR TITLE
Show error toasts on htmx error responses

### DIFF
--- a/docs/WEB-DESIGN-SYSTEM.md
+++ b/docs/WEB-DESIGN-SYSTEM.md
@@ -757,6 +757,12 @@ For displaying when lists have no content.
 
 **Variants:** `.toast-success`, `.toast-warning`, `.toast-error`, `.toast-info`
 
+Send toasts with the `respondToast` / `respondHtmlWithToast` / `respondTemplateWithToast` helpers
+rather than hand-writing the markup. An endpoint that rejects a request should answer with its real
+error status: the helpers mark error responses with `X-Hammer-Swap-Error`, which is what makes htmx
+swap a body it would otherwise discard, and toast-only errors also reswap to `none` so the request's
+target keeps its content. A raw `call.respond(HttpStatusCode.BadRequest, ...)` gets no toast.
+
 ---
 
 ## Form Components

--- a/server/src/jsTest/toast-logic.test.js
+++ b/server/src/jsTest/toast-logic.test.js
@@ -1,0 +1,29 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const logic = require('../main/resources/assets/js/toast-logic.js');
+
+test('marked error responses are swapped so their toast survives', () => {
+	assert.equal(logic.shouldSwapErrorResponse(400, 'true'), true);
+	assert.equal(logic.shouldSwapErrorResponse(422, 'true'), true);
+	assert.equal(logic.shouldSwapErrorResponse(500, 'true'), true);
+});
+
+test('unmarked error responses keep htmx default handling', () => {
+	// A bare 400 would swap an empty body over the target; a 404 would swap a whole error page.
+	assert.equal(logic.shouldSwapErrorResponse(400, null), false);
+	assert.equal(logic.shouldSwapErrorResponse(404, null), false);
+	assert.equal(logic.shouldSwapErrorResponse(401, undefined), false);
+	assert.equal(logic.shouldSwapErrorResponse(403, 'false'), false);
+	assert.equal(logic.shouldSwapErrorResponse(400, ''), false);
+});
+
+test('successful responses are left to htmx even if marked', () => {
+	assert.equal(logic.shouldSwapErrorResponse(200, 'true'), false);
+	assert.equal(logic.shouldSwapErrorResponse(204, 'true'), false);
+	assert.equal(logic.shouldSwapErrorResponse(302, 'true'), false);
+	assert.equal(logic.shouldSwapErrorResponse(399, 'true'), false);
+});
+
+test('the header name matches what the server sends', () => {
+	assert.equal(logic.SWAP_ERROR_HEADER, 'X-Hammer-Swap-Error');
+});

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/DashboardPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/DashboardPage.kt
@@ -321,10 +321,13 @@ fun Route.dashboardPage(
 				val typedEmail = call.receiveParameters()["confirmEmail"]?.trim() ?: ""
 
 				// The JS arming of the button is UX only; the typed email is the
-				// real confirmation and must be verified here. Errors respond OK
-				// because htmx does not swap OOB toasts on 4xx responses.
+				// real confirmation and must be verified here.
 				if (!typedEmail.equals(account.email, ignoreCase = true)) {
-					respondToast(call.msg("account_delete_error_email_mismatch"), Toast.Error)
+					respondToast(
+						call.msg("account_delete_error_email_mismatch"),
+						Toast.Error,
+						HttpStatusCode.BadRequest
+					)
 					return@post
 				}
 
@@ -336,7 +339,8 @@ fun Route.dashboardPage(
 				} else {
 					respondToast(
 						result.displayMessageText(call) ?: call.msg("account_delete_error_generic"),
-						Toast.Error
+						Toast.Error,
+						HttpStatusCode.BadRequest
 					)
 				}
 			}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/ToastUtils.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/ToastUtils.kt
@@ -74,8 +74,10 @@ suspend fun RoutingContext.respondToast(
 /**
  * The single exit for htmx swap payloads: content, its toast, and the headers that decide what
  * htmx does with an error response. Error statuses are marked with [SWAP_ERROR_HEADER] so the
- * client swaps them at all, and those with no content reswap to `none` so the toast lands without
- * emptying the request's target.
+ * client swaps them at all, and those with nothing to show reswap to `none` so the toast lands
+ * without emptying the request's target. Whitespace counts as nothing to show: a template of
+ * all-conditional sections renders to a stray newline, which would blank the target just as
+ * thoroughly as an empty body.
  */
 private suspend fun RoutingContext.respondSwap(
 	content: String,
@@ -85,7 +87,7 @@ private suspend fun RoutingContext.respondSwap(
 ) {
 	if (status.value >= 400) {
 		call.response.header(SWAP_ERROR_HEADER, "true")
-		if (content.isEmpty()) {
+		if (content.isBlank()) {
 			call.response.header(HxResponseHeaders.Reswap, HxSwap.none)
 		}
 	}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/ToastUtils.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/ToastUtils.kt
@@ -1,10 +1,18 @@
 package com.darkrockstudios.apps.hammer.frontend.utils
 
 import com.github.mustachejava.DefaultMustacheFactory
+import io.ktor.htmx.HxResponseHeaders
+import io.ktor.htmx.HxSwap
 import io.ktor.http.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import java.io.StringWriter
+
+/**
+ * Marks an error response whose body is an htmx swap payload. htmx discards 4xx and 5xx bodies by
+ * default; toast.js swaps the ones carrying this header so their toast reaches the user.
+ */
+const val SWAP_ERROR_HEADER = "X-Hammer-Swap-Error"
 
 /**
  * Toast notification types for server-driven OOB swaps
@@ -48,12 +56,7 @@ suspend fun RoutingContext.respondHtmlWithToast(
 	toast: Toast = Toast.Success,
 	status: HttpStatusCode = HttpStatusCode.OK
 ) {
-	val toastHtml = toastHtml(message, toast)
-	call.respondText(
-		text = "$content$toastHtml",
-		contentType = ContentType.Text.Html,
-		status = status
-	)
+	respondSwap(content, message, toast, status)
 }
 
 /**
@@ -65,8 +68,30 @@ suspend fun RoutingContext.respondToast(
 	toast: Toast = Toast.Success,
 	status: HttpStatusCode = HttpStatusCode.OK
 ) {
+	respondSwap(content = "", message = message, toast = toast, status = status)
+}
+
+/**
+ * The single exit for htmx swap payloads: content, its toast, and the headers that decide what
+ * htmx does with an error response. Error statuses are marked with [SWAP_ERROR_HEADER] so the
+ * client swaps them at all, and those with no content reswap to `none` so the toast lands without
+ * emptying the request's target.
+ */
+private suspend fun RoutingContext.respondSwap(
+	content: String,
+	message: String,
+	toast: Toast,
+	status: HttpStatusCode
+) {
+	if (status.value >= 400) {
+		call.response.header(SWAP_ERROR_HEADER, "true")
+		if (content.isEmpty()) {
+			call.response.header(HxResponseHeaders.Reswap, HxSwap.none)
+		}
+	}
+
 	call.respondText(
-		text = toastHtml(message, toast),
+		text = content + toastHtml(message, toast),
 		contentType = ContentType.Text.Html,
 		status = status
 	)
@@ -97,11 +122,5 @@ suspend fun RoutingContext.respondTemplateWithToast(
 	toast: Toast = Toast.Success,
 	status: HttpStatusCode = HttpStatusCode.OK
 ) {
-	val content = renderTemplate(templatePath, model)
-	val toastHtml = toastHtml(message, toast)
-	call.respondText(
-		text = "$content$toastHtml",
-		contentType = ContentType.Text.Html,
-		status = status
-	)
+	respondSwap(renderTemplate(templatePath, model), message, toast, status)
 }

--- a/server/src/main/resources/assets/js/toast-logic.js
+++ b/server/src/main/resources/assets/js/toast-logic.js
@@ -1,0 +1,30 @@
+/**
+ * Pure decision logic for htmx error responses — no DOM, no globals beyond these
+ * functions and constants. Kept DOM-free so it can be unit-tested under Node
+ * while still loading as a plain browser <script> (see the dual export at the
+ * end), mirroring pen-name-logic.js.
+ */
+
+// Set by the server's toast helpers on any error response they build. Must match
+// SWAP_ERROR_HEADER in ToastUtils.kt.
+const SWAP_ERROR_HEADER = 'X-Hammer-Swap-Error';
+
+/**
+ * Whether htmx should swap a response it would otherwise discard. htmx drops the body of a
+ * 4xx/5xx by default, which takes the out-of-band toast with it. Only responses the server
+ * built as swap payloads opt back in: everything else (a bare error status, a rendered error
+ * page from StatusPages) would land in the request's target and wreck it.
+ * @param {number} status HTTP status of the response
+ * @param {string|null} swapErrorHeader value of the SWAP_ERROR_HEADER response header, if any
+ * @returns {boolean}
+ */
+function shouldSwapErrorResponse(status, swapErrorHeader) {
+	return status >= 400 && swapErrorHeader === 'true';
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = {
+		SWAP_ERROR_HEADER: SWAP_ERROR_HEADER,
+		shouldSwapErrorResponse: shouldSwapErrorResponse,
+	};
+}

--- a/server/src/main/resources/assets/js/toast.js
+++ b/server/src/main/resources/assets/js/toast.js
@@ -1,9 +1,11 @@
 // Lets the toast on an error response through; see shouldSwapErrorResponse in toast-logic.js.
+// Only shouldSwap is flipped: the request did fail, so isError stays true and htmx keeps
+// reporting it as failed to htmx:responseError and to detail.successful listeners. The cost is
+// a console error per rejection, which beats a listener treating a rejection as a success.
 document.body.addEventListener('htmx:beforeSwap', function (evt) {
 	const xhr = evt.detail.xhr;
 	if (xhr && shouldSwapErrorResponse(xhr.status, xhr.getResponseHeader(SWAP_ERROR_HEADER))) {
 		evt.detail.shouldSwap = true;
-		evt.detail.isError = false;
 	}
 });
 

--- a/server/src/main/resources/assets/js/toast.js
+++ b/server/src/main/resources/assets/js/toast.js
@@ -1,9 +1,7 @@
-// htmx throws away the body of a 4xx/5xx response, which would take the toast with it. Responses
-// built by the server's toast helpers say they are swap payloads; swap those and leave the rest
-// to htmx's default handling.
+// Lets the toast on an error response through; see shouldSwapErrorResponse in toast-logic.js.
 document.body.addEventListener('htmx:beforeSwap', function (evt) {
 	const xhr = evt.detail.xhr;
-	if (xhr && xhr.status >= 400 && xhr.getResponseHeader('X-Hammer-Swap-Error') === 'true') {
+	if (xhr && shouldSwapErrorResponse(xhr.status, xhr.getResponseHeader(SWAP_ERROR_HEADER))) {
 		evt.detail.shouldSwap = true;
 		evt.detail.isError = false;
 	}

--- a/server/src/main/resources/assets/js/toast.js
+++ b/server/src/main/resources/assets/js/toast.js
@@ -1,3 +1,14 @@
+// htmx throws away the body of a 4xx/5xx response, which would take the toast with it. Responses
+// built by the server's toast helpers say they are swap payloads; swap those and leave the rest
+// to htmx's default handling.
+document.body.addEventListener('htmx:beforeSwap', function (evt) {
+	const xhr = evt.detail.xhr;
+	if (xhr && xhr.status >= 400 && xhr.getResponseHeader('X-Hammer-Swap-Error') === 'true') {
+		evt.detail.shouldSwap = true;
+		evt.detail.isError = false;
+	}
+});
+
 // Toast auto-dismiss and manual dismiss handling
 function initToast(toast) {
 	const duration = 5000;

--- a/server/src/main/resources/templates/footer.mustache
+++ b/server/src/main/resources/templates/footer.mustache
@@ -81,6 +81,7 @@
 <!-- Toast Container for OOB swaps -->
 <div id="toast-container" aria-live="polite" aria-atomic="false"></div>
 
+<script src="/assets/js/toast-logic.js?v={{version}}"></script>
 <script src="/assets/js/toast.js?v={{version}}"></script>
 {{#page_pre_script}}
 	<script src="{{page_pre_script}}?v={{version}}"></script>

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/DashboardBioTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/DashboardBioTest.kt
@@ -3,12 +3,8 @@ package com.darkrockstudios.apps.hammer.e2e
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.AppenderBase
-import com.darkrockstudios.apps.hammer.e2e.util.E2eTestData
-import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
-import com.darkrockstudios.apps.hammer.e2e.util.TestAccount
-import io.ktor.client.HttpClient
+import com.darkrockstudios.apps.hammer.e2e.util.WebEndToEndTest
 import io.ktor.client.plugins.compression.ContentEncoding
-import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -25,7 +21,6 @@ import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.time.Clock
 
 /**
  * Saving a bio renders a fragment large enough for the Compression plugin to rewrite the response,
@@ -34,7 +29,7 @@ import kotlin.time.Clock
  * The failure this guards against surfaces only in the log: the response is already written by the
  * time the handler's coroutine resumes, so a crash there leaves the client with a healthy 200.
  */
-class DashboardBioTest : EndToEndTest() {
+class DashboardBioTest : WebEndToEndTest() {
 
 	private val email = "author@test.com"
 	private val password = "password123!@#"
@@ -59,35 +54,12 @@ class DashboardBioTest : EndToEndTest() {
 		errorCollector.stop()
 	}
 
-	private fun seed() = runBlocking {
-		E2eTestData.createAccount(TestAccount(email, password), database())
-		database().serverDatabase.whiteListQueries
-			.addToWhiteList(email, Clock.System.now(), "Test author", null)
-		val account = database().serverDatabase.accountQueries.findAccount(email).executeAsOne()
-		database().serverDatabase.accountQueries.updatePenName("Test Author", account.id)
-	}
-
-	private suspend fun login(): HttpClient {
-		val authed = HttpClient {
-			install(HttpCookies)
-			install(ContentEncoding) { gzip() }
-		}
-		val response = authed.post(route("login")) {
-			contentType(ContentType.Application.FormUrlEncoded)
-			setBody(
-				"email=${URLEncoder.encode(email, "UTF-8")}" +
-					"&password=${URLEncoder.encode(password, "UTF-8")}"
-			)
-		}
-		assertEquals(HttpStatusCode.Found, response.status)
-		return authed
-	}
-
 	@Test
 	fun `saving a bio renders the section and a toast without failing the handler`(): Unit = runBlocking {
 		doStartServer()
-		seed()
-		val authed = login()
+		seedWhitelistedAccount(email, password, penName = "Test Author")
+		// Compression is what makes the send pipeline suspend, which is the point of this test.
+		val authed = login(email, password) { install(ContentEncoding) { gzip() } }
 		collectServerErrors()
 
 		val bio = "I write stories about the sea. ".repeat(30)

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/DashboardErrorToastTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/DashboardErrorToastTest.kt
@@ -1,0 +1,87 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.e2e.util.E2eTestData
+import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
+import com.darkrockstudios.apps.hammer.e2e.util.TestAccount
+import com.darkrockstudios.apps.hammer.frontend.utils.SWAP_ERROR_HEADER
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.net.URLEncoder
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.time.Clock
+
+/**
+ * The dashboard's rejection paths answer with an error status and an out-of-band toast. htmx
+ * discards the body of a 4xx unless the response says otherwise, so without these headers the
+ * user gets no feedback at all.
+ */
+class DashboardErrorToastTest : EndToEndTest() {
+
+	private val email = "author@test.com"
+	private val password = "password123!@#"
+
+	private fun seed() = runBlocking {
+		E2eTestData.createAccount(TestAccount(email, password), database())
+		database().serverDatabase.whiteListQueries
+			.addToWhiteList(email, Clock.System.now(), "Test author", null)
+	}
+
+	private suspend fun login(): HttpClient {
+		val authed = HttpClient { install(HttpCookies) }
+		val response = authed.post(route("login")) {
+			contentType(ContentType.Application.FormUrlEncoded)
+			setBody(
+				"email=${URLEncoder.encode(email, "UTF-8")}" +
+					"&password=${URLEncoder.encode(password, "UTF-8")}"
+			)
+		}
+		assertEquals(HttpStatusCode.Found, response.status)
+		return authed
+	}
+
+	private suspend fun HttpClient.postForm(path: String, body: String): HttpResponse =
+		post(route(path)) {
+			header("HX-Request", "true")
+			contentType(ContentType.Application.FormUrlEncoded)
+			setBody(body)
+		}
+
+	@Test
+	fun `a rejected pen name answers with a toast htmx will swap`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		val authed = login()
+
+		val response = authed.postForm("dashboard/penname", "penName=")
+
+		assertEquals(HttpStatusCode.BadRequest, response.status)
+		assertEquals("true", response.headers[SWAP_ERROR_HEADER])
+		// The form targets the displayed pen name; an empty error body must not wipe it.
+		assertEquals("none", response.headers["HX-Reswap"])
+		assertContains(response.bodyAsText(), "toast-error")
+	}
+
+	@Test
+	fun `a mismatched deletion confirmation answers with a toast htmx will swap`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		val authed = login()
+
+		val response = authed.postForm("dashboard/delete-account", "confirmEmail=someone@else.com")
+
+		assertEquals(HttpStatusCode.BadRequest, response.status)
+		assertEquals("true", response.headers[SWAP_ERROR_HEADER])
+		assertContains(response.bodyAsText(), "toast-error")
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/DashboardErrorToastTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/DashboardErrorToastTest.kt
@@ -1,11 +1,8 @@
 package com.darkrockstudios.apps.hammer.e2e
 
-import com.darkrockstudios.apps.hammer.e2e.util.E2eTestData
-import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
-import com.darkrockstudios.apps.hammer.e2e.util.TestAccount
+import com.darkrockstudios.apps.hammer.e2e.util.WebEndToEndTest
 import com.darkrockstudios.apps.hammer.frontend.utils.SWAP_ERROR_HEADER
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -16,39 +13,18 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
-import java.net.URLEncoder
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.time.Clock
 
 /**
  * The dashboard's rejection paths answer with an error status and an out-of-band toast. htmx
  * discards the body of a 4xx unless the response says otherwise, so without these headers the
  * user gets no feedback at all.
  */
-class DashboardErrorToastTest : EndToEndTest() {
+class DashboardErrorToastTest : WebEndToEndTest() {
 
 	private val email = "author@test.com"
 	private val password = "password123!@#"
-
-	private fun seed() = runBlocking {
-		E2eTestData.createAccount(TestAccount(email, password), database())
-		database().serverDatabase.whiteListQueries
-			.addToWhiteList(email, Clock.System.now(), "Test author", null)
-	}
-
-	private suspend fun login(): HttpClient {
-		val authed = HttpClient { install(HttpCookies) }
-		val response = authed.post(route("login")) {
-			contentType(ContentType.Application.FormUrlEncoded)
-			setBody(
-				"email=${URLEncoder.encode(email, "UTF-8")}" +
-					"&password=${URLEncoder.encode(password, "UTF-8")}"
-			)
-		}
-		assertEquals(HttpStatusCode.Found, response.status)
-		return authed
-	}
 
 	private suspend fun HttpClient.postForm(path: String, body: String): HttpResponse =
 		post(route(path)) {
@@ -60,8 +36,8 @@ class DashboardErrorToastTest : EndToEndTest() {
 	@Test
 	fun `a rejected pen name answers with a toast htmx will swap`(): Unit = runBlocking {
 		doStartServer()
-		seed()
-		val authed = login()
+		seedWhitelistedAccount(email, password)
+		val authed = login(email, password)
 
 		val response = authed.postForm("dashboard/penname", "penName=")
 
@@ -75,8 +51,8 @@ class DashboardErrorToastTest : EndToEndTest() {
 	@Test
 	fun `a mismatched deletion confirmation answers with a toast htmx will swap`(): Unit = runBlocking {
 		doStartServer()
-		seed()
-		val authed = login()
+		seedWhitelistedAccount(email, password)
+		val authed = login(email, password)
 
 		val response = authed.postForm("dashboard/delete-account", "confirmEmail=someone@else.com")
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/ToastResponseTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/ToastResponseTest.kt
@@ -57,6 +57,27 @@ class ToastResponseTest {
 	}
 
 	@Test
+	fun `an error response of only whitespace leaves the target alone`() = testApplication {
+		application {
+			routing {
+				get("/error-toast") {
+					// What a template of all-conditional sections renders to when none of them match.
+					respondHtmlWithToast(
+						content = "\n",
+						message = "nope",
+						toast = Toast.Error,
+						status = HttpStatusCode.BadRequest
+					)
+				}
+			}
+		}
+
+		val response = client.get("/error-toast")
+
+		assertEquals("none", response.headers["HX-Reswap"])
+	}
+
+	@Test
 	fun `an error response carrying content still swaps into the target`() = testApplication {
 		application {
 			routing {
@@ -98,6 +119,19 @@ class ToastResponseTest {
 			assertNull(response.headers[SWAP_ERROR_HEADER], path)
 			assertNull(response.headers["HX-Reswap"], path)
 		}
+	}
+
+	/**
+	 * The client half of the contract is a string literal in a JS asset, so a rename here would
+	 * leave every Kotlin test passing while error toasts silently stopped appearing again.
+	 */
+	@Test
+	fun `the client keys off the same header name`() {
+		val script = checkNotNull(javaClass.getResource("/assets/js/toast-logic.js")) {
+			"toast-logic.js is not on the classpath"
+		}.readText()
+
+		assertContains(script, "'$SWAP_ERROR_HEADER'")
 	}
 
 	@Test

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/ToastResponseTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/ToastResponseTest.kt
@@ -1,0 +1,122 @@
+package com.darkrockstudios.apps.hammer.frontend.utils
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * htmx drops the body of a 4xx response, out-of-band toast and all, so an error toast only reaches
+ * the user if the response opts back in with [SWAP_ERROR_HEADER]. The client-side handler in
+ * toast.js keys off exactly what is asserted here.
+ */
+class ToastResponseTest {
+
+	@Test
+	fun `a toast-only error response is marked swappable`() = testApplication {
+		application {
+			routing {
+				get("/error-toast") {
+					respondToast("nope", Toast.Error, HttpStatusCode.BadRequest)
+				}
+			}
+		}
+
+		val response = client.get("/error-toast")
+
+		assertEquals(HttpStatusCode.BadRequest, response.status)
+		assertEquals("true", response.headers[SWAP_ERROR_HEADER])
+		assertContains(response.bodyAsText(), "toast-error")
+	}
+
+	@Test
+	fun `an error response with no content leaves the target alone`() = testApplication {
+		application {
+			routing {
+				get("/error-toast") {
+					respondHtmlWithToast(
+						content = "",
+						message = "nope",
+						toast = Toast.Error,
+						status = HttpStatusCode.BadRequest
+					)
+				}
+			}
+		}
+
+		val response = client.get("/error-toast")
+
+		assertEquals("true", response.headers[SWAP_ERROR_HEADER])
+		assertEquals("none", response.headers["HX-Reswap"])
+	}
+
+	@Test
+	fun `an error response carrying content still swaps into the target`() = testApplication {
+		application {
+			routing {
+				get("/error-toast") {
+					respondHtmlWithToast(
+						content = "<p>replacement</p>",
+						message = "nope",
+						toast = Toast.Error,
+						status = HttpStatusCode.BadRequest
+					)
+				}
+			}
+		}
+
+		val response = client.get("/error-toast")
+
+		assertEquals("true", response.headers[SWAP_ERROR_HEADER])
+		assertNull(response.headers["HX-Reswap"])
+		assertContains(response.bodyAsText(), "<p>replacement</p>")
+	}
+
+	@Test
+	fun `successful toast responses are left untouched`() = testApplication {
+		application {
+			routing {
+				get("/ok-toast") {
+					respondToast("saved", Toast.Success)
+				}
+				get("/ok-content") {
+					respondHtmlWithToast(content = "", message = "saved")
+				}
+			}
+		}
+
+		listOf("/ok-toast", "/ok-content").forEach { path ->
+			val response = client.get(path)
+
+			assertEquals(HttpStatusCode.OK, response.status, path)
+			assertNull(response.headers[SWAP_ERROR_HEADER], path)
+			assertNull(response.headers["HX-Reswap"], path)
+		}
+	}
+
+	@Test
+	fun `rendered template responses carry the toast`() = testApplication {
+		application {
+			routing {
+				get("/template") {
+					respondTemplateWithToast(
+						templatePath = "partials/server-notice.mustache",
+						model = mapOf("hasInstanceNotice" to false),
+						message = "saved"
+					)
+				}
+			}
+		}
+
+		val response = client.get("/template")
+
+		assertEquals(HttpStatusCode.OK, response.status)
+		assertContains(response.bodyAsText(), "toast-success")
+	}
+}

--- a/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/WebEndToEndTest.kt
+++ b/server/src/testFixtures/kotlin/com/darkrockstudios/apps/hammer/e2e/util/WebEndToEndTest.kt
@@ -1,0 +1,65 @@
+package com.darkrockstudios.apps.hammer.e2e.util
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
+import java.net.URLEncoder
+import kotlin.time.Clock
+
+/**
+ * Base for end-to-end tests that drive the web frontend rather than the sync API: seeds a
+ * whitelisted account and signs it in through the real login form, leaving the session cookie
+ * on the returned client.
+ */
+abstract class WebEndToEndTest : EndToEndTest() {
+
+	/** Creates [email] as a whitelisted account, optionally with [penName] already claimed. */
+	protected fun seedWhitelistedAccount(
+		email: String,
+		password: String,
+		penName: String? = null,
+	) = runBlocking {
+		E2eTestData.createAccount(TestAccount(email, password), database())
+		database().serverDatabase.whiteListQueries
+			.addToWhiteList(email, Clock.System.now(), "Test author", null)
+
+		if (penName != null) {
+			val account = database().serverDatabase.accountQueries.findAccount(email).executeAsOne()
+			database().serverDatabase.accountQueries.updatePenName(penName, account.id)
+		}
+	}
+
+	/**
+	 * Signs in over the login form and returns the client holding the session. [configure] adds
+	 * to the client being built, for tests that need a particular transport behaviour.
+	 */
+	protected suspend fun login(
+		email: String,
+		password: String,
+		configure: HttpClientConfig<*>.() -> Unit = {},
+	): HttpClient {
+		val authed = HttpClient {
+			install(HttpCookies)
+			configure()
+		}
+
+		val response = authed.post(route("login")) {
+			contentType(ContentType.Application.FormUrlEncoded)
+			setBody(
+				"email=${URLEncoder.encode(email, "UTF-8")}" +
+					"&password=${URLEncoder.encode(password, "UTF-8")}"
+			)
+		}
+		check(response.status == HttpStatusCode.Found) {
+			"Harness could not log $email in: got ${response.status}"
+		}
+
+		return authed
+	}
+}


### PR DESCRIPTION
Fixes #812

htmx does not swap the body of a 4xx response, so the out-of-band toasts the dashboard's rejection paths send were being discarded and the user saw nothing happen.

## Approach

The issue suggested a global `htmx:beforeSwap` handler that swaps every 4xx. An audit turned up cases where that would introduce new bugs, so the swap is opt-in per response instead:

- `POST /dashboard/penname` errors send an empty body targeted at `#pen-name-value`, so a blanket swap would wipe the pen name from the display on a validation error.
- `StoryPage.kt` answers several htmx routes with a bare `respond(HttpStatusCode.BadRequest)`; those would blank their targets the same way.
- Any htmx request that hits a 404 or 401 gets a full error page from `StatusPages`, which would land inside a small target.

So the toast helpers mark the responses they build, and only those get swapped:

- `ToastUtils.kt`: the three toast helpers funnel through one responder. On an error status it sets `X-Hammer-Swap-Error: true`, plus `HX-Reswap: none` when there is no main content, so the toast lands without emptying the request's target.
- `toast.js`: an `htmx:beforeSwap` listener that flips `shouldSwap` for responses carrying that header. It ships in a file `footer.mustache` already loads on every page, and runs before the deferred htmx script.
- `DashboardPage.kt`: delete-account's 200-on-error workaround reverted to `BadRequest` on both branches.
- `WEB-DESIGN-SYSTEM.md`: documents the contract so new pages reach for the helpers rather than a raw `respond(BadRequest, ...)`.

## Verification

The mechanics were checked against the htmx 2.0.4 source rather than assumed: `HX-Reswap` is read before `htmx:beforeSwap` fires and the override re-read after, OOB swaps are processed inside `swap()` ahead of the main swap, and `swapWithStyle('none')` returns without touching the target.

- `ToastResponseTest` (new) covers the header contract; three of its assertions fail against the old code.
- `DashboardErrorToastTest` (new e2e) drives a real server: a rejected pen name and a mismatched deletion confirmation both answer 400 with the toast and headers.
- Confirmed in a real browser against a dev server. A rejected pen name shows the error toast and the displayed pen name survives; a mismatched deletion confirmation shows its toast; a 404 is still discarded rather than swapped into the target; the success path still swaps and toasts. The only console error logged is the 404.
- Manually exercised a dev server: every error path (`penname` empty and too-short, `bio` without a pen name, `delete-account` mismatch) returns 400 with both headers, and the success path returns 200 with neither.
- Full `:server:test` suite green.

## Noticed, not fixed

`AdminSecurity.kt:28` and `:55` call `respondHtml(...) { createHTML().div { +message } }`, which builds a string and throws it away, so those htmx 403/401 responses send an empty `<html></html>` instead of the message. Unrelated to this fix and left for its own issue.

