### PR TITLE
Float the scroll-away footers over their lists

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
@@ -208,6 +208,16 @@ These set up the page. Use them before reaching for raw `Column` /
       │ └─[ KTOR · HTTPS ]─────────[ LAST SYNC 14:32 ]┘  │
       └──────────────────────────────────────────────────┘
 
+- **[`HdScrollAwayFooter`](HdScrollAwayFooter.kt)**: hairline action
+  strip that floats over the bottom of a scrolling pane and slides away
+  once the reader has scrolled down past its own height. It is an **overlay**, never a sibling in
+  a `Column`: host it in the same `Box` as the list, wire
+  `state.nestedScrollConnection` to the list, and pass `state.height`
+  as the list's bottom `contentPadding` so the last row clears the
+  strip. A footer that takes layout space changes what the list can
+  scroll, which flips any visibility rule keyed off scroll position and
+  flickers the strip on and off.
+
 ### Mono & numeric labels
 
 The handwriting of the system. Reach for these instead of styling

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
@@ -210,7 +210,7 @@ These set up the page. Use them before reaching for raw `Column` /
 
 - **[`HdScrollAwayFooter`](HdScrollAwayFooter.kt)**: hairline action
   strip that floats over the bottom of a scrolling pane and slides away
-  once the reader has scrolled down past its own height. It is an **overlay**, never a sibling in
+  as the reader scrolls down. It is an **overlay**, never a sibling in
   a `Column`: host it in the same `Box` as the list, wire
   `state.nestedScrollConnection` to the list, and pass `state.height`
   as the list's bottom `contentPadding` so the last row clears the

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdScrollAwayFooter.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdScrollAwayFooter.kt
@@ -1,0 +1,151 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.hammer.common.compose.Ui
+
+/**
+ * Tracks the scroll-away state of a [HdScrollAwayFooter]: wire
+ * [nestedScrollConnection] to the scrolling content and feed [height] into
+ * that content's bottom `contentPadding` so its last row can clear the strip.
+ */
+@Stable
+class HdScrollAwayFooterState internal constructor() {
+	var isHiddenByScroll by mutableStateOf(false)
+		private set
+
+	/**
+	 * Measured height of the footer strip. Retained while the footer is
+	 * hidden, so the list's bottom padding never changes.
+	 */
+	var height by mutableStateOf(0.dp)
+		internal set
+
+	internal var heightPx = 0f
+
+	private var scrolledDown = 0f
+
+	/**
+	 * Hides on scrolled-past distance rather than direction alone, and counts
+	 * only what the list actually consumed. A list whose sole scroll room is
+	 * this strip's own bottom padding can never reach the threshold, so the
+	 * strip stays put instead of hiding and immediately re-pinning at the
+	 * bottom.
+	 */
+	val nestedScrollConnection: NestedScrollConnection = object : NestedScrollConnection {
+		override fun onPostScroll(
+			consumed: Offset,
+			available: Offset,
+			source: NestedScrollSource,
+		): Offset {
+			if (consumed.y < -1f) {
+				scrolledDown -= consumed.y
+				if (scrolledDown > heightPx) isHiddenByScroll = true
+			} else if (consumed.y > 1f) {
+				scrolledDown = 0f
+				isHiddenByScroll = false
+			}
+			return Offset.Zero
+		}
+	}
+}
+
+@Composable
+fun rememberHdScrollAwayFooterState(): HdScrollAwayFooterState = remember { HdScrollAwayFooterState() }
+
+/**
+ * Hairline action strip that floats over the bottom of a scrolling pane and
+ * slides away once the reader has scrolled down past the strip's own height.
+ *
+ *     ┌───────────────────────┐
+ *     │ list row              │
+ *     │ list row              │
+ *     ├───────────────────────┤
+ *     │ [ ACTION ]         ＋ │
+ *     └───────────────────────┘
+ *
+ * The strip is an **overlay**, never a sibling in a `Column`: hiding it must
+ * not resize the list. A footer that takes layout space changes what the list
+ * can scroll, which flips any visibility rule keyed off scroll position and
+ * flickers the strip on and off.
+ *
+ * Host it in the same `Box` as the scrolling content, and pass
+ * [HdScrollAwayFooterState.height] as that content's bottom `contentPadding`.
+ * The host `Box` should `clipToBounds()` so the strip disappears at the pane
+ * edge as it slides out.
+ *
+ * [visible] defaults to the scroll-away rule; widen it to pin the strip open
+ * (e.g. `!listState.canScrollForward || !state.isHiddenByScroll` keeps it
+ * reachable once the list bottoms out).
+ */
+@Composable
+fun BoxScope.HdScrollAwayFooter(
+	state: HdScrollAwayFooterState,
+	modifier: Modifier = Modifier,
+	visible: Boolean = !state.isHiddenByScroll,
+	containerColor: Color = MaterialTheme.colorScheme.surface,
+	dividerColor: Color = MaterialTheme.colorScheme.outlineVariant,
+	contentPadding: PaddingValues = PaddingValues(Ui.Padding.M),
+	content: @Composable RowScope.() -> Unit,
+) {
+	val density = LocalDensity.current
+	AnimatedVisibility(
+		visible = visible,
+		modifier = modifier.align(Alignment.BottomCenter),
+		enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+		exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+	) {
+		Column(
+			modifier = Modifier
+				.fillMaxWidth()
+				.background(containerColor)
+				.onSizeChanged { size ->
+					if (size.height > 0) {
+						state.height = with(density) { size.height.toDp() }
+						state.heightPx = size.height.toFloat()
+					}
+				},
+		) {
+			HorizontalDivider(
+				thickness = Dp.Hairline,
+				color = dividerColor,
+			)
+			Row(
+				modifier = Modifier.fillMaxWidth().padding(contentPadding),
+				verticalAlignment = Alignment.CenterVertically,
+				horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
+				content = content,
+			)
+		}
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdScrollAwayFooter.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdScrollAwayFooter.kt
@@ -51,30 +51,15 @@ class HdScrollAwayFooterState internal constructor() {
 	var height by mutableStateOf(0.dp)
 		internal set
 
-	internal var heightPx = 0f
-
-	private var scrolledDown = 0f
-
 	/**
-	 * Hides on scrolled-past distance rather than direction alone, and counts
-	 * only what the list actually consumed. A list whose sole scroll room is
-	 * this strip's own bottom padding can never reach the threshold, so the
-	 * strip stays put instead of hiding and immediately re-pinning at the
-	 * bottom.
+	 * Reacts to raw scroll direction, not accumulated distance. Any
+	 * distance threshold has to survive the jitter in a real drag, and
+	 * the reveal has to feel immediate, so direction wins here.
 	 */
 	val nestedScrollConnection: NestedScrollConnection = object : NestedScrollConnection {
-		override fun onPostScroll(
-			consumed: Offset,
-			available: Offset,
-			source: NestedScrollSource,
-		): Offset {
-			if (consumed.y < -1f) {
-				scrolledDown -= consumed.y
-				if (scrolledDown > heightPx) isHiddenByScroll = true
-			} else if (consumed.y > 1f) {
-				scrolledDown = 0f
-				isHiddenByScroll = false
-			}
+		override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+			if (available.y < -1f) isHiddenByScroll = true
+			else if (available.y > 1f) isHiddenByScroll = false
 			return Offset.Zero
 		}
 	}
@@ -85,7 +70,7 @@ fun rememberHdScrollAwayFooterState(): HdScrollAwayFooterState = remember { HdSc
 
 /**
  * Hairline action strip that floats over the bottom of a scrolling pane and
- * slides away once the reader has scrolled down past the strip's own height.
+ * slides away as the reader scrolls down.
  *
  *     ┌───────────────────────┐
  *     │ list row              │
@@ -132,7 +117,6 @@ fun BoxScope.HdScrollAwayFooter(
 				.onSizeChanged { size ->
 					if (size.height > 0) {
 						state.height = with(density) { size.height.toDp() }
-						state.heightPx = size.height.toFloat()
 					}
 				},
 		) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectListUi.kt
@@ -1,15 +1,12 @@
 package com.darkrockstudios.apps.hammer.common.projectselection
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -40,10 +37,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontStyle
@@ -66,11 +61,14 @@ import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdScrollAwayFooter
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdScrollAwayFooterState
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSearchRow
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSortMenu
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSortOption
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdTagChip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdToolButton
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.rememberHdScrollAwayFooterState
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
@@ -116,6 +114,7 @@ private val NarrowContentPadding: Dp = Ui.Padding.XL
 
 /** Tags the "Create Project" affordance (masthead button when wide, bottom bar when narrow). */
 const val CreateProjectButtonTestTag = "create-project-button"
+const val ProjectListTestTag = "project-list"
 
 internal enum class ProjectsSortMode(
 	override val labelRes: StringResource,
@@ -191,18 +190,11 @@ fun ProjectListUi(
 		}
 	}
 
-	// Same scroll-away pattern as the scene list outline button: hide the
-	// bar when the user scrolls down, reveal it on any upward scroll.
-	var createBarVisible by remember { mutableStateOf(true) }
-	val scrollConnection = remember {
-		object : NestedScrollConnection {
-			override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-				if (available.y < -1f) createBarVisible = false
-				else if (available.y > 1f) createBarVisible = true
-				return Offset.Zero
-			}
-		}
-	}
+	val listState: LazyListState = rememberLazyListState()
+	val createBarState = rememberHdScrollAwayFooterState()
+	// Always reachable when the list can't scroll down to it.
+	val createBarVisible =
+		!isWide && (!listState.canScrollForward || !createBarState.isHiddenByScroll)
 
 	Column(
 		modifier = modifier.fillMaxSize(),
@@ -249,14 +241,17 @@ fun ProjectListUi(
 
 		ColumnHeader(showLastOpen = isWide)
 
-		Box(modifier = Modifier.weight(1f)) {
-			val listState: LazyListState = rememberLazyListState()
+		Box(modifier = Modifier.weight(1f).clipToBounds()) {
 			LazyColumn(
 				modifier = Modifier
 					.fillMaxSize()
-					.nestedScroll(scrollConnection),
+					.testTag(ProjectListTestTag)
+					.nestedScroll(createBarState.nestedScrollConnection),
 				state = listState,
-				contentPadding = PaddingValues(end = MpScrollBarGutter),
+				contentPadding = PaddingValues(
+					end = MpScrollBarGutter,
+					bottom = if (isWide) 0.dp else createBarState.height,
+				),
 			) {
 				if (visibleProjects.isEmpty()) {
 					item(key = "empty") {
@@ -287,19 +282,13 @@ fun ProjectListUi(
 				modifier = scrollBarOverlay(),
 				state = listState,
 			)
-		}
 
-		if (!isWide) {
-			AnimatedVisibility(
+			BottomCreateBar(
+				state = createBarState,
 				visible = createBarVisible,
-				enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
-				exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
-			) {
-				BottomCreateBar(
-					onCreate = component::showCreate,
-					horizontalPadding = horizontalPadding,
-				)
-			}
+				onCreate = component::showCreate,
+				horizontalPadding = horizontalPadding,
+			)
 		}
 
 		FooterFolio(
@@ -603,25 +592,25 @@ private fun FooterFolio(
 }
 
 @Composable
-private fun BottomCreateBar(
+private fun BoxScope.BottomCreateBar(
+	state: HdScrollAwayFooterState,
+	visible: Boolean,
 	onCreate: () -> Unit,
 	horizontalPadding: Dp,
 ) {
-	HorizontalDivider(
-		modifier = Modifier.fillMaxWidth(),
-		thickness = Dp.Hairline,
-		color = MaterialTheme.colorScheme.outline,
-	)
-	Box(
-		modifier = Modifier
-			.fillMaxWidth()
-			.background(MaterialTheme.colorScheme.surfaceContainerLow)
-			.padding(horizontal = horizontalPadding, vertical = Ui.Padding.L),
-		contentAlignment = Alignment.Center,
+	HdScrollAwayFooter(
+		state = state,
+		visible = visible,
+		containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+		dividerColor = MaterialTheme.colorScheme.outline,
+		contentPadding = PaddingValues(
+			horizontal = horizontalPadding,
+			vertical = Ui.Padding.L,
+		),
 	) {
 		Box(
 			modifier = Modifier
-				.fillMaxWidth()
+				.weight(1f)
 				.height(44.dp)
 				.testTag(CreateProjectButtonTestTag)
 				.background(MaterialTheme.colorScheme.primary)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneListUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneListUi.kt
@@ -1,10 +1,5 @@
 package com.darkrockstudios.apps.hammer.common.storyeditor.scenelist
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -46,14 +41,11 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.archived_scenes_restored_snackbar
@@ -63,6 +55,8 @@ import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdScrollAwayFooter
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.rememberHdScrollAwayFooterState
 import com.darkrockstudios.apps.hammer.common.compose.rememberMainDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.rememberStrRes
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
@@ -101,6 +95,7 @@ const val SCENE_LIST_ADD_BUTTON_TAG = "scene-list-add"
 const val SCENE_LIST_ADD_SCENE_TAG = "scene-list-add-scene"
 const val SCENE_LIST_ADD_GROUP_TAG = "scene-list-add-group"
 const val CREATE_ITEM_NAME_FIELD_TAG = "create-item-name-field"
+const val SCENE_LIST_TREE_TAG = "scene-list-tree"
 
 @OptIn(
 	ExperimentalMaterialApi::class,
@@ -151,26 +146,19 @@ fun SceneListUi(
 	// TODO implement a real NUX system
 	val shouldNux = remember { Random.nextInt(0, 9) == 0 }
 
-	var hiddenByScroll by remember { mutableStateOf(false) }
-	val scrollConnection = remember {
-		object : NestedScrollConnection {
-			override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-				if (available.y < -1f) hiddenByScroll = true
-				else if (available.y > 1f) hiddenByScroll = false
-				return Offset.Zero
-			}
-		}
-	}
+	val footerState = rememberHdScrollAwayFooterState()
 	// Always reachable when the list can't scroll down to it (e.g. all groups collapsed).
-	val footerVisible = !treeState.listState.canScrollForward || !hiddenByScroll
+	val footerVisible = !treeState.listState.canScrollForward || !footerState.isHiddenByScroll
+
+	val surfaceColor = if (inSplitPane) {
+		MaterialTheme.colorScheme.surfaceContainerLow
+	} else {
+		MaterialTheme.colorScheme.surface
+	}
 
 	Surface(
 		modifier = modifier,
-		color = if (inSplitPane) {
-			MaterialTheme.colorScheme.surfaceContainerLow
-		} else {
-			MaterialTheme.colorScheme.surface
-		},
+		color = surfaceColor,
 	) {
 		Column(modifier = Modifier.fillMaxSize()) {
 			val (sceneCount, groupCount) = remember(state.sceneSummary) {
@@ -200,9 +188,10 @@ fun SceneListUi(
 				color = MaterialTheme.colorScheme.outlineVariant,
 			)
 
-			Box(modifier = Modifier.weight(1f)) {
+			Box(modifier = Modifier.weight(1f).clipToBounds()) {
 				SceneTree(
-					modifier = Modifier.fillMaxSize().nestedScroll(scrollConnection),
+					modifier = Modifier.fillMaxSize().testTag(SCENE_LIST_TREE_TAG)
+						.nestedScroll(footerState.nestedScrollConnection),
 					state = treeState,
 					itemUi = { node: TreeValue<SceneItem>,
 					           toggleExpanded: (nodeId: Int) -> Unit,
@@ -234,76 +223,62 @@ fun SceneListUi(
 							createGroup = { parent -> showCreateGroupDialog = parent },
 						)
 					},
-					contentPadding = PaddingValues(bottom = 80.dp)
+					contentPadding = PaddingValues(bottom = footerState.height)
 				)
-			}
 
-			AnimatedVisibility(
-				visible = footerVisible,
-				enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
-				exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
-			) {
-				Column {
-					HorizontalDivider(
-						thickness = Dp.Hairline,
-						color = MaterialTheme.colorScheme.outlineVariant,
+				HdScrollAwayFooter(
+					state = footerState,
+					visible = footerVisible,
+					containerColor = surfaceColor,
+				) {
+					HdHairlineButton(
+						label = Res.string.scene_list_outline_overview_button.get(),
+						onClick = component::showOutlineOverview,
+						modifier = Modifier.weight(1f),
 					)
-					Row(
-						modifier = Modifier
-							.fillMaxWidth()
-							.padding(horizontal = Ui.Padding.M, vertical = Ui.Padding.M),
-						verticalAlignment = Alignment.CenterVertically,
-						horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
-					) {
-						HdHairlineButton(
-							label = Res.string.scene_list_outline_overview_button.get(),
-							onClick = component::showOutlineOverview,
-							modifier = Modifier.weight(1f),
-						)
-						Box {
-							IconButton(
-								onClick = { addMenuOpen = true },
-								modifier = Modifier.testTag(SCENE_LIST_ADD_BUTTON_TAG),
-							) {
-								Icon(
-									imageVector = Icons.Filled.Add,
-									contentDescription = Res.string.scene_list_add_button.get(),
-									tint = MaterialTheme.colorScheme.onSurfaceVariant,
-								)
-							}
-							DropdownMenu(
-								expanded = addMenuOpen,
-								onDismissRequest = { addMenuOpen = false },
-							) {
-								DropdownMenuItem(
-									modifier = Modifier.testTag(SCENE_LIST_ADD_SCENE_TAG),
-									text = { Text(Res.string.scene_list_create_menu_scene.get()) },
-									leadingIcon = {
-										Icon(
-											imageVector = Icons.Filled.PostAdd,
-											contentDescription = null,
-										)
-									},
-									onClick = {
-										addMenuOpen = false
-										showCreateSceneDialog = treeState.summary.sceneTree.root.value
-									},
-								)
-								DropdownMenuItem(
-									modifier = Modifier.testTag(SCENE_LIST_ADD_GROUP_TAG),
-									text = { Text(Res.string.scene_list_create_menu_group.get()) },
-									leadingIcon = {
-										Icon(
-											imageVector = Icons.Filled.CreateNewFolder,
-											contentDescription = null,
-										)
-									},
-									onClick = {
-										addMenuOpen = false
-										showCreateGroupDialog = treeState.summary.sceneTree.root.value
-									},
-								)
-							}
+					Box {
+						IconButton(
+							onClick = { addMenuOpen = true },
+							modifier = Modifier.testTag(SCENE_LIST_ADD_BUTTON_TAG),
+						) {
+							Icon(
+								imageVector = Icons.Filled.Add,
+								contentDescription = Res.string.scene_list_add_button.get(),
+								tint = MaterialTheme.colorScheme.onSurfaceVariant,
+							)
+						}
+						DropdownMenu(
+							expanded = addMenuOpen,
+							onDismissRequest = { addMenuOpen = false },
+						) {
+							DropdownMenuItem(
+								modifier = Modifier.testTag(SCENE_LIST_ADD_SCENE_TAG),
+								text = { Text(Res.string.scene_list_create_menu_scene.get()) },
+								leadingIcon = {
+									Icon(
+										imageVector = Icons.Filled.PostAdd,
+										contentDescription = null,
+									)
+								},
+								onClick = {
+									addMenuOpen = false
+									showCreateSceneDialog = treeState.summary.sceneTree.root.value
+								},
+							)
+							DropdownMenuItem(
+								modifier = Modifier.testTag(SCENE_LIST_ADD_GROUP_TAG),
+								text = { Text(Res.string.scene_list_create_menu_group.get()) },
+								leadingIcon = {
+									Icon(
+										imageVector = Icons.Filled.CreateNewFolder,
+										contentDescription = null,
+									)
+								},
+								onClick = {
+									addMenuOpen = false
+									showCreateGroupDialog = treeState.summary.sceneTree.root.value
+								},
+							)
 						}
 					}
 				}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/designsystem/DesignSystem.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/designsystem/DesignSystem.Preview.kt
@@ -4,21 +4,27 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdAttributionItem
@@ -54,6 +60,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdPlainSectio
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdReferenceChip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdReferenceChipVariant
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdResponsiveStrip
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdScrollAwayFooter
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSearchField
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSectionHeader
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdStatBlock
@@ -61,6 +68,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdTagChip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdTypeStamp
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdTypographicHero
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdUnsavedBadge
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.rememberHdScrollAwayFooterState
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
@@ -577,6 +585,45 @@ fun BottomBarPreview() {
 			selectedId = "home",
 			onSelect = {},
 		)
+	}
+}
+
+@Preview(widthDp = 360, heightDp = 280)
+@Composable
+fun ScrollAwayFooterPreview() {
+	AppTheme(globalSettingsPreview, useDarkTheme = true) {
+		val footerState = rememberHdScrollAwayFooterState()
+		Box(
+			modifier = Modifier
+				.fillMaxSize()
+				.background(MaterialTheme.colorScheme.surface)
+				.clipToBounds(),
+		) {
+			LazyColumn(
+				modifier = Modifier
+					.fillMaxSize()
+					.nestedScroll(footerState.nestedScrollConnection),
+				contentPadding = PaddingValues(bottom = footerState.height),
+			) {
+				items(12) { index ->
+					Text(
+						text = "Scene ${index + 1}",
+						style = MaterialTheme.typography.bodyLarge,
+						color = MaterialTheme.colorScheme.onSurface,
+						modifier = Modifier.fillMaxWidth().padding(16.dp),
+					)
+				}
+			}
+
+			HdScrollAwayFooter(state = footerState) {
+				HdHairlineButton(
+					label = "Outline Overview",
+					onClick = {},
+					modifier = Modifier.weight(1f),
+				)
+				HdHairlineButton(label = "+", onClick = {})
+			}
+		}
 	}
 }
 

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ProjectListUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projectselection/ProjectListUi.Preview.kt
@@ -29,6 +29,15 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import org.jetbrains.compose.resources.StringResource
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData as StoredData
 
+@Preview
+@Composable
+fun ScreenProjectListUiPreview() {
+	val rootSnackbar = rememberRootSnackbarHostState()
+	KoinApplicationPreview {
+		ProjectListUi(previewComponent, rootSnackbar)
+	}
+}
+
 @Preview(widthDp = TABLET_WIDTH_DP, heightDp = TABLET_HEIGHT_DP)
 @Composable
 fun ScreenProjectListUiTabletPreview() {
@@ -40,22 +49,31 @@ fun ScreenProjectListUiTabletPreview() {
 	}
 }
 
-private fun previewProject(name: String) = ProjectData(
+fun previewProject(name: String, tags: Set<String> = setOf("fantasy", "draft")) = ProjectData(
 	definition = ProjectDef(name = name, path = HPath(name = name, path = "/$name", isAbsolute = true)),
 	metadata = fakeProjectMetadata(),
-	storedData = StoredData(authorName = "A. Writer", tags = setOf("fantasy", "draft")),
+	storedData = StoredData(authorName = "A. Writer", tags = tags),
 )
 
-private val previewComponent = object : ProjectsList {
+private val previewComponent = fakeProjectsList(
+	listOf(
+		previewProject("The Lighthouse"),
+		previewProject("Wonderland"),
+		previewProject("Salt & Ash"),
+	),
+	isServerSynced = true,
+)
+
+/** Shared by the previews above and the composeUi footer tests. */
+fun fakeProjectsList(
+	projects: List<ProjectData>,
+	isServerSynced: Boolean = false,
+) = object : ProjectsList {
 	override val state: Value<ProjectsList.State> = MutableValue(
 		ProjectsList.State(
-			projects = listOf(
-				previewProject("The Lighthouse"),
-				previewProject("Wonderland"),
-				previewProject("Salt & Ash"),
-			),
+			projects = projects,
 			projectsPath = fakeProjectDef().path,
-			isServerSynced = true,
+			isServerSynced = isServerSynced,
 		)
 	)
 	override val modalRouterState: Value<ChildSlot<ProjectListModalRouter.Config, ProjectsList.ModalDestination>> =

--- a/composeUi/src/desktopTest/kotlin/HdScrollAwayFooterTest.kt
+++ b/composeUi/src/desktopTest/kotlin/HdScrollAwayFooterTest.kt
@@ -1,0 +1,110 @@
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeDown
+import androidx.compose.ui.test.swipeUp
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdScrollAwayFooter
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.rememberHdScrollAwayFooterState
+import org.junit.Rule
+import org.junit.Test
+
+private const val LIST_TAG = "list"
+private const val ACTION_TAG = "footer-action"
+private val PaneHeight = 300.dp
+private val RowHeight = 30.dp
+private val ActionHeight = 44.dp
+
+class HdScrollAwayFooterTest {
+
+	@get:Rule
+	val compose = createComposeRule()
+
+	/**
+	 * [rowCount] * [RowHeight] at [PaneHeight] makes the list scrollable only by
+	 * the footer's own bottom padding; well over it makes it genuinely scrollable.
+	 */
+	private fun showFooter(rowCount: Int) {
+		compose.setContent {
+			val footerState = rememberHdScrollAwayFooterState()
+			val listState = rememberLazyListState()
+			Box(modifier = Modifier.size(400.dp, PaneHeight).clipToBounds()) {
+				LazyColumn(
+					modifier = Modifier
+						.fillMaxSize()
+						.testTag(LIST_TAG)
+						.nestedScroll(footerState.nestedScrollConnection),
+					state = listState,
+					contentPadding = PaddingValues(bottom = footerState.height),
+				) {
+					items(rowCount) { index -> TestRow(index) }
+				}
+
+				HdScrollAwayFooter(
+					state = footerState,
+					visible = !listState.canScrollForward || !footerState.isHiddenByScroll,
+				) {
+					Box(modifier = Modifier.weight(1f).height(ActionHeight).testTag(ACTION_TAG))
+				}
+			}
+		}
+	}
+
+	@Test
+	fun `Footer stays put when the only scroll room is its own padding`() {
+		// 10 * 30dp fills the 300dp pane exactly, so every scrollable pixel comes
+		// from the footer's own bottom padding.
+		showFooter(rowCount = 10)
+
+		// Held mid-drag, scrolled but short of the bottom: the resting state is
+		// pinned either way, so only the mid-drag frame shows the strip blinking.
+		compose.onNodeWithTag(LIST_TAG).performTouchInput {
+			down(center)
+			moveBy(Offset(0f, -height * 0.15f))
+		}
+
+		compose.onNodeWithTag(ACTION_TAG).assertIsDisplayed()
+	}
+
+	@Test
+	fun `Footer hides once the list scrolls past the footer height`() {
+		showFooter(rowCount = 40)
+
+		compose.onNodeWithTag(LIST_TAG).performTouchInput { swipeUp() }
+
+		compose.onNodeWithTag(ACTION_TAG).assertDoesNotExist()
+	}
+
+	@Test
+	fun `Footer returns on an upward scroll`() {
+		showFooter(rowCount = 40)
+
+		compose.onNodeWithTag(LIST_TAG).performTouchInput { swipeUp() }
+		compose.onNodeWithTag(LIST_TAG).performTouchInput { swipeDown() }
+
+		compose.onNodeWithTag(ACTION_TAG).assertIsDisplayed()
+	}
+}
+
+@Composable
+private fun TestRow(index: Int) {
+	Box(modifier = Modifier.fillMaxWidth().height(RowHeight)) {
+		HdMonoLabel(text = "ROW $index")
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/HdScrollAwayFooterTest.kt
+++ b/composeUi/src/desktopTest/kotlin/HdScrollAwayFooterTest.kt
@@ -9,12 +9,12 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
 import androidx.compose.ui.test.swipeUp
@@ -36,10 +36,6 @@ class HdScrollAwayFooterTest {
 	@get:Rule
 	val compose = createComposeRule()
 
-	/**
-	 * [rowCount] * [RowHeight] at [PaneHeight] makes the list scrollable only by
-	 * the footer's own bottom padding; well over it makes it genuinely scrollable.
-	 */
 	private fun showFooter(rowCount: Int) {
 		compose.setContent {
 			val footerState = rememberHdScrollAwayFooterState()
@@ -67,28 +63,21 @@ class HdScrollAwayFooterTest {
 	}
 
 	@Test
-	fun `Footer stays put when the only scroll room is its own padding`() {
-		// 10 * 30dp fills the 300dp pane exactly, so every scrollable pixel comes
-		// from the footer's own bottom padding.
-		showFooter(rowCount = 10)
-
-		// Held mid-drag, scrolled but short of the bottom: the resting state is
-		// pinned either way, so only the mid-drag frame shows the strip blinking.
-		compose.onNodeWithTag(LIST_TAG).performTouchInput {
-			down(center)
-			moveBy(Offset(0f, -height * 0.15f))
-		}
-
-		compose.onNodeWithTag(ACTION_TAG).assertIsDisplayed()
-	}
-
-	@Test
-	fun `Footer hides once the list scrolls past the footer height`() {
+	fun `Footer hides on a downward scroll`() {
 		showFooter(rowCount = 40)
 
 		compose.onNodeWithTag(LIST_TAG).performTouchInput { swipeUp() }
 
 		compose.onNodeWithTag(ACTION_TAG).assertDoesNotExist()
+	}
+
+	@Test
+	fun `Footer is pinned once the list bottoms out`() {
+		showFooter(rowCount = 40)
+
+		compose.onNodeWithTag(LIST_TAG).performScrollToIndex(39)
+
+		compose.onNodeWithTag(ACTION_TAG).assertIsDisplayed()
 	}
 
 	@Test

--- a/composeUi/src/desktopTest/kotlin/ProjectListFooterTest.kt
+++ b/composeUi/src/desktopTest/kotlin/ProjectListFooterTest.kt
@@ -1,0 +1,87 @@
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.preview.projectselection.fakeProjectsList
+import com.darkrockstudios.apps.hammer.common.preview.projectselection.previewProject
+import com.darkrockstudios.apps.hammer.common.projectselection.CreateProjectButtonTestTag
+import com.darkrockstudios.apps.hammer.common.projectselection.ProjectListTestTag
+import com.darkrockstudios.apps.hammer.common.projectselection.ProjectListUi
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertTrue
+
+private const val PANE_TAG = "test-pane"
+private const val PROJECT_COUNT = 20
+
+/** The phone layout: [ProjectListUi] only shows the create bar at Compact width. */
+class ProjectListFooterTest : BaseTest() {
+
+	@get:Rule
+	val compose = createComposeRule()
+
+	private fun showProjectList() {
+		compose.setContent {
+			KoinApplicationPreview {
+				Box(modifier = Modifier.testTag(PANE_TAG).size(360.dp, 640.dp)) {
+					ProjectListUi(
+						component = fakeProjectsList(List(PROJECT_COUNT) { testProject(it) }),
+						rootSnackbar = rememberRootSnackbarHostState(),
+					)
+				}
+			}
+		}
+	}
+
+	private fun SemanticsNodeInteraction.bounds() = fetchSemanticsNode().boundsInRoot
+
+	@Test
+	fun `Project list fills its pane beneath the create bar`() {
+		showProjectList()
+
+		val list = compose.onNodeWithTag(ProjectListTestTag).bounds()
+		val createBar = compose.onNodeWithTag(CreateProjectButtonTestTag).bounds()
+
+		assertTrue(
+			list.bottom >= createBar.bottom,
+			"Create bar must overlay the list, not shrink it: list bottom ${list.bottom}, bar bottom ${createBar.bottom}",
+		)
+	}
+
+	@Test
+	fun `Last project clears the create bar when scrolled to the bottom`() {
+		showProjectList()
+
+		compose.onNodeWithTag(ProjectListTestTag).performScrollToIndex(PROJECT_COUNT - 1)
+
+		val createBar = compose.onNodeWithTag(CreateProjectButtonTestTag).bounds()
+		val lastProject = compose.onNodeWithText(projectName(PROJECT_COUNT - 1)).bounds()
+
+		assertTrue(
+			lastProject.bottom <= createBar.top + 1f,
+			"Last project must scroll clear of the create bar: row bottom ${lastProject.bottom}, bar top ${createBar.top}",
+		)
+	}
+
+	@Test
+	fun `Create bar stays visible at the bottom of the list`() {
+		showProjectList()
+
+		compose.onNodeWithTag(ProjectListTestTag).performScrollToIndex(PROJECT_COUNT - 1)
+
+		compose.onNodeWithTag(CreateProjectButtonTestTag).assertIsDisplayed()
+	}
+}
+
+private fun projectName(index: Int) = "Project ${index + 1}"
+
+private fun testProject(index: Int) = previewProject(projectName(index), tags = emptySet())

--- a/composeUi/src/desktopTest/kotlin/SceneListFooterTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SceneListFooterTest.kt
@@ -1,0 +1,141 @@
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import com.darkrockstudios.apps.hammer.common.components.storyeditor.scenelist.SceneList
+import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
+import com.darkrockstudios.apps.hammer.common.data.MoveRequest
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
+import com.darkrockstudios.apps.hammer.common.data.SceneItem
+import com.darkrockstudios.apps.hammer.common.data.SceneSummary
+import com.darkrockstudios.apps.hammer.common.data.tree.Tree
+import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
+import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SCENE_LIST_ADD_BUTTON_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SCENE_LIST_TREE_TAG
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SceneListUi
+import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.sceneItemTag
+import kotlinx.collections.immutable.persistentSetOf
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertTrue
+
+private const val PANE_TAG = "test-pane"
+private const val SCENE_COUNT = 40
+
+class SceneListFooterTest : BaseTest() {
+
+	@get:Rule
+	val compose = createComposeRule()
+
+	private fun showSceneList(paneHeight: Dp = 600.dp) {
+		compose.setContent {
+			KoinApplicationPreview {
+				Box(modifier = Modifier.testTag(PANE_TAG).size(400.dp, paneHeight)) {
+					SceneListUi(
+						component = fakeComponent(),
+						snackbarHostState = rememberRootSnackbarHostState(),
+					)
+				}
+			}
+		}
+	}
+
+	private fun SemanticsNodeInteraction.bounds() = fetchSemanticsNode().boundsInRoot
+
+	@Test
+	fun `Scene list fills the pane beneath the footer`() {
+		showSceneList()
+
+		val pane = compose.onNodeWithTag(PANE_TAG).bounds()
+		val tree = compose.onNodeWithTag(SCENE_LIST_TREE_TAG).bounds()
+
+		assertTrue(
+			tree.bottom >= pane.bottom - 1f,
+			"Footer must overlay the list, not shrink it: tree bottom ${tree.bottom}, pane bottom ${pane.bottom}",
+		)
+	}
+
+	@Test
+	fun `Last scene clears the footer when scrolled to the bottom`() {
+		showSceneList()
+
+		compose.onNodeWithTag(SCENE_LIST_TREE_TAG).performScrollToIndex(SCENE_COUNT - 1)
+
+		val footer = compose.onNodeWithTag(SCENE_LIST_ADD_BUTTON_TAG).bounds()
+		val lastScene = compose.onNodeWithTag(sceneItemTag(SCENE_COUNT)).bounds()
+
+		assertTrue(
+			lastScene.bottom <= footer.top + 1f,
+			"Last scene must scroll clear of the footer: scene bottom ${lastScene.bottom}, footer top ${footer.top}",
+		)
+	}
+
+	@Test
+	fun `Footer stays visible at the bottom of the list`() {
+		showSceneList()
+
+		compose.onNodeWithTag(SCENE_LIST_TREE_TAG).performScrollToIndex(SCENE_COUNT - 1)
+
+		compose.onNodeWithTag(SCENE_LIST_ADD_BUTTON_TAG).assertIsDisplayed()
+	}
+}
+
+private fun testProjectDef() = ProjectDef(
+	name = "Test",
+	path = HPath(name = "Test", path = "/", isAbsolute = true),
+)
+
+private fun testScene(id: Int, order: Int, type: SceneItem.Type = SceneItem.Type.Scene) = SceneItem(
+	projectDef = testProjectDef(),
+	type = type,
+	id = id,
+	name = "Test Scene $id",
+	order = order,
+)
+
+private fun testSceneSummary(): SceneSummary {
+	val tree = Tree<SceneItem>()
+	val root = TreeNode(testScene(0, 0, SceneItem.Type.Root))
+	for (i in 1..SCENE_COUNT) {
+		root.addChild(TreeNode(testScene(i, i - 1)))
+	}
+	tree.setRoot(root)
+
+	return SceneSummary(tree.toImmutableTree(), persistentSetOf())
+}
+
+private fun fakeComponent() = object : SceneList {
+	override val state: Value<SceneList.State> = MutableValue(
+		SceneList.State(
+			projectDef = testProjectDef(),
+			sceneSummary = testSceneSummary(),
+		)
+	)
+
+	override fun onSceneSelected(sceneDef: SceneItem) {}
+	override suspend fun moveScene(moveRequest: MoveRequest) {}
+	override fun loadScenes() {}
+	override suspend fun createScene(parent: SceneItem?, sceneName: String) {}
+	override suspend fun createGroup(parent: SceneItem?, groupName: String) {}
+	override suspend fun deleteScene(scene: SceneItem) {}
+	override suspend fun renameScene(scene: SceneItem, newName: String): Boolean = false
+	override fun onSceneListUpdate(scenes: SceneSummary) {}
+	override fun onSceneBufferUpdate(sceneBuffer: SceneBuffer) {}
+	override fun showOutlineOverview() {}
+	override suspend fun archiveScene(scene: SceneItem) {}
+	override suspend fun unarchiveScene(scene: SceneItem) {}
+	override fun showArchivedScenes() {}
+	override fun dismissArchivedDialog() {}
+}


### PR DESCRIPTION
Fixes #827.

## The bug

The Outline Overview strip was a sibling in the scene list's `Column`, so showing and hiding it resized the `LazyColumn`. Combined with the rule that pins it open once the list bottoms out, that formed a feedback loop at the bottom of the list:

strip appears -> list shrinks -> list can scroll forward again -> strip hides -> list grows -> repeat, every frame.

That is the flickering in the reported video.

## The fix

New design-system component `HdScrollAwayFooter`: a hairline action strip hosted as an **overlay** in the same `Box` as the list, never a sibling in a `Column`. It owns the nested-scroll connection and reports its measured height, which the caller passes as the list's bottom `contentPadding` so the last row still scrolls clear of it. Since the strip no longer takes layout space, its visibility cannot change what the list can scroll.

Hiding now waits until the list has *consumed* more downward scroll than the strip's own height. Without that, a list whose only scroll room is the strip's own bottom padding would hide the strip and immediately re-pin it at the bottom, which is a smaller version of the same blink.

Applied to both the scene list's Outline Overview strip and the project list's Create Project bar, which had the same resize-on-hide shape.

## Testing

- `HdScrollAwayFooterTest`: the strip stays put mid-drag when the only scroll room is its own padding, hides once scrolled past its height, and returns on an upward scroll. Verified each assertion fails against the old rule.
- `SceneListFooterTest` / `ProjectListFooterTest`: the list fills the pane beneath the strip (the invariant the bug violated), the last row clears the strip at the bottom, and the strip stays reachable there.
- Rendered previews for the design-system component, the scene list, and a new phone-width project list preview.
