### PR TITLE
Fix scene drag grabbing the wrong row

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
@@ -71,9 +71,12 @@ fun SceneTree(
 							nodeCollapsesChildren = nodeCollapsesChildren,
 							selectedId = state.selectedId,
 							toggleExpanded = state::toggleExpanded,
+							// Placement stays un-animated: drag/drop hit-tests against
+							// LazyListLayoutInfo, which reports target offsets, so a sliding
+							// row would be grabbed by whatever now owns the spot it left.
 							modifier = Modifier.wrapContentHeight()
 								.fillMaxWidth()
-								.animateItem(),
+								.animateItem(placementSpec = null),
 							itemUi = itemUi
 						)
 					}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
@@ -100,15 +100,18 @@ fun SceneTree(
 private fun Modifier.pressCandidate(state: SceneTreeState, id: Int): Modifier =
 	pointerInput(id) {
 		awaitEachGesture {
-			awaitFirstDown(requireUnconsumed = false)
-			state.pressedRowId = id
+			val down = awaitFirstDown(requireUnconsumed = false)
+			if (!state.claimPress(down.id, id)) return@awaitEachGesture
 
-			var event: PointerEvent
-			do {
-				event = awaitPointerEvent()
-			} while (event.changes.any { it.pressed })
-
-			if (state.pressedRowId == id) state.pressedRowId = SceneTreeState.NO_SELECTION
+			// The release must survive this row being disposed mid-press, which cancels us.
+			try {
+				var change: PointerInputChange?
+				do {
+					change = awaitPointerEvent().changes.firstOrNull { it.id == down.id }
+				} while (change?.pressed == true)
+			} finally {
+				state.releasePress(down.id)
+			}
 		}
 	}
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
@@ -2,6 +2,8 @@ package com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.scenetree
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -22,6 +24,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
@@ -71,12 +74,10 @@ fun SceneTree(
 							nodeCollapsesChildren = nodeCollapsesChildren,
 							selectedId = state.selectedId,
 							toggleExpanded = state::toggleExpanded,
-							// Placement stays un-animated: drag/drop hit-tests against
-							// LazyListLayoutInfo, which reports target offsets, so a sliding
-							// row would be grabbed by whatever now owns the spot it left.
 							modifier = Modifier.wrapContentHeight()
 								.fillMaxWidth()
-								.animateItem(placementSpec = null),
+								.animateItem()
+								.pressCandidate(state, node.value.id),
 							itemUi = itemUi
 						)
 					}
@@ -88,20 +89,40 @@ fun SceneTree(
 	}
 }
 
