### PR TITLE
Cover the remaining host validation cases from #797

### DIFF
--- a/common/src/desktopTest/kotlin/components/projectselection/ServerUrlValidationTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/ServerUrlValidationTest.kt
@@ -60,6 +60,16 @@ class ServerUrlValidationTest {
 	}
 
 	@Test
+	fun `a hyphen in a subdomain validates`() {
+		assertTrue(validateUrl("my-sub.example.com"))
+	}
+
+	@Test
+	fun `a hyphen in a middle label validates`() {
+		assertTrue(validateUrl("machine.tailnet-name.ts.net"))
+	}
+
+	@Test
 	fun `a mixed case hostname validates`() {
 		assertTrue(validateUrl("Hammer.Example.com"))
 	}
@@ -97,5 +107,20 @@ class ServerUrlValidationTest {
 	@Test
 	fun `a host with a trailing hyphen does not validate`() {
 		assertFalse(validateUrl("hammer-.example.com"))
+	}
+
+	@Test
+	fun `a host with a leading hyphen does not validate`() {
+		assertFalse(validateUrl("-hammer.example.com"))
+	}
+
+	@Test
+	fun `a host with an empty label does not validate`() {
+		assertFalse(validateUrl("hammer..com"))
+	}
+
+	@Test
+	fun `a host with an underscore does not validate`() {
+		assertFalse(validateUrl("hammer_example.com"))
 	}
 }


### PR DESCRIPTION
Closes #797.

The behavior #797 asked for is already on `develop` (5acba728 for the main rewrite, f21fc6e2 for the lowercase nit). Auditing the issue's case table against `ServerUrlValidationTest` turned up five cases with no test, three of which are named directly in the acceptance criteria:

> Leading/trailing-hyphen labels, empty labels, and underscores are still rejected.

Only the trailing-hyphen case was covered. Hyphens in subdomain and middle labels were untested as well, despite being the original bug report.

All five already pass against the current `hostRegex`, so this is coverage, not a fix.

| Case | Expected |
| --- | --- |
| `my-sub.example.com` | validates |
| `machine.tailnet-name.ts.net` | validates |
| `-hammer.example.com` | rejected |
| `hammer..com` | rejected |
| `hammer_example.com` | rejected |

`ServerUrlValidationTest` goes from 18 to 23 tests, all passing.

## Out of scope

Two nits the issue itself flagged as "probably fine to leave" remain: label length is not capped at 63 chars, and a numeric host like `999.999.999.999` validates as an ordinary hostname (the old `ipWithPortRegex` with its unbounded octets is gone, so there is no separate IP path to tighten).
