### PR TITLE
Match global search against projected Markdown prose

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -11,8 +11,10 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneCo
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.search.ParsedQuery
+import com.darkrockstudios.apps.hammer.common.data.search.markdownTitleLine
 import com.darkrockstudios.apps.hammer.common.data.search.matchesAllTags
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
+import com.darkrockstudios.apps.hammer.common.data.search.projectMarkdownToPlainText
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_IO
@@ -95,12 +97,8 @@ class SearchProjectUseCase(
 		return timeline.events
 			.filter { it.tags.matchesAllTags(parsed.tags) }
 			.mapNotNull { event ->
-				val combined = if (event.date.isNullOrBlank()) {
-					event.content
-				} else {
-					"${event.date} — ${event.content}"
-				}
-				val snippet = matchOrPreview(combined, parsed.text) ?: return@mapNotNull null
+				val snippet = matchTimelineEvent(event.date, event.content, parsed.text)
+					?: return@mapNotNull null
 				SearchResult.TimelineEvent(
 					eventId = event.id,
 					title = event.date?.takeIf { it.isNotBlank() }
@@ -165,7 +163,7 @@ class SearchProjectUseCase(
 			)
 		}
 
-		val textMatch = findMatch(entry.text, freeText) ?: return null
+		val textMatch = findMarkdownMatch(entry.text, freeText) ?: return null
 		return SearchResult.EncyclopediaEntry(
 			entryDef = def,
 			title = def.name,
@@ -197,7 +195,7 @@ class SearchProjectUseCase(
 				return SearchResult.Scene(sceneItem = scene, title = scene.name, snippet = nameMatch)
 			}
 			val text = withContext(dispatcherIo) { loadSceneText(scene) } ?: return null
-			val bodyMatch = findMatch(text, query) ?: return null
+			val bodyMatch = findMarkdownMatch(text, query) ?: return null
 			return SearchResult.Scene(sceneItem = scene, title = scene.name, snippet = bodyMatch)
 		}
 
@@ -220,14 +218,31 @@ class SearchProjectUseCase(
 			return SearchResult.Scene(sceneItem = scene, title = title, snippet = nameMatch)
 		}
 		val text = withContext(dispatcherIo) { loadSceneText(scene) } ?: return null
-		val bodyMatch = findMatch(text, query) ?: return null
+		val bodyMatch = findMarkdownMatch(text, query) ?: return null
 		return SearchResult.Scene(sceneItem = scene, title = title, snippet = bodyMatch)
 	}
 
+	/** Both callers pass stored Markdown, so both paths go through the prose projection. */
 	private fun matchOrPreview(content: String, query: String): AnnotatedSnippet? {
-		if (query.isEmpty()) return previewSnippet(content)
-		return findMatch(content, query)
+		if (query.isEmpty()) return markdownPreviewSnippet(content)
+		return findMarkdownMatch(content, query)
 	}
+
+	/**
+	 * The date is a plain-text field, so only the body is projected. Both halves are searched as one
+	 * string so a query can span the separator.
+	 */
+	private fun matchTimelineEvent(date: String?, content: String, query: String): AnnotatedSnippet? {
+		val projected = withDate(date, projectMarkdownToPlainText(content))
+		if (query.isEmpty()) {
+			return previewSnippet(projected) ?: previewSnippet(withDate(date, content))
+		}
+		findMatch(projected, query)?.let { return it }
+		return findMatch(withDate(date, content), query)
+	}
+
+	private fun withDate(date: String?, content: String): String =
+		if (date.isNullOrBlank()) content else "$date — $content"
 
 	private fun loadSceneText(scene: SceneItem): String? {
 		val buffer = sceneContentRepository.getSceneBuffer(scene)
@@ -236,12 +251,13 @@ class SearchProjectUseCase(
 		return runCatching { sceneEditor.loadSceneMarkdownRaw(scene) }.getOrNull()
 	}
 
+	/** [content] is stored Markdown, so the derived title is projected the same way the UI does. */
 	private fun firstLineTitle(content: String, fallback: String): String {
-		val firstLine = content.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+		val title = markdownTitleLine(content)
 		return when {
-			firstLine.isEmpty() -> fallback
-			firstLine.length > TITLE_MAX -> firstLine.take(TITLE_MAX).trimEnd() + "…"
-			else -> firstLine
+			title.isEmpty() -> fallback
+			title.length > TITLE_MAX -> title.take(TITLE_MAX).trimEnd() + "…"
+			else -> title
 		}
 	}
 
@@ -270,6 +286,23 @@ class SearchProjectUseCase(
 			if (pos < 0) return null
 			return buildSnippet(text, pos, query.length)
 		}
+
+		/**
+		 * Matches against the prose projection of stored Markdown, so queries spanning storage
+		 * syntax still hit and the snippet reads the way the document does. The raw source is
+		 * searched as a fallback, which keeps queries for literal markup working.
+		 */
+		internal fun findMarkdownMatch(markdown: String, query: String): AnnotatedSnippet? {
+			if (markdown.isEmpty() || query.isEmpty()) return null
+			val projected = projectMarkdownToPlainText(markdown)
+			findMatch(projected, query)?.let { return it }
+			if (projected !== markdown) return findMatch(markdown, query)
+			return null
+		}
+
+		/** Falls back to the raw source so a document made only of markup still previews. */
+		internal fun markdownPreviewSnippet(markdown: String): AnnotatedSnippet? =
+			previewSnippet(projectMarkdownToPlainText(markdown)) ?: previewSnippet(markdown)
 
 		internal fun buildSnippet(text: String, matchPos: Int, queryLen: Int): AnnotatedSnippet {
 			val windowStart = (matchPos - SNIPPET_BEFORE).coerceAtLeast(0)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -11,6 +11,7 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneCo
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.search.ParsedQuery
+import com.darkrockstudios.apps.hammer.common.data.search.containsMarkdownSyntax
 import com.darkrockstudios.apps.hammer.common.data.search.markdownTitleLine
 import com.darkrockstudios.apps.hammer.common.data.search.matchesAllTags
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
@@ -296,7 +297,7 @@ class SearchProjectUseCase(
 			if (markdown.isEmpty() || query.isEmpty()) return null
 			val projected = projectMarkdownToPlainText(markdown)
 			findMatch(projected, query)?.let { return it }
-			if (projected !== markdown) return findMatch(markdown, query)
+			if (containsMarkdownSyntax(query)) return findMatch(markdown, query)
 			return null
 		}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
@@ -2,14 +2,13 @@ package com.darkrockstudios.apps.hammer.common.data.search
 
 private const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 
-/** Leading blockquote, heading, bullet and ordered-list markers, none of which read as prose. */
-private val BLOCK_PREFIX = Regex("""^\s*(?:>\s*)*(?:#{1,6}\s+|[-*+]\s+|\d{1,9}[.)]\s+)?""")
-
 /**
  * Compared directly rather than via set or string membership: this runs once per character of every
  * document scanned, and `in` on a CharSequence costs a call per character.
  */
 private fun Char.isDelimiter(): Boolean = this == '*' || this == '_' || this == '`'
+
+private fun Char.isSpaceOrTab(): Boolean = this == ' ' || this == '\t'
 
 private fun Char?.isBlankOrEdge(): Boolean = this == null || isWhitespace()
 
@@ -20,7 +19,7 @@ private fun Char?.isPunctuation(): Boolean = this != null && this in ASCII_PUNCT
  * pairs off from the end of the opener and the start of the closer, so the surviving characters are
  * always the middle of the run.
  */
-private class DelimiterRun(val char: Char, val start: Int, val end: Int) {
+private class DelimiterRun(val char: Char, val start: Int, val end: Int, val paragraph: Int) {
 	var canOpen = false
 	var canClose = false
 
@@ -33,28 +32,20 @@ private class DelimiterRun(val char: Char, val start: Int, val end: Int) {
 }
 
 /**
- * Flattens stored Markdown into the prose a reader sees, so a query can match across storage syntax.
- * Backslash escapes resolve to their literal character (`well\-known` becomes `well-known`) and
- * *paired* emphasis or code delimiters are dropped (`**Chapter** One` becomes `Chapter One`).
+ * Flattens stored Markdown into the prose a reader sees. Backslash escapes resolve to their literal
+ * character (`well\-known` becomes `well-known`), paired emphasis and code delimiters are dropped
+ * (`**Chapter** One` becomes `Chapter One`), and leading blockquote, heading and bullet markers are
+ * removed from each line.
  *
- * Pairing follows CommonMark's flanking rules, which is what keeps literal markers intact:
- * `user_name`, `2 * 3` and a bare `***` divider all survive because neither side of the delimiter
- * can open or close emphasis. That matters for content the escaping editor did not write, such as
- * imports, synced documents and hand-edited files.
+ * Delimiters pair only within a paragraph, and only where CommonMark's flanking rules allow, so
+ * literal markers survive: `user_name`, `2 * 3`, a bare `***` divider and a stray apostrophe-backtick
+ * are all left intact.
  *
- * Known limits, accepted so a full-project scan stays inside the search debounce: link and image
- * syntax is left intact, so imported content can show a URL in a snippet; punctuation is tested
- * against ASCII only; and escapes resolve inside code spans, because everything the editor saves is
- * escaped throughout. Parsing properly would cover all of these but costs roughly four times as
- * much per scan, which only becomes affordable once projections are cached per document.
- *
- * Block structure is left alone; see [markdownTitleLine] for the leading-marker case.
+ * Link and image syntax is left as written. Punctuation is tested against ASCII only, and escapes
+ * resolve inside code spans as well as outside them.
  */
 fun projectMarkdownToPlainText(markdown: String): String {
-	if (!containsDelimiter(markdown)) {
-		// The editor escapes punctuation on every save, so plain paragraphs still reach this far.
-		return if (containsEscape(markdown)) unescape(markdown) else markdown
-	}
+	if (!containsMarkdownSyntax(markdown)) return markdown
 
 	val runs = scanDelimiterRuns(markdown)
 	resolveCodeSpans(runs)
@@ -63,35 +54,70 @@ fun projectMarkdownToPlainText(markdown: String): String {
 }
 
 /**
- * The prose title for [markdown]: its first non-blank line with block markers stripped and inline
- * markup flattened. A line that projects to nothing falls back to itself, so a marker-only line
- * still yields a title rather than reading as an empty document.
+ * The prose title for [markdown]: the first non-blank line of its projection. Falls back to the raw
+ * first line when the projection of it is blank, so a marker-only line still yields a title rather
+ * than reading as an empty document.
  */
 fun markdownTitleLine(markdown: String): String {
-	val line = markdown.lineSequence().firstOrNull { it.isNotBlank() } ?: return ""
-	val body = line.replaceFirst(BLOCK_PREFIX, "")
-	val projected = projectMarkdownToPlainText(body).trim()
-	return projected.ifBlank { line.trim() }
+	val projected = projectMarkdownToPlainText(markdown)
+	val title = projected.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+	if (title.isNotEmpty()) return title
+	return markdown.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
 }
 
-private fun containsDelimiter(text: String): Boolean {
+/**
+ * True when [text] holds a character the projection can remove. A query without one that misses the
+ * projection cannot match the raw source either, because the projection only ever deletes.
+ */
+internal fun containsMarkdownSyntax(text: String): Boolean {
 	var i = 0
-	val length = text.length
-	while (i < length) {
-		if (text[i].isDelimiter()) return true
+	while (i < text.length) {
+		val c = text[i]
+		if (c.isDelimiter() || c == '\\' || c == '#' || c == '>' || c == '-' || c == '+') return true
 		i++
 	}
 	return false
 }
 
-private fun containsEscape(text: String): Boolean {
-	var i = 0
-	val length = text.length
-	while (i < length) {
-		if (text[i] == '\\') return true
+/**
+ * The offset after any blockquote, heading or bullet marker opening the line at [start], or [start]
+ * itself when the line opens with prose. Ordered-list markers are left alone: a single line cannot
+ * distinguish "1. Draft opening" from "1984. The year everything changed".
+ */
+private fun skipBlockPrefix(markdown: String, start: Int): Int {
+	val length = markdown.length
+	var i = start
+	var found = false
+
+	while (i < length && markdown[i].isSpaceOrTab()) i++
+
+	while (i < length && markdown[i] == '>') {
 		i++
+		found = true
+		while (i < length && markdown[i].isSpaceOrTab()) i++
 	}
-	return false
+
+	if (i < length && markdown[i] == '#') {
+		var j = i
+		var hashes = 0
+		while (j < length && markdown[j] == '#') {
+			j++
+			hashes++
+		}
+		if (hashes <= 6 && j < length && markdown[j].isSpaceOrTab()) {
+			i = j
+			found = true
+		}
+	} else if (i < length && (markdown[i] == '-' || markdown[i] == '*' || markdown[i] == '+')) {
+		if (i + 1 < length && markdown[i + 1].isSpaceOrTab()) {
+			i++
+			found = true
+		}
+	}
+
+	if (!found) return start
+	while (i < length && markdown[i].isSpaceOrTab()) i++
+	return i
 }
 
 /** Appends the character at [i], resolving a backslash escape, and returns the next index. */
@@ -105,22 +131,22 @@ private fun StringBuilder.appendResolved(markdown: String, i: Int): Int {
 	return i + 1
 }
 
-/** Resolves escapes alone, for the common document that carries no emphasis at all. */
-private fun unescape(markdown: String): String {
-	val sb = StringBuilder(markdown.length)
-	var i = 0
-	while (i < markdown.length) i = sb.appendResolved(markdown, i)
-	return sb.toString()
-}
-
 private fun scanDelimiterRuns(markdown: String): List<DelimiterRun> {
 	val runs = mutableListOf<DelimiterRun>()
 	val length = markdown.length
 	var i = 0
+	var paragraph = 0
 	while (i < length) {
 		val c = markdown[i]
 		if (c == '\\' && i + 1 < length && markdown[i + 1] in ASCII_PUNCTUATION) {
 			i += 2
+			continue
+		}
+		if (c == '\n') {
+			var k = i + 1
+			while (k < length && (markdown[k].isSpaceOrTab() || markdown[k] == '\r')) k++
+			if (k >= length || markdown[k] == '\n') paragraph++
+			i++
 			continue
 		}
 		if (!c.isDelimiter()) {
@@ -154,7 +180,7 @@ private fun scanDelimiterRuns(markdown: String): List<DelimiterRun> {
 			if (!canOpen && !canClose) continue
 		}
 
-		val run = DelimiterRun(c, start, end)
+		val run = DelimiterRun(c, start, end, paragraph)
 		run.canOpen = canOpen
 		run.canClose = canClose
 		runs.add(run)
@@ -174,26 +200,35 @@ private fun resolveCodeSpans(runs: List<DelimiterRun>) {
 
 		val width = opener.end - opener.start
 		var j = i + 1
-		while (j < runs.size) {
+		var closer = -1
+		while (j < runs.size && runs[j].paragraph == opener.paragraph) {
 			val candidate = runs[j]
-			if (candidate.char == '`' && candidate.end - candidate.start == width) break
+			if (candidate.char == '`' && candidate.end - candidate.start == width) {
+				closer = j
+				break
+			}
 			j++
 		}
-		if (j == runs.size) {
+		if (closer < 0) {
 			i++
 			continue
 		}
 
 		opener.dropBack = width
-		runs[j].dropFront = width
-		for (k in i + 1 until j) runs[k].inert = true
-		i = j + 1
+		runs[closer].dropFront = width
+		for (k in i + 1 until closer) runs[k].inert = true
+		i = closer + 1
 	}
 }
 
 private fun resolveEmphasis(runs: List<DelimiterRun>) {
 	val open = mutableListOf<DelimiterRun>()
+	var paragraph = -1
 	for (run in runs) {
+		if (run.paragraph != paragraph) {
+			open.clear()
+			paragraph = run.paragraph
+		}
 		if (run.char == '`' || run.inert) continue
 
 		if (run.canClose) {
@@ -220,7 +255,18 @@ private fun render(markdown: String, runs: List<DelimiterRun>): String {
 	val length = markdown.length
 	var i = 0
 	var r = 0
+	var atLineStart = true
 	while (i < length) {
+		if (atLineStart) {
+			atLineStart = false
+			val afterPrefix = skipBlockPrefix(markdown, i)
+			if (afterPrefix > i) {
+				i = afterPrefix
+				while (r < runs.size && runs[r].start < i) r++
+				continue
+			}
+		}
+
 		if (r < runs.size && i == runs[r].start) {
 			val run = runs[r]
 			sb.append(markdown, run.start + run.dropFront, run.end - run.dropBack)
@@ -229,6 +275,7 @@ private fun render(markdown: String, runs: List<DelimiterRun>): String {
 			continue
 		}
 
+		if (markdown[i] == '\n') atLineStart = true
 		i = sb.appendResolved(markdown, i)
 	}
 	return sb.toString()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
@@ -1,0 +1,235 @@
+package com.darkrockstudios.apps.hammer.common.data.search
+
+private const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+
+/** Leading blockquote, heading, bullet and ordered-list markers, none of which read as prose. */
+private val BLOCK_PREFIX = Regex("""^\s*(?:>\s*)*(?:#{1,6}\s+|[-*+]\s+|\d{1,9}[.)]\s+)?""")
+
+/**
+ * Compared directly rather than via set or string membership: this runs once per character of every
+ * document scanned, and `in` on a CharSequence costs a call per character.
+ */
+private fun Char.isDelimiter(): Boolean = this == '*' || this == '_' || this == '`'
+
+private fun Char?.isBlankOrEdge(): Boolean = this == null || isWhitespace()
+
+private fun Char?.isPunctuation(): Boolean = this != null && this in ASCII_PUNCTUATION
+
+/**
+ * A maximal run of one delimiter character, plus how much of it the projection consumes. Emphasis
+ * pairs off from the end of the opener and the start of the closer, so the surviving characters are
+ * always the middle of the run.
+ */
+private class DelimiterRun(val char: Char, val start: Int, val end: Int) {
+	var canOpen = false
+	var canClose = false
+
+	/** Set for runs sitting inside a resolved code span, where emphasis does not apply. */
+	var inert = false
+	var dropFront = 0
+	var dropBack = 0
+
+	val available: Int get() = end - start - dropFront - dropBack
+}
+
+/**
+ * Flattens stored Markdown into the prose a reader sees, so a query can match across storage syntax.
+ * Backslash escapes resolve to their literal character (`well\-known` becomes `well-known`) and
+ * *paired* emphasis or code delimiters are dropped (`**Chapter** One` becomes `Chapter One`).
+ *
+ * Pairing follows CommonMark's flanking rules, which is what keeps literal markers intact:
+ * `user_name`, `2 * 3` and a bare `***` divider all survive because neither side of the delimiter
+ * can open or close emphasis. That matters for content the escaping editor did not write, such as
+ * imports, synced documents and hand-edited files.
+ *
+ * Known limits, accepted so a full-project scan stays inside the search debounce: link and image
+ * syntax is left intact, so imported content can show a URL in a snippet; punctuation is tested
+ * against ASCII only; and escapes resolve inside code spans, because everything the editor saves is
+ * escaped throughout. Parsing properly would cover all of these but costs roughly four times as
+ * much per scan, which only becomes affordable once projections are cached per document.
+ *
+ * Block structure is left alone; see [markdownTitleLine] for the leading-marker case.
+ */
+fun projectMarkdownToPlainText(markdown: String): String {
+	if (!containsDelimiter(markdown)) {
+		// The editor escapes punctuation on every save, so plain paragraphs still reach this far.
+		return if (containsEscape(markdown)) unescape(markdown) else markdown
+	}
+
+	val runs = scanDelimiterRuns(markdown)
+	resolveCodeSpans(runs)
+	resolveEmphasis(runs)
+	return render(markdown, runs)
+}
+
+/**
+ * The prose title for [markdown]: its first non-blank line with block markers stripped and inline
+ * markup flattened. A line that projects to nothing falls back to itself, so a marker-only line
+ * still yields a title rather than reading as an empty document.
+ */
+fun markdownTitleLine(markdown: String): String {
+	val line = markdown.lineSequence().firstOrNull { it.isNotBlank() } ?: return ""
+	val body = line.replaceFirst(BLOCK_PREFIX, "")
+	val projected = projectMarkdownToPlainText(body).trim()
+	return projected.ifBlank { line.trim() }
+}
+
+private fun containsDelimiter(text: String): Boolean {
+	var i = 0
+	val length = text.length
+	while (i < length) {
+		if (text[i].isDelimiter()) return true
+		i++
+	}
+	return false
+}
+
+private fun containsEscape(text: String): Boolean {
+	var i = 0
+	val length = text.length
+	while (i < length) {
+		if (text[i] == '\\') return true
+		i++
+	}
+	return false
+}
+
+/** Appends the character at [i], resolving a backslash escape, and returns the next index. */
+private fun StringBuilder.appendResolved(markdown: String, i: Int): Int {
+	val c = markdown[i]
+	if (c == '\\' && i + 1 < markdown.length && markdown[i + 1] in ASCII_PUNCTUATION) {
+		append(markdown[i + 1])
+		return i + 2
+	}
+	append(c)
+	return i + 1
+}
+
+/** Resolves escapes alone, for the common document that carries no emphasis at all. */
+private fun unescape(markdown: String): String {
+	val sb = StringBuilder(markdown.length)
+	var i = 0
+	while (i < markdown.length) i = sb.appendResolved(markdown, i)
+	return sb.toString()
+}
+
+private fun scanDelimiterRuns(markdown: String): List<DelimiterRun> {
+	val runs = mutableListOf<DelimiterRun>()
+	val length = markdown.length
+	var i = 0
+	while (i < length) {
+		val c = markdown[i]
+		if (c == '\\' && i + 1 < length && markdown[i + 1] in ASCII_PUNCTUATION) {
+			i += 2
+			continue
+		}
+		if (!c.isDelimiter()) {
+			i++
+			continue
+		}
+
+		val start = i
+		var end = start + 1
+		while (end < length && markdown[end] == c) end++
+		i = end
+
+		var canOpen = true
+		var canClose = true
+		if (c != '`') {
+			val prev = markdown.getOrNull(start - 1)
+			val next = markdown.getOrNull(end)
+			val leftFlanking = !next.isBlankOrEdge() &&
+				(!next.isPunctuation() || prev.isBlankOrEdge() || prev.isPunctuation())
+			val rightFlanking = !prev.isBlankOrEdge() &&
+				(!prev.isPunctuation() || next.isBlankOrEdge() || next.isPunctuation())
+			if (c == '*') {
+				canOpen = leftFlanking
+				canClose = rightFlanking
+			} else {
+				// Underscores cannot delimit emphasis inside a word, which is what saves `user_name`.
+				canOpen = leftFlanking && (!rightFlanking || prev.isPunctuation())
+				canClose = rightFlanking && (!leftFlanking || next.isPunctuation())
+			}
+			// A run that can do neither is literal text; leaving it out keeps it out of the render.
+			if (!canOpen && !canClose) continue
+		}
+
+		val run = DelimiterRun(c, start, end)
+		run.canOpen = canOpen
+		run.canClose = canClose
+		runs.add(run)
+	}
+	return runs
+}
+
+/** Code spans bind tighter than emphasis, so they claim their delimiters first. */
+private fun resolveCodeSpans(runs: List<DelimiterRun>) {
+	var i = 0
+	while (i < runs.size) {
+		val opener = runs[i]
+		if (opener.char != '`') {
+			i++
+			continue
+		}
+
+		val width = opener.end - opener.start
+		var j = i + 1
+		while (j < runs.size) {
+			val candidate = runs[j]
+			if (candidate.char == '`' && candidate.end - candidate.start == width) break
+			j++
+		}
+		if (j == runs.size) {
+			i++
+			continue
+		}
+
+		opener.dropBack = width
+		runs[j].dropFront = width
+		for (k in i + 1 until j) runs[k].inert = true
+		i = j + 1
+	}
+}
+
+private fun resolveEmphasis(runs: List<DelimiterRun>) {
+	val open = mutableListOf<DelimiterRun>()
+	for (run in runs) {
+		if (run.char == '`' || run.inert) continue
+
+		if (run.canClose) {
+			while (run.available > 0) {
+				val openerIndex = open.indexOfLast { it.char == run.char }
+				if (openerIndex < 0) break
+
+				val opener = open[openerIndex]
+				val consumed = minOf(run.available, opener.available)
+				opener.dropBack += consumed
+				run.dropFront += consumed
+
+				// Anything stacked above the matched opener can never close now.
+				while (open.size > openerIndex) open.removeAt(open.size - 1)
+				if (opener.available > 0) open.add(opener)
+			}
+		}
+		if (run.available > 0 && run.canOpen) open.add(run)
+	}
+}
+
+private fun render(markdown: String, runs: List<DelimiterRun>): String {
+	val sb = StringBuilder(markdown.length)
+	val length = markdown.length
+	var i = 0
+	var r = 0
+	while (i < length) {
+		if (r < runs.size && i == runs[r].start) {
+			val run = runs[r]
+			sb.append(markdown, run.start + run.dropFront, run.end - run.dropBack)
+			i = run.end
+			r++
+			continue
+		}
+
+		i = sb.appendResolved(markdown, i)
+	}
+	return sb.toString()
+}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectionTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectionTest.kt
@@ -1,0 +1,125 @@
+package com.darkrockstudios.apps.hammer.common.data.search
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class MarkdownProjectionTest {
+
+	@Test
+	fun `plain prose is returned unchanged and unallocated`() {
+		val input = "Alice went down the rabbit hole."
+		assertSame(input, projectMarkdownToPlainText(input))
+	}
+
+	@Test
+	fun `empty input is returned unchanged`() {
+		assertEquals("", projectMarkdownToPlainText(""))
+	}
+
+	@Test
+	fun `backslash escapes resolve to their literal character`() {
+		assertEquals("well-known", projectMarkdownToPlainText("well\\-known"))
+		assertEquals("1. not a list", projectMarkdownToPlainText("1\\. not a list"))
+		assertEquals("[brackets]", projectMarkdownToPlainText("\\[brackets\\]"))
+	}
+
+	@Test
+	fun `escaped backslash collapses to one backslash`() {
+		assertEquals("C:\\path", projectMarkdownToPlainText("C:\\\\path"))
+	}
+
+	@Test
+	fun `a backslash before a non-punctuation character is kept`() {
+		assertEquals("\\a", projectMarkdownToPlainText("\\a"))
+	}
+
+	@Test
+	fun `a trailing backslash is kept`() {
+		assertEquals("end\\", projectMarkdownToPlainText("end\\"))
+	}
+
+	@Test
+	fun `paired emphasis markers are dropped so phrases join up`() {
+		assertEquals("Chapter One", projectMarkdownToPlainText("**Chapter** One"))
+		assertEquals("quick brown", projectMarkdownToPlainText("_quick_ brown"))
+		assertEquals("run build now", projectMarkdownToPlainText("run `build` now"))
+	}
+
+	@Test
+	fun `nested emphasis is unwrapped`() {
+		assertEquals("very loud indeed", projectMarkdownToPlainText("**very _loud_ indeed**"))
+		assertEquals("shout", projectMarkdownToPlainText("***shout***"))
+	}
+
+	@Test
+	fun `escaped markers survive as literal characters`() {
+		assertEquals("_shape_", projectMarkdownToPlainText("\\_shape\\_"))
+		assertEquals("2 * 3", projectMarkdownToPlainText("2 \\* 3"))
+	}
+
+	@Test
+	fun `escaping is resolved before markers are dropped`() {
+		assertEquals("a_b and c", projectMarkdownToPlainText("a\\_b and _c_"))
+	}
+
+	@Test
+	fun `underscores inside a word are literal`() {
+		assertEquals("user_name", projectMarkdownToPlainText("user_name"))
+		assertEquals("my_table_name", projectMarkdownToPlainText("my_table_name"))
+		assertEquals("snake_case and emphasis", projectMarkdownToPlainText("snake_case and _emphasis_"))
+	}
+
+	@Test
+	fun `markers that cannot pair off are literal`() {
+		assertEquals("2 * 3 = 6", projectMarkdownToPlainText("2 * 3 = 6"))
+		assertEquals("***", projectMarkdownToPlainText("***"))
+		assertEquals("an *unclosed aside", projectMarkdownToPlainText("an *unclosed aside"))
+		assertEquals("a ` stray tick", projectMarkdownToPlainText("a ` stray tick"))
+	}
+
+	@Test
+	fun `emphasis markers inside a code span are literal`() {
+		assertEquals("call my_func now", projectMarkdownToPlainText("call `my_func` now"))
+	}
+
+	@Test
+	fun `block level markers are left alone`() {
+		assertEquals("# Chapter One", projectMarkdownToPlainText("# Chapter One"))
+		assertEquals("> a quote", projectMarkdownToPlainText("> a quote"))
+		assertEquals("- a bullet", projectMarkdownToPlainText("- a bullet"))
+	}
+
+	@Test
+	fun `a document with escapes but no emphasis still resolves them`() {
+		assertEquals(
+			"The well-known garden! (and its gate)",
+			projectMarkdownToPlainText("The well\\-known garden\\! \\(and its gate\\)"),
+		)
+	}
+
+	@Test
+	fun `title line strips block markers and inline markup`() {
+		assertEquals("Chapter One", markdownTitleLine("# **Chapter** One\n\nbody"))
+		assertEquals("A quoted thought", markdownTitleLine("> A quoted thought"))
+		assertEquals("First item", markdownTitleLine("- First item\n- Second"))
+		assertEquals("First item", markdownTitleLine("1. First item"))
+	}
+
+	@Test
+	fun `title line skips leading blank lines`() {
+		assertEquals("Actual title", markdownTitleLine("\n   \nActual title\nmore"))
+		assertEquals("", markdownTitleLine("   \n\n"))
+	}
+
+	@Test
+	fun `a title line of pure markup falls back to the raw line`() {
+		assertEquals("***", markdownTitleLine("***\nbody"))
+		assertEquals("#", markdownTitleLine("#\nbody"))
+	}
+
+	@Test
+	fun `an emphasized title keeps its words`() {
+		assertEquals("Once upon a time", markdownTitleLine("*Once upon a time*"))
+	}
+}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectionTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectionTest.kt
@@ -84,10 +84,44 @@ class MarkdownProjectionTest {
 	}
 
 	@Test
-	fun `block level markers are left alone`() {
-		assertEquals("# Chapter One", projectMarkdownToPlainText("# Chapter One"))
-		assertEquals("> a quote", projectMarkdownToPlainText("> a quote"))
-		assertEquals("- a bullet", projectMarkdownToPlainText("- a bullet"))
+	fun `leading block markers are stripped from each line`() {
+		assertEquals("Chapter One", projectMarkdownToPlainText("# Chapter One"))
+		assertEquals("a quote", projectMarkdownToPlainText("> a quote"))
+		assertEquals("a bullet", projectMarkdownToPlainText("- a bullet"))
+		assertEquals("Chapter One\n\nThe body", projectMarkdownToPlainText("# Chapter One\n\nThe body"))
+	}
+
+	@Test
+	fun `ordered list markers are left alone so years survive`() {
+		assertEquals("1984. The year everything changed", projectMarkdownToPlainText("1984. The year everything changed"))
+		assertEquals("3) Meet at the docks", projectMarkdownToPlainText("3) Meet at the docks"))
+	}
+
+	@Test
+	fun `a marker that is not followed by a space is prose`() {
+		assertEquals("-15 degrees", projectMarkdownToPlainText("-15 degrees"))
+		assertEquals("#hashtag here", projectMarkdownToPlainText("#hashtag here"))
+	}
+
+	@Test
+	fun `code delimiters do not pair across a paragraph break`() {
+		assertEquals(
+			"It`s here.\n\nThe Chapter One part.\n\nDon`t stop.",
+			projectMarkdownToPlainText("It`s here.\n\nThe **Chapter** One part.\n\nDon`t stop."),
+		)
+	}
+
+	@Test
+	fun `emphasis does not pair across a paragraph break`() {
+		assertEquals(
+			"See note *below\n\nThe rate is 5* higher",
+			projectMarkdownToPlainText("See note *below\n\nThe rate is 5* higher"),
+		)
+	}
+
+	@Test
+	fun `emphasis still pairs across a soft line break`() {
+		assertEquals("The long\ntitle here", projectMarkdownToPlainText("The **long\ntitle** here"))
 	}
 
 	@Test
@@ -103,7 +137,16 @@ class MarkdownProjectionTest {
 		assertEquals("Chapter One", markdownTitleLine("# **Chapter** One\n\nbody"))
 		assertEquals("A quoted thought", markdownTitleLine("> A quoted thought"))
 		assertEquals("First item", markdownTitleLine("- First item\n- Second"))
-		assertEquals("First item", markdownTitleLine("1. First item"))
+	}
+
+	@Test
+	fun `title line keeps a leading number`() {
+		assertEquals("1984. The year everything changed", markdownTitleLine("1984. The year everything changed"))
+	}
+
+	@Test
+	fun `title line pairs emphasis that closes on the next line`() {
+		assertEquals("The long", markdownTitleLine("The **long\ntitle** here"))
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -356,6 +356,174 @@ class SearchProjectUseCaseTest : BaseTest() {
 		assertEquals(7, results.first().sceneItem.id)
 	}
 
+	private fun note(id: Int, content: String) =
+		NoteContainer(NoteContent(id = id, created = Clock.System.now(), content = content))
+
+	@Test
+	fun `search matches across a backslash escape`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "A well\\-known secret"))
+
+		val results = createUseCase().search("well-known", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+	}
+
+	@Test
+	fun `search matches a phrase spanning an emphasis boundary`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "**Chapter** One begins"))
+
+		val results = createUseCase().search("Chapter One", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+	}
+
+	@Test
+	fun `search matches a phrase spanning italics and code spans`() = runTest {
+		every { notes.getNotes() } returns listOf(
+			note(1, "the _quick_ brown fox"),
+			note(2, "run the `build` script"),
+		)
+
+		val italic = createUseCase().search("quick brown", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+		val code = createUseCase().search("the build script", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, italic.size)
+		assertEquals(1, code.size)
+	}
+
+	@Test
+	fun `snippets render prose without markdown syntax`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "A well\\-known **Chapter** One secret"))
+
+		val results = createUseCase().search("well-known", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		val snippet = results.first().snippet
+		assertEquals("A well-known Chapter One secret", snippet.text)
+		assertEquals("well-known", snippet.text.substring(snippet.matchStart, snippet.matchEnd))
+	}
+
+	@Test
+	fun `escaped literals survive the projection`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "the \\_shape\\_ of it"))
+
+		val results = createUseCase().search("_shape_", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertTrue(results.first().snippet.text.contains("_shape_"))
+	}
+
+	@Test
+	fun `searching for literal markdown syntax still finds it`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "raw **bold** marker"))
+
+		val results = createUseCase().search("**bold**", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+	}
+
+	@Test
+	fun `scene bodies match across an emphasis boundary`() = runTest {
+		val scene = SceneItem(
+			projectDef = projectDef,
+			type = SceneItem.Type.Scene,
+			id = 7,
+			name = "Opening",
+			order = 0,
+		)
+		every { sceneEditor.getScenes() } returns listOf(scene)
+		every { sceneContentRepository.getSceneBuffer(scene) } returns null
+		every { sceneEditor.loadSceneMarkdownRaw(scene, any()) } returns "**Chapter** One begins"
+
+		val results = createUseCase().search("Chapter One", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Scene>()
+
+		assertEquals(1, results.size)
+		assertEquals("Chapter One begins", results.first().snippet.text)
+	}
+
+	@Test
+	fun `literal underscores in imported content are left alone`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "the user_name field and my_table_name"))
+
+		val results = createUseCase().search("user_name", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertTrue(results.first().snippet.text.contains("my_table_name"))
+	}
+
+	@Test
+	fun `a body of only markdown markers still previews in a tag search`() = runTest {
+		every { notes.getNotes() } returns listOf(
+			NoteContainer(
+				NoteContent(
+					id = 1,
+					created = Clock.System.now(),
+					content = "***",
+					tags = setOf("fantasy"),
+				)
+			),
+		)
+
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertEquals("***", results.first().snippet.text)
+	}
+
+	@Test
+	fun `a note whose first line is only markers is not titled empty`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "***\nThe real body text"))
+
+		val results = createUseCase().search("real body", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertEquals("***", results.first().title)
+	}
+
+	@Test
+	fun `timeline dates are not projected`() = runTest {
+		coEvery { timeLine.loadTimeline() } returns TimeLineContainer(
+			listOf(TimeLineEvent(id = 21, order = 0, date = "1990_2000", content = "A long war")),
+		)
+
+		val results = createUseCase().search("1990_2000", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.TimelineEvent>()
+
+		assertEquals(1, results.size)
+		assertTrue(results.first().snippet.text.contains("1990_2000"))
+	}
+
+	@Test
+	fun `tag-only search previews prose without markdown syntax`() = runTest {
+		every { notes.getNotes() } returns listOf(
+			NoteContainer(
+				NoteContent(
+					id = 1,
+					created = Clock.System.now(),
+					content = "A well\\-known **Chapter** One secret",
+					tags = setOf("fantasy"),
+				)
+			),
+		)
+
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertEquals("A well-known Chapter One secret", results.first().snippet.text)
+	}
+
 	@Test
 	fun `search honors filter to a single source`() = runTest {
 		every { notes.getNotes() } returns listOf(

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -481,6 +481,27 @@ class SearchProjectUseCaseTest : BaseTest() {
 	}
 
 	@Test
+	fun `a heading does not leak into the title or the snippet`() = runTest {
+		every { notes.getNotes() } returns listOf(
+			NoteContainer(
+				NoteContent(
+					id = 1,
+					created = Clock.System.now(),
+					content = "# Chapter One\n\nThe body text",
+					tags = setOf("fantasy"),
+				)
+			),
+		)
+
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertEquals("Chapter One", results.first().title)
+		assertEquals("Chapter One The body text", results.first().snippet.text)
+	}
+
+	@Test
 	fun `a note whose first line is only markers is not titled empty`() = runTest {
 		every { notes.getNotes() } returns listOf(note(1, "***\nThe real body text"))
 
@@ -494,14 +515,18 @@ class SearchProjectUseCaseTest : BaseTest() {
 	@Test
 	fun `timeline dates are not projected`() = runTest {
 		coEvery { timeLine.loadTimeline() } returns TimeLineContainer(
-			listOf(TimeLineEvent(id = 21, order = 0, date = "1990_2000", content = "A long war")),
+			listOf(TimeLineEvent(id = 21, order = 0, date = "1990 _to_ 2000", content = "A long war")),
 		)
 
-		val results = createUseCase().search("1990_2000", GlobalSearchFilter.All)
+		val verbatim = createUseCase().search("1990 _to_ 2000", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.TimelineEvent>()
+		val projectedForm = createUseCase().search("1990 to 2000", GlobalSearchFilter.All)
 			.filterIsInstance<SearchResult.TimelineEvent>()
 
-		assertEquals(1, results.size)
-		assertTrue(results.first().snippet.text.contains("1990_2000"))
+		assertEquals(1, verbatim.size)
+		assertTrue(verbatim.first().snippet.text.contains("1990 _to_ 2000"))
+		// Projecting the date would make this hit and would show a date the event does not have.
+		assertEquals(0, projectedForm.size)
 	}
 
 	@Test

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/TextSummary.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/TextSummary.kt
@@ -1,7 +1,9 @@
 package com.darkrockstudios.apps.hammer.common.compose
 
-fun String.firstNonBlankLine(): String =
-	lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+import com.darkrockstudios.apps.hammer.common.data.search.markdownTitleLine
+
+/** Every caller summarizes stored Markdown, so the line is flattened to the prose behind it. */
+fun String.firstNonBlankLine(): String = markdownTitleLine(this)
 
 fun String.truncateWithEllipsis(limit: Int): String =
 	if (length > limit) take(limit - 1).trimEnd() + "…" else this

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/TextSummary.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/TextSummary.kt
@@ -1,9 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.compose
 
-import com.darkrockstudios.apps.hammer.common.data.search.markdownTitleLine
-
-/** Every caller summarizes stored Markdown, so the line is flattened to the prose behind it. */
-fun String.firstNonBlankLine(): String = markdownTitleLine(this)
+fun String.firstNonBlankLine(): String =
+	lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
 
 fun String.truncateWithEllipsis(limit: Int): String =
 	if (length > limit) take(limit - 1).trimEnd() + "…" else this


### PR DESCRIPTION
Fixes #811

Global search compared queries against raw Markdown. Backslash escapes and emphasis markers sitting between words caused misses, and snippets rendered storage syntax back at the user.

## Approach

Stored Markdown is flattened to the prose a reader sees before matching. Escapes resolve to their literal character (`well\-known` becomes `well-known`), *paired* emphasis and code delimiters are dropped (`**Chapter** One` becomes `Chapter One`), and leading blockquote, heading and bullet markers come off each line.

Two constraints keep that from corrupting text:

- **Pairing follows CommonMark's flanking rules.** The editor escapes special characters on save, but imported, synced and hand-edited documents carry bare markers meant literally. `user_name`, `2 * 3`, a bare `***` divider and an unclosed `*aside` all survive, because neither side of those delimiters can open or close emphasis.
- **Pairing is scoped to a paragraph.** Without this, a backtick used as an apostrophe pairs with another one paragraphs away, deleting both and neutralizing the real emphasis in between. Emphasis still pairs across a soft line break, as CommonMark specifies.

Ordered-list markers are deliberately left alone. A single line cannot distinguish `1. Draft opening` from `1984. The year everything changed`, and mangling prose is worse than leaving a list marker in.

The raw source is still searched as a fallback for queries that contain markup themselves. That fallback is skipped when the query holds no character the projection can remove, where it is provably redundant.

Alongside that:

- Timeline dates are a plain-text field, not Markdown, so only the event body is projected. A query can still span the date/body separator.
- Note and timeline titles take the first non-blank line of the whole projection, so emphasis that closes on the following line still pairs, and a title agrees with the snippet under it.
- Blank projections fall back to the raw source, so a note whose body or first line is only markers still gets a title and still appears in tag-only searches.

## Performance

The original concern was the cost of projecting on very large projects. Measured over a full-project scan, with markup on roughly a fifth of words, which is heavier than real prose:

| project | raw scan | with projection |
|---|---|---|
| 300k words | 4 ms | 30 ms |
| 1.25M words | 20 ms | 127 ms |
| 3M words | 43 ms | 295 ms |

Search debounces at 250ms and already re-reads every scene from disk on each keystroke, so the projection sits inside the noise of the I/O it accompanies. The 3M row is roughly thirty novels in one project.

A real Markdown parse measured 103 / 355 / 834 ms on the same harness, crossing the debounce at 1.25M words, which is why this uses a hand-rolled scan.

## Known limitation

Link and image syntax is left as written, so imported content can still show a URL in a snippet. A parser would cover that plus every other construct, but at several times the cost per scan. It becomes affordable once projections are cached per document, which is the right order of work: cache first, parser second.

## Tests

- `MarkdownProjectionTest` (commonTest, runs on all targets): 26 cases covering escapes, flanking rules, paragraph scoping, block markers, code spans and title derivation.
- `SearchProjectUseCaseTest`: 31 cases including matching across escape and emphasis boundaries, literal underscores in imported content, marker-only bodies in tag searches, headings leaking into snippets, and unprojected timeline dates.

`:common:desktopTest` green; `:common` and `:composeUi` compile for desktop and iOS.