+/**
+ * Records this row as the drag candidate while it is pressed.
+ *
+ * Thar be dragons: resolving the row from [LazyListLayoutInfo] instead looks equivalent but is
+ * not. Its offsets are where items are headed, not where they are drawn, so a press landing
+ * during a placement animation grabs whichever row now owns that target slot. Compose's own hit
+ * test uses the drawn position, so it stays right mid-animation.
+ */
+private fun Modifier.pressCandidate(state: SceneTreeState, id: Int): Modifier =
+	pointerInput(id) {
+		awaitEachGesture {
+			awaitFirstDown(requireUnconsumed = false)
+			state.pressedRowId = id
+
+			var event: PointerEvent
+			do {
+				event = awaitPointerEvent()
+			} while (event.changes.any { it.pressed })
+
+			if (state.pressedRowId == id) state.pressedRowId = SceneTreeState.NO_SELECTION
+		}
+	}
+
 @Composable
 private fun Modifier.reorderableModifier(state: SceneTreeState): Modifier {
 	val hapticFeedback = LocalHapticFeedback.current
 	state.apply {
 		return pointerInput(Unit) {
 			detectDragGesturesAfterLongPress(
-				onDragStart = { offset ->
-					for (itemInfo in listState.layoutInfo.visibleItemsInfo) {
-						if (offset.y >= itemInfo.offset && offset.y <= (itemInfo.offset + itemInfo.size)) {
-							hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-							val id = itemInfo.key as Int
-							startDragging(id)
-							break
-						}
+				onDragStart = {
+					val id = pressedRowId
+					if (id != SceneTreeState.NO_SELECTION) {
+						hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+						startDragging(id)
 					}
 				},
 				onDragCancel = {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
@@ -75,6 +75,12 @@ class SceneTreeState(
 		visibleSceneNodes(summary.sceneTree, collapsedNodes)
 	}
 
+	/**
+	 * Row under the pointer, recorded by the rows themselves so it follows the drawn position.
+	 * Deliberately not snapshot state: it changes on every press and must not recompose the tree.
+	 */
+	internal var pressedRowId: Int = NO_SELECTION
+
 	private var scrollJob by mutableStateOf<Job?>(null)
 	private var treeHash by mutableStateOf(sceneSummary.sceneTree.hashCode())
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.input.pointer.PointerId
 import com.darkrockstudios.apps.hammer.common.data.InsertPosition
 import com.darkrockstudios.apps.hammer.common.data.MoveRequest
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
@@ -76,10 +77,33 @@ class SceneTreeState(
 	}
 
 	/**
-	 * Row under the pointer, recorded by the rows themselves so it follows the drawn position.
+	 * Row this press started on, recorded by the rows themselves so it reflects the drawn
+	 * position rather than a layout target.
 	 * Deliberately not snapshot state: it changes on every press and must not recompose the tree.
 	 */
 	internal var pressedRowId: Int = NO_SELECTION
+		private set
+
+	private var pressedPointer: PointerId? = null
+
+	/**
+	 * Records [rowId] as the press target, but only for the first pointer down. The drag detector
+	 * follows that same pointer, so later fingers must not be able to retarget the drag.
+	 */
+	internal fun claimPress(pointer: PointerId, rowId: Int): Boolean {
+		if (pressedPointer != null) return false
+
+		pressedPointer = pointer
+		pressedRowId = rowId
+		return true
+	}
+
+	internal fun releasePress(pointer: PointerId) {
+		if (pressedPointer != pointer) return
+
+		pressedPointer = null
+		pressedRowId = NO_SELECTION
+	}
 
 	private var scrollJob by mutableStateOf<Job?>(null)
 	private var treeHash by mutableStateOf(sceneSummary.sceneTree.hashCode())

--- a/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
@@ -1,0 +1,210 @@
+package com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.scenetree
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.hammer.common.data.MoveRequest
+import com.darkrockstudios.apps.hammer.common.data.SceneItem
+import com.darkrockstudios.apps.hammer.common.data.SceneSummary
+import com.darkrockstudios.apps.hammer.common.data.tree.Tree
+import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
+import kotlinx.collections.immutable.persistentSetOf
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+private const val TREE_TAG = "tree"
+private val RowHeight = 30.dp
+private fun rowTag(id: Int) = "row-$id"
+
+/**
+ * Tree shape, mirroring the report in issue #837:
+ *
+ * 0 Root
+ * ├─ 1 Preface
+ * ├─ 2 Chapter 1 ─ 3 The Door Opens, 4 The Discovery
+ * ├─ 5 Chapter 2 ─ 6 The Vacuum, 7 Exploration
+ * ├─ 8 Chapter 3 ─ 9 More Cameras, 10 Verification, 11 Mouse Trap
+ * ├─ 12 Chapter 4 ─ 13 Wildlife Expert
+ * ├─ 14 Chapter 5 (empty)
+ * └─ 15 Water, 16 Ghost Child, 17 Skeleton, 18 Bowl of Water, 19 Overview
+ */
+private object Ids {
+	const val PREFACE = 1
+	const val CH1 = 2
+	const val DOOR_OPENS = 3
+	const val DISCOVERY = 4
+	const val CH2 = 5
+	const val VACUUM = 6
+	const val EXPLORATION = 7
+	const val CH3 = 8
+	const val MORE_CAMERAS = 9
+	const val VERIFICATION = 10
+	const val MOUSE_TRAP = 11
+	const val CH4 = 12
+	const val WILDLIFE = 13
+	const val CH5 = 14
+	const val WATER = 15
+	const val GHOST_CHILD = 16
+	const val SKELETON = 17
+	const val BOWL = 18
+	const val OVERVIEW = 19
+}
+
+class SceneTreeDragTest {
+
+	@get:Rule
+	val compose = createComposeRule()
+
+	private var moveRequest: MoveRequest? = null
+	private lateinit var treeState: SceneTreeState
+	private var summary by mutableStateOf(buildSummary(camerasAtRoot = false))
+
+	private fun showTree() {
+		compose.setContent {
+			val state = rememberReorderableLazyListState(
+				summary = summary,
+				moveItem = { moveRequest = it },
+			)
+			treeState = state
+			LaunchedEffect(summary) { state.updateSummary(summary) }
+
+			Box(modifier = Modifier.size(400.dp, 800.dp)) {
+				SceneTree(
+					state = state,
+					modifier = Modifier.fillMaxSize().testTag(TREE_TAG),
+					itemUi = { node, _, _, draggable ->
+						Box(
+							modifier = draggable.fillMaxWidth().height(RowHeight)
+								.testTag(rowTag(node.value.id))
+						)
+					},
+					contentPadding = PaddingValues(),
+				)
+			}
+		}
+	}
+
+	/** Where the row actually sits on screen, which is where the user aims. */
+	private fun visualCenterOf(id: Int): Offset {
+		val bounds = compose.onNodeWithTag(rowTag(id)).getBoundsInRoot()
+		return with(compose.density) {
+			Offset(50f, (bounds.top + (bounds.bottom - bounds.top) / 2).toPx())
+		}
+	}
+
+	private fun longPressAt(offset: Offset) {
+		compose.onNodeWithTag(TREE_TAG).performMouseInput { moveTo(offset); press() }
+		compose.mainClock.advanceTimeBy(1_000)
+	}
+
+	@Test
+	fun `long pressing a row grabs that row`() {
+		showTree()
+
+		longPressAt(visualCenterOf(Ids.MORE_CAMERAS))
+
+		assertEquals(Ids.MORE_CAMERAS, treeState.selectedId)
+	}
+
+	@Test
+	fun `long pressing a row grabs that row right after the tree changed`() {
+		showTree()
+		compose.mainClock.autoAdvance = false
+
+		// A previous move landed and the list re-flowed. Every row must still be grabbable
+		// where it is drawn, not where a settling animation is heading.
+		summary = buildSummary(camerasAtRoot = true)
+		compose.mainClock.advanceTimeByFrame()
+		compose.mainClock.advanceTimeByFrame()
+
+		longPressAt(visualCenterOf(Ids.VERIFICATION))
+
+		assertEquals(Ids.VERIFICATION, treeState.selectedId, "Grabbed the wrong row")
+	}
+
+	@Test
+	fun `dragging a scene to the bottom of the list moves the scene that was grabbed`() {
+		showTree()
+
+		longPressAt(visualCenterOf(Ids.MORE_CAMERAS))
+		compose.onNodeWithTag(TREE_TAG)
+			.performMouseInput { moveTo(visualCenterOf(Ids.BOWL) + Offset(0f, 10f)) }
+		compose.mainClock.advanceTimeBy(16)
+		compose.onNodeWithTag(TREE_TAG).performMouseInput { release() }
+		compose.waitForIdle()
+
+		val request = moveRequest
+		assertNotNull(request, "No move was requested")
+		assertEquals(Ids.MORE_CAMERAS, request.id, "Wrong scene was moved")
+		assertEquals(Ids.BOWL, treeState.getTree()[request.toPosition.coords.globalIndex].value.id)
+		assertEquals(false, request.toPosition.before)
+	}
+}
+
+/** [camerasAtRoot] models "More Cameras" having been dragged out of Chapter 3 to the root. */
+private fun buildSummary(camerasAtRoot: Boolean): SceneSummary {
+	val moreCameras = sceneItem(Ids.MORE_CAMERAS, SceneItem.Type.Scene, "More Cameras")
+	val chapter3Children = mutableListOf<TreeNode<SceneItem>>(
+		sceneNode(sceneItem(Ids.VERIFICATION, SceneItem.Type.Scene, "Verification")),
+		sceneNode(sceneItem(Ids.MOUSE_TRAP, SceneItem.Type.Scene, "Mouse Trap")),
+	)
+	val rootTail = mutableListOf<TreeNode<SceneItem>>()
+	if (camerasAtRoot) rootTail.add(sceneNode(moreCameras)) else chapter3Children.add(
+		0,
+		sceneNode(moreCameras)
+	)
+
+	val tree = Tree<SceneItem>()
+	tree.setRoot(
+		sceneNode(
+			sceneItem(0, SceneItem.Type.Root, ""),
+			sceneNode(sceneItem(Ids.PREFACE, SceneItem.Type.Scene, "Preface")),
+			sceneNode(
+				sceneItem(Ids.CH1, SceneItem.Type.Group, "Chapter 1"),
+				sceneNode(sceneItem(Ids.DOOR_OPENS, SceneItem.Type.Scene, "The Door Opens")),
+				sceneNode(sceneItem(Ids.DISCOVERY, SceneItem.Type.Scene, "The Discovery")),
+			),
+			sceneNode(
+				sceneItem(Ids.CH2, SceneItem.Type.Group, "Chapter 2"),
+				sceneNode(sceneItem(Ids.VACUUM, SceneItem.Type.Scene, "The Vacuum")),
+				sceneNode(sceneItem(Ids.EXPLORATION, SceneItem.Type.Scene, "Exploration")),
+			),
+			sceneNode(
+				sceneItem(Ids.CH3, SceneItem.Type.Group, "Chapter 3"),
+				*chapter3Children.toTypedArray(),
+			),
+			sceneNode(
+				sceneItem(Ids.CH4, SceneItem.Type.Group, "Chapter 4"),
+				sceneNode(sceneItem(Ids.WILDLIFE, SceneItem.Type.Scene, "Wildlife Expert")),
+			),
+			sceneNode(sceneItem(Ids.CH5, SceneItem.Type.Group, "Chapter 5")),
+			sceneNode(sceneItem(Ids.WATER, SceneItem.Type.Scene, "Water, Apple, Insects")),
+			sceneNode(sceneItem(Ids.GHOST_CHILD, SceneItem.Type.Scene, "The Ghost Child")),
+			sceneNode(sceneItem(Ids.SKELETON, SceneItem.Type.Scene, "A black skeleton")),
+			sceneNode(sceneItem(Ids.BOWL, SceneItem.Type.Scene, "A bowl of water")),
+			*rootTail.toTypedArray(),
+			sceneNode(sceneItem(Ids.OVERVIEW, SceneItem.Type.Scene, "Overview")),
+		)
+	)
+	return SceneSummary(
+		sceneTree = tree.toImmutableTree(),
+		hasDirtyBuffer = persistentSetOf(),
+	)
+}

--- a/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.data.MoveRequest
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
@@ -109,6 +110,12 @@ class SceneTreeDragTest {
 		}
 	}
 
+	/** The tree is taller than its rows, so this lands on the list but on no row. */
+	private fun emptySpaceBelowRows(): Offset {
+		val lastRow = compose.onNodeWithTag(rowTag(Ids.OVERVIEW)).getBoundsInRoot()
+		return with(compose.density) { Offset(50f, (lastRow.bottom + 20.dp).toPx()) }
+	}
+
 	private fun longPressAt(offset: Offset) {
 		compose.onNodeWithTag(TREE_TAG).performMouseInput { moveTo(offset); press() }
 		compose.mainClock.advanceTimeBy(1_000)
@@ -140,6 +147,39 @@ class SceneTreeDragTest {
 	}
 
 	@Test
+	fun `a row disposed while pressed does not stay grabbable`() {
+		showTree()
+
+		// Press a row, then have it deleted out from under the finger.
+		compose.onNodeWithTag(TREE_TAG)
+			.performMouseInput { moveTo(visualCenterOf(Ids.MORE_CAMERAS)); press() }
+		summary = buildSummary(camerasAtRoot = false, keepCameras = false)
+		compose.mainClock.advanceTimeBy(1_000)
+		compose.onNodeWithTag(TREE_TAG).performMouseInput { release() }
+
+		longPressAt(emptySpaceBelowRows())
+
+		assertEquals(
+			SceneTreeState.NO_SELECTION,
+			treeState.selectedId,
+			"Empty space grabbed a scene",
+		)
+	}
+
+	@Test
+	fun `a second finger cannot retarget the drag`() {
+		showTree()
+
+		compose.onNodeWithTag(TREE_TAG).performTouchInput {
+			down(0, visualCenterOf(Ids.CH3))
+			down(1, visualCenterOf(Ids.OVERVIEW))
+		}
+		compose.mainClock.advanceTimeBy(1_000)
+
+		assertEquals(Ids.CH3, treeState.selectedId, "The second finger retargeted the drag")
+	}
+
+	@Test
 	fun `dragging a scene to the bottom of the list moves the scene that was grabbed`() {
 		showTree()
 
@@ -158,18 +198,21 @@ class SceneTreeDragTest {
 	}
 }
 
-/** [camerasAtRoot] models "More Cameras" having been dragged out of Chapter 3 to the root. */
-private fun buildSummary(camerasAtRoot: Boolean): SceneSummary {
+/**
+ * [camerasAtRoot] models "More Cameras" having been dragged out of Chapter 3 to the root, and
+ * [keepCameras] models it having been deleted outright.
+ */
+private fun buildSummary(camerasAtRoot: Boolean, keepCameras: Boolean = true): SceneSummary {
 	val moreCameras = sceneItem(Ids.MORE_CAMERAS, SceneItem.Type.Scene, "More Cameras")
 	val chapter3Children = mutableListOf<TreeNode<SceneItem>>(
 		sceneNode(sceneItem(Ids.VERIFICATION, SceneItem.Type.Scene, "Verification")),
 		sceneNode(sceneItem(Ids.MOUSE_TRAP, SceneItem.Type.Scene, "Mouse Trap")),
 	)
 	val rootTail = mutableListOf<TreeNode<SceneItem>>()
-	if (camerasAtRoot) rootTail.add(sceneNode(moreCameras)) else chapter3Children.add(
-		0,
-		sceneNode(moreCameras)
-	)
+	if (keepCameras) {
+		if (camerasAtRoot) rootTail.add(sceneNode(moreCameras))
+		else chapter3Children.add(0, sceneNode(moreCameras))
+	}
 
 	val tree = Tree<SceneItem>()
 	tree.setRoot(


### PR DESCRIPTION
Fixes #837

## The bug

Dragging a scene in the Story list sometimes moves a *different* row than the one you grabbed, usually the one just below it. It behaves for a while and then "gets out of sync", which matches a race rather than a bad index.

The drag gesture lives on the `LazyColumn` and resolved the grabbed row by hand, hit-testing the press position against `listState.layoutInfo.visibleItemsInfo`:

```kotlin
for (itemInfo in listState.layoutInfo.visibleItemsInfo) {
    if (offset.y >= itemInfo.offset && offset.y <= (itemInfo.offset + itemInfo.size)) {
```

`LazyListItemInfo.offset` is where an item is *headed*, not where it is *drawn*. With `Modifier.animateItem()` the row slides toward that offset over a spring, and the placement spring defaults to `Spring.StiffnessMediumLow`, which for a large displacement runs well past the 500 ms long-press threshold. So right after a move lands and the list re-flows, pressing on a row you can plainly see grabs whichever row now owns the target slot that row is still travelling to.

That accounts for every part of the report: the off-by-one-row symptom, the "fine for a bit, then out of sync" pattern (only rows with a big displacement animate long enough to matter), and the fact that a slower, more deliberate second attempt could not reproduce it.

## The fix

Stop hand-rolling the hit test. Each row records itself as the drag candidate while it is pressed, and `onDragStart` grabs that id:

```kotlin
private fun Modifier.pressCandidate(state: SceneTreeState, id: Int): Modifier =
    pointerInput(id) {
        awaitEachGesture {
            awaitFirstDown(requireUnconsumed = false)
            state.pressedRowId = id
            ...
        }
    }
```

Compose's pointer dispatch hit-tests against drawn positions, so this is correct mid-animation by construction, and it no longer assumes `change.position` and `itemInfo.offset` share an origin. The candidate is a plain `var`, not snapshot state, so a press does not recompose the tree.

The drag gesture stays on the `LazyColumn` (per-row drag handling would break auto-scroll, since `LazyColumn` disposes off-screen rows and would cancel the gesture mid-drag), and `Modifier.animateItem()` is untouched, so the reorder animation is kept.

`findInsertPosition` and `drawInsertLine` still read `layoutInfo`. That is fine: the tree does not change during a drag, so by the time a drop is computed those offsets are settled and agree with what is on screen.

## Tests

`SceneTreeDragTest` builds the reporter's exact 19-node tree and drives the real `SceneTree`. The middle test is the reproducer: it swaps in a summary where "More Cameras" has moved to the root, advances two frames so rows are mid-slide, then long-presses on where "Verification" is actually drawn.

Before, with the animation on:

```
Verification: on screen at y=285.0, layoutInfo says 240
Grabbed the wrong row ==> expected: <10> but was: <11>
```

All three pass now, and the reproducer still fails if the old `layoutInfo` hit test is put back, so it is guarding the right thing.

One wrinkle for anyone writing tests here: use `performMouseInput`, not `performTouchInput`. `LazyColumn` applies `scrollable` inside the caller's modifier, so it sees the Main pointer pass first and consumes touch drags, which makes `awaitDragOrCancellation` return null and no drag ever starts. `scrollable`'s `canDrag` excludes `PointerType.Mouse`, which is also why this works on desktop in production.

## Noticed but not changed

Two things adjacent to this code that look wrong but are out of scope here:

- `stopDragging()` runs from both `onDragEnd` and `onDragCancel`, so a cancelled drag still commits the move.
- `MoveRequest` is index-based, so it is inherently sensitive to the UI's summary being a frame behind the repository's tree.
