### PR TITLE
Unify search matching on resolved Markdown

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -231,9 +231,7 @@ class SearchProjectUseCase(
 	private fun matchTimelineEvent(date: String?, content: String, query: String): AnnotatedSnippet? {
 		val resolved = withDate(date, unescapeMarkdown(content))
 		if (query.isEmpty()) return previewSnippet(resolved)
-		findMatch(resolved, query)?.let { return it }
-		if (query.contains('\\')) return findMatch(withDate(date, content), query)
-		return null
+		return findMatch(resolved, query)
 	}
 
 	private fun withDate(date: String?, content: String): String =
@@ -281,15 +279,12 @@ class SearchProjectUseCase(
 
 		/**
 		 * Matches stored Markdown with its escapes resolved, so a query matches the prose on screen
-		 * and the snippet renders the same way. A query holding a backslash also tries the raw
-		 * source, so searching for a literal escape keeps working.
+		 * and the snippet renders the same way. The resolved text is the only thing searched, so a
+		 * snippet can never disagree with the title derived from it.
 		 */
 		internal fun findMarkdownMatch(markdown: String, query: String): AnnotatedSnippet? {
 			if (markdown.isEmpty() || query.isEmpty()) return null
-			val resolved = unescapeMarkdown(markdown)
-			findMatch(resolved, query)?.let { return it }
-			if (query.contains('\\')) return findMatch(markdown, query)
-			return null
+			return findMatch(unescapeMarkdown(markdown), query)
 		}
 
 		internal fun findMatch(text: String, query: String): AnnotatedSnippet? {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
@@ -39,11 +39,15 @@ fun parseQuery(query: String): ParsedQuery {
 }
 
 /**
- * True when [query] appears in [content], comparing the prose a reader sees rather than the
- * Markdown it is stored as, so `well-known` finds text stored as `well\-known`.
+ * True when [query] appears in [content] once the stored backslash escapes are resolved, so
+ * `well-known` finds text stored as `well\-known`.
  *
- * The query is taken literally. Markdown syntax typed into a search box is not interpreted, because
- * nobody searches for the storage form of their own text.
+ * Only escapes are resolved. Emphasis, code and link markers are compared as stored, so a phrase
+ * spanning them does not match; see #811. The query is taken literally, so the escaped storage form
+ * of a phrase does not match either.
+ *
+ * Global search needs offsets rather than a boolean, so it resolves and matches separately in
+ * `SearchProjectUseCase.findMarkdownMatch`. `MarkdownContainsTest` pins the two to the same answer.
  */
 fun markdownContains(content: String, query: String): Boolean =
 	unescapeMarkdown(content).contains(query, ignoreCase = true)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
@@ -38,6 +38,16 @@ fun parseQuery(query: String): ParsedQuery {
 	return ParsedQuery(text = text, tags = tags)
 }
 
+/**
+ * True when [query] appears in [content], comparing the prose a reader sees rather than the
+ * Markdown it is stored as, so `well-known` finds text stored as `well\-known`.
+ *
+ * The query is taken literally. Markdown syntax typed into a search box is not interpreted, because
+ * nobody searches for the storage form of their own text.
+ */
+fun markdownContains(content: String, query: String): Boolean =
+	unescapeMarkdown(content).contains(query, ignoreCase = true)
+
 /** True when every needle is contained (case-insensitively) in at least one tag. */
 fun Set<String>.matchesAllTags(needles: List<String>): Boolean {
 	if (needles.isEmpty()) return true

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownContainsTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownContainsTest.kt
@@ -23,7 +23,7 @@ class MarkdownContainsTest {
 	}
 
 	@Test
-	fun `the query is taken literally, not as markdown`() {
+	fun `the query is taken literally rather than as markdown`() {
 		// Searching the storage form is deliberately unsupported: readers type what they see.
 		assertFalse(markdownContains("A well\\-known secret", "well\\-known"))
 	}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownContainsTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownContainsTest.kt
@@ -1,0 +1,42 @@
+package com.darkrockstudios.apps.hammer.common.data.search
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MarkdownContainsTest {
+
+	@Test
+	fun `a query matches text stored with escapes`() {
+		assertTrue(markdownContains("A well\\-known secret", "well-known"))
+		assertTrue(markdownContains("Alice \\(the elder\\) waited", "Alice (the elder)"))
+	}
+
+	@Test
+	fun `a phrase spanning an escape matches`() {
+		assertTrue(markdownContains("the well\\-known road home", "known road"))
+	}
+
+	@Test
+	fun `matching is case insensitive`() {
+		assertTrue(markdownContains("A Well\\-Known secret", "well-known"))
+	}
+
+	@Test
+	fun `the query is taken literally, not as markdown`() {
+		// Searching the storage form is deliberately unsupported: readers type what they see.
+		assertFalse(markdownContains("A well\\-known secret", "well\\-known"))
+	}
+
+	@Test
+	fun `unescaped markup is matched as it is stored`() {
+		assertTrue(markdownContains("The cost is 5*4 today", "5*4"))
+		assertTrue(markdownContains("a **Chapter** heading", "**Chapter**"))
+	}
+
+	@Test
+	fun `text that is absent does not match`() {
+		assertFalse(markdownContains("A well\\-known secret", "unrelated"))
+		assertFalse(markdownContains("", "anything"))
+	}
+}

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -20,6 +20,7 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneCo
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
+import com.darkrockstudios.apps.hammer.common.data.search.markdownContains
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineContainer
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
@@ -77,6 +78,29 @@ class SearchProjectUseCaseTest : BaseTest() {
 		encyclopedia = encyclopedia,
 		timeLine = timeLine,
 	)
+
+	@Test
+	fun `global search agrees with the shared match rule`() {
+		// Global search needs offsets so it resolves separately; the two must not drift apart.
+		val cases = listOf(
+			"A well\\-known secret" to "well-known",
+			"A well\\-known secret" to "well\\-known",
+			"A well\\-known secret" to "unrelated",
+			"the user_name field" to "user_name",
+			"The cost is 5\\*4" to "5*4",
+			"a **Chapter** heading" to "**Chapter**",
+			"a **Chapter** heading" to "Chapter heading",
+			"path C:\\temp here" to "C:\\temp",
+		)
+
+		for ((content, query) in cases) {
+			assertEquals(
+				markdownContains(content, query),
+				SearchProjectUseCase.findMarkdownMatch(content, query) != null,
+				"disagreement on content=<$content> query=<$query>",
+			)
+		}
+	}
 
 	@Test
 	fun `findMatch returns null for empty text or query`() {
@@ -411,7 +435,6 @@ class SearchProjectUseCaseTest : BaseTest() {
 		val asRead = createUseCase().search("well-known", GlobalSearchFilter.All)
 			.filterIsInstance<SearchResult.Note>()
 
-		// Readers type what they see; supporting the escaped form cost precision everywhere else.
 		assertEquals(0, asStored.size)
 		assertEquals(1, asRead.size)
 	}

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -403,13 +403,29 @@ class SearchProjectUseCaseTest : BaseTest() {
 	}
 
 	@Test
-	fun `searching for a literal backslash escape still finds it`() = runTest {
+	fun `searching the storage form of text is not supported`() = runTest {
 		every { notes.getNotes() } returns listOf(note(1, "raw well\\-known marker"))
 
-		val results = createUseCase().search("well\\-known", GlobalSearchFilter.All)
+		val asStored = createUseCase().search("well\\-known", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+		val asRead = createUseCase().search("well-known", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		// Readers type what they see; supporting the escaped form cost precision everywhere else.
+		assertEquals(0, asStored.size)
+		assertEquals(1, asRead.size)
+	}
+
+	@Test
+	fun `title and snippet render the same way`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "Alice \\(the elder\\) is well\\-known"))
+
+		val results = createUseCase().search("well-known", GlobalSearchFilter.All)
 			.filterIsInstance<SearchResult.Note>()
 
 		assertEquals(1, results.size)
+		assertEquals("Alice (the elder) is well-known", results.first().title)
+		assertEquals("Alice (the elder) is well-known", results.first().snippet.text)
 	}
 
 	@Test

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/BrowseNotesUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/BrowseNotesUi.kt
@@ -70,7 +70,7 @@ import com.darkrockstudios.apps.hammer.common.compose.firstNonBlankLine
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
-import com.darkrockstudios.apps.hammer.common.data.search.unescapeMarkdown
+import com.darkrockstudios.apps.hammer.common.data.search.markdownContains
 import com.darkrockstudios.apps.hammer.common.util.format
 import com.darkrockstudios.apps.hammer.notes_create_note_button
 import com.darkrockstudios.apps.hammer.notes_filter_all
@@ -113,6 +113,10 @@ private enum class NotesSortMode(
 	WordsAsc(Res.string.notes_sort_shortest, Res.string.notes_sort_glyph_words_asc),
 	TitleAsc(Res.string.notes_sort_title_az, Res.string.notes_sort_glyph_title_az),
 }
+
+/** A note matches on its body, read as prose rather than as stored Markdown. */
+internal fun noteMatchesQuery(note: NoteContent, query: String): Boolean =
+	markdownContains(note.content, query)
 
 private fun NoteContent.wordCount(): Int =
 	content.split(Regex("\\s+")).count { it.isNotBlank() }
@@ -162,9 +166,8 @@ fun BrowseNotesUi(
 			val byText = if (searchQuery.isBlank()) {
 				state.notes
 			} else {
-				state.notes.filter {
-					unescapeMarkdown(it.content).contains(searchQuery.trim(), ignoreCase = true)
-				}
+				val query = searchQuery.trim()
+				state.notes.filter { noteMatchesQuery(it, query) }
 			}
 			val byTags = if (activeTags.isEmpty()) {
 				byText

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/storyideas/StoryIdeasUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/storyideas/StoryIdeasUi.kt
@@ -111,6 +111,7 @@ import com.darkrockstudios.apps.hammer.common.data.ideasrepository.IdeaError
 import com.darkrockstudios.apps.hammer.common.data.ideasrepository.IdeasRepository
 import com.darkrockstudios.apps.hammer.base.http.storyideas.StoryIdea
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
+import com.darkrockstudios.apps.hammer.common.data.search.markdownContains
 import com.darkrockstudios.apps.hammer.common.data.tagindex.TagCount
 import com.darkrockstudios.apps.hammer.common.util.format
 import com.darkrockstudios.apps.hammer.ideas_archive_button
@@ -203,6 +204,11 @@ private enum class IdeasSortMode(
 private fun StoryIdea.wordCount(): Int =
 	content.split(Regex("\\s+")).count { it.isNotBlank() }
 
+/** An idea matches on its body read as prose, or on its plain-text title. */
+internal fun ideaMatchesQuery(idea: StoryIdea, query: String): Boolean =
+	markdownContains(idea.content, query) ||
+		idea.title?.contains(query, ignoreCase = true) == true
+
 private fun StoryIdea.displayTitle(): String = title ?: content.firstNonBlankLine()
 
 private fun applySort(ideas: List<StoryIdea>, mode: IdeasSortMode): List<StoryIdea> = when (mode) {
@@ -288,10 +294,7 @@ private fun IdeasBrowse(
 			val byText = if (query.isBlank()) {
 				scopedIdeas
 			} else {
-				scopedIdeas.filter { idea ->
-					idea.content.contains(query, ignoreCase = true) ||
-						idea.title?.contains(query, ignoreCase = true) == true
-				}
+				scopedIdeas.filter { ideaMatchesQuery(it, query) }
 			}
 			val byTags = if (activeTags.isEmpty()) {
 				byText

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/TimeLineOverviewUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/TimeLineOverviewUi.kt
@@ -107,6 +107,7 @@ internal fun eventMatchesQuery(event: TimeLineEvent, query: String): Boolean =
 
 const val TIME_LINE_CREATE_TAG = "Timeline Overview Create"
 const val TIME_LINE_LIST_TAG = "Timeline Overview List"
+const val TIME_LINE_SEARCH_TAG = "Timeline Overview Search"
 const val EVENT_CARD_TAG = "Timeline Event Card"
 const val EVENT_CARD_DATE_TAG = "Timeline Event Card Date"
 const val EVENT_CARD_CONTENT_TAG = "Timeline Event Card Content"
@@ -193,6 +194,7 @@ fun TimeLineOverviewUi(
 					},
 					collapseContentDescription = Res.string.timeline_search_close.get(),
 					modifier = Modifier.fillMaxSize(),
+					testTag = TIME_LINE_SEARCH_TAG,
 				)
 			} else {
 				Row(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/TimeLineOverviewUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/TimeLineOverviewUi.kt
@@ -82,7 +82,7 @@ import com.darkrockstudios.apps.hammer.common.compose.reorderable.DragDropList
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
-import com.darkrockstudios.apps.hammer.common.data.search.unescapeMarkdown
+import com.darkrockstudios.apps.hammer.common.data.search.markdownContains
 import com.darkrockstudios.apps.hammer.common.data.tagindex.TagCount
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
 import com.darkrockstudios.apps.hammer.timeline_filter_all
@@ -99,6 +99,11 @@ import com.darkrockstudios.apps.hammer.timeline_view_undated
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
+
+/** An event matches on its body read as prose, or on its plain-text date. */
+internal fun eventMatchesQuery(event: TimeLineEvent, query: String): Boolean =
+	markdownContains(event.content, query) ||
+		event.date?.contains(query, ignoreCase = true) == true
 
 const val TIME_LINE_CREATE_TAG = "Timeline Overview Create"
 const val TIME_LINE_LIST_TAG = "Timeline Overview List"
@@ -137,10 +142,8 @@ fun TimeLineOverviewUi(
 			val byText = if (searchQuery.isBlank()) {
 				events
 			} else {
-				events.filter { event ->
-					unescapeMarkdown(event.content).contains(searchQuery.trim(), ignoreCase = true) ||
-						event.date?.contains(searchQuery.trim(), ignoreCase = true) == true
-				}
+				val query = searchQuery.trim()
+				events.filter { eventMatchesQuery(it, query) }
 			}
 			val byTags = if (activeTags.isEmpty()) {
 				byText

--- a/composeUi/src/desktopTest/kotlin/SearchFilterTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SearchFilterTest.kt
@@ -12,9 +12,11 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 
 /**
- * The in-screen filters must agree with global search, which matches the prose a reader sees. These
- * pin each screen's own composition of that rule, since a screen matching one of its fields the
- * wrong way is invisible to the shared helper's own tests.
+ * Each screen's match predicate, covering which fields it consults and how. A screen matching one of
+ * its own fields the wrong way is invisible to the shared helper's tests.
+ *
+ * These assert the predicates, not the composables that call them; `TimeLineOverviewUiTest` drives a
+ * screen's search field end to end.
  */
 class SearchFilterTest {
 

--- a/composeUi/src/desktopTest/kotlin/SearchFilterTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SearchFilterTest.kt
@@ -1,0 +1,71 @@
+import com.darkrockstudios.apps.hammer.base.IdeaId
+import com.darkrockstudios.apps.hammer.base.http.storyideas.StoryIdea
+import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteContent
+import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
+import com.darkrockstudios.apps.hammer.common.notes.noteMatchesQuery
+import com.darkrockstudios.apps.hammer.common.projectselection.storyideas.ideaMatchesQuery
+import com.darkrockstudios.apps.hammer.common.timeline.eventMatchesQuery
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * The in-screen filters must agree with global search, which matches the prose a reader sees. These
+ * pin each screen's own composition of that rule, since a screen matching one of its fields the
+ * wrong way is invisible to the shared helper's own tests.
+ */
+class SearchFilterTest {
+
+	private fun note(content: String) =
+		NoteContent(id = 1, created = Clock.System.now(), content = content)
+
+	private fun event(content: String, date: String? = null) =
+		TimeLineEvent(id = 1, order = 0, date = date, content = content)
+
+	private fun idea(content: String, title: String? = null) = StoryIdea(
+		id = IdeaId("00000000-0000-0000-0000-000000000001"),
+		created = Instant.parse("2026-07-01T12:00:00Z"),
+		updated = Instant.parse("2026-07-01T12:00:00Z"),
+		title = title,
+		content = content,
+		archived = null,
+	)
+
+	@Test
+	fun `notes match a query across a stored escape`() {
+		assertTrue(noteMatchesQuery(note("A well\\-known secret"), "well-known"))
+		assertFalse(noteMatchesQuery(note("A well\\-known secret"), "unrelated"))
+	}
+
+	@Test
+	fun `timeline events match on the body across a stored escape`() {
+		assertTrue(eventMatchesQuery(event("A well\\-known war"), "well-known"))
+	}
+
+	@Test
+	fun `timeline events match on the plain-text date as stored`() {
+		assertTrue(eventMatchesQuery(event("A long war", date = "1990-2000"), "1990-2000"))
+		// The date is not Markdown, so it is matched exactly as the user typed it.
+		assertTrue(eventMatchesQuery(event("A long war", date = "1990\\-2000"), "1990\\-2000"))
+	}
+
+	@Test
+	fun `story ideas match on the body across a stored escape`() {
+		assertTrue(ideaMatchesQuery(idea("A well\\-known twist"), "well-known"))
+	}
+
+	@Test
+	fun `story ideas match on the plain-text title`() {
+		assertTrue(ideaMatchesQuery(idea("body text", title = "The well-known twist"), "well-known"))
+		assertFalse(ideaMatchesQuery(idea("body text", title = "Something else"), "well-known"))
+	}
+
+	@Test
+	fun `literal markup is not rewritten by any screen filter`() {
+		assertTrue(noteMatchesQuery(note("The cost is 5*4"), "5*4"))
+		assertTrue(eventMatchesQuery(event("the user_name field"), "user_name"))
+		assertTrue(ideaMatchesQuery(idea("a **Chapter** heading"), "**Chapter**"))
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/TimeLineOverviewUiTest.kt
+++ b/composeUi/src/desktopTest/kotlin/TimeLineOverviewUiTest.kt
@@ -136,6 +136,42 @@ class TimeLineOverviewUiTest : BaseTest() {
 	}
 	*/
 
+	@OptIn(ExperimentalTestApi::class, ExperimentalSharedTransitionApi::class)
+	@Test
+	fun `Search filters the list on the prose a reader sees`() {
+		val data = TimeLineOverview.State(
+			timeLine = TimeLineContainer(
+				events = listOf(
+					TimeLineEvent(id = 0, order = 0, date = null, content = "A well\\-known road"),
+					TimeLineEvent(id = 1, order = 1, date = null, content = "An unrelated event"),
+				)
+			)
+		)
+		val component = componentSetup(data)
+
+		compose.setContent {
+			SharedTransitionLayout {
+				AnimatedVisibility(visible = true) {
+					TimeLineOverviewUi(
+						component = component,
+						scope = scope,
+						showCreate = {},
+						viewEvent = {},
+						sharedTransitionScope = this@SharedTransitionLayout,
+						animatedVisibilityScope = this@AnimatedVisibility,
+					)
+				}
+			}
+		}
+
+		compose.onNodeWithContentDescription("Search timeline").performClick()
+		compose.onNodeWithTag(TIME_LINE_SEARCH_TAG).performTextInput("well-known")
+
+		// The query never contains the stored escape, so only resolving the content can match it.
+		compose.onAllNodesWithTag(EVENT_CARD_TAG).assertCountEquals(1)
+		compose.onNodeWithText("An unrelated event").assertDoesNotExist()
+	}
+
 	@OptIn(ExperimentalSharedTransitionApi::class)
 	@Test
 	fun `Event Card Click`() {


### PR DESCRIPTION
Follow-up to #824, addressing findings from reviews of its second commit and of this branch's first attempt.

## The problem

#824 resolved Markdown escapes before matching, but the rule ended up implemented three different ways:

| surface | before |
|---|---|
| Global search | resolve content, then retry the **raw** source if the query holds a backslash |
| Notes filter | resolve content only |
| Timeline filter | resolve content only |
| Story Ideas filter | raw only, never updated |

So `\%` found a note in global search and returned the empty state on the Notes screen, and `well-known` found a note and a timeline event but not a story idea holding the same text.

The raw-source retry caused a second problem: on that path the snippet was built from raw Markdown while the title was built from resolved text, so one result row rendered the same sentence two ways.

## The fix

**Drop the retry rather than spread it.** Searching for the storage form of your own text is not something readers do: the editor escapes on save, and what a user sees and types is prose. Supporting it cost real precision, which a first attempt at this PR demonstrated:

- A query of `\*` fell back to `*` and matched every emphasis marker in the project, burying the genuine hit past the per-source cap.
- A query ending in a backslash matched nothing at all, so a note vanished at the keystroke where the backslash was typed.
- The snippet and title had to come from different strings, which is what made them disagree.

What remains is one rule: **resolve the stored escapes, match the query literally.** `markdownContains` carries it, next to `matchesAllTags`, and all four surfaces call it.

Names, tags, dates and idea titles are not Markdown, so matching them exactly as stored is now *consistent* with the rule rather than a bypass of it.

Since only the resolved text is ever searched, a snippet can no longer disagree with the title derived from it.

## Tests

`MarkdownContainsTest` (commonTest, all targets) pins the rule, including the deliberate non-support:

```kotlin
assertTrue(markdownContains("A well\-known secret", "well-known"))
assertFalse(markdownContains("A well\-known secret", "well\-known"))
```

`SearchProjectUseCaseTest` gains `searching the storage form of text is not supported` and `title and snippet render the same way`. The pre-existing test asserting the escaped form *did* work was updated, since that behaviour is intentionally removed.

**`composeUi/src/desktopTest/SearchFilterTest`** is new, and is the gap the last review identified. Each screen's own composition of the rule is extracted (`noteMatchesQuery`, `eventMatchesQuery`, `ideaMatchesQuery`) so the per-screen wiring is testable: matching across an escape, the timeline's plain-text date, the idea title, and literal markup surviving on every screen. Both bugs the previous attempt shipped — the date bypass and the title bypass — would have been caught by this file.

## Verification

`:common:desktopTest` and `:composeUi:desktopTest` green (48 cases in composeUi, zero failures); `:common` and `:composeUi` compile for desktop and iOS.

Not exercised in a running app.
