### PR TITLE
Add visible scrollbars to scrolling screens

### DIFF
--- a/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/MpScrollBar.kt
+++ b/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/MpScrollBar.kt
@@ -3,9 +3,13 @@ package com.darkrockstudios.apps.hammer.common.compose
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -16,209 +20,176 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
+// The Android bar fades in over the content, so it reserves no layout space.
+actual val MpScrollBarGutter: Dp = 0.dp
+
 @Composable
 actual fun MpScrollBarList(
 	modifier: Modifier,
 	state: LazyListState
 ) {
-	AndroidScrollbar(
-		modifier = modifier,
-		state = state,
-		horizontal = false,
-		fixedKnobRatio = 0.1f
+	ScrollbarCanvas(modifier = modifier, isScrollInProgress = state.isScrollInProgress) { viewportSize ->
+		val firstVisibleItem = state.layoutInfo.visibleItemsInfo.firstOrNull()
+		val firstItemSize = firstVisibleItem?.size ?: 0
+		// Estimated from the first visible item, so the knob drifts when item sizes are not uniform.
+		// A fixed knob size keeps it from visibly growing and shrinking as you scroll.
+		val estimatedContentSize = (firstItemSize * state.layoutInfo.totalItemsCount).toFloat()
+		if (estimatedContentSize <= 0f) {
+			null
+		} else {
+			val offset = state.firstVisibleItemIndex * firstItemSize + state.firstVisibleItemScrollOffset
+			ScrollbarKnob(
+				position = (viewportSize / estimatedContentSize) * offset,
+				size = viewportSize * FixedKnobRatio,
+			)
+		}
+	}
+}
+
+@Composable
+actual fun MpScrollBarColumn(
+	modifier: Modifier,
+	state: ScrollState
+) {
+	ScrollbarCanvas(modifier = modifier, isScrollInProgress = state.isScrollInProgress) { viewportSize ->
+		val scrollRange = state.maxValue
+		// A ScrollState that was never attached to a scrolling container reports Int.MAX_VALUE.
+		if (scrollRange <= 0 || scrollRange == Int.MAX_VALUE) {
+			null
+		} else {
+			val contentSize = viewportSize + scrollRange
+			ScrollbarKnob(
+				position = (viewportSize / contentSize) * state.value,
+				size = (viewportSize / contentSize) * viewportSize,
+			)
+		}
+	}
+}
+
+@Composable
+actual fun MpScrollBarGrid(
+	modifier: Modifier,
+	state: LazyGridState
+) {
+	ScrollbarCanvas(modifier = modifier, isScrollInProgress = state.isScrollInProgress) { viewportSize ->
+		itemCountKnob(
+			viewportSize = viewportSize,
+			firstVisibleIndex = state.firstVisibleItemIndex,
+			visibleCount = state.layoutInfo.visibleItemsInfo.size,
+			totalCount = state.layoutInfo.totalItemsCount,
+		)
+	}
+}
+
+@Composable
+actual fun MpScrollBarStaggeredGrid(
+	modifier: Modifier,
+	state: LazyStaggeredGridState
+) {
+	ScrollbarCanvas(modifier = modifier, isScrollInProgress = state.isScrollInProgress) { viewportSize ->
+		itemCountKnob(
+			viewportSize = viewportSize,
+			firstVisibleIndex = state.firstVisibleItemIndex,
+			visibleCount = state.layoutInfo.visibleItemsInfo.size,
+			totalCount = state.layoutInfo.totalItemsCount,
+		)
+	}
+}
+
+/** Knob ratio for lists, whose content extent can only be estimated. */
+private const val FixedKnobRatio = 0.1f
+
+/**
+ * Knob driven by item counts rather than pixel extents, so it works the same for uniform and
+ * staggered grids. It moves one item at a time, fine-grained enough for grids that hold more items
+ * than fit on screen.
+ */
+private fun itemCountKnob(
+	viewportSize: Float,
+	firstVisibleIndex: Int,
+	visibleCount: Int,
+	totalCount: Int,
+): ScrollbarKnob? = if (totalCount <= 0 || visibleCount <= 0 || visibleCount >= totalCount) {
+	null
+} else {
+	ScrollbarKnob(
+		position = viewportSize * (firstVisibleIndex.toFloat() / totalCount),
+		size = viewportSize * (visibleCount.toFloat() / totalCount),
 	)
 }
 
+/** Where the knob sits along the track and how long it is, both in pixels. */
+private data class ScrollbarKnob(
+	val position: Float,
+	val size: Float,
+)
 
 /**
- * Renders a scrollbar.
+ * Vertical scrollbar that appears when the user starts scrolling and fades out once they stop.
+ * It is composed of a track and a knob that moves across it; [knob] supplies the knob's position
+ * and length for a given viewport, and returns `null` when there is nothing to scroll.
  *
- * <ul> <li> A scrollbar is composed of two components: a track and a knob. The knob moves across
- * the track <li> The scrollbar appears automatically when the user starts scrolling and disappears
- * after the scrolling is finished </ul>
+ * The knob is measured inside the draw lambda, so scroll position reads invalidate draw only.
  *
- * @param state The [LazyListState] that has been passed into the lazy list or lazy row
- * @param horizontal If `true`, this will be a horizontally-scrolling (left and right) scroll bar,
- * if `false`, it will be vertically-scrolling (up and down)
- * @param alignEnd If `true`, the scrollbar will appear at the "end" of the scrollable composable it
- * is decorating (at the right-hand side in left-to-right locales or left-hand side in right-to-left
- * locales, for the vertical scrollbars -or- the bottom for horizontal scrollbars). If `false`, the
- * scrollbar will appear at the "start" of the scrollable composable it is decorating (at the
- * left-hand side in left-to-right locales or right-hand side in right-to-left locales, for the
- * vertical scrollbars -or- the top for horizontal scrollbars)
- * @param thickness How thick/wide the track and knob should be
- * @param fixedKnobRatio If not `null`, the knob will always have this size, proportional to the
- * size of the track. You should consider doing this if the size of the items in the scrollable
- * composable is not uniform, to avoid the knob from oscillating in size as you scroll through the
- * list
- * @param knobCornerRadius The corner radius for the knob
- * @param trackCornerRadius The corner radius for the track
- * @param knobColor The color of the knob
- * @param trackColor The color of the track. Make it [Color.Transparent] to hide it
- * @param padding Edge padding to "squeeze" the scrollbar start/end in so it's not flush with the
- * contents of the scrollable composable it is decorating
- * @param visibleAlpha The alpha when the scrollbar is fully faded-in
- * @param hiddenAlpha The alpha when the scrollbar is fully faded-out. Use a non-`0` number to keep
- * the scrollbar from ever fading out completely
- * @param fadeInAnimationDurationMs The duration of the fade-in animation when the scrollbar appears
- * once the user starts scrolling
- * @param fadeOutAnimationDurationMs The duration of the fade-out animation when the scrollbar
- * disappears after the user is finished scrolling
- * @param fadeOutAnimationDelayMs Amount of time to wait after the user is finished scrolling before
- * the scrollbar begins its fade-out animation
+ * @param thickness how thick the track and knob should be
+ * @param trackColor colour of the track; [Color.Transparent] hides it
+ * @param padding edge padding, so the knob is not flush with the ends of the track
+ * @param hiddenAlpha use a non-zero value to keep the scrollbar from fading out completely
  */
 @Composable
-fun AndroidScrollbar(
-	modifier: Modifier = Modifier,
-	state: LazyListState,
-	horizontal: Boolean,
-	alignEnd: Boolean = true,
+private fun ScrollbarCanvas(
+	modifier: Modifier,
+	isScrollInProgress: Boolean,
 	thickness: Dp = 4.dp,
-	fixedKnobRatio: Float? = null,
 	knobCornerRadius: Dp = 4.dp,
 	trackCornerRadius: Dp = 2.dp,
-	knobColor: Color = Color.Black,
-	trackColor: Color = Color.White,
+	knobColor: Color = MaterialTheme.colorScheme.outline,
+	trackColor: Color = Color.Transparent,
 	padding: Dp = 0.dp,
 	visibleAlpha: Float = 1f,
 	hiddenAlpha: Float = 0f,
 	fadeInAnimationDurationMs: Int = 150,
 	fadeOutAnimationDurationMs: Int = 500,
 	fadeOutAnimationDelayMs: Int = 1000,
+	knob: (viewportSize: Float) -> ScrollbarKnob?,
 ) {
-	check(thickness > 0.dp) { "Thickness must be a positive integer." }
-	check(fixedKnobRatio == null || fixedKnobRatio < 1f) {
-		"A fixed knob ratio must be smaller than 1."
-	}
-	check(knobCornerRadius >= 0.dp) { "Knob corner radius must be greater than or equal to 0." }
-	check(trackCornerRadius >= 0.dp) { "Track corner radius must be greater than or equal to 0." }
-	check(hiddenAlpha <= visibleAlpha) { "Hidden alpha cannot be greater than visible alpha." }
-	check(fadeInAnimationDurationMs >= 0) {
-		"Fade in animation duration must be greater than or equal to 0."
-	}
-	check(fadeOutAnimationDurationMs >= 0) {
-		"Fade out animation duration must be greater than or equal to 0."
-	}
-	check(fadeOutAnimationDelayMs >= 0) {
-		"Fade out animation delay must be greater than or equal to 0."
-	}
-
-	val targetAlpha =
-		if (state.isScrollInProgress) {
-			visibleAlpha
-		} else {
-			hiddenAlpha
-		}
+	val targetAlpha = if (isScrollInProgress) visibleAlpha else hiddenAlpha
 	val animationDurationMs =
-		if (state.isScrollInProgress) {
-			fadeInAnimationDurationMs
-		} else {
-			fadeOutAnimationDurationMs
-		}
-	val animationDelayMs =
-		if (state.isScrollInProgress) {
-			0
-		} else {
-			fadeOutAnimationDelayMs
-		}
+		if (isScrollInProgress) fadeInAnimationDurationMs else fadeOutAnimationDurationMs
+	val animationDelayMs = if (isScrollInProgress) 0 else fadeOutAnimationDelayMs
 
-	val alpha by
-	animateFloatAsState(
+	val alpha by animateFloatAsState(
 		targetValue = targetAlpha,
-		animationSpec =
-		tween(delayMillis = animationDelayMs, durationMillis = animationDurationMs)
+		animationSpec = tween(delayMillis = animationDelayMs, durationMillis = animationDurationMs),
 	)
 
-	return Canvas(
+	Canvas(
 		modifier = modifier
 			.width(thickness)
 			.fillMaxHeight()
 	) {
-		state.layoutInfo.visibleItemsInfo.firstOrNull()?.let { firstVisibleItem ->
-			if (state.isScrollInProgress || alpha > 0f) {
-				// Size of the viewport, the entire size of the scrollable composable we are decorating with
-				// this scrollbar.
-				val viewportSize =
-					if (horizontal) {
-						size.width
-					} else {
-						size.height
-					} - padding.toPx() * 2
+		if (!isScrollInProgress && alpha <= 0f) return@Canvas
 
-				// The size of the first visible item. We use this to estimate how many items can fit in the
-				// viewport. Of course, this works perfectly when all items have the same size. When they
-				// don't, the scrollbar knob size will grow and shrink as we scroll.
-				val firstItemSize = firstVisibleItem.size
+		val thicknessPx = thickness.toPx()
+		val paddingPx = padding.toPx()
+		val trackLength = size.height - paddingPx * 2
+		val measured = knob(trackLength) ?: return@Canvas
+		val left = size.width - thicknessPx
 
-				// The *estimated* size of the entire scrollable composable, as if it's all on screen at
-				// once. It is estimated because it's possible that the size of the first visible item does
-				// not represent the size of other items. This will cause the scrollbar knob size to grow
-				// and shrink as we scroll, if the item sizes are not uniform.
-				val estimatedFullListSize = firstItemSize * state.layoutInfo.totalItemsCount
+		drawRoundRect(
+			color = trackColor,
+			topLeft = Offset(left, paddingPx),
+			size = Size(thicknessPx, trackLength),
+			alpha = alpha,
+			cornerRadius = CornerRadius(x = trackCornerRadius.toPx(), y = trackCornerRadius.toPx()),
+		)
 
-				// The difference in position between the first pixels visible in our viewport as we scroll
-				// and the top of the fully-populated scrollable composable, if it were to show all the
-				// items at once. At first, the value is 0 since we start all the way to the top (or start
-				// edge). As we scroll down (or towards the end), this number will grow.
-				val viewportOffsetInFullListSpace =
-					state.firstVisibleItemIndex * firstItemSize + state.firstVisibleItemScrollOffset
-
-				// Where we should render the knob in our composable.
-				val knobPosition =
-					(viewportSize / estimatedFullListSize) * viewportOffsetInFullListSpace + padding.toPx()
-				// How large should the knob be.
-				val knobSize =
-					fixedKnobRatio?.let { it * viewportSize }
-						?: (viewportSize * viewportSize) / estimatedFullListSize
-
-				// Draw the track
-				drawRoundRect(
-					color = trackColor,
-					topLeft =
-					when {
-						// When the scrollbar is horizontal and aligned to the bottom:
-						horizontal && alignEnd -> Offset(padding.toPx(), size.height - thickness.toPx())
-						// When the scrollbar is horizontal and aligned to the top:
-						horizontal && !alignEnd -> Offset(padding.toPx(), 0f)
-						// When the scrollbar is vertical and aligned to the end:
-						alignEnd -> Offset(size.width - thickness.toPx(), padding.toPx())
-						// When the scrollbar is vertical and aligned to the start:
-						else -> Offset(0f, padding.toPx())
-					},
-					size =
-					if (horizontal) {
-						Size(size.width - padding.toPx() * 2, thickness.toPx())
-					} else {
-						Size(thickness.toPx(), size.height - padding.toPx() * 2)
-					},
-					alpha = alpha,
-					cornerRadius = CornerRadius(x = trackCornerRadius.toPx(), y = trackCornerRadius.toPx()),
-				)
-
-				// Draw the knob
-				drawRoundRect(
-					color = knobColor,
-					topLeft =
-					when {
-						// When the scrollbar is horizontal and aligned to the bottom:
-						horizontal && alignEnd -> Offset(knobPosition, size.height - thickness.toPx())
-						// When the scrollbar is horizontal and aligned to the top:
-						horizontal && !alignEnd -> Offset(knobPosition, 0f)
-						// When the scrollbar is vertical and aligned to the end:
-						alignEnd -> Offset(size.width - thickness.toPx(), knobPosition)
-						// When the scrollbar is vertical and aligned to the start:
-						else -> Offset(0f, knobPosition)
-					},
-					size =
-					if (horizontal) {
-						Size(knobSize, thickness.toPx())
-					} else {
-						Size(thickness.toPx(), knobSize)
-					},
-					alpha = alpha,
-					cornerRadius = CornerRadius(x = knobCornerRadius.toPx(), y = knobCornerRadius.toPx()),
-				)
-			}
-		}
+		drawRoundRect(
+			color = knobColor,
+			topLeft = Offset(left, measured.position + paddingPx),
+			size = Size(thicknessPx, measured.size),
+			alpha = alpha,
+			cornerRadius = CornerRadius(x = knobCornerRadius.toPx(), y = knobCornerRadius.toPx()),
+		)
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/MpScrollBar.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/MpScrollBar.kt
@@ -1,12 +1,41 @@
 package com.darkrockstudios.apps.hammer.common.compose
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Width the scrollbar occupies at the scrollable edge. Screens whose content runs edge to edge
+ * should reserve this much trailing space so the bar does not sit on top of it. Zero on platforms
+ * whose scrollbar is a transient overlay.
+ */
+expect val MpScrollBarGutter: Dp
 
 @Composable
 expect fun MpScrollBarList(
 	modifier: Modifier = Modifier.fillMaxHeight(),
 	state: LazyListState
+)
+
+@Composable
+expect fun MpScrollBarColumn(
+	modifier: Modifier = Modifier.fillMaxHeight(),
+	state: ScrollState
+)
+
+@Composable
+expect fun MpScrollBarGrid(
+	modifier: Modifier = Modifier.fillMaxHeight(),
+	state: LazyGridState
+)
+
+@Composable
+expect fun MpScrollBarStaggeredGrid(
+	modifier: Modifier = Modifier.fillMaxHeight(),
+	state: LazyStaggeredGridState
 )

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ScrollBarOverlay.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ScrollBarOverlay.kt
@@ -1,0 +1,22 @@
+package com.darkrockstudios.apps.hammer.common.compose
+
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/** Whether there is anywhere left to scroll in either direction. */
+val ScrollableState.isScrollable: Boolean
+	get() = canScrollForward || canScrollBackward
+
+/**
+ * Placement for a scrollbar overlaid on a scrolling sibling: full height, pinned to the trailing
+ * edge. Uses [BoxScope.matchParentSize] rather than `fillMaxHeight` so the bar never contributes to
+ * the parent's size, which matters in the wrap-content boxes the detail screens use.
+ */
+@Suppress("ModifierFactoryExtensionFunction")
+fun BoxScope.scrollBarOverlay(): Modifier =
+	Modifier
+		.matchParentSize()
+		.wrapContentWidth(Alignment.End)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
@@ -689,6 +689,59 @@ Encyclopedia). Tag collapse lives inside `HdHairlineTagField` so it
 works wherever the field is used; date and crumb rows are wrapped at
 their call sites.
 
+### Scrollbar rail
+
+Desktop scrollbars are drawn as a **hatched rail** rather than a bare
+thumb: a vertical `outlineVariant` hairline marking the scrollable edge,
+with 45° hairline hatching filling the track behind an opaque square
+thumb.
+
+```
+│╱╱╱│
+│███│  <- thumb, masking the hatch
+│╱╱╱│
+ ^ edge rule
+```
+
+The hatch is [greeble](#greebles) logic applied to texture — it means
+something. The thumb masks it as it travels, so the hatching that
+remains is exactly the part of the document you haven't reached. It also
+follows rule 1: the edge rule is the same vertical hairline
+`HdHairlineSection` uses to group content, so a scrolling screen reads
+as bounded rather than cut off.
+
+Both the rule and the hatch are drawn **only while there is somewhere to
+scroll**, so a screen whose content fits gets no chrome at all. The
+thumb rests at `outlineVariant` and promotes to `outline` on hover —
+Compose's default is 12% black, which vanishes on a dark surface.
+
+Screens don't build any of this. Overlay the bar on its scrolling
+sibling inside a `Box`:
+
+```kotlin
+Box(Modifier.weight(1f)) {
+    LazyColumn(state = listState) { … }
+    MpScrollBarList(modifier = scrollBarOverlay(), state = listState)
+}
+```
+
+- **[`scrollBarOverlay()`](../ScrollBarOverlay.kt)** is the only correct
+  placement — `matchParentSize()`, so the bar never contributes to the
+  parent's size. `fillMaxHeight()` would stretch the wrap-content boxes
+  the detail screens use.
+- **[`MpScrollBarGutter`](../MpScrollBar.kt)** is the width to reserve
+  when content runs *edge to edge* (a full-bleed row that paints its own
+  background, or a drag surface). Screens with normal horizontal padding
+  need nothing — the rail sits in the padding they already have.
+
+**Platform caveat, and a known exception to cross-platform parity.** The
+rail is `desktopMain` only. Android draws a transient fading thumb and
+iOS uses its native inline indicators, so `MpScrollBarGutter` is `0.dp`
+on both. This is the one piece of visual vocabulary that isn't
+`commonMain`; a persistent hatched rail is right for a pointer and wrong
+for a touch screen. If it ever needs to be shared, the drawing belongs
+in an `Hd*` here and the platform files should supply only the thumb.
+
 ---
 
 ## Adding to the system

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/reorderable/DragDropList.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/reorderable/DragDropList.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
@@ -20,6 +22,9 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.zIndex
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarGutter
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarList
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
@@ -64,58 +69,67 @@ fun <T> DragDropList(
 		})
 
 	val hapticFeedback = LocalHapticFeedback.current
-	LazyColumn(
-		modifier = modifier
-			.pointerInput(Unit) {
-				detectDragGesturesAfterLongPress(
-					onDrag = { change, offset ->
-						change.consume()
-						dragDropListState.onDrag(offset)
+	Box(modifier = modifier) {
+		LazyColumn(
+			modifier = Modifier
+				.fillMaxSize()
+				.padding(end = MpScrollBarGutter)
+				.pointerInput(Unit) {
+					detectDragGesturesAfterLongPress(
+						onDrag = { change, offset ->
+							change.consume()
+							dragDropListState.onDrag(offset)
 
-						if (overscrollJob?.isActive == true)
-							return@detectDragGesturesAfterLongPress
+							if (overscrollJob?.isActive == true)
+								return@detectDragGesturesAfterLongPress
 
-						dragDropListState.checkForOverScroll()
-							.takeIf { it != 0f }
-							?.let { overscrollJob = scope.launch { dragDropListState.lazyListState.scrollBy(it) } }
-							?: run { overscrollJob?.cancel() }
-					},
-					onDragStart = { offset ->
-						if (dragDropListState.onDragStart(offset)) {
-							hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-						}
-					},
-					onDragEnd = { dragDropListState.onDragEnd() },
-					onDragCancel = { dragDropListState.onDragInterrupted() }
-				)
-			},
-		state = dragDropListState.lazyListState,
-		contentPadding = contentPadding
-	) {
-		itemsIndexed(data, key) { index, item ->
-			val isDragging = index == dragDropListState.currentIndexOfDraggedItem
-			val isReordering = dragDropListState.currentIndexOfDraggedItem != null
-			val zIndex = if (isDragging) {
-				1f
-			} else {
-				0f
-			}
-			// Animate placement only while reordering, so the displaced items
-			// slide into place; otherwise plain scrolling would animate them too.
-			val itemModifier = when {
-				isDragging -> Modifier.graphicsLayer {
-					translationY = dragDropListState.elementDisplacement ?: 0f
+							dragDropListState.checkForOverScroll()
+								.takeIf { it != 0f }
+								?.let { overscrollJob = scope.launch { dragDropListState.lazyListState.scrollBy(it) } }
+								?: run { overscrollJob?.cancel() }
+						},
+						onDragStart = { offset ->
+							if (dragDropListState.onDragStart(offset)) {
+								hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+							}
+						},
+						onDragEnd = { dragDropListState.onDragEnd() },
+						onDragCancel = { dragDropListState.onDragInterrupted() }
+					)
+				},
+			state = dragDropListState.lazyListState,
+			contentPadding = contentPadding
+		) {
+			itemsIndexed(data, key) { index, item ->
+				val isDragging = index == dragDropListState.currentIndexOfDraggedItem
+				val isReordering = dragDropListState.currentIndexOfDraggedItem != null
+				val zIndex = if (isDragging) {
+					1f
+				} else {
+					0f
 				}
-				isReordering -> Modifier.animateItem()
-				else -> Modifier
-			}
-			Box(
-				modifier = Modifier
-					.zIndex(zIndex)
-					.then(itemModifier)
-			) {
-				itemContent(item, isDragging)
+				// Animate placement only while reordering, so the displaced items
+				// slide into place; otherwise plain scrolling would animate them too.
+				val itemModifier = when {
+					isDragging -> Modifier.graphicsLayer {
+						translationY = dragDropListState.elementDisplacement ?: 0f
+					}
+					isReordering -> Modifier.animateItem()
+					else -> Modifier
+				}
+				Box(
+					modifier = Modifier
+						.zIndex(zIndex)
+						.then(itemModifier)
+				) {
+					itemContent(item, isDragging)
+				}
 			}
 		}
+
+		MpScrollBarList(
+			modifier = scrollBarOverlay(),
+			state = dragDropListState.lazyListState,
+		)
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/BrowseEntriesUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/BrowseEntriesUi.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -22,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Create
@@ -51,6 +53,7 @@ import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.encyclopedia.BrowseEntries
 import com.darkrockstudios.apps.hammer.common.components.encyclopedia.Encyclopedia
 import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarGrid
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdCollapsingStrip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdEntryFilterBar
@@ -63,6 +66,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSearchRow
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSectionHeader
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdTagChip
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
@@ -224,37 +228,46 @@ fun BrowseEntriesUi(
 		// Card grid — adaptive 320dp min cell so on wide screens we get
 		// 3-4 columns and on narrow screens cards stack into a single
 		// column.
-		LazyVerticalGrid(
-			columns = GridCells.Adaptive(minSize = 320.dp),
-			modifier = Modifier.fillMaxSize(),
-			contentPadding = PaddingValues(Ui.Padding.XL),
-			verticalArrangement = Arrangement.spacedBy(Ui.Padding.XL),
-			horizontalArrangement = Arrangement.spacedBy(Ui.Padding.XL),
-		) {
-			if (filteredEntries.isEmpty()) {
-				item {
-					Text(
-						text = Res.string.encyclopedia_browse_list_empty.get(),
-						style = MaterialTheme.typography.headlineSmall,
-						color = MaterialTheme.colorScheme.onBackground,
-						modifier = Modifier.padding(Ui.Padding.XL),
-					)
-				}
-			} else {
-				items(filteredEntries.size) { index ->
-					EncyclopediaEntryItem(
-						entryDef = filteredEntries[index],
-						component = component,
-						viewEntry = viewEntry,
-						scope = scope,
-						sharedTransitionScope = sharedTransitionScope,
-						animatedVisibilityScope = animatedVisibilityScope,
-						activeTags = activeTags.toSet(),
-						tagsScrollHorizontally = !isWide,
-						filterByType = onSelectType,
-					)
+		val gridState = rememberLazyGridState()
+		Box(modifier = Modifier.weight(1f)) {
+			LazyVerticalGrid(
+				state = gridState,
+				columns = GridCells.Adaptive(minSize = 320.dp),
+				modifier = Modifier.fillMaxSize(),
+				contentPadding = PaddingValues(Ui.Padding.XL),
+				verticalArrangement = Arrangement.spacedBy(Ui.Padding.XL),
+				horizontalArrangement = Arrangement.spacedBy(Ui.Padding.XL),
+			) {
+				if (filteredEntries.isEmpty()) {
+					item {
+						Text(
+							text = Res.string.encyclopedia_browse_list_empty.get(),
+							style = MaterialTheme.typography.headlineSmall,
+							color = MaterialTheme.colorScheme.onBackground,
+							modifier = Modifier.padding(Ui.Padding.XL),
+						)
+					}
+				} else {
+					items(filteredEntries.size) { index ->
+						EncyclopediaEntryItem(
+							entryDef = filteredEntries[index],
+							component = component,
+							viewEntry = viewEntry,
+							scope = scope,
+							sharedTransitionScope = sharedTransitionScope,
+							animatedVisibilityScope = animatedVisibilityScope,
+							activeTags = activeTags.toSet(),
+							tagsScrollHorizontally = !isWide,
+							filterByType = onSelectType,
+						)
+					}
 				}
 			}
+
+			MpScrollBarGrid(
+				modifier = scrollBarOverlay(),
+				state = gridState,
+			)
 		}
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
@@ -136,146 +136,157 @@ internal fun ViewEntryUi(
 	} else {
 		Modifier.fillMaxSize().verticalScroll(outerScrollState)
 	}
-	Column(
-		modifier = outerModifier,
-		horizontalAlignment = Alignment.CenterHorizontally,
-	) {
-		with(sharedTransitionScope) {
-			Column(
-				modifier = modifier
-					.padding(
-						start = Ui.Padding.M,
-						end = Ui.Padding.M,
-					)
-					.widthIn(max = Ui.MaxWidth.CatalogueCard)
-					.fillMaxWidth()
-					.then(if (editing) Modifier.fillMaxHeight() else Modifier)
-					.background(MaterialTheme.colorScheme.surface)
-					.border(width = Dp.Hairline, color = ruleColor, shape = RectangleShape)
-					.sharedElement(
-						sharedContentState = rememberSharedContentState(
-							key = "encyclopedia-card-${state.entryDef.id}",
+	Box {
+		Column(
+			modifier = outerModifier,
+			horizontalAlignment = Alignment.CenterHorizontally,
+		) {
+			with(sharedTransitionScope) {
+				Column(
+					modifier = modifier
+						.padding(
+							start = Ui.Padding.M,
+							end = Ui.Padding.M,
+						)
+						.widthIn(max = Ui.MaxWidth.CatalogueCard)
+						.fillMaxWidth()
+						.then(if (editing) Modifier.fillMaxHeight() else Modifier)
+						.background(MaterialTheme.colorScheme.surface)
+						.border(width = Dp.Hairline, color = ruleColor, shape = RectangleShape)
+						.sharedElement(
+							sharedContentState = rememberSharedContentState(
+								key = "encyclopedia-card-${state.entryDef.id}",
+							),
+							animatedVisibilityScope = animatedVisibilityScope,
 						),
-						animatedVisibilityScope = animatedVisibilityScope,
-					),
-			) {
-				CollapseWhileTyping(enabled = editing) {
-					Column {
-						CrumbRow(
-							title = entryNameText.ifBlank { state.entryDef.name }.uppercase(),
-							menuSlot = { DetailViewDropdownMenu(menuItems = state.menuItems) },
-							onClose = {
-								val isDirty = content != null &&
-									(entryNameText != content.name || entryText != content.text)
-								when {
-									editing && isDirty -> component.confirmClose()
-									editing -> {
-										component.finishNameEdit()
-										component.finishTextEdit()
-										closeEntry()
+				) {
+					CollapseWhileTyping(enabled = editing) {
+						Column {
+							CrumbRow(
+								title = entryNameText.ifBlank { state.entryDef.name }.uppercase(),
+								menuSlot = { DetailViewDropdownMenu(menuItems = state.menuItems) },
+								onClose = {
+									val isDirty = content != null &&
+										(entryNameText != content.name || entryText != content.text)
+									when {
+										editing && isDirty -> component.confirmClose()
+										editing -> {
+											component.finishNameEdit()
+											component.finishTextEdit()
+											closeEntry()
+										}
+
+										else -> closeEntry()
 									}
+								},
+							)
 
-									else -> closeEntry()
-								}
-							},
-						)
-
-						HorizontalDivider(thickness = Dp.Hairline, color = ruleColor)
-					}
-				}
-
-				StampRow(
-					entryDef = state.entryDef,
-					editing = editing,
-					onEdit = {
-						component.startNameEdit()
-						component.startTextEdit()
-					},
-					onSave = saveChanges,
-					onCancel = {
-						val isDirty = content != null &&
-							(entryNameText != content.name || entryText != content.text)
-						if (isDirty) {
-							discardConfirm = true
-						} else {
-							discardChanges()
+							HorizontalDivider(thickness = Dp.Hairline, color = ruleColor)
 						}
-					},
-				)
+					}
 
-				HorizontalDivider(thickness = 2.dp, color = ruleStrong)
-
-				// The big name collapses while the body editor has focus; kept visible while the name
-				// field itself holds focus so it stays reachable.
-				var nameFocused by remember { mutableStateOf(false) }
-				CollapseWhileTyping(keepVisible = nameFocused) {
-					NameZone(
-						entryNameText = entryNameText,
-						onNameChange = { entryNameText = it },
-						editName = state.editName,
-						onStartEdit = component::startNameEdit,
-						onFocusChanged = { nameFocused = it },
-						compact = isCompact,
-						sharedKey = "encyclopedia-title-${state.entryDef.id}",
-						sharedTransitionScope = sharedTransitionScope,
-						animatedVisibilityScope = animatedVisibilityScope,
+					StampRow(
+						entryDef = state.entryDef,
+						editing = editing,
+						onEdit = {
+							component.startNameEdit()
+							component.startTextEdit()
+						},
+						onSave = saveChanges,
+						onCancel = {
+							val isDirty = content != null &&
+								(entryNameText != content.name || entryText != content.text)
+							if (isDirty) {
+								discardConfirm = true
+							} else {
+								discardChanges()
+							}
+						},
 					)
-				}
 
-				val bodyOuterModifier = if (editing) Modifier.weight(1f) else Modifier
-				if (isCompact) {
-					CompactBody(
-						state = state,
-						entryText = entryText,
-						setEntryText = { entryText = it },
-						onStartTextEdit = component::startTextEdit,
-						onShowDeleteImage = component::showDeleteImageDialog,
-						onAddImage = component::showAddImageDialog,
-						outerModifier = bodyOuterModifier,
-						sharedTransitionScope = sharedTransitionScope,
-						animatedVisibilityScope = animatedVisibilityScope,
-					)
-				} else {
-					WideBody(
-						state = state,
-						entryText = entryText,
-						setEntryText = { entryText = it },
-						onStartTextEdit = component::startTextEdit,
-						onShowDeleteImage = component::showDeleteImageDialog,
-						onAddImage = component::showAddImageDialog,
-						outerModifier = bodyOuterModifier,
-						sharedTransitionScope = sharedTransitionScope,
-						animatedVisibilityScope = animatedVisibilityScope,
-					)
-				}
+					HorizontalDivider(thickness = 2.dp, color = ruleStrong)
 
-				if (!editing) {
-					if (content != null) {
-						ParticularsLedger(
-							state = state,
-							modifier = Modifier
-								.padding(horizontal = Ui.Padding.XXL)
-								.padding(top = 28.dp),
+					// The big name collapses while the body editor has focus; kept visible while the name
+					// field itself holds focus so it stays reachable.
+					var nameFocused by remember { mutableStateOf(false) }
+					CollapseWhileTyping(keepVisible = nameFocused) {
+						NameZone(
+							entryNameText = entryNameText,
+							onNameChange = { entryNameText = it },
+							editName = state.editName,
+							onStartEdit = component::startNameEdit,
+							onFocusChanged = { nameFocused = it },
+							compact = isCompact,
+							sharedKey = "encyclopedia-title-${state.entryDef.id}",
+							sharedTransitionScope = sharedTransitionScope,
+							animatedVisibilityScope = animatedVisibilityScope,
 						)
 					}
 
-					TagsAndAliasesZone(
-						state = state,
-						component = component,
-						compact = isCompact,
-					)
+					val bodyOuterModifier = if (editing) Modifier.weight(1f) else Modifier
+					if (isCompact) {
+						CompactBody(
+							state = state,
+							entryText = entryText,
+							setEntryText = { entryText = it },
+							onStartTextEdit = component::startTextEdit,
+							onShowDeleteImage = component::showDeleteImageDialog,
+							onAddImage = component::showAddImageDialog,
+							outerModifier = bodyOuterModifier,
+							sharedTransitionScope = sharedTransitionScope,
+							animatedVisibilityScope = animatedVisibilityScope,
+						)
+					} else {
+						WideBody(
+							state = state,
+							entryText = entryText,
+							setEntryText = { entryText = it },
+							onStartTextEdit = component::startTextEdit,
+							onShowDeleteImage = component::showDeleteImageDialog,
+							onAddImage = component::showAddImageDialog,
+							outerModifier = bodyOuterModifier,
+							sharedTransitionScope = sharedTransitionScope,
+							animatedVisibilityScope = animatedVisibilityScope,
+						)
+					}
 
-					AppearsInZone(
-						state = state,
-						component = component,
-					)
+					if (!editing) {
+						if (content != null) {
+							ParticularsLedger(
+								state = state,
+								modifier = Modifier
+									.padding(horizontal = Ui.Padding.XXL)
+									.padding(top = 28.dp),
+							)
+						}
 
-					FooterColophon(
-						compact = isCompact,
-						ruleSoft = ruleSoft,
-					)
+						TagsAndAliasesZone(
+							state = state,
+							component = component,
+							compact = isCompact,
+						)
+
+						AppearsInZone(
+							state = state,
+							component = component,
+						)
+
+						FooterColophon(
+							compact = isCompact,
+							ruleSoft = ruleSoft,
+						)
+					}
 				}
 			}
+		}
+
+		// Editing swaps in a non-scrolling layout, leaving outerScrollState detached but still
+		// reporting its last measured extent, so only the screen knows the bar is stale.
+		if (!editing) {
+			MpScrollBarColumn(
+				modifier = scrollBarOverlay(),
+				state = outerScrollState,
+			)
 		}
 	}
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/BrowseNotesUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/BrowseNotesUi.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.Search
@@ -51,6 +52,7 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.notes.BrowseNotes
 import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarStaggeredGrid
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdActiveFiltersStrip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdCollapsingStrip
@@ -66,6 +68,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSortOption
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdTagFilterBar
 import com.darkrockstudios.apps.hammer.common.compose.firstNonBlankLine
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
 import com.darkrockstudios.apps.hammer.common.util.format
 import com.darkrockstudios.apps.hammer.notes_create_note_button
@@ -326,46 +329,55 @@ fun BrowseNotesUi(
 			)
 		}
 
-		LazyVerticalStaggeredGrid(
-			columns = StaggeredGridCells.Adaptive(400.dp),
-			modifier = Modifier.fillMaxSize(),
-			contentPadding = PaddingValues(
-				horizontal = Ui.Padding.XL,
-				vertical = Ui.Padding.L,
-			),
-			horizontalArrangement = Arrangement.spacedBy(Ui.Padding.L),
-		) {
-			if (visibleNotes.isEmpty()) {
-				item(span = StaggeredGridItemSpan.FullLine) {
-					Box(
-						modifier = Modifier
-							.fillMaxWidth()
-							.padding(vertical = Ui.Padding.XXL),
-						contentAlignment = Alignment.Center,
-					) {
-						Text(
-							text = Res.string.notes_list_empty.get(),
-							style = MaterialTheme.typography.headlineSmall,
-							color = MaterialTheme.colorScheme.onSurfaceVariant,
-						)
+		val gridState = rememberLazyStaggeredGridState()
+		Box(modifier = Modifier.weight(1f)) {
+			LazyVerticalStaggeredGrid(
+				state = gridState,
+				columns = StaggeredGridCells.Adaptive(400.dp),
+				modifier = Modifier.fillMaxSize(),
+				contentPadding = PaddingValues(
+					horizontal = Ui.Padding.XL,
+					vertical = Ui.Padding.L,
+				),
+				horizontalArrangement = Arrangement.spacedBy(Ui.Padding.L),
+			) {
+				if (visibleNotes.isEmpty()) {
+					item(span = StaggeredGridItemSpan.FullLine) {
+						Box(
+							modifier = Modifier
+								.fillMaxWidth()
+								.padding(vertical = Ui.Padding.XXL),
+							contentAlignment = Alignment.Center,
+						) {
+							Text(
+								text = Res.string.notes_list_empty.get(),
+								style = MaterialTheme.typography.headlineSmall,
+								color = MaterialTheme.colorScheme.onSurfaceVariant,
+							)
+						}
 					}
+				}
+
+				staggeredItems(
+					items = visibleNotes,
+					key = { note -> note.id },
+				) { note ->
+					NoteCard(
+						note = note,
+						activeTags = activeTags,
+						onTagClick = toggleTag,
+						sharedTransitionScope = sharedTransitionScope,
+						animatedVisibilityScope = animatedVisibilityScope,
+						modifier = Modifier.padding(bottom = Ui.Padding.L),
+						onClick = { component.viewNote(note.id) },
+					)
 				}
 			}
 
-			staggeredItems(
-				items = visibleNotes,
-				key = { note -> note.id },
-			) { note ->
-				NoteCard(
-					note = note,
-					activeTags = activeTags,
-					onTagClick = toggleTag,
-					sharedTransitionScope = sharedTransitionScope,
-					animatedVisibilityScope = animatedVisibilityScope,
-					modifier = Modifier.padding(bottom = Ui.Padding.L),
-					onClick = { component.viewNote(note.id) },
-				)
-			}
+			MpScrollBarStaggeredGrid(
+				modifier = scrollBarOverlay(),
+				state = gridState,
+			)
 		}
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/ViewNoteUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/ViewNoteUi.kt
@@ -314,52 +314,59 @@ private fun ViewBody(
 	modifier: Modifier = Modifier,
 ) {
 	val scrollState = rememberScrollState()
-	Column(
-		modifier = modifier
-			.fillMaxWidth()
-			.verticalScroll(scrollState)
-			.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.XL),
-	) {
-		val noteTags = note?.tags
-		if (!noteTags.isNullOrEmpty()) {
-			FlowRow(
-				modifier = Modifier
-					.fillMaxWidth()
-					.padding(bottom = Ui.Padding.L),
-				horizontalArrangement = Arrangement.spacedBy(6.dp),
-				verticalArrangement = Arrangement.spacedBy(6.dp),
-			) {
-				noteTags.sorted().forEach { tag ->
-					HdTagChip(
-						label = tag,
-						active = true,
-						onClick = { onTagClick(tag) },
-						onRemove = { onTagRemove(tag) },
-					)
+	Box(modifier = modifier) {
+		Column(
+			modifier = Modifier
+				.fillMaxWidth()
+				.verticalScroll(scrollState)
+				.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.XL),
+		) {
+			val noteTags = note?.tags
+			if (!noteTags.isNullOrEmpty()) {
+				FlowRow(
+					modifier = Modifier
+						.fillMaxWidth()
+						.padding(bottom = Ui.Padding.L),
+					horizontalArrangement = Arrangement.spacedBy(6.dp),
+					verticalArrangement = Arrangement.spacedBy(6.dp),
+				) {
+					noteTags.sorted().forEach { tag ->
+						HdTagChip(
+							label = tag,
+							active = true,
+							onClick = { onTagClick(tag) },
+							onRemove = { onTagRemove(tag) },
+						)
+					}
 				}
+
+				HorizontalDivider(
+					thickness = Dp.Hairline,
+					color = MaterialTheme.colorScheme.outlineVariant,
+					modifier = Modifier.padding(bottom = Ui.Padding.L),
+				)
 			}
 
-			HorizontalDivider(
-				thickness = Dp.Hairline,
-				color = MaterialTheme.colorScheme.outlineVariant,
-				modifier = Modifier.padding(bottom = Ui.Padding.L),
-			)
+			with(sharedTransitionScope) {
+				MarkdownView(
+					markdown = noteText,
+					modifier = Modifier
+						.fillMaxWidth()
+						.sharedElement(
+							sharedContentState = rememberSharedContentState(
+								key = "note-content-${note?.id}",
+							),
+							animatedVisibilityScope = animatedVisibilityScope,
+						)
+						.clickable(onClick = onEnterEdit),
+				)
+			}
 		}
 
-		with(sharedTransitionScope) {
-			MarkdownView(
-				markdown = noteText,
-				modifier = Modifier
-					.fillMaxWidth()
-					.sharedElement(
-						sharedContentState = rememberSharedContentState(
-							key = "note-content-${note?.id}",
-						),
-						animatedVisibilityScope = animatedVisibilityScope,
-					)
-					.clickable(onClick = onEnterEdit),
-			)
-		}
+		MpScrollBarColumn(
+			modifier = scrollBarOverlay(),
+			state = scrollState,
+		)
 	}
 }
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
@@ -30,12 +30,14 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.projecthome.ProjectSettings
 import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarColumn
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdCrumbBackLink
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineSection
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
 import com.darkrockstudios.apps.hammer.common.projectselection.settings.SpellCheckSettingsContent
 import com.darkrockstudios.apps.hammer.project_settings_autosaved
@@ -75,41 +77,52 @@ fun ProjectSettingsUi(
 		)
 		HdFolioDivider()
 
-		Column(
+		val scrollState = rememberScrollState()
+		Box(
 			modifier = Modifier
 				.weight(1f)
-				.fillMaxWidth()
-				.verticalScroll(rememberScrollState())
-				.padding(horizontal = outerHorizontal, vertical = outerVertical),
+				.fillMaxWidth(),
 		) {
-			Box(
+			Column(
 				modifier = Modifier
-					.widthIn(max = MaxColumnWidth)
-					.fillMaxWidth()
-					.align(Alignment.CenterHorizontally),
+					.fillMaxSize()
+					.verticalScroll(scrollState)
+					.padding(horizontal = outerHorizontal, vertical = outerVertical),
 			) {
-				Column(verticalArrangement = Arrangement.spacedBy(64.dp)) {
-					Hero(
-						projectName = component.projectName,
-						authorName = state.data.authorName,
-						isCompact = isCompact,
-					)
+				Box(
+					modifier = Modifier
+						.widthIn(max = MaxColumnWidth)
+						.fillMaxWidth()
+						.align(Alignment.CenterHorizontally),
+				) {
+					Column(verticalArrangement = Arrangement.spacedBy(64.dp)) {
+						Hero(
+							projectName = component.projectName,
+							authorName = state.data.authorName,
+							isCompact = isCompact,
+						)
 
-					if (state.isLoaded) {
-						ProjectInfoSettingsUi(component)
+						if (state.isLoaded) {
+							ProjectInfoSettingsUi(component)
 
-						HdHairlineSection(
-							section = 4,
-							title = Res.string.project_settings_spellcheck_section_title.get(),
-							contentSpacing = 18.dp,
-						) {
-							SpellCheckSettingsContent(component.spellCheckSettings)
+							HdHairlineSection(
+								section = 4,
+								title = Res.string.project_settings_spellcheck_section_title.get(),
+								contentSpacing = 18.dp,
+							) {
+								SpellCheckSettingsContent(component.spellCheckSettings)
+							}
 						}
-					}
 
-					Spacer(Modifier.height(8.dp))
+						Spacer(Modifier.height(8.dp))
+					}
 				}
 			}
+
+			MpScrollBarColumn(
+				modifier = scrollBarOverlay(),
+				state = scrollState,
+			)
 		}
 
 		FolioCaption(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
@@ -36,8 +36,10 @@ import com.darkrockstudios.apps.hammer.common.components.projecthome.ProjectHome
 import com.darkrockstudios.apps.hammer.common.components.projecthome.TagBreakdown
 import com.darkrockstudios.apps.hammer.common.compose.HeaderUi
 import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarColumn
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
 import com.darkrockstudios.apps.hammer.common.compose.theme.hammerMonoFontFamily
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
@@ -70,52 +72,60 @@ fun ProjectStatsUi(
 	val state by component.state.subscribeAsState()
 	val isWide = LocalScreenCharacteristic.current.isWide
 
-	Column(
-		modifier = modifier
-			.testTag(PROJECT_STATS_TAG)
-			.fillMaxSize()
-			.verticalScroll(rememberScrollState())
-			.padding(horizontal = 24.dp, vertical = 16.dp),
-		verticalArrangement = Arrangement.spacedBy(20.dp),
-	) {
-		DashboardHeader(
-			state = state,
-			component = component,
-			scope = scope,
-		)
+	val scrollState = rememberScrollState()
+	Box(modifier = modifier.fillMaxSize()) {
+		Column(
+			modifier = Modifier
+				.testTag(PROJECT_STATS_TAG)
+				.fillMaxSize()
+				.verticalScroll(scrollState)
+				.padding(horizontal = 24.dp, vertical = 16.dp),
+			verticalArrangement = Arrangement.spacedBy(20.dp),
+		) {
+			DashboardHeader(
+				state = state,
+				component = component,
+				scope = scope,
+			)
 
-		if (state.isLoadingStats) {
-			LoadingRow()
-		}
+			if (state.isLoadingStats) {
+				LoadingRow()
+			}
 
-		StatsStrip(state = state, isWide = isWide)
+			StatsStrip(state = state, isWide = isWide)
 
-		StructureSection(
-			state = state,
-			isWide = isWide,
-			onShowLongestScene = component::showLongestScene,
-			onShowLastEditedScene = component::showLastEditedScene,
-		)
-
-		if (state.dailyWordTotals.isNotEmpty() || state.encyclopediaEntriesByType.isNotEmpty() || state.topAppearances.isNotEmpty()) {
-			InhabitantsSection(
+			StructureSection(
 				state = state,
 				isWide = isWide,
-				onShowEntry = component::showEntry,
+				onShowLongestScene = component::showLongestScene,
+				onShowLastEditedScene = component::showLastEditedScene,
 			)
+
+			if (state.dailyWordTotals.isNotEmpty() || state.encyclopediaEntriesByType.isNotEmpty() || state.topAppearances.isNotEmpty()) {
+				InhabitantsSection(
+					state = state,
+					isWide = isWide,
+					onShowEntry = component::showEntry,
+				)
+			}
+
+			if (state.tagBreakdowns.isNotEmpty()) {
+				ThemesSection(
+					state = state,
+					isWide = isWide,
+					onTagClick = component::showGlobalSearchForTag,
+				)
+			}
+
+			if (state.wordsPerDevice.size >= 2) {
+				DevicesSection(state = state)
+			}
 		}
 
-		if (state.tagBreakdowns.isNotEmpty()) {
-			ThemesSection(
-				state = state,
-				isWide = isWide,
-				onTagClick = component::showGlobalSearchForTag,
-			)
-		}
-
-		if (state.wordsPerDevice.size >= 2) {
-			DevicesSection(state = state)
-		}
+		MpScrollBarColumn(
+			modifier = scrollBarOverlay(),
+			state = scrollState,
+		)
 	}
 
 	ExportOptionsDialog(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
@@ -11,9 +11,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -58,6 +58,7 @@ import com.darkrockstudios.apps.hammer.common.components.projectselection.Projec
 import com.darkrockstudios.apps.hammer.common.components.projectselection.projectslist.ProjectsList
 import com.darkrockstudios.apps.hammer.common.components.projectselection.projectslist.filterProjects
 import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarGutter
 import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarList
 import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.Toaster
@@ -71,6 +72,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSortOption
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdTagChip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdToolButton
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
 import com.darkrockstudios.apps.hammer.common.protocolmismatch.ProtocolMismatchDialog
 import com.darkrockstudios.apps.hammer.common.reauthentication.ReauthenticationUi
@@ -254,6 +256,7 @@ fun ProjectListUi(
 					.fillMaxSize()
 					.nestedScroll(scrollConnection),
 				state = listState,
+				contentPadding = PaddingValues(end = MpScrollBarGutter),
 			) {
 				if (visibleProjects.isEmpty()) {
 					item(key = "empty") {
@@ -281,7 +284,7 @@ fun ProjectListUi(
 				}
 			}
 			MpScrollBarList(
-				modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+				modifier = scrollBarOverlay(),
 				state = listState,
 			)
 		}
@@ -507,7 +510,7 @@ private fun ColumnHeader(showLastOpen: Boolean) {
 				.fillMaxWidth()
 				.padding(
 					start = 4.dp + Ui.Padding.XL,
-					end = Ui.Padding.L,
+					end = Ui.Padding.L + MpScrollBarGutter,
 					top = Ui.Padding.M,
 					bottom = Ui.Padding.M,
 				),

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/AboutAppUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/AboutAppUi.kt
@@ -20,6 +20,7 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.common.components.projectselection.aboutapp.AboutApp
 import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarColumn
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.icons.AboutIcons
@@ -27,6 +28,7 @@ import com.darkrockstudios.apps.hammer.common.compose.icons.Discord
 import com.darkrockstudios.apps.hammer.common.compose.icons.Github
 import com.darkrockstudios.apps.hammer.common.compose.icons.Reddit
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import korlibs.io.lang.format
 import org.jetbrains.compose.resources.painterResource
 
@@ -51,76 +53,87 @@ fun AboutAppUi(component: AboutApp, modifier: Modifier = Modifier) {
 		Breadcrumb(isCompact = isCompact)
 		HdFolioDivider()
 
-		Column(
+		val scrollState = rememberScrollState()
+		Box(
 			modifier = Modifier
 				.weight(1f)
-				.fillMaxWidth()
-				.verticalScroll(rememberScrollState())
-				.padding(horizontal = outerHorizontal, vertical = outerVertical),
+				.fillMaxWidth(),
 		) {
-			Box(
+			Column(
 				modifier = Modifier
-					.widthIn(max = MaxColumnWidth)
-					.fillMaxWidth()
-					.align(Alignment.CenterHorizontally),
+					.fillMaxSize()
+					.verticalScroll(scrollState)
+					.padding(horizontal = outerHorizontal, vertical = outerVertical),
 			) {
-				Column(verticalArrangement = Arrangement.spacedBy(64.dp)) {
-					Hero(isCompact = isCompact)
+				Box(
+					modifier = Modifier
+						.widthIn(max = MaxColumnWidth)
+						.fillMaxWidth()
+						.align(Alignment.CenterHorizontally),
+				) {
+					Column(verticalArrangement = Arrangement.spacedBy(64.dp)) {
+						Hero(isCompact = isCompact)
 
-					HdHairlineSection(
-						section = 1,
-						title = "MANUSCRIPT",
-						contentSpacing = 12.dp,
-					) {
-						Text(
-							text = Res.string.about_description_line_two.get(),
-							style = MaterialTheme.typography.bodyLarge,
-							color = MaterialTheme.colorScheme.onSurface,
-						)
+						HdHairlineSection(
+							section = 1,
+							title = "MANUSCRIPT",
+							contentSpacing = 12.dp,
+						) {
+							Text(
+								text = Res.string.about_description_line_two.get(),
+								style = MaterialTheme.typography.bodyLarge,
+								color = MaterialTheme.colorScheme.onSurface,
+							)
+						}
+
+						HdHairlineSection(
+							section = 2,
+							title = Res.string.about_community_header.get(),
+							contentSpacing = 0.dp,
+						) {
+							CommunityLink(
+								label = Res.string.about_community_discord_link.get(),
+								icon = AboutIcons.Discord,
+								onClick = component::openDiscord,
+							)
+							CommunityRowDivider()
+							CommunityLink(
+								label = Res.string.about_community_reddit_link.get(),
+								icon = AboutIcons.Reddit,
+								onClick = component::openReddit,
+							)
+							CommunityRowDivider()
+							CommunityLink(
+								label = Res.string.about_community_github_link.get(),
+								icon = AboutIcons.Github,
+								onClick = component::openGithub,
+							)
+						}
+
+						VersionCard(state, onViewReleaseDetails = component::viewReleaseDetails)
+
+						HdHairlineSection(
+							section = 4,
+							title = Res.string.about_attribution_header.get(),
+							contentSpacing = 14.dp,
+						) {
+							HdHairlineButton(
+								label = Res.string.about_attribution_libraries_button.get(),
+								onClick = { showLibraries = true },
+							)
+						}
+
+						PlatformAboutSection(component, section = 5)
+
+						Spacer(Modifier.height(8.dp))
 					}
-
-					HdHairlineSection(
-						section = 2,
-						title = Res.string.about_community_header.get(),
-						contentSpacing = 0.dp,
-					) {
-						CommunityLink(
-							label = Res.string.about_community_discord_link.get(),
-							icon = AboutIcons.Discord,
-							onClick = component::openDiscord,
-						)
-						CommunityRowDivider()
-						CommunityLink(
-							label = Res.string.about_community_reddit_link.get(),
-							icon = AboutIcons.Reddit,
-							onClick = component::openReddit,
-						)
-						CommunityRowDivider()
-						CommunityLink(
-							label = Res.string.about_community_github_link.get(),
-							icon = AboutIcons.Github,
-							onClick = component::openGithub,
-						)
-					}
-
-					VersionCard(state, onViewReleaseDetails = component::viewReleaseDetails)
-
-					HdHairlineSection(
-						section = 4,
-						title = Res.string.about_attribution_header.get(),
-						contentSpacing = 14.dp,
-					) {
-						HdHairlineButton(
-							label = Res.string.about_attribution_libraries_button.get(),
-							onClick = { showLibraries = true },
-						)
-					}
-
-					PlatformAboutSection(component, section = 5)
-
-					Spacer(Modifier.height(8.dp))
 				}
 			}
+
+			MpScrollBarColumn(
+				modifier = scrollBarOverlay(),
+				state = scrollState,
+			)
 		}
 
 		FolioCaption(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/AccountSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/AccountSettingsUi.kt
@@ -21,11 +21,13 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettings
 import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarColumn
 import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.Toaster
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.InitialProjectScreen
@@ -60,104 +62,115 @@ internal fun AccountSettingsUi(
 		Breadcrumb(isCompact = isCompact)
 		HdFolioDivider()
 
-		Column(
+		val scrollState = rememberScrollState()
+		Box(
 			modifier = Modifier
 				.weight(1f)
-				.fillMaxWidth()
-				.verticalScroll(rememberScrollState())
-				.padding(horizontal = outerHorizontal, vertical = outerVertical),
+				.fillMaxWidth(),
 		) {
-			Box(
+			Column(
 				modifier = Modifier
-					.widthIn(max = MaxColumnWidth)
-					.fillMaxWidth()
-					.align(Alignment.CenterHorizontally),
+					.fillMaxSize()
+					.verticalScroll(scrollState)
+					.padding(horizontal = outerHorizontal, vertical = outerVertical),
 			) {
-				Column(verticalArrangement = Arrangement.spacedBy(64.dp)) {
-					Hero(
-						loggedIn = state.serverIsLoggedIn,
-						email = state.currentEmail,
-						isCompact = isCompact,
-					)
-
-					HdHairlineSection(
-						section = 1,
-						title = Res.string.settings_theme_label.get(),
-						headerTrailing = {
-							HdMonoLabel(text = uiThemeLabel(state.uiTheme))
-						},
-						contentSpacing = 12.dp,
-					) {
-						HdHairlineSegmentedPicker(
-							options = UiTheme.entries,
-							selected = state.uiTheme,
-							onSelect = { component.setUiTheme(it) },
-							label = { uiThemeLabel(it) },
+				Box(
+					modifier = Modifier
+						.widthIn(max = MaxColumnWidth)
+						.fillMaxWidth()
+						.align(Alignment.CenterHorizontally),
+				) {
+					Column(verticalArrangement = Arrangement.spacedBy(64.dp)) {
+						Hero(
+							loggedIn = state.serverIsLoggedIn,
+							email = state.currentEmail,
+							isCompact = isCompact,
 						)
-					}
 
-					HdHairlineSection(
-						section = 2,
-						title = Res.string.settings_initial_screen_label.get(),
-						headerTrailing = {
-							HdMonoLabel(text = initialScreenLabel(state.initialProjectScreen))
-						},
-						contentSpacing = 12.dp,
-					) {
-						HdHairlineSegmentedPicker(
-							options = InitialProjectScreen.entries,
-							selected = state.initialProjectScreen,
-							onSelect = { component.setInitialProjectScreen(it) },
-							label = { initialScreenLabel(it) },
-						)
-					}
-
-					HdHairlineSection(
-						section = 3,
-						title = Res.string.settings_spellcheck_heading.get(),
-						contentSpacing = 18.dp,
-					) {
-						SpellCheckSettingsContent(component.spellCheckSettings)
-					}
-
-					ServerSettingsUi(
-						component = component,
-						scope = scope,
-						rootSnackbar = rootSnackbar,
-					)
-
-					HdHairlineSection(
-						section = 5,
-						title = Res.string.settings_backups_header.get(),
-						headerTrailing = {
-							HdMonoLabel(
-								text = "${state.maxBackups} / ${GlobalSettings.MAX_BACKUPS}",
+						HdHairlineSection(
+							section = 1,
+							title = Res.string.settings_theme_label.get(),
+							headerTrailing = {
+								HdMonoLabel(text = uiThemeLabel(state.uiTheme))
+							},
+							contentSpacing = 12.dp,
+						) {
+							HdHairlineSegmentedPicker(
+								options = UiTheme.entries,
+								selected = state.uiTheme,
+								onSelect = { component.setUiTheme(it) },
+								label = { uiThemeLabel(it) },
 							)
-						},
-						contentSpacing = 16.dp,
-					) {
-						BackupsSettingsUi(component, scope)
-					}
+						}
 
-					HdHairlineSection(
-						section = 6,
-						title = Res.string.settings_platform_settings_title.get(),
-						contentSpacing = 16.dp,
-					) {
-						PlatformSettingsUi(component.platformSettings)
-					}
+						HdHairlineSection(
+							section = 2,
+							title = Res.string.settings_initial_screen_label.get(),
+							headerTrailing = {
+								HdMonoLabel(text = initialScreenLabel(state.initialProjectScreen))
+							},
+							contentSpacing = 12.dp,
+						) {
+							HdHairlineSegmentedPicker(
+								options = InitialProjectScreen.entries,
+								selected = state.initialProjectScreen,
+								onSelect = { component.setInitialProjectScreen(it) },
+								label = { initialScreenLabel(it) },
+							)
+						}
 
-					HdHairlineSection(
-						section = 7,
-						title = Res.string.settings_example_project_header.get(),
-						contentSpacing = 14.dp,
-					) {
-						ExampleProjectSection(component, rootSnackbar)
-					}
+						HdHairlineSection(
+							section = 3,
+							title = Res.string.settings_spellcheck_heading.get(),
+							contentSpacing = 18.dp,
+						) {
+							SpellCheckSettingsContent(component.spellCheckSettings)
+						}
 
-					Spacer(Modifier.height(8.dp))
+						ServerSettingsUi(
+							component = component,
+							scope = scope,
+							rootSnackbar = rootSnackbar,
+						)
+
+						HdHairlineSection(
+							section = 5,
+							title = Res.string.settings_backups_header.get(),
+							headerTrailing = {
+								HdMonoLabel(
+									text = "${state.maxBackups} / ${GlobalSettings.MAX_BACKUPS}",
+								)
+							},
+							contentSpacing = 16.dp,
+						) {
+							BackupsSettingsUi(component, scope)
+						}
+
+						HdHairlineSection(
+							section = 6,
+							title = Res.string.settings_platform_settings_title.get(),
+							contentSpacing = 16.dp,
+						) {
+							PlatformSettingsUi(component.platformSettings)
+						}
+
+						HdHairlineSection(
+							section = 7,
+							title = Res.string.settings_example_project_header.get(),
+							contentSpacing = 14.dp,
+						) {
+							ExampleProjectSection(component, rootSnackbar)
+						}
+
+						Spacer(Modifier.height(8.dp))
+					}
 				}
 			}
+
+			MpScrollBarColumn(
+				modifier = scrollBarOverlay(),
+				state = scrollState,
+			)
 		}
 
 		FolioCaption(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/storyideas/StoryIdeasUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/storyideas/StoryIdeasUi.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Search
@@ -75,6 +76,8 @@ import com.darkrockstudios.apps.hammer.common.components.projectselection.storyi
 import com.darkrockstudios.apps.hammer.common.compose.CollapseWhileTyping
 import com.darkrockstudios.apps.hammer.common.compose.DetailViewDropdownMenu
 import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarColumn
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarStaggeredGrid
 import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.SimpleConfirm
 import com.darkrockstudios.apps.hammer.common.compose.Ui
@@ -102,6 +105,7 @@ import com.darkrockstudios.apps.hammer.common.compose.rememberMainDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.rememberStrRes
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.saveShortcutModifier
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.data.MenuItemDescriptor
 import com.darkrockstudios.apps.hammer.common.data.ideasrepository.IdeaError
 import com.darkrockstudios.apps.hammer.common.data.ideasrepository.IdeasRepository
@@ -450,47 +454,56 @@ private fun IdeasBrowse(
 				)
 			}
 
-			LazyVerticalStaggeredGrid(
-				columns = StaggeredGridCells.Adaptive(400.dp),
-				modifier = Modifier.fillMaxSize(),
-				contentPadding = PaddingValues(
-					horizontal = Ui.Padding.XL,
-					vertical = Ui.Padding.L,
-				),
-				horizontalArrangement = Arrangement.spacedBy(Ui.Padding.L),
-			) {
-				if (visibleIdeas.isEmpty()) {
-					item(span = StaggeredGridItemSpan.FullLine) {
-						Box(
-							modifier = Modifier
-								.fillMaxWidth()
-								.padding(vertical = Ui.Padding.XXL),
-							contentAlignment = Alignment.Center,
-						) {
-							Text(
-								text = (if (showArchived) Res.string.ideas_list_empty_archived
-									else Res.string.ideas_list_empty).get(),
-								style = MaterialTheme.typography.headlineSmall,
-								color = MaterialTheme.colorScheme.onSurfaceVariant,
-							)
+			val gridState = rememberLazyStaggeredGridState()
+			Box(modifier = Modifier.weight(1f)) {
+				LazyVerticalStaggeredGrid(
+					state = gridState,
+					columns = StaggeredGridCells.Adaptive(400.dp),
+					modifier = Modifier.fillMaxSize(),
+					contentPadding = PaddingValues(
+						horizontal = Ui.Padding.XL,
+						vertical = Ui.Padding.L,
+					),
+					horizontalArrangement = Arrangement.spacedBy(Ui.Padding.L),
+				) {
+					if (visibleIdeas.isEmpty()) {
+						item(span = StaggeredGridItemSpan.FullLine) {
+							Box(
+								modifier = Modifier
+									.fillMaxWidth()
+									.padding(vertical = Ui.Padding.XXL),
+								contentAlignment = Alignment.Center,
+							) {
+								Text(
+									text = (if (showArchived) Res.string.ideas_list_empty_archived
+										else Res.string.ideas_list_empty).get(),
+									style = MaterialTheme.typography.headlineSmall,
+									color = MaterialTheme.colorScheme.onSurfaceVariant,
+								)
+							}
 						}
+					}
+
+					staggeredItems(
+						items = visibleIdeas,
+						key = { idea -> idea.id.id },
+					) { idea ->
+						IdeaCard(
+							idea = idea,
+							activeTags = activeTags,
+							onTagClick = toggleTag,
+							sharedTransitionScope = sharedTransitionScope,
+							animatedVisibilityScope = animatedVisibilityScope,
+							modifier = Modifier.padding(bottom = Ui.Padding.L),
+							onClick = { component.editIdea(idea.id) },
+						)
 					}
 				}
 
-				staggeredItems(
-					items = visibleIdeas,
-					key = { idea -> idea.id.id },
-				) { idea ->
-					IdeaCard(
-						idea = idea,
-						activeTags = activeTags,
-						onTagClick = toggleTag,
-						sharedTransitionScope = sharedTransitionScope,
-						animatedVisibilityScope = animatedVisibilityScope,
-						modifier = Modifier.padding(bottom = Ui.Padding.L),
-						onClick = { component.editIdea(idea.id) },
-					)
-				}
+				MpScrollBarStaggeredGrid(
+					modifier = scrollBarOverlay(),
+					state = gridState,
+				)
 			}
 		}
 
@@ -1073,77 +1086,84 @@ private fun ViewBody(
 	modifier: Modifier = Modifier,
 ) = with(sharedTransitionScope) {
 	val scrollState = rememberScrollState()
-	Column(
-		modifier = modifier
-			.fillMaxWidth()
-			.verticalScroll(scrollState)
-			.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.XL),
-	) {
-		title?.let {
-			Text(
-				text = it,
-				style = MaterialTheme.typography.headlineSmall,
-				color = MaterialTheme.colorScheme.onSurface,
+	Box(modifier = modifier) {
+		Column(
+			modifier = Modifier
+				.fillMaxWidth()
+				.verticalScroll(scrollState)
+				.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.XL),
+		) {
+			title?.let {
+				Text(
+					text = it,
+					style = MaterialTheme.typography.headlineSmall,
+					color = MaterialTheme.colorScheme.onSurface,
+					modifier = Modifier
+						.padding(bottom = Ui.Padding.M)
+						.then(
+							if (idea != null) {
+								Modifier.sharedElement(
+									sharedContentState = rememberSharedContentState(
+										key = "idea-title-${idea.id.id}",
+									),
+									animatedVisibilityScope = animatedVisibilityScope,
+								)
+							} else {
+								Modifier
+							}
+						),
+				)
+			}
+
+			idea?.let { IdeaStamps(it) }
+
+			if (tags.isNotEmpty()) {
+				FlowRow(
+					modifier = Modifier
+						.fillMaxWidth()
+						.padding(top = Ui.Padding.M, bottom = Ui.Padding.L),
+					horizontalArrangement = Arrangement.spacedBy(6.dp),
+					verticalArrangement = Arrangement.spacedBy(6.dp),
+				) {
+					tags.sorted().forEach { tag ->
+						HdTagChip(
+							label = tag,
+							active = true,
+							onClick = {},
+						)
+					}
+				}
+
+				HorizontalDivider(
+					thickness = Dp.Hairline,
+					color = MaterialTheme.colorScheme.outlineVariant,
+					modifier = Modifier.padding(bottom = Ui.Padding.L),
+				)
+			}
+
+			MarkdownView(
+				markdown = markdown,
 				modifier = Modifier
-					.padding(bottom = Ui.Padding.M)
+					.fillMaxWidth()
 					.then(
 						if (idea != null) {
 							Modifier.sharedElement(
 								sharedContentState = rememberSharedContentState(
-									key = "idea-title-${idea.id.id}",
+									key = "idea-content-${idea.id.id}",
 								),
 								animatedVisibilityScope = animatedVisibilityScope,
 							)
 						} else {
 							Modifier
 						}
-					),
-			)
-		}
-
-		idea?.let { IdeaStamps(it) }
-
-		if (tags.isNotEmpty()) {
-			FlowRow(
-				modifier = Modifier
-					.fillMaxWidth()
-					.padding(top = Ui.Padding.M, bottom = Ui.Padding.L),
-				horizontalArrangement = Arrangement.spacedBy(6.dp),
-				verticalArrangement = Arrangement.spacedBy(6.dp),
-			) {
-				tags.sorted().forEach { tag ->
-					HdTagChip(
-						label = tag,
-						active = true,
-						onClick = {},
 					)
-				}
-			}
-
-			HorizontalDivider(
-				thickness = Dp.Hairline,
-				color = MaterialTheme.colorScheme.outlineVariant,
-				modifier = Modifier.padding(bottom = Ui.Padding.L),
+					.clickable(onClick = onEnterEdit),
 			)
 		}
 
-		MarkdownView(
-			markdown = markdown,
-			modifier = Modifier
-				.fillMaxWidth()
-				.then(
-					if (idea != null) {
-						Modifier.sharedElement(
-							sharedContentState = rememberSharedContentState(
-								key = "idea-content-${idea.id.id}",
-							),
-							animatedVisibilityScope = animatedVisibilityScope,
-						)
-					} else {
-						Modifier
-					}
-				)
-				.clickable(onClick = onEnterEdit),
+		MpScrollBarColumn(
+			modifier = scrollBarOverlay(),
+			state = scrollState,
 		)
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/OutlineOverviewUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/OutlineOverviewUi.kt
@@ -32,11 +32,14 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.outlineoverview.OutlineOverview
 import com.darkrockstudios.apps.hammer.common.compose.AnimatedFullScreenDialog
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarGutter
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarList
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.romanNumeral
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import kotlinx.coroutines.launch
 
@@ -324,15 +327,27 @@ private fun ChapterRail(
 				bottom = Ui.Padding.M,
 			),
 		)
-		LazyColumn(modifier = Modifier.fillMaxSize()) {
-			itemsIndexed(chapters, key = { idx, _ -> "rail-$idx" }) { index, ch ->
-				ChapterRailItem(
-					index = index,
-					chapter = ch,
-					selected = index == activeChapterIndex,
-					onClick = { onJumpTo(index) },
-				)
+		val railState = rememberLazyListState()
+		Box {
+			LazyColumn(
+				modifier = Modifier.fillMaxSize(),
+				state = railState,
+				contentPadding = PaddingValues(end = MpScrollBarGutter),
+			) {
+				itemsIndexed(chapters, key = { idx, _ -> "rail-$idx" }) { index, ch ->
+					ChapterRailItem(
+						index = index,
+						chapter = ch,
+						selected = index == activeChapterIndex,
+						onClick = { onJumpTo(index) },
+					)
+				}
 			}
+
+			MpScrollBarList(
+				modifier = scrollBarOverlay(),
+				state = railState,
+			)
 		}
 	}
 }
@@ -519,31 +534,38 @@ private fun ReadingColumn(
 	modifier: Modifier = Modifier,
 ) {
 	val horizontalPad = if (wide) Ui.Padding.XXL else Ui.Padding.XL
-	LazyColumn(
-		modifier = modifier,
-		state = listState,
-		contentPadding = PaddingValues(
-			start = horizontalPad,
-			end = horizontalPad,
-			top = Ui.Padding.XXL,
-			bottom = Ui.Padding.XXL,
-		),
-	) {
-		item(key = "frontispiece") {
-			Frontispiece(projectName = projectName)
+	Box(modifier = modifier) {
+		LazyColumn(
+			modifier = Modifier.fillMaxSize(),
+			state = listState,
+			contentPadding = PaddingValues(
+				start = horizontalPad,
+				end = horizontalPad,
+				top = Ui.Padding.XXL,
+				bottom = Ui.Padding.XXL,
+			),
+		) {
+			item(key = "frontispiece") {
+				Frontispiece(projectName = projectName)
+			}
+			itemsIndexed(chapters, key = { idx, _ -> "ch-$idx" }) { index, ch ->
+				ChapterBlock(
+					chapterIndex = index,
+					chapter = ch,
+					showSeparator = index < chapters.size - 1,
+					wide = wide,
+					onSceneClick = onSceneClick,
+				)
+			}
+			item(key = "end") {
+				EndOfOutline()
+			}
 		}
-		itemsIndexed(chapters, key = { idx, _ -> "ch-$idx" }) { index, ch ->
-			ChapterBlock(
-				chapterIndex = index,
-				chapter = ch,
-				showSeparator = index < chapters.size - 1,
-				wide = wide,
-				onSceneClick = onSceneClick,
-			)
-		}
-		item(key = "end") {
-			EndOfOutline()
-		}
+
+		MpScrollBarList(
+			modifier = scrollBarOverlay(),
+			state = listState,
+		)
 	}
 }
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneMetadataPanelUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneMetadataPanelUi.kt
@@ -72,191 +72,199 @@ fun SceneMetadataPanelUi(
 		color = MaterialTheme.colorScheme.surfaceContainerLow,
 		tonalElevation = 0.dp,
 	) {
-		Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+		val scrollState = rememberScrollState()
+		Box {
+			Column(modifier = Modifier.verticalScroll(scrollState)) {
 
-			Row(
-				modifier = Modifier
-					.fillMaxWidth()
-					.padding(start = Ui.Padding.M, end = Ui.Padding.L, top = Ui.Padding.S, bottom = Ui.Padding.S),
-				verticalAlignment = Alignment.CenterVertically,
-			) {
-				IconButton(
-					onClick = closeMetadata,
-					modifier = Modifier.size(36.dp),
+				Row(
+					modifier = Modifier
+						.fillMaxWidth()
+						.padding(start = Ui.Padding.M, end = Ui.Padding.L, top = Ui.Padding.S, bottom = Ui.Padding.S),
+					verticalAlignment = Alignment.CenterVertically,
 				) {
-					Icon(
-						imageVector = Icons.Default.Close,
-						contentDescription = Res.string.scene_editor_metadata_hide_button.get(),
-						tint = MaterialTheme.colorScheme.onSurface,
-					)
-				}
-				Spacer(Modifier.width(Ui.Padding.S))
-				Text(
-					text = Res.string.scene_editor_metadata_title.get(),
-					style = MaterialTheme.typography.titleMedium,
-					color = MaterialTheme.colorScheme.onSurface,
-				)
-			}
-			HorizontalDivider(
-				thickness = Dp.Hairline,
-				color = MaterialTheme.colorScheme.outlineVariant,
-			)
-
-			Row(
-				modifier = Modifier
-					.fillMaxWidth()
-					.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.L),
-				verticalAlignment = Alignment.Bottom,
-			) {
-				Column(modifier = Modifier.weight(1f).padding(end = Ui.Padding.M)) {
+					IconButton(
+						onClick = closeMetadata,
+						modifier = Modifier.size(36.dp),
+					) {
+						Icon(
+							imageVector = Icons.Default.Close,
+							contentDescription = Res.string.scene_editor_metadata_hide_button.get(),
+							tint = MaterialTheme.colorScheme.onSurface,
+						)
+					}
+					Spacer(Modifier.width(Ui.Padding.S))
 					Text(
-						text = state.sceneItem.name,
-						style = MaterialTheme.typography.titleLarge,
-						color = MaterialTheme.colorScheme.onSurface,
-					)
-					HdEntityId(
-						prefix = "SCN",
-						id = state.sceneItem.id,
-						modifier = Modifier.padding(top = 2.dp),
-					)
-				}
-				Row(verticalAlignment = Alignment.Bottom) {
-					HdMonoLabel(
-						text = Res.string.scene_editor_metadata_word_count_label.get().removeSuffix(":"),
-						modifier = Modifier.padding(end = 6.dp, bottom = 2.dp),
-					)
-					Text(
-						text = "${state.wordCount}",
+						text = Res.string.scene_editor_metadata_title.get(),
 						style = MaterialTheme.typography.titleMedium,
 						color = MaterialTheme.colorScheme.onSurface,
 					)
 				}
-			}
-			TimestampStrip(
-				created = state.metadata.created,
-				edited = state.metadata.lastEdited,
-			)
-			HorizontalDivider(
-				thickness = Dp.Hairline,
-				color = MaterialTheme.colorScheme.outlineVariant,
-			)
-
-			Column(modifier = Modifier.padding(Ui.Padding.XL)) {
-
-				HdHairlineField(
-					label = Res.string.scene_editor_metadata_outline_label.get(),
-					value = state.metadata.outline,
-					onValueChange = component::updateOutline,
-					placeholder = Res.string.scene_editor_metadata_outline_placeholder.get(),
-					singleLine = false,
-					minLines = 3,
+				HorizontalDivider(
+					thickness = Dp.Hairline,
+					color = MaterialTheme.colorScheme.outlineVariant,
 				)
 
-				SpacerXL()
-
-				HdHairlineField(
-					label = Res.string.scene_editor_metadata_notes_label.get(),
-					value = state.metadata.notes,
-					onValueChange = component::updateNotes,
-					placeholder = Res.string.scene_editor_metadata_notes_placeholder.get(),
-					singleLine = false,
-					minLines = 3,
-				)
-
-				SpacerXL()
-
-				var isDraftNameValid by remember(state.metadata.currentDraftName) {
-					mutableStateOf(component.validateDraftName(state.metadata.currentDraftName))
-				}
-				HdHairlineField(
-					label = Res.string.scene_editor_metadata_draft_name_label.get(),
-					value = state.metadata.currentDraftName,
-					onValueChange = { newName ->
-						isDraftNameValid = component.validateDraftName(newName)
-						component.updateDraftName(newName)
-					},
-					singleLine = true,
-				)
-				if (!isDraftNameValid) {
-					SpacerM()
-					Text(
-						Res.string.scene_draft_invalid_name.get(),
-						style = MaterialTheme.typography.bodySmall,
-						color = MaterialTheme.colorScheme.error,
-					)
-				}
-
-				SpacerXL()
-
-				CollapsableSection(
-					startExpanded = true,
-					header = {
+				Row(
+					modifier = Modifier
+						.fillMaxWidth()
+						.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.L),
+					verticalAlignment = Alignment.Bottom,
+				) {
+					Column(modifier = Modifier.weight(1f).padding(end = Ui.Padding.M)) {
+						Text(
+							text = state.sceneItem.name,
+							style = MaterialTheme.typography.titleLarge,
+							color = MaterialTheme.colorScheme.onSurface,
+						)
+						HdEntityId(
+							prefix = "SCN",
+							id = state.sceneItem.id,
+							modifier = Modifier.padding(top = 2.dp),
+						)
+					}
+					Row(verticalAlignment = Alignment.Bottom) {
 						HdMonoLabel(
-							text = Res.string.scene_editor_metadata_references_header.get(),
-							modifier = Modifier.padding(end = Ui.Padding.M),
+							text = Res.string.scene_editor_metadata_word_count_label.get().removeSuffix(":"),
+							modifier = Modifier.padding(end = 6.dp, bottom = 2.dp),
 						)
-					},
-					trailingAction = {
-						HdHairlineButton(
-							label = Res.string.scene_editor_metadata_references_add_button.get(),
-							onClick = { showAddDialog = true },
+						Text(
+							text = "${state.wordCount}",
+							style = MaterialTheme.typography.titleMedium,
+							color = MaterialTheme.colorScheme.onSurface,
 						)
-					},
-					body = { ReferencesBody(state, component) }
+					}
+				}
+				TimestampStrip(
+					created = state.metadata.created,
+					edited = state.metadata.lastEdited,
+				)
+				HorizontalDivider(
+					thickness = Dp.Hairline,
+					color = MaterialTheme.colorScheme.outlineVariant,
 				)
 
-				if (state.dismissedRefs.isNotEmpty()) {
+				Column(modifier = Modifier.padding(Ui.Padding.XL)) {
+
+					HdHairlineField(
+						label = Res.string.scene_editor_metadata_outline_label.get(),
+						value = state.metadata.outline,
+						onValueChange = component::updateOutline,
+						placeholder = Res.string.scene_editor_metadata_outline_placeholder.get(),
+						singleLine = false,
+						minLines = 3,
+					)
+
 					SpacerXL()
-					CollapsableSection(
-						startExpanded = false,
-						header = {
-							Row(verticalAlignment = Alignment.CenterVertically) {
-								HdMonoLabel(
-									text = Res.string.scene_editor_metadata_references_dismissed_label.get(),
-								)
-								Text(
-									text = " · ${state.dismissedRefs.size}",
-									style = MaterialTheme.typography.labelSmall,
-									color = MaterialTheme.colorScheme.onSurfaceVariant,
-									modifier = Modifier.padding(start = 4.dp, end = Ui.Padding.M),
-								)
-							}
+
+					HdHairlineField(
+						label = Res.string.scene_editor_metadata_notes_label.get(),
+						value = state.metadata.notes,
+						onValueChange = component::updateNotes,
+						placeholder = Res.string.scene_editor_metadata_notes_placeholder.get(),
+						singleLine = false,
+						minLines = 3,
+					)
+
+					SpacerXL()
+
+					var isDraftNameValid by remember(state.metadata.currentDraftName) {
+						mutableStateOf(component.validateDraftName(state.metadata.currentDraftName))
+					}
+					HdHairlineField(
+						label = Res.string.scene_editor_metadata_draft_name_label.get(),
+						value = state.metadata.currentDraftName,
+						onValueChange = { newName ->
+							isDraftNameValid = component.validateDraftName(newName)
+							component.updateDraftName(newName)
 						},
-						body = { DismissedBody(state, component) }
+						singleLine = true,
+					)
+					if (!isDraftNameValid) {
+						SpacerM()
+						Text(
+							Res.string.scene_draft_invalid_name.get(),
+							style = MaterialTheme.typography.bodySmall,
+							color = MaterialTheme.colorScheme.error,
+						)
+					}
+
+					SpacerXL()
+
+					CollapsableSection(
+						startExpanded = true,
+						header = {
+							HdMonoLabel(
+								text = Res.string.scene_editor_metadata_references_header.get(),
+								modifier = Modifier.padding(end = Ui.Padding.M),
+							)
+						},
+						trailingAction = {
+							HdHairlineButton(
+								label = Res.string.scene_editor_metadata_references_add_button.get(),
+								onClick = { showAddDialog = true },
+							)
+						},
+						body = { ReferencesBody(state, component) }
+					)
+
+					if (state.dismissedRefs.isNotEmpty()) {
+						SpacerXL()
+						CollapsableSection(
+							startExpanded = false,
+							header = {
+								Row(verticalAlignment = Alignment.CenterVertically) {
+									HdMonoLabel(
+										text = Res.string.scene_editor_metadata_references_dismissed_label.get(),
+									)
+									Text(
+										text = " · ${state.dismissedRefs.size}",
+										style = MaterialTheme.typography.labelSmall,
+										color = MaterialTheme.colorScheme.onSurfaceVariant,
+										modifier = Modifier.padding(start = 4.dp, end = Ui.Padding.M),
+									)
+								}
+							},
+							body = { DismissedBody(state, component) }
+						)
+					}
+
+					SpacerXL()
+
+					CollapsableSection(
+						startExpanded = true,
+						header = {
+							HdMonoLabel(
+								text = Res.string.scene_editor_metadata_tags_header.get(),
+								modifier = Modifier.padding(end = Ui.Padding.M),
+							)
+						},
+						trailingAction = {
+							HdHairlineButton(
+								label = Res.string.scene_editor_metadata_tags_add_button.get(),
+								onClick = { showAddTagDialog = true },
+							)
+						},
+						body = { TagsBody(state, component) }
+					)
+
+					SpacerXL()
+
+					CollapsableSection(
+						header = {
+							HdMonoLabel(
+								text = Res.string.scene_editor_metadata_advanced_header.get(),
+								modifier = Modifier.padding(end = Ui.Padding.M),
+							)
+						},
+						body = { AdvancedBody(state) }
 					)
 				}
-
-				SpacerXL()
-
-				CollapsableSection(
-					startExpanded = true,
-					header = {
-						HdMonoLabel(
-							text = Res.string.scene_editor_metadata_tags_header.get(),
-							modifier = Modifier.padding(end = Ui.Padding.M),
-						)
-					},
-					trailingAction = {
-						HdHairlineButton(
-							label = Res.string.scene_editor_metadata_tags_add_button.get(),
-							onClick = { showAddTagDialog = true },
-						)
-					},
-					body = { TagsBody(state, component) }
-				)
-
-				SpacerXL()
-
-				CollapsableSection(
-					header = {
-						HdMonoLabel(
-							text = Res.string.scene_editor_metadata_advanced_header.get(),
-							modifier = Modifier.padding(end = Ui.Padding.M),
-						)
-					},
-					body = { AdvancedBody(state) }
-				)
 			}
+
+			MpScrollBarColumn(
+				modifier = scrollBarOverlay(),
+				state = scrollState,
+			)
 		}
 	}
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/TimeLineOverviewUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/TimeLineOverviewUi.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -67,6 +68,7 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.timeline.TimeLineOverview
 import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarList
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdDragHandle
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
@@ -78,6 +80,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdTagChip
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownView
 import com.darkrockstudios.apps.hammer.common.compose.reorderable.DragDropList
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
 import com.darkrockstudios.apps.hammer.common.data.tagindex.TagCount
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
@@ -340,18 +343,27 @@ fun TimeLineOverviewUi(
 			}
 
 			else -> {
-				LazyColumn(
-					modifier = Modifier
-						.fillMaxSize()
-						.testTag(TIME_LINE_LIST_TAG),
-					contentPadding = listContentPadding,
-				) {
-					items(
-						items = visibleEvents,
-						key = { event -> event.id },
-					) { event ->
-						eventRow(event, false)
+				val listState = rememberLazyListState()
+				Box {
+					LazyColumn(
+						state = listState,
+						modifier = Modifier
+							.fillMaxSize()
+							.testTag(TIME_LINE_LIST_TAG),
+						contentPadding = listContentPadding,
+					) {
+						items(
+							items = visibleEvents,
+							key = { event -> event.id },
+						) { event ->
+							eventRow(event, false)
+						}
 					}
+
+					MpScrollBarList(
+						modifier = scrollBarOverlay(),
+						state = listState,
+					)
 				}
 			}
 		}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/ViewTimeLineEventUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/ViewTimeLineEventUi.kt
@@ -321,52 +321,59 @@ private fun ViewBody(
 	modifier: Modifier = Modifier,
 ) {
 	val scrollState = rememberScrollState()
-	Column(
-		modifier = modifier
-			.fillMaxWidth()
-			.verticalScroll(scrollState)
-			.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.XL),
-	) {
-		val eventTags = event?.tags
-		if (!eventTags.isNullOrEmpty()) {
-			FlowRow(
-				modifier = Modifier
-					.fillMaxWidth()
-					.padding(bottom = Ui.Padding.L),
-				horizontalArrangement = Arrangement.spacedBy(6.dp),
-				verticalArrangement = Arrangement.spacedBy(6.dp),
-			) {
-				eventTags.sorted().forEach { tag ->
-					HdTagChip(
-						label = tag,
-						active = true,
-						onClick = { onTagClick(tag) },
-						onRemove = { onTagRemove(tag) },
-					)
+	Box(modifier = modifier) {
+		Column(
+			modifier = Modifier
+				.fillMaxWidth()
+				.verticalScroll(scrollState)
+				.padding(horizontal = Ui.Padding.XL, vertical = Ui.Padding.XL),
+		) {
+			val eventTags = event?.tags
+			if (!eventTags.isNullOrEmpty()) {
+				FlowRow(
+					modifier = Modifier
+						.fillMaxWidth()
+						.padding(bottom = Ui.Padding.L),
+					horizontalArrangement = Arrangement.spacedBy(6.dp),
+					verticalArrangement = Arrangement.spacedBy(6.dp),
+				) {
+					eventTags.sorted().forEach { tag ->
+						HdTagChip(
+							label = tag,
+							active = true,
+							onClick = { onTagClick(tag) },
+							onRemove = { onTagRemove(tag) },
+						)
+					}
 				}
+
+				HorizontalDivider(
+					thickness = Dp.Hairline,
+					color = MaterialTheme.colorScheme.outlineVariant,
+					modifier = Modifier.padding(bottom = Ui.Padding.L),
+				)
 			}
 
-			HorizontalDivider(
-				thickness = Dp.Hairline,
-				color = MaterialTheme.colorScheme.outlineVariant,
-				modifier = Modifier.padding(bottom = Ui.Padding.L),
-			)
+			with(sharedTransitionScope) {
+				MarkdownView(
+					markdown = eventText,
+					modifier = Modifier
+						.fillMaxWidth()
+						.sharedElement(
+							sharedContentState = rememberSharedContentState(
+								key = "timeline-content-${event?.id}",
+							),
+							animatedVisibilityScope = animatedVisibilityScope,
+						)
+						.clickable(onClick = onEnterEdit),
+				)
+			}
 		}
 
-		with(sharedTransitionScope) {
-			MarkdownView(
-				markdown = eventText,
-				modifier = Modifier
-					.fillMaxWidth()
-					.sharedElement(
-						sharedContentState = rememberSharedContentState(
-							key = "timeline-content-${event?.id}",
-						),
-						animatedVisibilityScope = animatedVisibilityScope,
-					)
-					.clickable(onClick = onEnterEdit),
-			)
-		}
+		MpScrollBarColumn(
+			modifier = scrollBarOverlay(),
+			state = scrollState,
+		)
 	}
 }
 

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/MpScrollBar.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/MpScrollBar.kt
@@ -1,18 +1,180 @@
 package com.darkrockstudios.apps.hammer.common.compose
 
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.v2.ScrollbarAdapter
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+private val RailWidth = 10.dp
+
+/** Strip reserved for the edge rule; the thumb covers the rest of the rail exactly. */
+private val RuleInset = 1.dp
+private val ThumbThickness = RailWidth - RuleInset
+private val HatchSpacing = 5.dp
+
+actual val MpScrollBarGutter: Dp = RailWidth
 
 @Composable
 actual fun MpScrollBarList(
 	modifier: Modifier,
 	state: LazyListState
 ) {
-	VerticalScrollbar(
+	ScrollbarRail(modifier, state.isScrollable, rememberScrollbarAdapter(state))
+}
+
+@Composable
+actual fun MpScrollBarColumn(
+	modifier: Modifier,
+	state: ScrollState
+) {
+	// A ScrollState that was never attached to a scrolling container reports maxValue as
+	// Int.MAX_VALUE, which would otherwise read as "scrollable" and draw a rail over nothing.
+	val scrollable = state.maxValue != Int.MAX_VALUE && state.isScrollable
+	ScrollbarRail(modifier, scrollable, rememberScrollbarAdapter(state))
+}
+
+@Composable
+actual fun MpScrollBarGrid(
+	modifier: Modifier,
+	state: LazyGridState
+) {
+	ScrollbarRail(modifier, state.isScrollable, rememberScrollbarAdapter(state))
+}
+
+@Composable
+actual fun MpScrollBarStaggeredGrid(
+	modifier: Modifier,
+	state: LazyStaggeredGridState
+) {
+	ScrollbarRail(
 		modifier = modifier,
-		adapter = rememberScrollbarAdapter(state)
+		scrollable = state.isScrollable,
+		adapter = remember(state) { StaggeredGridScrollbarAdapter(state) },
 	)
+}
+
+/**
+ * Gutter the scrollbar lives in: a vertical `outlineVariant` hairline marking the scrollable edge,
+ * with a hatched track inside it that the thumb masks as it travels. Both are drawn only while
+ * there is somewhere to scroll, so screens that fit get no chrome at all.
+ *
+ * ```
+ * │╱╱╱│
+ * │███│  <- thumb, masking the hatch
+ * │╱╱╱│
+ *  ^ edge rule
+ * ```
+ */
+@Composable
+private fun ScrollbarRail(
+	modifier: Modifier,
+	scrollable: Boolean,
+	adapter: ScrollbarAdapter,
+) {
+	val colorScheme = MaterialTheme.colorScheme
+	val ruleColor = colorScheme.outlineVariant
+	val hatchColor = ruleColor.copy(alpha = 0.55f)
+	val style = remember(colorScheme) {
+		ScrollbarStyle(
+			minimalHeight = 24.dp,
+			thickness = ThumbThickness,
+			shape = RectangleShape,
+			hoverDurationMillis = 220,
+			unhoverColor = colorScheme.outlineVariant,
+			hoverColor = colorScheme.outline,
+		)
+	}
+	Box(
+		modifier = modifier
+			.width(RailWidth)
+			.drawWithCache {
+				val stroke = Stroke(width = Dp.Hairline.toPx().coerceAtLeast(1f))
+				val rule = Path().apply {
+					val x = stroke.width / 2f
+					moveTo(x, 0f)
+					lineTo(x, size.height)
+				}
+				val hatch = hatchPath(
+					inset = RuleInset.toPx(),
+					spacing = HatchSpacing.toPx(),
+					width = size.width,
+					height = size.height,
+				)
+				onDrawBehind {
+					if (!scrollable) return@onDrawBehind
+					drawPath(rule, ruleColor, style = stroke)
+					drawPath(hatch, hatchColor, style = stroke)
+				}
+			},
+		contentAlignment = Alignment.CenterEnd,
+	) {
+		VerticalScrollbar(
+			adapter = adapter,
+			modifier = Modifier.fillMaxHeight(),
+			style = style,
+		)
+	}
+}
+
+/**
+ * 45 degree hatching for the track, built once per size rather than a line per draw pass. Segments
+ * are clamped to the track rather than clipped, so no off-screen geometry is submitted.
+ */
+private fun hatchPath(inset: Float, spacing: Float, width: Float, height: Float): Path {
+	val path = Path()
+	if (spacing <= 0f || width <= inset || height <= 0f) return path
+	// Each line runs bottom-left to top-right: y = height - (x - origin).
+	var origin = inset - height
+	while (origin < width) {
+		val x1 = maxOf(inset, origin)
+		val x2 = minOf(width, origin + height)
+		if (x2 > x1) {
+			path.moveTo(x1, height - (x1 - origin))
+			path.lineTo(x2, height - (x2 - origin))
+		}
+		origin += spacing
+	}
+	return path
+}
+
+/**
+ * Compose ships no scrollbar adapter for staggered grids, but the state exposes the same metrics
+ * the built-in adapters are built from. Dragging scrolls by pixel delta rather than snapping.
+ */
+private class StaggeredGridScrollbarAdapter(
+	private val state: LazyStaggeredGridState,
+) : ScrollbarAdapter {
+
+	override val viewportSize: Double
+		get() = state.scrollIndicatorState?.viewportSize?.toDouble() ?: 0.0
+
+	// Matching the viewport means "nothing to scroll", which is the right reading before measurement.
+	override val contentSize: Double
+		get() = state.scrollIndicatorState?.contentSize?.toDouble() ?: viewportSize
+
+	override val scrollOffset: Double
+		get() = state.scrollIndicatorState?.scrollOffset?.toDouble() ?: 0.0
+
+	override suspend fun scrollTo(scrollOffset: Double) {
+		state.scrollBy((scrollOffset - this.scrollOffset).toFloat())
+	}
 }

--- a/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/MpScrollBar.kt
+++ b/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/MpScrollBar.kt
@@ -1,13 +1,44 @@
 package com.darkrockstudios.apps.hammer.common.compose
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+actual val MpScrollBarGutter: Dp = 0.dp
 
 @Composable
 actual fun MpScrollBarList(
 	modifier: Modifier,
 	state: LazyListState
+) {
+	// iOS shows inline scroll indicators natively; no explicit scrollbar composable needed.
+}
+
+@Composable
+actual fun MpScrollBarColumn(
+	modifier: Modifier,
+	state: ScrollState
+) {
+	// iOS shows inline scroll indicators natively; no explicit scrollbar composable needed.
+}
+
+@Composable
+actual fun MpScrollBarGrid(
+	modifier: Modifier,
+	state: LazyGridState
+) {
+	// iOS shows inline scroll indicators natively; no explicit scrollbar composable needed.
+}
+
+@Composable
+actual fun MpScrollBarStaggeredGrid(
+	modifier: Modifier,
+	state: LazyStaggeredGridState
 ) {
 	// iOS shows inline scroll indicators natively; no explicit scrollbar composable needed.
 }


### PR DESCRIPTION
Fixes #787.

The reporter was on Linux and couldn't tell the settings page scrolled at all — there was no scrollbar. The codebase had a scrollbar abstraction (`MpScrollBarList`) but it only accepted `LazyListState` and only two screens used it.

## What's here

Three new scrollbar variants alongside the existing one — `ScrollState`, `LazyGridState` and `LazyStaggeredGridState` — wired into every screen that scrolls:

account settings, project settings, About, project stats, the encyclopedia / notes / timeline / story-idea detail views and their browse grids, the outline reading column and chapter rail, the scene metadata panel, and the shared reorderable list.

Compose ships no staggered-grid scrollbar adapter, so that one is implemented over the state's `ScrollIndicatorState`.

## The desktop look

The bar is drawn as a hatched rail: an `outlineVariant` hairline on the scrollable edge with 45° hatching filling the track behind an opaque square thumb.

```
│╱╱╱│
│███│  <- thumb, masking the hatch
│╱╱╱│
 ^ edge rule
```

The thumb masks the hatch as it travels, so what's left marks the part of the document you haven't reached. The rule reuses the same vertical hairline `HdHairlineSection` uses to group content. Both are drawn only while there's somewhere to scroll, so a screen whose content fits gets no chrome at all. Documented in `DESIGN_README.md`.

Android keeps its transient fading thumb — now themed rather than the previous hard-coded black-on-white, which looked broken in dark mode. iOS keeps its native inline indicators.

## Notes for review

- **`scrollBarOverlay()`** is the one correct placement for the bar: `matchParentSize()`, so it never contributes to its parent's size. `fillMaxHeight()` stretches the wrap-content boxes the detail screens use.
- **`MpScrollBarGutter`** is the width full-bleed content must reserve so the rail doesn't sit on top of it. Needed by the project list, the outline chapter rail and the reorderable list; screens with normal horizontal padding need nothing. It's `0.dp` on Android and iOS.
- The rail is `desktopMain` only, which is a deliberate exception to the design system's cross-platform-parity rule — a persistent hatched rail suits a pointer and not a touch screen. Called out in the doc.
- `AndroidScrollbar` is gone. It was public but had no callers, and `horizontal`/`alignEnd` were constant at every call site, so a fair amount of it was unreachable.
- Much of the diff is re-indentation from wrapping scrollers in a `Box`. `git diff -w` is a lot smaller and closer to the real change.

## Verification

Compiles on desktop, Android and iosMain. `:composeUi:desktopTest` and `:common:desktopTest` pass, including `TimeLineOverviewUiTest` and `StoryIdeasUiTest`, which cover two of the changed screens. Checked by hand on desktop in dark theme.
