### PR TITLE
Fix tag search dropping bodiless items and ignoring entry names

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -142,7 +142,9 @@ class SearchProjectUseCase(
 				parsed.tags.any { tag.contains(it, ignoreCase = true) }
 			}
 			val title = if (matchedTag != null) "${def.name}  •  #$matchedTag" else def.name
-			val snippet = matchOrPreview(entry.text, freeText) ?: return null
+			val snippet = findMatch(def.name, freeText)
+				?: matchOrPreview(entry.text, freeText, fallback = def.name)
+				?: return null
 			return SearchResult.EncyclopediaEntry(
 				entryDef = def,
 				title = title,
@@ -209,7 +211,7 @@ class SearchProjectUseCase(
 		val title = if (matchedTag != null) "${scene.name}  •  #$matchedTag" else scene.name
 
 		if (query.isEmpty()) {
-			val snippet = previewSnippet(scene.name) ?: return null
+			val snippet = previewSnippet(scene.name) ?: EMPTY_SNIPPET
 			return SearchResult.Scene(sceneItem = scene, title = title, snippet = snippet)
 		}
 		val nameMatch = findMatch(scene.name, query)
@@ -221,16 +223,24 @@ class SearchProjectUseCase(
 		return SearchResult.Scene(sceneItem = scene, title = title, snippet = bodyMatch)
 	}
 
-	/** Both callers pass stored Markdown, so escapes are resolved before matching. */
-	private fun matchOrPreview(content: String, query: String): AnnotatedSnippet? {
-		if (query.isEmpty()) return previewSnippet(unescapeMarkdown(content))
+	/**
+	 * Both callers pass stored Markdown, so escapes are resolved before matching. With no free text
+	 * the item already matched on its tags, so a blank body falls back to [fallback] and then to an
+	 * empty snippet rather than discarding the result.
+	 */
+	private fun matchOrPreview(content: String, query: String, fallback: String = ""): AnnotatedSnippet? {
+		if (query.isEmpty()) {
+			return previewSnippet(unescapeMarkdown(content))
+				?: previewSnippet(fallback)
+				?: EMPTY_SNIPPET
+		}
 		return findMarkdownMatch(content, query)
 	}
 
 	/** The date is a plain-text field, so only the event body is unescaped. */
 	private fun matchTimelineEvent(date: String?, content: String, query: String): AnnotatedSnippet? {
 		val resolved = withDate(date, unescapeMarkdown(content))
-		if (query.isEmpty()) return previewSnippet(resolved)
+		if (query.isEmpty()) return previewSnippet(resolved) ?: EMPTY_SNIPPET
 		findMatch(resolved, query)?.let { return it }
 		if (query.contains('\\')) return findMatch(withDate(date, content), query)
 		return null
@@ -265,6 +275,9 @@ class SearchProjectUseCase(
 		const val TITLE_MAX = 60
 		const val SNIPPET_BEFORE = 40
 		const val SNIPPET_AFTER = 80
+
+		/** A tag match with nothing to preview: the result stands on the tag alone. */
+		internal val EMPTY_SNIPPET = AnnotatedSnippet(text = "", matchStart = 0, matchEnd = 0)
 
 		internal fun previewSnippet(content: String): AnnotatedSnippet? {
 			if (content.isEmpty()) return null

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -26,6 +26,9 @@ import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 import kotlin.coroutines.CoroutineContext
 
+/** A tag match with nothing to preview: the result stands on the tag alone. */
+private val EMPTY_SNIPPET = AnnotatedSnippet(text = "", matchStart = 0, matchEnd = 0)
+
 /**
  * Stateless cross-repo project search. Given a query and a filter it fans out across the
  * scene/notes/encyclopedia/timeline repositories and returns the matched results. Holds no state.
@@ -275,9 +278,6 @@ class SearchProjectUseCase(
 		const val TITLE_MAX = 60
 		const val SNIPPET_BEFORE = 40
 		const val SNIPPET_AFTER = 80
-
-		/** A tag match with nothing to preview: the result stands on the tag alone. */
-		internal val EMPTY_SNIPPET = AnnotatedSnippet(text = "", matchStart = 0, matchEnd = 0)
 
 		internal fun previewSnippet(content: String): AnnotatedSnippet? {
 			if (content.isEmpty()) return null

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -486,6 +486,85 @@ class SearchProjectUseCaseTest : BaseTest() {
 		assertEquals("A well-known secret", results.first().snippet.text)
 	}
 
+	@Test
+	fun `tag-only search returns a note with no content`() = runTest {
+		every { notes.getNotes() } returns listOf(
+			NoteContainer(
+				NoteContent(
+					id = 1,
+					created = Clock.System.now(),
+					content = "",
+					tags = setOf("fantasy"),
+				)
+			),
+		)
+
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertEquals(1, results.first().noteId)
+	}
+
+	@Test
+	fun `tag-only search returns an encyclopedia entry with no body text`() = runTest {
+		val def = EntryDef(projectDef = projectDef, id = 13, type = EntryType.PERSON, name = "Alice")
+		coEvery { encyclopedia.ensureEntriesLoaded() } returns listOf(def)
+		every { encyclopedia.loadEntry(def) } returns EntryContainer(
+			EntryContent(
+				id = 13,
+				name = "Alice",
+				type = EntryType.PERSON,
+				text = "",
+				tags = setOf("fantasy"),
+			)
+		)
+
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.EncyclopediaEntry>()
+
+		assertEquals(1, results.size)
+		assertEquals(13, results.first().entryDef.id)
+		assertTrue(results.first().title.contains("Alice"))
+	}
+
+	@Test
+	fun `tag-only search returns a timeline event with no content`() = runTest {
+		coEvery { timeLine.loadTimeline() } returns TimeLineContainer(
+			listOf(
+				TimeLineEvent(id = 21, order = 0, date = null, content = "", tags = setOf("fantasy")),
+			)
+		)
+
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.TimelineEvent>()
+
+		assertEquals(1, results.size)
+		assertEquals(21, results.first().eventId)
+	}
+
+	@Test
+	fun `tag search combined with free text matches an encyclopedia entry name`() = runTest {
+		val def = EntryDef(projectDef = projectDef, id = 14, type = EntryType.PERSON, name = "Alice")
+		coEvery { encyclopedia.ensureEntriesLoaded() } returns listOf(def)
+		every { encyclopedia.loadEntry(def) } returns EntryContainer(
+			EntryContent(
+				id = 14,
+				name = "Alice",
+				type = EntryType.PERSON,
+				text = "A traveler from the north.",
+				tags = setOf("fantasy"),
+			)
+		)
+
+		val results = createUseCase().search("#fantasy alice", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.EncyclopediaEntry>()
+
+		assertEquals(1, results.size)
+		assertEquals(14, results.first().entryDef.id)
+		assertTrue(results.first().snippet.text.contains("Alice"))
+	}
+
 	private fun note(id: Int, content: String) =
 		NoteContainer(NoteContent(id = id, created = Clock.System.now(), content = content))
 

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -526,6 +526,7 @@ class SearchProjectUseCaseTest : BaseTest() {
 		assertEquals(1, results.size)
 		assertEquals(13, results.first().entryDef.id)
 		assertTrue(results.first().title.contains("Alice"))
+		assertEquals("Alice", results.first().snippet.text)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -530,18 +530,19 @@ class SearchProjectUseCaseTest : BaseTest() {
 	}
 
 	@Test
-	fun `tag-only search returns a timeline event with no content`() = runTest {
+	fun `tag-only search returns timeline events with and without content`() = runTest {
 		coEvery { timeLine.loadTimeline() } returns TimeLineContainer(
 			listOf(
 				TimeLineEvent(id = 21, order = 0, date = null, content = "", tags = setOf("fantasy")),
+				TimeLineEvent(id = 22, order = 1, date = "Year 3", content = "Coronation", tags = setOf("fantasy")),
 			)
 		)
 
 		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
 			.filterIsInstance<SearchResult.TimelineEvent>()
 
-		assertEquals(1, results.size)
-		assertEquals(21, results.first().eventId)
+		assertEquals(listOf(21, 22), results.map { it.eventId })
+		assertTrue(results.last().snippet.text.contains("Coronation"))
 	}
 
 	@Test
@@ -564,6 +565,66 @@ class SearchProjectUseCaseTest : BaseTest() {
 		assertEquals(1, results.size)
 		assertEquals(14, results.first().entryDef.id)
 		assertTrue(results.first().snippet.text.contains("Alice"))
+	}
+
+	@Test
+	fun `tag search with free text falls through to the encyclopedia entry body`() = runTest {
+		val def = EntryDef(projectDef = projectDef, id = 15, type = EntryType.PLACE, name = "Mordor")
+		coEvery { encyclopedia.ensureEntriesLoaded() } returns listOf(def)
+		every { encyclopedia.loadEntry(def) } returns EntryContainer(
+			EntryContent(
+				id = 15,
+				name = "Mordor",
+				type = EntryType.PLACE,
+				text = "Sauron rules here.",
+				tags = setOf("fantasy"),
+			)
+		)
+
+		val results = createUseCase().search("#fantasy sauron", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.EncyclopediaEntry>()
+
+		assertEquals(1, results.size)
+		assertTrue(results.first().snippet.text.contains("Sauron"))
+	}
+
+	@Test
+	fun `tag search drops an encyclopedia entry when the free text matches neither name nor body`() = runTest {
+		val def = EntryDef(projectDef = projectDef, id = 16, type = EntryType.PERSON, name = "Alice")
+		coEvery { encyclopedia.ensureEntriesLoaded() } returns listOf(def)
+		every { encyclopedia.loadEntry(def) } returns EntryContainer(
+			EntryContent(
+				id = 16,
+				name = "Alice",
+				type = EntryType.PERSON,
+				text = "A traveler from the north.",
+				tags = setOf("fantasy"),
+			)
+		)
+
+		val results = createUseCase().search("#fantasy dragon", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.EncyclopediaEntry>()
+
+		assertEquals(0, results.size)
+	}
+
+	@Test
+	fun `tag-only search returns a scene with a blank name`() = runTest {
+		val scene = SceneItem(
+			projectDef = projectDef,
+			type = SceneItem.Type.Scene,
+			id = 7,
+			name = "  ",
+			order = 0,
+		)
+		every { sceneEditor.getScenes() } returns listOf(scene)
+		coEvery { sceneMetadataRepository.loadSceneMetadata(7) } returns SceneMetadata(tags = setOf("plot"))
+
+		val results = createUseCase().search("#plot", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Scene>()
+
+		assertEquals(1, results.size)
+		assertEquals(7, results.first().sceneItem.id)
 	}
 
 	private fun note(id: Int, content: String) =


### PR DESCRIPTION
Fixes #828, two pre-existing bugs in `SearchProjectUseCase`.

## 1. Tag-only searches dropped items with no body text

`matchOrPreview` returned null for a blank body, and both callers read that null as "no result". An encyclopedia entry with a name, an image and the tag `fantasy` but no description was never returned by `#fantasy`, even though the tag is visible on the entry in the Encyclopedia screen. Same for a tagged note with empty content.

A tag match is already a match; the snippet is decoration. The empty-query path now falls back to a caller-supplied string (the entry name for encyclopedia) and then to an empty snippet. The same guard went on the timeline path (a tagged event with no date and no content was dropped identically) and on the tagged-scene preview.

## 2. Encyclopedia entry names were not matched alongside a tag

The tags-present branch only matched free text against `entry.text`. `#fantasy alice` dropped an entry named "Alice" tagged `fantasy` whose body does not contain "alice", while a scene named "Alice" with the same tag came back. The branch now tries `def.name` before the body, mirroring `matchScene`.

## Tests

Four regression tests in `SearchProjectUseCaseTest`, written first and confirmed failing before the fix: bodiless tagged note, bodiless tagged encyclopedia entry, contentless and dateless tagged timeline event, and `#fantasy alice` matching an entry by name. Full `:common:desktopTest` suite passes.
