### PR TITLE
Harden the remaining E2E workflow clicks against dropped taps

### DIFF
--- a/android/src/androidTest/kotlin/EditorTestHarness.kt
+++ b/android/src/androidTest/kotlin/EditorTestHarness.kt
@@ -104,6 +104,9 @@ fun ComposeTestRule.navigateTo(navTag: String) {
  * A single injected tap is occasionally dropped before `clickable` resolves it into an onClick,
  * which leaves the screen unchanged and reports no error. Re-inject until the expected outcome
  * appears rather than trusting one injection.
+ *
+ * Fails if [matcher] never resolves, and never reports success without having clicked: a [landed]
+ * that is already true on entry would otherwise pass the step without touching the target.
  */
 fun ComposeTestRule.clickUntil(
 	matcher: SemanticsMatcher,
@@ -111,12 +114,25 @@ fun ComposeTestRule.clickUntil(
 	landed: () -> Boolean,
 ) {
 	val deadline = SystemClock.uptimeMillis() + timeoutMillis
+	var clicked = false
 	while (true) {
 		// Only re-click while the target is still on screen; once it's gone the click did land and
 		// the screen is mid-change, so clicking again would hit whatever replaced it.
 		if (onAllNodes(matcher).fetchSemanticsNodes().isNotEmpty()) {
 			onAllNodes(matcher).onFirst().performClick()
+			clicked = true
 		}
+
+		if (!clicked) {
+			if (SystemClock.uptimeMillis() >= deadline) {
+				throw AssertionError(
+					"'${matcher.description}' never appeared within ${timeoutMillis}ms, so it was never clicked",
+				)
+			}
+			SystemClock.sleep(CLICK_RETRY_INTERVAL_MS)
+			continue
+		}
+
 		try {
 			waitUntil(timeoutMillis = 1_000L) { landed() }
 			return
@@ -130,6 +146,8 @@ fun ComposeTestRule.clickUntil(
 		}
 	}
 }
+
+private const val CLICK_RETRY_INTERVAL_MS = 100L
 
 /**
  * Type into the tagged markdown/scene editor and wait for the edit to land.

--- a/android/src/androidTest/kotlin/ProjectLifecycleTest.kt
+++ b/android/src/androidTest/kotlin/ProjectLifecycleTest.kt
@@ -44,10 +44,11 @@ class ProjectLifecycleTest {
 	@Test
 	fun createProjectThenOpenIt() {
 		// 1. Open the create dialog (masthead button when wide, bottom bar when narrow).
-		// 2. Type the project name into the dialog's only editable field, then confirm.
 		composeRule.clickUntil(hasTestTag(CreateProjectButtonTestTag)) {
 			composeRule.onAllNodes(hasSetTextAction()).fetchSemanticsNodes().isNotEmpty()
 		}
+
+		// 2. Type the project name into the dialog's only editable field, then confirm.
 		composeRule.onNode(hasSetTextAction()).performTextInput(projectName)
 
 		// The confirm button and the dialog title both read "Create Project";

--- a/android/src/androidTest/kotlin/ProjectLifecycleTest.kt
+++ b/android/src/androidTest/kotlin/ProjectLifecycleTest.kt
@@ -3,10 +3,10 @@ import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
@@ -44,10 +44,8 @@ class ProjectLifecycleTest {
 	@Test
 	fun createProjectThenOpenIt() {
 		// 1. Open the create dialog (masthead button when wide, bottom bar when narrow).
-		composeRule.onNodeWithTag(CreateProjectButtonTestTag).performClick()
-
 		// 2. Type the project name into the dialog's only editable field, then confirm.
-		composeRule.waitUntil(timeoutMillis = 5_000) {
+		composeRule.clickUntil(hasTestTag(CreateProjectButtonTestTag)) {
 			composeRule.onAllNodes(hasSetTextAction()).fetchSemanticsNodes().isNotEmpty()
 		}
 		composeRule.onNode(hasSetTextAction()).performTextInput(projectName)

--- a/android/src/androidTest/kotlin/SceneEditorWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/SceneEditorWorkflowTest.kt
@@ -44,9 +44,6 @@ class SceneEditorWorkflowTest {
 		composeRule.navigateTo(NAV_EDITOR_TAG)
 
 		// Create a scene and open it.
-		composeRule.waitUntil(10_000) {
-			composeRule.onAllNodesWithTag(SCENE_LIST_ADD_BUTTON_TAG).fetchSemanticsNodes().isNotEmpty()
-		}
 		composeRule.clickUntil(hasTestTag(SCENE_LIST_ADD_BUTTON_TAG)) {
 			composeRule.onAllNodesWithTag(SCENE_LIST_ADD_SCENE_TAG).fetchSemanticsNodes().isNotEmpty()
 		}

--- a/android/src/androidTest/kotlin/SceneEditorWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/SceneEditorWorkflowTest.kt
@@ -1,7 +1,7 @@
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ActivityScenario
@@ -47,9 +47,10 @@ class SceneEditorWorkflowTest {
 		composeRule.waitUntil(10_000) {
 			composeRule.onAllNodesWithTag(SCENE_LIST_ADD_BUTTON_TAG).fetchSemanticsNodes().isNotEmpty()
 		}
-		composeRule.onNodeWithTag(SCENE_LIST_ADD_BUTTON_TAG).performClick()
-		composeRule.onNodeWithTag(SCENE_LIST_ADD_SCENE_TAG).performClick()
-		composeRule.waitUntil(10_000) {
+		composeRule.clickUntil(hasTestTag(SCENE_LIST_ADD_BUTTON_TAG)) {
+			composeRule.onAllNodesWithTag(SCENE_LIST_ADD_SCENE_TAG).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.clickUntil(hasTestTag(SCENE_LIST_ADD_SCENE_TAG)) {
 			composeRule.onAllNodesWithTag(CREATE_ITEM_NAME_FIELD_TAG).fetchSemanticsNodes().isNotEmpty()
 		}
 		composeRule.onNodeWithTag(CREATE_ITEM_NAME_FIELD_TAG).performTextInput("Opening")
@@ -65,8 +66,7 @@ class SceneEditorWorkflowTest {
 		}
 
 		// Saving clears the dirty buffer, so the save action disappears.
-		composeRule.onNodeWithTag(SCENE_EDITOR_SAVE_TAG).performClick()
-		composeRule.waitUntil(10_000) {
+		composeRule.clickUntil(hasTestTag(SCENE_EDITOR_SAVE_TAG)) {
 			composeRule.onAllNodesWithTag(SCENE_EDITOR_SAVE_TAG).fetchSemanticsNodes().isEmpty()
 		}
 	}

--- a/android/src/androidTest/kotlin/SceneListWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/SceneListWorkflowTest.kt
@@ -62,9 +62,6 @@ class SceneListWorkflowTest {
 
 	// Open the add menu, pick scene/group, type a name, submit via the IME action.
 	private fun addItem(menuItemTag: String, name: String) {
-		composeRule.waitUntil(10_000) {
-			composeRule.onAllNodesWithTag(SCENE_LIST_ADD_BUTTON_TAG).fetchSemanticsNodes().isNotEmpty()
-		}
 		composeRule.clickUntil(hasTestTag(SCENE_LIST_ADD_BUTTON_TAG)) {
 			composeRule.onAllNodesWithTag(menuItemTag).fetchSemanticsNodes().isNotEmpty()
 		}

--- a/android/src/androidTest/kotlin/SceneListWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/SceneListWorkflowTest.kt
@@ -1,9 +1,9 @@
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ActivityScenario
@@ -65,9 +65,10 @@ class SceneListWorkflowTest {
 		composeRule.waitUntil(10_000) {
 			composeRule.onAllNodesWithTag(SCENE_LIST_ADD_BUTTON_TAG).fetchSemanticsNodes().isNotEmpty()
 		}
-		composeRule.onNodeWithTag(SCENE_LIST_ADD_BUTTON_TAG).performClick()
-		composeRule.onNodeWithTag(menuItemTag).performClick()
-		composeRule.waitUntil(10_000) {
+		composeRule.clickUntil(hasTestTag(SCENE_LIST_ADD_BUTTON_TAG)) {
+			composeRule.onAllNodesWithTag(menuItemTag).fetchSemanticsNodes().isNotEmpty()
+		}
+		composeRule.clickUntil(hasTestTag(menuItemTag)) {
 			composeRule.onAllNodesWithTag(CREATE_ITEM_NAME_FIELD_TAG).fetchSemanticsNodes().isNotEmpty()
 		}
 		composeRule.onNodeWithTag(CREATE_ITEM_NAME_FIELD_TAG).performTextInput(name)

--- a/android/src/androidTest/kotlin/TimelineWorkflowTest.kt
+++ b/android/src/androidTest/kotlin/TimelineWorkflowTest.kt
@@ -1,4 +1,5 @@
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -42,14 +43,8 @@ class TimelineWorkflowTest {
 	fun createEventThenOpenIt() {
 		composeRule.navigateTo(NAV_TIMELINE_TAG)
 
-		// Open the create screen via the FAB.
-		composeRule.waitUntil(10_000) {
-			composeRule.onAllNodesWithTag(TIME_LINE_CREATE_TAG).fetchSemanticsNodes().isNotEmpty()
-		}
-		composeRule.onNodeWithTag(TIME_LINE_CREATE_TAG).performClick()
-
-		// Content is optional, so a date alone persists an event.
-		composeRule.waitUntil(10_000) {
+		// Open the create screen via the FAB. Content is optional, so a date alone persists an event.
+		composeRule.clickUntil(hasTestTag(TIME_LINE_CREATE_TAG)) {
 			composeRule.onAllNodesWithTag(TIME_LINE_CREATE_DATE_TAG).fetchSemanticsNodes().isNotEmpty()
 		}
 		composeRule.onNodeWithTag(TIME_LINE_CREATE_DATE_TAG).performTextInput("Year One")
@@ -62,8 +57,7 @@ class TimelineWorkflowTest {
 		composeRule.onAllNodesWithTag(EVENT_CARD_TAG)[0].assertIsDisplayed()
 
 		// Opening the event leaves the overview - the create FAB only shows there.
-		composeRule.onAllNodesWithTag(EVENT_CARD_TAG)[0].performClick()
-		composeRule.waitUntil(10_000) {
+		composeRule.clickUntil(hasTestTag(EVENT_CARD_TAG)) {
 			composeRule.onAllNodesWithTag(TIME_LINE_CREATE_TAG).fetchSemanticsNodes().isEmpty()
 		}
 	}


### PR DESCRIPTION
Follow-up to #817, which fixed a dropped tap in `EncyclopediaWorkflowTest`. This applies the same `clickUntil` convention to the navigational and menu clicks in the other workflow tests.

## What this is, and isn't

This is prophylactic hardening, not a fix for an observed failure. I checked all 8 develop runs where `android-instrumented-tests` actually failed, and only the encyclopedia test ever failed on a dropped tap:

| Test | Failures | Cause |
| --- | --- | --- |
| `SceneEditorWorkflowTest` | 4 | teardown `IOException: failed to delete ...`, already fixed by #780 |
| `EncyclopediaWorkflowTest` | 2 | dropped tap, fixed by #817 |
| `TimelineWorkflowTest` | 1 | `IllegalArgumentException: performMeasureAndLayout called during measure layout` |
| `SceneListWorkflowTest` | 1 | `IOException: failed to create directory .../scenes` from `storeMetadata` |

All four `SceneEditorWorkflowTest` failures predate #780 (committed 2026-07-27T21:35Z; the last of those runs started 15:49Z the same day), so that test needed nothing.

The one genuine latent bug fixed here: `addItem` clicked the dropdown item with **no wait** for the menu to open, in both `SceneListWorkflowTest` and `SceneEditorWorkflowTest`. `clickUntil` closes that race because it skips the click while the target is absent.

## Deliberately not converted

Mutating confirms stay single-injection. The timeline confirm's `onClick` launches a coroutine, suspends through `createEvent` over a disk write, and only then calls `closeCreation()`, so the button stays on screen across the whole operation and a retry would persist a **second event**. Same for the create-dialog IME submit and the project-create confirm. The project-card tap in `ProjectLifecycleTest` is also left alone: a retry would launch a second `ProjectRootActivity` and break teardown.

## Testing

8 rounds x 5 workflow tests = 40 executions on an emulator running `-gpu swiftshader_indirect`, which is what reproduces these flakes locally (host GPU never does). All green.

## Still open, both app-side and unexplained

- Timeline's `performMeasureAndLayout called during measure layout`, thrown from `AndroidComposeView.dispatchDraw`.
- SceneList's `failed to create directory .../scenes` from `SceneEditorService.storeMetadata` on an IO coroutine.

One occurrence each, both predating #780. Neither is addressed here.
