### PR TITLE
Allow accented and non-latin characters in tags

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanel.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanel.kt
@@ -36,9 +36,8 @@ interface SceneMetadataPanel : HammerComponent, TagSuggesting {
 	fun searchEntriesForAdd(query: String, maxResults: Int = 20): List<AddSuggestion>
 
 	/**
-	 * Adds one or more tags from a free-form space-separated string. Input is
-	 * normalized (trim, strip `#`, regex `[\w-]+`); invalid pieces are dropped.
-	 * Tags already on the scene are silently no-ops.
+	 * Adds one or more tags from a free-form space-separated string. Input is normalized by
+	 * `parseTagInput`; invalid pieces are dropped. Tags already on the scene are silently no-ops.
 	 */
 	fun addTags(input: String)
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.kt
@@ -1,26 +1,92 @@
 package com.darkrockstudios.apps.hammer.common.data.tagindex
 
-private val TAG_INPUT_SPLIT = Regex("""[\s,]+""")
+private const val ZERO_WIDTH_NON_JOINER = '\u200C'
+private const val ZERO_WIDTH_JOINER = '\u200D'
+private const val FULLWIDTH_NUMBER_SIGN = '\uFF03'
+private const val FULLWIDTH_COMMA = '\uFF0C'
+private const val IDEOGRAPHIC_COMMA = '\u3001'
+
+/**
+ * Canonically compose [text] (Unicode NFC) so the two spellings of an accented tag - precomposed
+ * `è`, and `e` plus a combining grave - are stored and indexed as one string. Tags are compared
+ * by exact equality everywhere downstream, so they have to agree on a single form.
+ */
+internal expect fun normalizeTagForm(text: String): String
+
+/** True when the supplementary-plane [codePoint] is a letter or a digit. */
+internal expect fun isSupplementaryLetterOrDigit(codePoint: Int): Boolean
+
+/** Separates one tag from the next in free-form input, in any script's punctuation. */
+fun Char.isTagSeparator(): Boolean =
+	isWhitespace() ||
+		this == ',' ||
+		this == FULLWIDTH_COMMA ||
+		this == IDEOGRAPHIC_COMMA
 
 private fun Char.isTagChar(): Boolean =
 	isLetterOrDigit() ||
 		category == CharCategory.NON_SPACING_MARK ||
 		category == CharCategory.COMBINING_SPACING_MARK ||
+		this == ZERO_WIDTH_NON_JOINER ||
+		this == ZERO_WIDTH_JOINER ||
 		this == '_' ||
 		this == '-'
 
-/** A tag is a run of letters, digits and combining marks, plus `_` and `-`. */
-private fun isValidTag(tag: String): Boolean = tag.isNotEmpty() && tag.all { it.isTagChar() }
+/**
+ * A tag is a run of letters, digits, combining marks and word-joiners, plus `_` and `-`, and
+ * must carry at least one letter or digit so it has something to render.
+ */
+private fun isValidTag(tag: String): Boolean {
+	var hasLetterOrDigit = false
+	var i = 0
+	while (i < tag.length) {
+		val char = tag[i]
+		val next = if (i + 1 < tag.length) tag[i + 1] else null
+		// Astral characters (rare kanji, Adlam, ...) are a surrogate pair, and neither half is a
+		// letter on its own, so they have to be tested as a whole code point.
+		if (char.isHighSurrogate() && next != null && next.isLowSurrogate()) {
+			if (!isSupplementaryLetterOrDigit(codePointOf(char, next))) return false
+			hasLetterOrDigit = true
+			i += 2
+		} else {
+			if (!char.isTagChar()) return false
+			if (char.isLetterOrDigit()) hasLetterOrDigit = true
+			i++
+		}
+	}
+	return hasLetterOrDigit
+}
+
+private fun codePointOf(high: Char, low: Char): Int =
+	0x10000 + ((high.code - 0xD800) shl 10) + (low.code - 0xDC00)
+
+private fun String.removeTagPrefix(): String =
+	if (startsWith('#') || startsWith(FULLWIDTH_NUMBER_SIGN)) substring(1) else this
 
 fun cleanTags(tags: Set<String>): Set<String> =
 	tags.asSequence()
-		.map { it.trim().removePrefix("#") }
+		.map { normalizeTagForm(it.trim()).removeTagPrefix() }
 		.filter(::isValidTag)
 		.toSet()
 
 /**
  * Parse free-form user tag input into a normalized set: split on whitespace + commas,
- * strip leading `#`, drop pieces that aren't valid tags.
+ * strip a leading `#`, drop pieces that aren't valid tags.
  */
-fun parseTagInput(input: String): Set<String> =
-	cleanTags(input.split(TAG_INPUT_SPLIT).toSet())
+fun parseTagInput(input: String): Set<String> {
+	val pieces = mutableListOf<String>()
+	val piece = StringBuilder()
+	for (char in input) {
+		if (char.isTagSeparator()) {
+			if (piece.isNotEmpty()) {
+				pieces.add(piece.toString())
+				piece.clear()
+			}
+		} else {
+			piece.append(char)
+		}
+	}
+	if (piece.isNotEmpty()) pieces.add(piece.toString())
+
+	return cleanTags(pieces.toSet())
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.kt
@@ -1,17 +1,26 @@
 package com.darkrockstudios.apps.hammer.common.data.tagindex
 
-private val TAG_PATTERN = Regex("""[\w-]+""")
 private val TAG_INPUT_SPLIT = Regex("""[\s,]+""")
+
+private fun Char.isTagChar(): Boolean =
+	isLetterOrDigit() ||
+		category == CharCategory.NON_SPACING_MARK ||
+		category == CharCategory.COMBINING_SPACING_MARK ||
+		this == '_' ||
+		this == '-'
+
+/** A tag is a run of letters, digits and combining marks, plus `_` and `-`. */
+private fun isValidTag(tag: String): Boolean = tag.isNotEmpty() && tag.all { it.isTagChar() }
 
 fun cleanTags(tags: Set<String>): Set<String> =
 	tags.asSequence()
 		.map { it.trim().removePrefix("#") }
-		.filter { it.isNotEmpty() && TAG_PATTERN.matches(it) }
+		.filter(::isValidTag)
 		.toSet()
 
 /**
  * Parse free-form user tag input into a normalized set: split on whitespace + commas,
- * strip leading `#`, drop pieces that don't match [TAG_PATTERN].
+ * strip leading `#`, drop pieces that aren't valid tags.
  */
 fun parseTagInput(input: String): Set<String> =
 	cleanTags(input.split(TAG_INPUT_SPLIT).toSet())

--- a/common/src/desktopTest/kotlin/repositories/tagindex/TagNormalizerTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/tagindex/TagNormalizerTest.kt
@@ -1,4 +1,4 @@
-﻿package repositories.tagindex
+package repositories.tagindex
 
 import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
 import com.darkrockstudios.apps.hammer.common.data.tagindex.parseTagInput
@@ -9,24 +9,31 @@ class TagNormalizerTest {
 
 	@Test
 	fun `Clean tags keeps accented letters`() {
-		val tags = setOf("thème", "café", "año", "Ærø")
+		val tags = setOf("th\u00e8me", "caf\u00e9", "a\u00f1o", "\u00c6r\u00f8")
 
 		assertEquals(tags, cleanTags(tags))
-	}
-
-	/** Text entered on iOS/macOS can arrive decomposed: base letter plus a combining mark. */
-	@Test
-	fun `Clean tags keeps decomposed accents`() {
-		val decomposed = "the\u0300me"
-
-		assertEquals(setOf(decomposed), cleanTags(setOf(decomposed)))
 	}
 
 	@Test
 	fun `Clean tags keeps non-latin scripts`() {
-		val tags = setOf("персонаж", "人物", "ちから")
+		val tags = setOf("\u043f\u0435\u0440\u0441\u043e\u043d\u0430\u0436", "\u4eba\u7269", "\u3061\u304b\u3089")
 
 		assertEquals(tags, cleanTags(tags))
+	}
+
+	@Test
+	fun `Clean tags keeps supplementary plane letters`() {
+		val rareKanji = "\uD842\uDFB7\u7530"
+		val adlam = "\uD83A\uDD00\uD83A\uDD22"
+
+		assertEquals(setOf(rareKanji, adlam), cleanTags(setOf(rareKanji, adlam)))
+	}
+
+	@Test
+	fun `Clean tags keeps word joiners`() {
+		val withZwnj = "\u0645\u06cc\u200c\u0631\u0648\u062f"
+
+		assertEquals(setOf(withZwnj), cleanTags(setOf(withZwnj)))
 	}
 
 	@Test
@@ -36,9 +43,30 @@ class TagNormalizerTest {
 		assertEquals(tags, cleanTags(tags))
 	}
 
+	/** Text entered on iOS/macOS can arrive decomposed: base letter plus a combining mark. */
+	@Test
+	fun `Clean tags composes decomposed accents`() {
+		val decomposed = "the\u0300me"
+
+		assertEquals(setOf("th\u00e8me"), cleanTags(setOf(decomposed)))
+	}
+
+	@Test
+	fun `Clean tags treats both spellings of a tag as one`() {
+		val composed = "th\u00e8me"
+		val decomposed = "the\u0300me"
+
+		assertEquals(setOf(composed), cleanTags(setOf(composed, decomposed)))
+	}
+
 	@Test
 	fun `Clean tags strips leading hash and surrounding whitespace`() {
-		assertEquals(setOf("thème"), cleanTags(setOf("  #thème  ")))
+		assertEquals(setOf("th\u00e8me"), cleanTags(setOf("  #th\u00e8me  ")))
+	}
+
+	@Test
+	fun `Clean tags strips a fullwidth hash`() {
+		assertEquals(setOf("\u4eba\u7269"), cleanTags(setOf("\uff03\u4eba\u7269")))
 	}
 
 	@Test
@@ -49,9 +77,30 @@ class TagNormalizerTest {
 	}
 
 	@Test
-	fun `Parse tag input splits on whitespace and commas`() {
-		val input = " #thème, guerre  été,héros "
+	fun `Clean tags drops tags with no letter or digit`() {
+		val tags = setOf("\u0301", "---", "___", "\u200c")
 
-		assertEquals(setOf("thème", "guerre", "été", "héros"), parseTagInput(input))
+		assertEquals(emptySet(), cleanTags(tags))
+	}
+
+	@Test
+	fun `Parse tag input splits on whitespace and commas`() {
+		val input = " #th\u00e8me, guerre  \u00e9t\u00e9,h\u00e9ros "
+
+		assertEquals(setOf("th\u00e8me", "guerre", "\u00e9t\u00e9", "h\u00e9ros"), parseTagInput(input))
+	}
+
+	@Test
+	fun `Parse tag input splits on ideographic separators`() {
+		val input = "\u4eba\u7269\u3000\u5834\u6240\u3001\u9b54\u6cd5"
+
+		assertEquals(setOf("\u4eba\u7269", "\u5834\u6240", "\u9b54\u6cd5"), parseTagInput(input))
+	}
+
+	@Test
+	fun `Parse tag input splits on non-breaking spaces`() {
+		val input = "one\u00a0two"
+
+		assertEquals(setOf("one", "two"), parseTagInput(input))
 	}
 }

--- a/common/src/desktopTest/kotlin/repositories/tagindex/TagNormalizerTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/tagindex/TagNormalizerTest.kt
@@ -1,0 +1,57 @@
+﻿package repositories.tagindex
+
+import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
+import com.darkrockstudios.apps.hammer.common.data.tagindex.parseTagInput
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class TagNormalizerTest {
+
+	@Test
+	fun `Clean tags keeps accented letters`() {
+		val tags = setOf("thème", "café", "año", "Ærø")
+
+		assertEquals(tags, cleanTags(tags))
+	}
+
+	/** Text entered on iOS/macOS can arrive decomposed: base letter plus a combining mark. */
+	@Test
+	fun `Clean tags keeps decomposed accents`() {
+		val decomposed = "the\u0300me"
+
+		assertEquals(setOf(decomposed), cleanTags(setOf(decomposed)))
+	}
+
+	@Test
+	fun `Clean tags keeps non-latin scripts`() {
+		val tags = setOf("персонаж", "人物", "ちから")
+
+		assertEquals(tags, cleanTags(tags))
+	}
+
+	@Test
+	fun `Clean tags keeps ascii word characters`() {
+		val tags = setOf("animal", "side-quest", "act_two", "chapter3")
+
+		assertEquals(tags, cleanTags(tags))
+	}
+
+	@Test
+	fun `Clean tags strips leading hash and surrounding whitespace`() {
+		assertEquals(setOf("thème"), cleanTags(setOf("  #thème  ")))
+	}
+
+	@Test
+	fun `Clean tags drops separators and punctuation`() {
+		val tags = setOf("two words", "comma,tag", "quote\"tag", "slash/tag", "")
+
+		assertEquals(emptySet(), cleanTags(tags))
+	}
+
+	@Test
+	fun `Parse tag input splits on whitespace and commas`() {
+		val input = " #thème, guerre  été,héros "
+
+		assertEquals(setOf("thème", "guerre", "été", "héros"), parseTagInput(input))
+	}
+}

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.ios.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.ios.kt
@@ -1,0 +1,14 @@
+package com.darkrockstudios.apps.hammer.common.data.tagindex
+
+import platform.Foundation.NSCharacterSet
+import platform.Foundation.NSString
+import platform.Foundation.precomposedStringWithCanonicalMapping
+
+internal actual fun normalizeTagForm(text: String): String =
+	(text as NSString).precomposedStringWithCanonicalMapping
+
+/** Foundation's alphanumeric set is Unicode categories L, M and N, which all read as tag content. */
+private val alphanumeric = NSCharacterSet.alphanumericCharacterSet
+
+internal actual fun isSupplementaryLetterOrDigit(codePoint: Int): Boolean =
+	alphanumeric.longCharacterIsMember(codePoint.toUInt())

--- a/common/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.jvm.kt
+++ b/common/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.jvm.kt
@@ -1,0 +1,10 @@
+package com.darkrockstudios.apps.hammer.common.data.tagindex
+
+import java.text.Normalizer
+
+internal actual fun normalizeTagForm(text: String): String =
+	if (Normalizer.isNormalized(text, Normalizer.Form.NFC)) text
+	else Normalizer.normalize(text, Normalizer.Form.NFC)
+
+internal actual fun isSupplementaryLetterOrDigit(codePoint: Int): Boolean =
+	Character.isLetterOrDigit(codePoint)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.compose.CollapseWhileTyping
+import com.darkrockstudios.apps.hammer.common.data.tagindex.isTagSeparator
+import com.darkrockstudios.apps.hammer.common.data.tagindex.parseTagInput
 
 /**
  * Tag chip field — labeled hairline-underline input that keeps its
@@ -50,15 +52,17 @@ fun HdHairlineTagField(
 		onDraftChange(it)
 	}
 
+	// Parsed with the same rule that persistence uses, so a chip is never shown for input
+	// that would be dropped on save.
 	val addTag: (String) -> Unit = { raw ->
-		val candidate = raw.trim().removePrefix("#")
-		if (candidate.isNotEmpty() && !tags.contains(candidate)) {
-			onTagsChange(tags + candidate)
+		val candidates = parseTagInput(raw).filter { it !in tags }
+		if (candidates.isNotEmpty()) {
+			onTagsChange(tags + candidates)
 		}
 		updateDraft("")
 	}
 	val addCurrent: () -> Boolean = add@{
-		if (draft.trim().removePrefix("#").isEmpty()) return@add false
+		if (parseTagInput(draft).isEmpty()) return@add false
 		addTag(draft)
 		true
 	}
@@ -126,7 +130,7 @@ fun HdHairlineTagField(
 						value = draft,
 						onValueChange = { next ->
 							val last = next.lastOrNull()
-							if (last == ',' || last == ' ') {
+							if (last != null && last.isTagSeparator()) {
 								updateDraft(next.dropLast(1))
 								addCurrent()
 							} else {


### PR DESCRIPTION
Fixes #778

A tag like `thème` showed up as a chip while editing and survived the save, but was gone as soon as you navigated away and came back.

## Cause

`TagNormalizer` validated tags with `Regex("""[\w-]+""")`. `\w` is ASCII-only (`[a-zA-Z0-9_]`) on both JVM and Native, so `cleanTags()` silently dropped every tag containing an accented letter, Cyrillic, CJK, or anything else outside ASCII.

The disappearing act comes from where the cleaning happens: `HdHairlineTagField` accepted any input and rendered the chip immediately, and the component kept that in its own state after saving. Only `NotesRepository.updateNote` (and its peers) run `cleanTags()` on the way to disk, so the tag was never actually persisted.

## Fix

Tags are now validated per code point rather than by an ASCII regex, and the surrounding steps were widened to match:

- **Validation** accepts letters, digits, combining marks, ZWJ/ZWNJ (needed word-internally by Persian and Indic scripts), `_` and `-`, and requires at least one letter or digit so a mark-only tag can't exist with no base glyph. Surrogate pairs are tested as whole code points, so astral letters (rare kanji, Adlam) aren't read as two non-letter halves and rejected.
- **Normalization to NFC** via a new `expect`/`actual` (`java.text.Normalizer` on JVM, `precomposedStringWithCanonicalMapping` on iOS). Combining marks are now accepted, and every consumer compares tags by exact string equality, so without this the precomposed and decomposed spellings of `thème` would become two index keys, two identical-looking chips and split counts.
- **Splitting** happens on any Unicode whitespace and on the fullwidth/ideographic commas, so an IME's fullwidth space (U+3000) separates tags instead of fusing `人物　場所` into one token that then fails validation.
- **Prefix stripping** handles the fullwidth `＃` a CJK IME produces, not just the ASCII `#`.
- `HdHairlineTagField` commits chips on the same separator rule and runs the draft through `parseTagInput`, so what the field shows is what survives the save.

The accepted set is otherwise unchanged, and whitespace/punctuation is still rejected. This covers all the tag surfaces at once, since they share `cleanTags`: notes, encyclopedia, timeline, scene metadata, story ideas and project tags.

## Testing

`TagNormalizerTest` covers accented Latin, non-Latin scripts, supplementary-plane letters, ZWNJ, NFC folding of both spellings, `#`/`＃`/whitespace stripping, punctuation and mark-only rejection, and splitting on ideographic and non-breaking separators. Confirmed the original 5 accented-tag cases fail on `develop` before the change.

`:common:desktopTest` and `:composeUi:desktopTest` are green; `:common:compileIosMainKotlinMetadata` type-checks the iOS actuals.

## Notes

- Nothing else in the pipeline needed changing: `TagIndexService` keys on the exact tag string, and `parseQuery`/`matchesAllTags` use `contains(ignoreCase = true)` with no character classes.
- No migration is needed for the NFC change: the old regex rejected every decomposed accented tag outright, so no such tag can exist in stored data.
- Tags a user already typed and lost are gone; this only prevents future ones from being dropped.
