### PR TITLE
Send htmx callers somewhere when access is denied

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/AdminSecurity.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/utils/AdminSecurity.kt
@@ -3,16 +3,17 @@ package com.darkrockstudios.apps.hammer.frontend.utils
 import com.darkrockstudios.apps.hammer.account.AccountsRepository
 import com.darkrockstudios.apps.hammer.frontend.data.UserSession
 import io.ktor.htmx.HxRequestHeaders
+import io.ktor.htmx.HxResponseHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.auth.authenticate
-import io.ktor.server.html.respondHtml
+import io.ktor.server.response.header
+import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Route
 import io.ktor.server.sessions.get
 import io.ktor.server.sessions.sessions
-import kotlinx.html.div
-import kotlinx.html.stream.createHTML
 import org.koin.ktor.ext.get
 
 val AdminOnlyPlugin = createRouteScopedPlugin(
@@ -23,14 +24,7 @@ val AdminOnlyPlugin = createRouteScopedPlugin(
 		val session = call.sessions.get<UserSession>()
 
 		if (session == null || !accountsRepository.isAdmin(session.userId)) {
-			if (call.request.headers[HxRequestHeaders.Request] == "true") {
-				val message = call.msg("security_access_denied")
-				call.respondHtml(HttpStatusCode.Forbidden) {
-					createHTML().div { +message }
-				}
-			} else {
-				call.respondRedirect("/unauthorized")
-			}
+			call.denyAccess(HttpStatusCode.Forbidden, "/unauthorized")
 			return@onCall
 		}
 	}
@@ -50,14 +44,7 @@ val AuthenticatedOnlyPlugin = createRouteScopedPlugin(
 		val session = call.sessions.get<UserSession>()
 
 		if (session == null) {
-			if (call.request.headers[HxRequestHeaders.Request] == "true") {
-				val message = call.msg("security_please_login")
-				call.respondHtml(HttpStatusCode.Unauthorized) {
-					createHTML().div { +message }
-				}
-			} else {
-				call.respondRedirect("/login")
-			}
+			call.denyAccess(HttpStatusCode.Unauthorized, "/login")
 			return@onCall
 		}
 	}
@@ -67,5 +54,22 @@ fun Route.authenticatedOnly(build: Route.() -> Unit): Route {
 	return authenticate("auth-session") {
 		install(AuthenticatedOnlyPlugin)
 		apply(build)
+	}
+}
+
+/**
+ * Turns a caller away to [destination], keeping [status] honest for the access log.
+ *
+ * An htmx request is redirected by header rather than by body: htmx acts on HX-Redirect before it
+ * decides what to do with the response body, so this still works where a body cannot be relied on.
+ * A body would be the wrong tool anyway — htmx discards the body of a 4xx, and StatusPages answers
+ * a 401 with the whole unauthorized page, which has no business being swapped into a fragment.
+ */
+private suspend fun ApplicationCall.denyAccess(status: HttpStatusCode, destination: String) {
+	if (request.headers[HxRequestHeaders.Request] == "true") {
+		response.header(HxResponseHeaders.Redirect, destination)
+		respond(status)
+	} else {
+		respondRedirect(destination)
 	}
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/AdminSecurityTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/AdminSecurityTest.kt
@@ -5,16 +5,22 @@ import com.darkrockstudios.apps.hammer.account.AccountsRepository
 import com.darkrockstudios.apps.hammer.admin.WhiteListRepository
 import com.darkrockstudios.apps.hammer.frontend.data.UserSession
 import com.darkrockstudios.apps.hammer.frontend.utils.adminOnly
+import com.darkrockstudios.apps.hammer.frontend.utils.authenticatedOnly
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import com.darkrockstudios.apps.hammer.utils.setupKtorTestKoin
 import io.ktor.client.request.cookie
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.statement.bodyAsText
+import io.ktor.htmx.HxRequestHeaders
+import io.ktor.htmx.HxResponseHeaders
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.parseServerSetCookieHeader
 import io.ktor.server.application.install
 import io.ktor.server.auth.Authentication
+import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -29,6 +35,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import org.koin.dsl.module
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.time.Clock
 
@@ -100,6 +107,93 @@ class AdminSecurityTest : BaseTest() {
 
 		assertEquals(HttpStatusCode.Found, response.status)
 		assertEquals("/unauthorized", response.headers["Location"])
+	}
+
+	@Test
+	fun `an htmx request from a non-admin is redirected like any other`() = testApplication {
+		coEvery { accountRepo.getAccount(7) } returns account(admin = false)
+		coEvery { whitelistRepo.useWhiteList() } returns false
+		coEvery { accountRepo.isAdmin(7) } returns false
+
+		configureApp()
+		val noRedirect = createClient { followRedirects = false }
+		val (name, value) = adminClaimingCookie()
+
+		val response = noRedirect.get("/admin-area") {
+			cookie(name, value)
+			header(HxRequestHeaders.Request, "true")
+		}
+
+		assertEquals(HttpStatusCode.Forbidden, response.status)
+		assertEquals("/unauthorized", response.headers[HxResponseHeaders.Redirect])
+	}
+
+	/**
+	 * StatusPages answers a 401 with the whole unauthorized page, replacing whatever the plugin
+	 * wrote. Redirecting by header rather than by body is what makes the denial survive that, so
+	 * this pins both halves: the page comes back, and the redirect still reaches htmx.
+	 */
+	@Test
+	fun `an htmx request with no session is redirected even though StatusPages rewrites the body`() =
+		testApplication {
+			application {
+				setupKtorTestKoin(
+					this@AdminSecurityTest,
+					module {
+						single { accountRepo }
+						single { whitelistRepo }
+					}
+				)
+				install(Sessions) { cookie<UserSession>(COOKIE_USER_SESSION) }
+				install(Authentication) { frontendAuthentication(accountRepo, whitelistRepo) }
+				install(StatusPages) {
+					status(HttpStatusCode.Unauthorized) { call, _ ->
+						call.respondText(
+							"FULL-UNAUTHORIZED-PAGE",
+							ContentType.Text.Html,
+							HttpStatusCode.Unauthorized
+						)
+					}
+				}
+				routing {
+					authenticatedOnly {
+						get("/private") { call.respondText("private ok") }
+					}
+				}
+			}
+
+			val noRedirect = createClient { followRedirects = false }
+			val response = noRedirect.get("/private") { header(HxRequestHeaders.Request, "true") }
+
+			assertEquals(HttpStatusCode.Unauthorized, response.status)
+			assertEquals("/login", response.headers[HxResponseHeaders.Redirect])
+			assertContains(response.bodyAsText(), "FULL-UNAUTHORIZED-PAGE")
+		}
+
+	@Test
+	fun `a browser request with no session is redirected to login`() = testApplication {
+		application {
+			setupKtorTestKoin(
+				this@AdminSecurityTest,
+				module {
+					single { accountRepo }
+					single { whitelistRepo }
+				}
+			)
+			install(Sessions) { cookie<UserSession>(COOKIE_USER_SESSION) }
+			install(Authentication) { frontendAuthentication(accountRepo, whitelistRepo) }
+			routing {
+				authenticatedOnly {
+					get("/private") { call.respondText("private ok") }
+				}
+			}
+		}
+
+		val noRedirect = createClient { followRedirects = false }
+		val response = noRedirect.get("/private")
+
+		assertEquals(HttpStatusCode.Found, response.status)
+		assertEquals("/login", response.headers["Location"])
 	}
 
 	@Test


### PR DESCRIPTION
Follow-up to #818, which surfaced this.

Both access-control plugins built their htmx denial response like this:

```kotlin
call.respondHtml(HttpStatusCode.Forbidden) {
    createHTML().div { +message }
}
```

`createHTML()` builds a separate string and throws it away, so the block contributes nothing to the document. The response body is literally `<!DOCTYPE html>\n<html></html>` and the message never existed. Confirmed by a test against the old code:

```
assertContains(response.bodyAsText(), "Access denied")
               |        |
               |        <!DOCTYPE html>
               |        <html></html>
```

## Why a redirect rather than fixing the markup

Delivering the message in the body cannot be made to work here:

- htmx discards the body of a 4xx. Opting in via the `X-Hammer-Swap-Error` marker added in #818 would work for the 403, but not the 401.
- **`StatusPages` replaces the body of a 401** with the entire `unauthorized.mustache` page. Marking that response as swappable would swap a full page into whatever fragment the request targeted — the regression #818 was specifically designed to avoid. Verified, not assumed: a test installs `StatusPages` and asserts the page comes back.

`HX-Redirect` is handled at htmx.js:4711, before it looks at the body at all, so it survives the rewrite. It also matches what both plugins already do for browser requests, so htmx and browser callers now land in the same place.

| caller | no session | non-admin hitting /admin |
|---|---|---|
| browser | 302 → `/login` | 302 → `/unauthorized` |
| htmx | 401 + `HX-Redirect: /login` | 403 + `HX-Redirect: /unauthorized` |

Status codes stay honest for the access log; only the delivery mechanism differs.

## Verification

- Four tests in `AdminSecurityTest`, including one that pins the `StatusPages` interaction that dictated the design — it asserts the full page comes back *and* the redirect header survives it.
- All four paths exercised against a running dev server (table above).
- In a real browser, a non-admin firing an htmx request at an admin route now navigates to `/unauthorized` instead of silently doing nothing.
- Full `:server:test` green: 1047 tests, 157 classes.

## Note

`security_access_denied` and `security_please_login` are now unused, in `Messages_en.properties` and 6 locale files. I left them rather than delete translated strings across all 7 — say the word if you want them removed.
