### PR TITLE
Match search on rendered prose, with a scan that does not allocate

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -10,12 +10,12 @@ import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesReposito
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
+import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjector
+import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjectorPool
 import com.darkrockstudios.apps.hammer.common.data.search.ParsedQuery
 import com.darkrockstudios.apps.hammer.common.data.search.containsMarkdownSyntax
-import com.darkrockstudios.apps.hammer.common.data.search.markdownTitleLine
 import com.darkrockstudios.apps.hammer.common.data.search.matchesAllTags
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
-import com.darkrockstudios.apps.hammer.common.data.search.projectMarkdownToPlainText
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_IO
@@ -46,6 +46,9 @@ class SearchProjectUseCase(
 
 	private val dispatcherDefault: CoroutineContext by inject(named(DISPATCHER_DEFAULT))
 	private val dispatcherIo: CoroutineContext by inject(named(DISPATCHER_IO))
+
+	// Outlives a single search so the buffers one scan grew are still sized for the next keystroke.
+	private val projectors = MarkdownProjectorPool()
 
 	suspend fun search(query: String, filter: GlobalSearchFilter): List<SearchResult> {
 		val parsed = parseQuery(query)
@@ -81,46 +84,51 @@ class SearchProjectUseCase(
 	private val GlobalSearchFilter.includesTimeline: Boolean
 		get() = this == GlobalSearchFilter.All || this == GlobalSearchFilter.Timeline
 
-	private fun searchNotes(parsed: ParsedQuery): List<SearchResult> {
-		return notes.getNotes()
-			.filter { it.note.tags.matchesAllTags(parsed.tags) }
-			.mapNotNull { container ->
-				val snippet = matchOrPreview(container.note.content, parsed.text)
-					?: return@mapNotNull null
-				SearchResult.Note(
-					noteId = container.note.id,
-					title = firstLineTitle(container.note.content, fallback = "(empty note)"),
-					snippet = snippet,
-				)
-			}
-			.take(PER_SOURCE_CAP)
-	}
+	private suspend fun searchNotes(parsed: ParsedQuery): List<SearchResult> =
+		projectors.borrow { projector ->
+			notes.getNotes()
+				.filter { it.note.tags.matchesAllTags(parsed.tags) }
+				.mapNotNull { container ->
+					val snippet = matchOrPreview(projector, container.note.content, parsed.text)
+						?: return@mapNotNull null
+					SearchResult.Note(
+						noteId = container.note.id,
+						title = firstLineTitle(projector, container.note.content, fallback = "(empty note)"),
+						snippet = snippet,
+					)
+				}
+				.take(PER_SOURCE_CAP)
+		}
 
-	private suspend fun searchTimeline(parsed: ParsedQuery): List<SearchResult> {
+	private suspend fun searchTimeline(parsed: ParsedQuery): List<SearchResult> = projectors.borrow { projector ->
 		val timeline = timeLine.loadTimeline()
-		return timeline.events
+		timeline.events
 			.filter { it.tags.matchesAllTags(parsed.tags) }
 			.mapNotNull { event ->
-				val snippet = matchTimelineEvent(event.date, event.content, parsed.text)
+				val snippet = matchTimelineEvent(projector, event.date, event.content, parsed.text)
 					?: return@mapNotNull null
 				SearchResult.TimelineEvent(
 					eventId = event.id,
 					title = event.date?.takeIf { it.isNotBlank() }
-						?: firstLineTitle(event.content, fallback = "(empty event)"),
+						?: firstLineTitle(projector, event.content, fallback = "(empty event)"),
 					snippet = snippet,
 				)
 			}
 			.take(PER_SOURCE_CAP)
 	}
 
-	private suspend fun searchEncyclopedia(parsed: ParsedQuery): List<SearchResult> {
-		val entries = collectEntryDefs()
-		return entries
-			.mapNotNull { def -> matchEncyclopediaEntry(def, parsed) }
-			.take(PER_SOURCE_CAP)
-	}
+	private suspend fun searchEncyclopedia(parsed: ParsedQuery): List<SearchResult> =
+		projectors.borrow { projector ->
+			collectEntryDefs()
+				.mapNotNull { def -> matchEncyclopediaEntry(projector, def, parsed) }
+				.take(PER_SOURCE_CAP)
+		}
 
-	private suspend fun matchEncyclopediaEntry(def: EntryDef, parsed: ParsedQuery): SearchResult? {
+	private suspend fun matchEncyclopediaEntry(
+		projector: MarkdownProjector,
+		def: EntryDef,
+		parsed: ParsedQuery,
+	): SearchResult? {
 		val needTags = parsed.tags.isNotEmpty()
 		val freeText = parsed.text
 
@@ -148,7 +156,7 @@ class SearchProjectUseCase(
 			}
 			val title = if (matchedTag != null) "${def.name}  •  #$matchedTag" else def.name
 			val snippet = findMatch(def.name, freeText)
-				?: matchOrPreview(entry.text, freeText, fallback = def.name)
+				?: matchOrPreview(projector, entry.text, freeText, fallback = def.name)
 				?: return null
 			return SearchResult.EncyclopediaEntry(
 				entryDef = def,
@@ -169,7 +177,7 @@ class SearchProjectUseCase(
 			)
 		}
 
-		val textMatch = findMarkdownMatch(entry.text, freeText) ?: return null
+		val textMatch = findMarkdownMatch(projector, entry.text, freeText) ?: return null
 		return SearchResult.EncyclopediaEntry(
 			entryDef = def,
 			title = def.name,
@@ -179,16 +187,18 @@ class SearchProjectUseCase(
 
 	private suspend fun collectEntryDefs(): List<EntryDef> = encyclopedia.ensureEntriesLoaded()
 
-	private suspend fun searchScenes(parsed: ParsedQuery): List<SearchResult> {
-		val query = parsed.text
-		val needTags = parsed.tags.isNotEmpty()
-		val scenes = sceneEditor.getScenes().filter { it.type == SceneItem.Type.Scene }
-		return scenes
-			.mapNotNull { scene -> matchScene(scene, query, needTags, parsed.tags) }
-			.take(PER_SOURCE_CAP)
-	}
+	private suspend fun searchScenes(parsed: ParsedQuery): List<SearchResult> =
+		projectors.borrow { projector ->
+			val query = parsed.text
+			val needTags = parsed.tags.isNotEmpty()
+			sceneEditor.getScenes()
+				.filter { it.type == SceneItem.Type.Scene }
+				.mapNotNull { scene -> matchScene(projector, scene, query, needTags, parsed.tags) }
+				.take(PER_SOURCE_CAP)
+		}
 
 	private suspend fun matchScene(
+		projector: MarkdownProjector,
 		scene: SceneItem,
 		query: String,
 		needTags: Boolean,
@@ -200,8 +210,9 @@ class SearchProjectUseCase(
 			if (nameMatch != null) {
 				return SearchResult.Scene(sceneItem = scene, title = scene.name, snippet = nameMatch)
 			}
-			val text = withContext(dispatcherIo) { loadSceneText(scene) } ?: return null
-			val bodyMatch = findMarkdownMatch(text, query) ?: return null
+			val loaded = withContext(dispatcherIo) { projectScene(projector, scene) }
+			if (!loaded) return null
+			val bodyMatch = findProjectedMatch(projector, query) ?: return null
 			return SearchResult.Scene(sceneItem = scene, title = scene.name, snippet = bodyMatch)
 		}
 
@@ -223,8 +234,9 @@ class SearchProjectUseCase(
 		if (nameMatch != null) {
 			return SearchResult.Scene(sceneItem = scene, title = title, snippet = nameMatch)
 		}
-		val text = withContext(dispatcherIo) { loadSceneText(scene) } ?: return null
-		val bodyMatch = findMarkdownMatch(text, query) ?: return null
+		val loaded = withContext(dispatcherIo) { projectScene(projector, scene) }
+		if (!loaded) return null
+		val bodyMatch = findProjectedMatch(projector, query) ?: return null
 		return SearchResult.Scene(sceneItem = scene, title = title, snippet = bodyMatch)
 	}
 
@@ -233,21 +245,32 @@ class SearchProjectUseCase(
 	 * text the item already matched on its tags, so a blank body falls back to [fallback] and then to
 	 * an empty snippet rather than discarding the result.
 	 */
-	private fun matchOrPreview(content: String, query: String, fallback: String = ""): AnnotatedSnippet? {
+	private fun matchOrPreview(
+		projector: MarkdownProjector,
+		content: String,
+		query: String,
+		fallback: String = "",
+	): AnnotatedSnippet? {
 		if (query.isEmpty()) {
-			return markdownPreviewSnippet(content)
+			return markdownPreviewSnippet(projector, content)
 				?: previewSnippet(fallback)
 				?: EMPTY_SNIPPET
 		}
-		return findMarkdownMatch(content, query)
+		return findMarkdownMatch(projector, content, query)
 	}
 
 	/**
 	 * The date is a plain-text field, so only the body is projected. Both halves are searched as one
 	 * string so a query can span the separator.
 	 */
-	private fun matchTimelineEvent(date: String?, content: String, query: String): AnnotatedSnippet? {
-		val projected = withDate(date, projectMarkdownToPlainText(content))
+	private fun matchTimelineEvent(
+		projector: MarkdownProjector,
+		date: String?,
+		content: String,
+		query: String,
+	): AnnotatedSnippet? {
+		projector.project(content)
+		val projected = withDate(date, projector.projected())
 		if (query.isEmpty()) {
 			return previewSnippet(projected)
 				?: previewSnippet(withDate(date, content))
@@ -260,16 +283,36 @@ class SearchProjectUseCase(
 	private fun withDate(date: String?, content: String): String =
 		if (date.isNullOrBlank()) content else "$date — $content"
 
-	private fun loadSceneText(scene: SceneItem): String? {
-		val buffer = sceneContentRepository.getSceneBuffer(scene)
-		val bufferText = buffer?.content?.markdown
-		if (bufferText != null) return bufferText
-		return runCatching { sceneEditor.loadSceneMarkdownRaw(scene) }.getOrNull()
+	/**
+	 * Loads the scene into [projector] and returns whether there is anything to match. An unsaved
+	 * scene is already in memory as a string; a saved one is decoded straight off disk into the
+	 * projector's own buffer, so scanning a project takes no string per file.
+	 */
+	private fun projectScene(projector: MarkdownProjector, scene: SceneItem): Boolean {
+		val bufferText = sceneContentRepository.getSceneBuffer(scene)?.content?.markdown
+		if (bufferText != null) {
+			if (bufferText.isEmpty()) return false
+			projector.project(bufferText)
+			return true
+		}
+		val chars = runCatching {
+			sceneEditor.readSceneMarkdownInto(scene, projector)
+		}.getOrDefault(0)
+		if (chars <= 0) return false
+		projector.projectSource(chars)
+		return true
 	}
 
 	/** [content] is stored Markdown, so the derived title is projected the same way the UI does. */
-	private fun firstLineTitle(content: String, fallback: String): String {
-		val title = markdownTitleLine(content)
+	private fun firstLineTitle(
+		projector: MarkdownProjector,
+		content: String,
+		fallback: String,
+	): String {
+		projector.project(content)
+		val title = projector.firstNonBlankLine().ifEmpty {
+			content.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+		}
 		return when {
 			title.isEmpty() -> fallback
 			title.length > TITLE_MAX -> title.take(TITLE_MAX).trimEnd() + "…"
@@ -283,9 +326,12 @@ class SearchProjectUseCase(
 		const val SNIPPET_BEFORE = 40
 		const val SNIPPET_AFTER = 80
 
+		/** Compiled once: snippet assembly runs per result, and `Regex(…)` rebuilds the pattern. */
+		private val WHITESPACE_RUN = Regex("\\s+")
+
 		internal fun previewSnippet(content: String): AnnotatedSnippet? {
 			if (content.isEmpty()) return null
-			val flattened = content.replace(Regex("\\s+"), " ").trim()
+			val flattened = content.replace(WHITESPACE_RUN, " ").trim()
 			if (flattened.isEmpty()) return null
 			val maxLen = SNIPPET_BEFORE + SNIPPET_AFTER
 			val truncated = if (flattened.length > maxLen) {
@@ -307,30 +353,98 @@ class SearchProjectUseCase(
 		 * Matches against the prose projection of stored Markdown, so queries spanning storage
 		 * syntax still hit and the snippet reads the way the document does. The raw source is
 		 * searched as a fallback, which keeps queries for literal markup working.
+		 *
+		 * The projection is matched inside [projector]'s buffer, so a document that does not match
+		 * costs nothing but the scan.
 		 */
-		internal fun findMarkdownMatch(markdown: String, query: String): AnnotatedSnippet? {
+		internal fun findMarkdownMatch(
+			projector: MarkdownProjector,
+			markdown: String,
+			query: String,
+		): AnnotatedSnippet? {
 			if (markdown.isEmpty() || query.isEmpty()) return null
-			val projected = projectMarkdownToPlainText(markdown)
-			findMatch(projected, query)?.let { return it }
-			if (containsMarkdownSyntax(query)) return findMatch(markdown, query)
+			projector.project(markdown)
+			return findProjectedMatch(projector, query)
+		}
+
+		/**
+		 * Matches a document [projector] already holds, whether it was copied in or read straight
+		 * off disk. The raw fallback searches the source buffer, so neither path needs the document
+		 * as a string.
+		 */
+		internal fun findProjectedMatch(
+			projector: MarkdownProjector,
+			query: String,
+		): AnnotatedSnippet? {
+			if (query.isEmpty()) return null
+			val pos = projector.indexOf(query)
+			if (pos >= 0) {
+				return buildSnippetFrom(projector.length, pos, query.length, projector::substring)
+			}
+			if (containsMarkdownSyntax(query)) {
+				val rawPos = projector.indexOfInSource(query)
+				if (rawPos >= 0) {
+					return buildSnippetFrom(
+						projector.sourceLength,
+						rawPos,
+						query.length,
+						projector::sourceSubstring,
+					)
+				}
+			}
 			return null
 		}
 
 		/** Falls back to the raw source so a document made only of markup still previews. */
-		internal fun markdownPreviewSnippet(markdown: String): AnnotatedSnippet? =
-			previewSnippet(projectMarkdownToPlainText(markdown)) ?: previewSnippet(markdown)
+		internal fun markdownPreviewSnippet(
+			projector: MarkdownProjector,
+			markdown: String,
+		): AnnotatedSnippet? {
+			if (markdown.isEmpty()) return null
+			projector.project(markdown)
+			val preview = projector.collapsedPreview(SNIPPET_BEFORE + SNIPPET_AFTER)
+			if (preview.isNotEmpty()) {
+				return AnnotatedSnippet(text = preview, matchStart = 0, matchEnd = 0)
+			}
+			return previewSnippet(markdown)
+		}
 
-		internal fun buildSnippet(text: String, matchPos: Int, queryLen: Int): AnnotatedSnippet {
+		internal fun buildSnippet(text: String, matchPos: Int, queryLen: Int): AnnotatedSnippet =
+			buildSnippetFrom(text.length, matchPos, queryLen, text::substring)
+
+		/**
+		 * Only the snippet window is copied out of [slice], so a hit costs a line rather than a
+		 * document, whether the text lives in a String or in a scan buffer.
+		 */
+		private fun buildSnippetFrom(
+			totalLength: Int,
+			matchPos: Int,
+			queryLen: Int,
+			slice: (Int, Int) -> String,
+		): AnnotatedSnippet {
 			val windowStart = (matchPos - SNIPPET_BEFORE).coerceAtLeast(0)
-			val windowEnd = (matchPos + queryLen + SNIPPET_AFTER).coerceAtMost(text.length)
-			val rawWindow = text.substring(windowStart, windowEnd)
-			val flattened = rawWindow.replace(Regex("\\s+"), " ").trim()
+			val windowEnd = (matchPos + queryLen + SNIPPET_AFTER).coerceAtMost(totalLength)
+			return assembleSnippet(
+				rawWindow = slice(windowStart, windowEnd),
+				matchedTerm = slice(matchPos, matchPos + queryLen),
+				hasPrefix = windowStart > 0,
+				hasSuffix = windowEnd < totalLength,
+				queryLen = queryLen,
+			)
+		}
 
-			val matchedTerm = text.substring(matchPos, matchPos + queryLen)
+		private fun assembleSnippet(
+			rawWindow: String,
+			matchedTerm: String,
+			hasPrefix: Boolean,
+			hasSuffix: Boolean,
+			queryLen: Int,
+		): AnnotatedSnippet {
+			val flattened = rawWindow.replace(WHITESPACE_RUN, " ").trim()
 			val matchInFlattened = flattened.indexOf(matchedTerm, ignoreCase = true)
 
-			val prefix = if (windowStart > 0) "…" else ""
-			val suffix = if (windowEnd < text.length) "…" else ""
+			val prefix = if (hasPrefix) "…" else ""
+			val suffix = if (hasSuffix) "…" else ""
 			val snippet = prefix + flattened + suffix
 
 			val highlightStart = if (matchInFlattened >= 0) prefix.length + matchInFlattened else prefix.length

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -11,6 +11,7 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneCo
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.search.ParsedQuery
+import com.darkrockstudios.apps.hammer.common.data.search.containsMarkdownSyntax
 import com.darkrockstudios.apps.hammer.common.data.search.markdownTitleLine
 import com.darkrockstudios.apps.hammer.common.data.search.matchesAllTags
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
@@ -311,7 +312,7 @@ class SearchProjectUseCase(
 			if (markdown.isEmpty() || query.isEmpty()) return null
 			val projected = projectMarkdownToPlainText(markdown)
 			findMatch(projected, query)?.let { return it }
-			if (projected !== markdown) return findMatch(markdown, query)
+			if (containsMarkdownSyntax(query)) return findMatch(markdown, query)
 			return null
 		}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -13,7 +13,6 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRe
 import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjector
 import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjectorPool
 import com.darkrockstudios.apps.hammer.common.data.search.ParsedQuery
-import com.darkrockstudios.apps.hammer.common.data.search.containsInlineMarkup
 import com.darkrockstudios.apps.hammer.common.data.search.matchesAllTags
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
@@ -380,17 +379,6 @@ class SearchProjectUseCase(
 			val pos = projector.indexOf(query)
 			if (pos >= 0) {
 				return buildSnippetFrom(projector.length, pos, query.length, projector::substring)
-			}
-			if (containsInlineMarkup(query)) {
-				val rawPos = projector.indexOfInSource(query)
-				if (rawPos >= 0) {
-					return buildSnippetFrom(
-						projector.sourceLength,
-						rawPos,
-						query.length,
-						projector::sourceSubstring,
-					)
-				}
 			}
 			return null
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -11,9 +11,10 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneCo
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
 import com.darkrockstudios.apps.hammer.common.data.search.ParsedQuery
+import com.darkrockstudios.apps.hammer.common.data.search.markdownTitleLine
 import com.darkrockstudios.apps.hammer.common.data.search.matchesAllTags
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
-import com.darkrockstudios.apps.hammer.common.data.search.unescapeMarkdown
+import com.darkrockstudios.apps.hammer.common.data.search.projectMarkdownToPlainText
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_IO
@@ -227,24 +228,32 @@ class SearchProjectUseCase(
 	}
 
 	/**
-	 * Both callers pass stored Markdown, so escapes are resolved before matching. With no free text
-	 * the item already matched on its tags, so a blank body falls back to [fallback] and then to an
-	 * empty snippet rather than discarding the result.
+	 * Both callers pass stored Markdown, so both paths go through the prose projection. With no free
+	 * text the item already matched on its tags, so a blank body falls back to [fallback] and then to
+	 * an empty snippet rather than discarding the result.
 	 */
 	private fun matchOrPreview(content: String, query: String, fallback: String = ""): AnnotatedSnippet? {
 		if (query.isEmpty()) {
-			return previewSnippet(unescapeMarkdown(content))
+			return markdownPreviewSnippet(content)
 				?: previewSnippet(fallback)
 				?: EMPTY_SNIPPET
 		}
 		return findMarkdownMatch(content, query)
 	}
 
-	/** The date is a plain-text field, so only the event body is unescaped. */
+	/**
+	 * The date is a plain-text field, so only the body is projected. Both halves are searched as one
+	 * string so a query can span the separator.
+	 */
 	private fun matchTimelineEvent(date: String?, content: String, query: String): AnnotatedSnippet? {
-		val resolved = withDate(date, unescapeMarkdown(content))
-		if (query.isEmpty()) return previewSnippet(resolved) ?: EMPTY_SNIPPET
-		return findMatch(resolved, query)
+		val projected = withDate(date, projectMarkdownToPlainText(content))
+		if (query.isEmpty()) {
+			return previewSnippet(projected)
+				?: previewSnippet(withDate(date, content))
+				?: EMPTY_SNIPPET
+		}
+		findMatch(projected, query)?.let { return it }
+		return findMatch(withDate(date, content), query)
 	}
 
 	private fun withDate(date: String?, content: String): String =
@@ -257,17 +266,13 @@ class SearchProjectUseCase(
 		return runCatching { sceneEditor.loadSceneMarkdownRaw(scene) }.getOrNull()
 	}
 
-	/** [content] is stored Markdown, so the title resolves escapes the way its snippet does. */
+	/** [content] is stored Markdown, so the derived title is projected the same way the UI does. */
 	private fun firstLineTitle(content: String, fallback: String): String {
-		val firstLine = content.lineSequence()
-			.firstOrNull { it.isNotBlank() }
-			?.let { unescapeMarkdown(it) }
-			?.trim()
-			.orEmpty()
+		val title = markdownTitleLine(content)
 		return when {
-			firstLine.isEmpty() -> fallback
-			firstLine.length > TITLE_MAX -> firstLine.take(TITLE_MAX).trimEnd() + "…"
-			else -> firstLine
+			title.isEmpty() -> fallback
+			title.length > TITLE_MAX -> title.take(TITLE_MAX).trimEnd() + "…"
+			else -> title
 		}
 	}
 
@@ -290,22 +295,29 @@ class SearchProjectUseCase(
 			return AnnotatedSnippet(text = truncated, matchStart = 0, matchEnd = 0)
 		}
 
-		/**
-		 * Matches stored Markdown with its escapes resolved, so a query matches the prose on screen
-		 * and the snippet renders the same way. The resolved text is the only thing searched, so a
-		 * snippet can never disagree with the title derived from it.
-		 */
-		internal fun findMarkdownMatch(markdown: String, query: String): AnnotatedSnippet? {
-			if (markdown.isEmpty() || query.isEmpty()) return null
-			return findMatch(unescapeMarkdown(markdown), query)
-		}
-
 		internal fun findMatch(text: String, query: String): AnnotatedSnippet? {
 			if (text.isEmpty() || query.isEmpty()) return null
 			val pos = text.indexOf(query, ignoreCase = true)
 			if (pos < 0) return null
 			return buildSnippet(text, pos, query.length)
 		}
+
+		/**
+		 * Matches against the prose projection of stored Markdown, so queries spanning storage
+		 * syntax still hit and the snippet reads the way the document does. The raw source is
+		 * searched as a fallback, which keeps queries for literal markup working.
+		 */
+		internal fun findMarkdownMatch(markdown: String, query: String): AnnotatedSnippet? {
+			if (markdown.isEmpty() || query.isEmpty()) return null
+			val projected = projectMarkdownToPlainText(markdown)
+			findMatch(projected, query)?.let { return it }
+			if (projected !== markdown) return findMatch(markdown, query)
+			return null
+		}
+
+		/** Falls back to the raw source so a document made only of markup still previews. */
+		internal fun markdownPreviewSnippet(markdown: String): AnnotatedSnippet? =
+			previewSnippet(projectMarkdownToPlainText(markdown)) ?: previewSnippet(markdown)
 
 		internal fun buildSnippet(text: String, matchPos: Int, queryLen: Int): AnnotatedSnippet {
 			val windowStart = (matchPos - SNIPPET_BEFORE).coerceAtLeast(0)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsearch/SearchProjectUseCase.kt
@@ -13,7 +13,7 @@ import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRe
 import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjector
 import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjectorPool
 import com.darkrockstudios.apps.hammer.common.data.search.ParsedQuery
-import com.darkrockstudios.apps.hammer.common.data.search.containsMarkdownSyntax
+import com.darkrockstudios.apps.hammer.common.data.search.containsInlineMarkup
 import com.darkrockstudios.apps.hammer.common.data.search.matchesAllTags
 import com.darkrockstudios.apps.hammer.common.data.search.parseQuery
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
@@ -381,7 +381,7 @@ class SearchProjectUseCase(
 			if (pos >= 0) {
 				return buildSnippetFrom(projector.length, pos, query.length, projector::substring)
 			}
-			if (containsMarkdownSyntax(query)) {
+			if (containsInlineMarkup(query)) {
 				val rawPos = projector.indexOfInSource(query)
 				if (rawPos >= 0) {
 					return buildSnippetFrom(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
@@ -10,6 +10,8 @@ import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import com.darkrockstudios.apps.hammer.common.util.ScanBuffers
+import com.darkrockstudios.apps.hammer.common.util.readUtf8Into
 import io.github.aakira.napier.Napier
 import okio.FileSystem
 import okio.IOException
@@ -237,6 +239,28 @@ class SceneDatasource(
 		}
 
 		return content
+	}
+
+	/**
+	 * Decodes the scene's Markdown into a buffer from [sink] and returns how many chars it holds,
+	 * so a caller scanning every scene can reuse one buffer instead of taking a string per file.
+	 * Returns 0 for a missing, empty or unreadable scene, and for anything that is not a scene.
+	 */
+	fun readSceneMarkdownInto(
+		sceneItem: SceneItem,
+		scenePath: HPath,
+		sink: ScanBuffers,
+	): Int {
+		if (sceneItem.type != SceneItem.Type.Scene) return 0
+		val path = scenePath.toOkioPath()
+		return try {
+			val byteCount = fileSystem.metadata(path).size ?: return 0
+			if (byteCount <= 0L || byteCount > Int.MAX_VALUE) return 0
+			fileSystem.read(path) { readUtf8Into(sink, byteCount.toInt()) }
+		} catch (e: IOException) {
+			Napier.e("Failed to read Scene markdown (${sceneItem.name})")
+			0
+		}
 	}
 
 	suspend fun storeSceneMarkdownRaw(sceneItem: SceneContent, scenePath: HPath): Boolean {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
@@ -11,6 +11,7 @@ import com.darkrockstudios.apps.hammer.common.data.tree.Tree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.util.ScanBuffers
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.util.numDigits
@@ -757,6 +758,17 @@ class SceneRepository(
 		scenePath: HPath = getSceneFilePath(sceneItem)
 	): String =
 		sceneDatasource.loadSceneMarkdownRaw(sceneItem, scenePath)
+
+	/**
+	 * Reads the scene's Markdown into a caller-owned buffer and returns its length in chars. Global
+	 * search scans every scene on each keystroke, so it reuses one buffer rather than taking a
+	 * string per file.
+	 */
+	fun readSceneMarkdownInto(
+		sceneItem: SceneItem,
+		sink: ScanBuffers,
+		scenePath: HPath = getSceneFilePath(sceneItem),
+	): Int = sceneDatasource.readSceneMarkdownInto(sceneItem, scenePath, sink)
 
 	/**
 	 * This should only be used for server syncing

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
@@ -2,14 +2,13 @@ package com.darkrockstudios.apps.hammer.common.data.search
 
 private const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 
-/** Leading blockquote, heading, bullet and ordered-list markers, none of which read as prose. */
-private val BLOCK_PREFIX = Regex("""^\s*(?:>\s*)*(?:#{1,6}\s+|[-*+]\s+|\d{1,9}[.)]\s+)?""")
-
 /**
  * Compared directly rather than via set or string membership: this runs once per character of every
  * document scanned, and `in` on a CharSequence costs a call per character.
  */
 private fun Char.isDelimiter(): Boolean = this == '*' || this == '_' || this == '`'
+
+private fun Char.isSpaceOrTab(): Boolean = this == ' ' || this == '\t'
 
 private fun Char?.isBlankOrEdge(): Boolean = this == null || isWhitespace()
 
@@ -20,7 +19,7 @@ private fun Char?.isPunctuation(): Boolean = this != null && this in ASCII_PUNCT
  * pairs off from the end of the opener and the start of the closer, so the surviving characters are
  * always the middle of the run.
  */
-private class DelimiterRun(val char: Char, val start: Int, val end: Int) {
+private class DelimiterRun(val char: Char, val start: Int, val end: Int, val paragraph: Int) {
 	var canOpen = false
 	var canClose = false
 
@@ -33,28 +32,20 @@ private class DelimiterRun(val char: Char, val start: Int, val end: Int) {
 }
 
 /**
- * Flattens stored Markdown into the prose a reader sees, so a query can match across storage syntax.
- * Backslash escapes resolve to their literal character (`well\-known` becomes `well-known`) and
- * *paired* emphasis or code delimiters are dropped (`**Chapter** One` becomes `Chapter One`).
+ * Flattens stored Markdown into the prose a reader sees. Backslash escapes resolve to their literal
+ * character (`well\-known` becomes `well-known`), paired emphasis and code delimiters are dropped
+ * (`**Chapter** One` becomes `Chapter One`), and leading blockquote, heading and bullet markers are
+ * removed from each line.
  *
- * Pairing follows CommonMark's flanking rules, which is what keeps literal markers intact:
- * `user_name`, `2 * 3` and a bare `***` divider all survive because neither side of the delimiter
- * can open or close emphasis. That matters for content the escaping editor did not write, such as
- * imports, synced documents and hand-edited files.
+ * Delimiters pair only within a paragraph, and only where CommonMark's flanking rules allow, so
+ * literal markers survive: `user_name`, `2 * 3`, a bare `***` divider and a stray apostrophe-backtick
+ * are all left intact.
  *
- * Known limits, accepted so a full-project scan stays inside the search debounce: link and image
- * syntax is left intact, so imported content can show a URL in a snippet; punctuation is tested
- * against ASCII only; and escapes resolve inside code spans, because everything the editor saves is
- * escaped throughout. Parsing properly would cover all of these but costs roughly four times as
- * much per scan, which only becomes affordable once projections are cached per document.
- *
- * Block structure is left alone; see [markdownTitleLine] for the leading-marker case.
+ * Link and image syntax is left as written. Punctuation is tested against ASCII only, and escapes
+ * resolve inside code spans as well as outside them.
  */
 fun projectMarkdownToPlainText(markdown: String): String {
-	if (!containsDelimiter(markdown)) {
-		// The editor escapes punctuation on every save, so plain paragraphs still reach this far.
-		return if (containsEscape(markdown)) unescape(markdown) else markdown
-	}
+	if (!containsMarkdownSyntax(markdown)) return markdown
 
 	val runs = scanDelimiterRuns(markdown)
 	resolveCodeSpans(runs)
@@ -63,35 +54,70 @@ fun projectMarkdownToPlainText(markdown: String): String {
 }
 
 /**
- * The prose title for [markdown]: its first non-blank line with block markers stripped and inline
- * markup flattened. A line that projects to nothing falls back to itself, so a marker-only line
- * still yields a title rather than reading as an empty document.
+ * The prose title for [markdown]: the first non-blank line of its projection. Falls back to the raw
+ * first line when the projection of it is blank, so a marker-only line still yields a title rather
+ * than reading as an empty document.
  */
 fun markdownTitleLine(markdown: String): String {
-	val line = markdown.lineSequence().firstOrNull { it.isNotBlank() } ?: return ""
-	val body = line.replaceFirst(BLOCK_PREFIX, "")
-	val projected = projectMarkdownToPlainText(body).trim()
-	return projected.ifBlank { line.trim() }
+	val projected = projectMarkdownToPlainText(markdown)
+	val title = projected.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+	if (title.isNotEmpty()) return title
+	return markdown.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
 }
 
-private fun containsDelimiter(text: String): Boolean {
+/**
+ * True when [text] holds a character the projection can remove. A query without one that misses the
+ * projection cannot match the raw source either, because the projection only ever deletes.
+ */
+internal fun containsMarkdownSyntax(text: String): Boolean {
 	var i = 0
-	val length = text.length
-	while (i < length) {
-		if (text[i].isDelimiter()) return true
+	while (i < text.length) {
+		val c = text[i]
+		if (c.isDelimiter() || c == '\\' || c == '#' || c == '>' || c == '-' || c == '+') return true
 		i++
 	}
 	return false
 }
 
-private fun containsEscape(text: String): Boolean {
-	var i = 0
-	val length = text.length
-	while (i < length) {
-		if (text[i] == '\\') return true
+/**
+ * The offset after any blockquote, heading or bullet marker opening the line at [start], or [start]
+ * itself when the line opens with prose. Ordered-list markers are left alone: a single line cannot
+ * distinguish "1. Draft opening" from "1984. The year everything changed".
+ */
+private fun skipBlockPrefix(markdown: String, start: Int): Int {
+	val length = markdown.length
+	var i = start
+	var found = false
+
+	while (i < length && markdown[i].isSpaceOrTab()) i++
+
+	while (i < length && markdown[i] == '>') {
 		i++
+		found = true
+		while (i < length && markdown[i].isSpaceOrTab()) i++
 	}
-	return false
+
+	if (i < length && markdown[i] == '#') {
+		var j = i
+		var hashes = 0
+		while (j < length && markdown[j] == '#') {
+			j++
+			hashes++
+		}
+		if (hashes <= 6 && j < length && markdown[j].isSpaceOrTab()) {
+			i = j
+			found = true
+		}
+	} else if (i < length && (markdown[i] == '-' || markdown[i] == '*' || markdown[i] == '+')) {
+		if (i + 1 < length && markdown[i + 1].isSpaceOrTab()) {
+			i++
+			found = true
+		}
+	}
+
+	if (!found) return start
+	while (i < length && markdown[i].isSpaceOrTab()) i++
+	return i
 }
 
 /** Appends the character at [i], resolving a backslash escape, and returns the next index. */
@@ -105,22 +131,22 @@ private fun StringBuilder.appendResolved(markdown: String, i: Int): Int {
 	return i + 1
 }
 
-/** Resolves escapes alone, for the common document that carries no emphasis at all. */
-private fun unescape(markdown: String): String {
-	val sb = StringBuilder(markdown.length)
-	var i = 0
-	while (i < markdown.length) i = sb.appendResolved(markdown, i)
-	return sb.toString()
-}
-
 private fun scanDelimiterRuns(markdown: String): List<DelimiterRun> {
 	val runs = mutableListOf<DelimiterRun>()
 	val length = markdown.length
 	var i = 0
+	var paragraph = 0
 	while (i < length) {
 		val c = markdown[i]
 		if (c == '\\' && i + 1 < length && markdown[i + 1] in ASCII_PUNCTUATION) {
 			i += 2
+			continue
+		}
+		if (c == '\n') {
+			var k = i + 1
+			while (k < length && (markdown[k].isSpaceOrTab() || markdown[k] == '\r')) k++
+			if (k >= length || markdown[k] == '\n') paragraph++
+			i++
 			continue
 		}
 		if (!c.isDelimiter()) {
@@ -154,7 +180,7 @@ private fun scanDelimiterRuns(markdown: String): List<DelimiterRun> {
 			if (!canOpen && !canClose) continue
 		}
 
-		val run = DelimiterRun(c, start, end)
+		val run = DelimiterRun(c, start, end, paragraph)
 		run.canOpen = canOpen
 		run.canClose = canClose
 		runs.add(run)
@@ -174,26 +200,35 @@ private fun resolveCodeSpans(runs: List<DelimiterRun>) {
 
 		val width = opener.end - opener.start
 		var j = i + 1
-		while (j < runs.size) {
+		var closer = -1
+		while (j < runs.size && runs[j].paragraph == opener.paragraph) {
 			val candidate = runs[j]
-			if (candidate.char == '`' && candidate.end - candidate.start == width) break
+			if (candidate.char == '`' && candidate.end - candidate.start == width) {
+				closer = j
+				break
+			}
 			j++
 		}
-		if (j == runs.size) {
+		if (closer < 0) {
 			i++
 			continue
 		}
 
 		opener.dropBack = width
-		runs[j].dropFront = width
-		for (k in i + 1 until j) runs[k].inert = true
-		i = j + 1
+		runs[closer].dropFront = width
+		for (k in i + 1 until closer) runs[k].inert = true
+		i = closer + 1
 	}
 }
 
 private fun resolveEmphasis(runs: List<DelimiterRun>) {
 	val open = mutableListOf<DelimiterRun>()
+	var paragraph = -1
 	for (run in runs) {
+		if (run.paragraph != paragraph) {
+			open.clear()
+			paragraph = run.paragraph
+		}
 		if (run.char == '`' || run.inert) continue
 
 		if (run.canClose) {
@@ -220,7 +255,18 @@ private fun render(markdown: String, runs: List<DelimiterRun>): String {
 	val length = markdown.length
 	var i = 0
 	var r = 0
+	var atLineStart = true
 	while (i < length) {
+		if (atLineStart) {
+			atLineStart = false
+			val afterPrefix = skipBlockPrefix(markdown, i)
+			if (afterPrefix > i) {
+				i = afterPrefix
+				while (r < runs.size && runs[r].start < i) r++
+				continue
+			}
+		}
+
 		if (r < runs.size && i == runs[r].start) {
 			val run = runs[r]
 			sb.append(markdown, run.start + run.dropFront, run.end - run.dropBack)
@@ -229,6 +275,7 @@ private fun render(markdown: String, runs: List<DelimiterRun>): String {
 			continue
 		}
 
+		if (markdown[i] == '\n') atLineStart = true
 		i = sb.appendResolved(markdown, i)
 	}
 	return sb.toString()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
@@ -1,36 +1,5 @@
 package com.darkrockstudios.apps.hammer.common.data.search
 
-private const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
-
-/**
- * Compared directly rather than via set or string membership: this runs once per character of every
- * document scanned, and `in` on a CharSequence costs a call per character.
- */
-private fun Char.isDelimiter(): Boolean = this == '*' || this == '_' || this == '`'
-
-private fun Char.isSpaceOrTab(): Boolean = this == ' ' || this == '\t'
-
-private fun Char?.isBlankOrEdge(): Boolean = this == null || isWhitespace()
-
-private fun Char?.isPunctuation(): Boolean = this != null && this in ASCII_PUNCTUATION
-
-/**
- * A maximal run of one delimiter character, plus how much of it the projection consumes. Emphasis
- * pairs off from the end of the opener and the start of the closer, so the surviving characters are
- * always the middle of the run.
- */
-private class DelimiterRun(val char: Char, val start: Int, val end: Int, val paragraph: Int) {
-	var canOpen = false
-	var canClose = false
-
-	/** Set for runs sitting inside a resolved code span, where emphasis does not apply. */
-	var inert = false
-	var dropFront = 0
-	var dropBack = 0
-
-	val available: Int get() = end - start - dropFront - dropBack
-}
-
 /**
  * Flattens stored Markdown into the prose a reader sees. Backslash escapes resolve to their literal
  * character (`well\-known` becomes `well-known`), paired emphasis and code delimiters are dropped
@@ -43,14 +12,15 @@ private class DelimiterRun(val char: Char, val start: Int, val end: Int, val par
  *
  * Link and image syntax is left as written. Punctuation is tested against ASCII only, and escapes
  * resolve inside code spans as well as outside them.
+ *
+ * Scanning a whole project repeatedly wants [MarkdownProjector] instead: this convenience builds a
+ * workspace per call, where the projector reuses one across every document in a scan.
  */
 fun projectMarkdownToPlainText(markdown: String): String {
 	if (!containsMarkdownSyntax(markdown)) return markdown
-
-	val runs = scanDelimiterRuns(markdown)
-	resolveCodeSpans(runs)
-	resolveEmphasis(runs)
-	return render(markdown, runs)
+	val projector = MarkdownProjector(markdown.length)
+	projector.project(markdown)
+	return projector.projected()
 }
 
 /**
@@ -59,8 +29,12 @@ fun projectMarkdownToPlainText(markdown: String): String {
  * than reading as an empty document.
  */
 fun markdownTitleLine(markdown: String): String {
-	val projected = projectMarkdownToPlainText(markdown)
-	val title = projected.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+	if (!containsMarkdownSyntax(markdown)) {
+		return markdown.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+	}
+	val projector = MarkdownProjector(markdown.length)
+	projector.project(markdown)
+	val title = projector.firstNonBlankLine()
 	if (title.isNotEmpty()) return title
 	return markdown.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
 }
@@ -69,214 +43,16 @@ fun markdownTitleLine(markdown: String): String {
  * True when [text] holds a character the projection can remove. A query without one that misses the
  * projection cannot match the raw source either, because the projection only ever deletes.
  */
-internal fun containsMarkdownSyntax(text: String): Boolean {
+internal fun containsMarkdownSyntax(text: CharSequence): Boolean {
 	var i = 0
 	while (i < text.length) {
 		val c = text[i]
-		if (c.isDelimiter() || c == '\\' || c == '#' || c == '>' || c == '-' || c == '+') return true
+		if (c == '*' || c == '_' || c == '`' ||
+			c == '\\' || c == '#' || c == '>' || c == '-' || c == '+'
+		) {
+			return true
+		}
 		i++
 	}
 	return false
-}
-
-/**
- * The offset after any blockquote, heading or bullet marker opening the line at [start], or [start]
- * itself when the line opens with prose. Ordered-list markers are left alone: a single line cannot
- * distinguish "1. Draft opening" from "1984. The year everything changed".
- */
-private fun skipBlockPrefix(markdown: String, start: Int): Int {
-	val length = markdown.length
-	var i = start
-	var found = false
-
-	while (i < length && markdown[i].isSpaceOrTab()) i++
-
-	while (i < length && markdown[i] == '>') {
-		i++
-		found = true
-		while (i < length && markdown[i].isSpaceOrTab()) i++
-	}
-
-	if (i < length && markdown[i] == '#') {
-		var j = i
-		var hashes = 0
-		while (j < length && markdown[j] == '#') {
-			j++
-			hashes++
-		}
-		if (hashes <= 6 && j < length && markdown[j].isSpaceOrTab()) {
-			i = j
-			found = true
-		}
-	} else if (i < length && (markdown[i] == '-' || markdown[i] == '*' || markdown[i] == '+')) {
-		if (i + 1 < length && markdown[i + 1].isSpaceOrTab()) {
-			i++
-			found = true
-		}
-	}
-
-	if (!found) return start
-	while (i < length && markdown[i].isSpaceOrTab()) i++
-	return i
-}
-
-/** Appends the character at [i], resolving a backslash escape, and returns the next index. */
-private fun StringBuilder.appendResolved(markdown: String, i: Int): Int {
-	val c = markdown[i]
-	if (c == '\\' && i + 1 < markdown.length && markdown[i + 1] in ASCII_PUNCTUATION) {
-		append(markdown[i + 1])
-		return i + 2
-	}
-	append(c)
-	return i + 1
-}
-
-private fun scanDelimiterRuns(markdown: String): List<DelimiterRun> {
-	val runs = mutableListOf<DelimiterRun>()
-	val length = markdown.length
-	var i = 0
-	var paragraph = 0
-	while (i < length) {
-		val c = markdown[i]
-		if (c == '\\' && i + 1 < length && markdown[i + 1] in ASCII_PUNCTUATION) {
-			i += 2
-			continue
-		}
-		if (c == '\n') {
-			var k = i + 1
-			while (k < length && (markdown[k].isSpaceOrTab() || markdown[k] == '\r')) k++
-			if (k >= length || markdown[k] == '\n') paragraph++
-			i++
-			continue
-		}
-		if (!c.isDelimiter()) {
-			i++
-			continue
-		}
-
-		val start = i
-		var end = start + 1
-		while (end < length && markdown[end] == c) end++
-		i = end
-
-		var canOpen = true
-		var canClose = true
-		if (c != '`') {
-			val prev = markdown.getOrNull(start - 1)
-			val next = markdown.getOrNull(end)
-			val leftFlanking = !next.isBlankOrEdge() &&
-				(!next.isPunctuation() || prev.isBlankOrEdge() || prev.isPunctuation())
-			val rightFlanking = !prev.isBlankOrEdge() &&
-				(!prev.isPunctuation() || next.isBlankOrEdge() || next.isPunctuation())
-			if (c == '*') {
-				canOpen = leftFlanking
-				canClose = rightFlanking
-			} else {
-				// Underscores cannot delimit emphasis inside a word, which is what saves `user_name`.
-				canOpen = leftFlanking && (!rightFlanking || prev.isPunctuation())
-				canClose = rightFlanking && (!leftFlanking || next.isPunctuation())
-			}
-			// A run that can do neither is literal text; leaving it out keeps it out of the render.
-			if (!canOpen && !canClose) continue
-		}
-
-		val run = DelimiterRun(c, start, end, paragraph)
-		run.canOpen = canOpen
-		run.canClose = canClose
-		runs.add(run)
-	}
-	return runs
-}
-
-/** Code spans bind tighter than emphasis, so they claim their delimiters first. */
-private fun resolveCodeSpans(runs: List<DelimiterRun>) {
-	var i = 0
-	while (i < runs.size) {
-		val opener = runs[i]
-		if (opener.char != '`') {
-			i++
-			continue
-		}
-
-		val width = opener.end - opener.start
-		var j = i + 1
-		var closer = -1
-		while (j < runs.size && runs[j].paragraph == opener.paragraph) {
-			val candidate = runs[j]
-			if (candidate.char == '`' && candidate.end - candidate.start == width) {
-				closer = j
-				break
-			}
-			j++
-		}
-		if (closer < 0) {
-			i++
-			continue
-		}
-
-		opener.dropBack = width
-		runs[closer].dropFront = width
-		for (k in i + 1 until closer) runs[k].inert = true
-		i = closer + 1
-	}
-}
-
-private fun resolveEmphasis(runs: List<DelimiterRun>) {
-	val open = mutableListOf<DelimiterRun>()
-	var paragraph = -1
-	for (run in runs) {
-		if (run.paragraph != paragraph) {
-			open.clear()
-			paragraph = run.paragraph
-		}
-		if (run.char == '`' || run.inert) continue
-
-		if (run.canClose) {
-			while (run.available > 0) {
-				val openerIndex = open.indexOfLast { it.char == run.char }
-				if (openerIndex < 0) break
-
-				val opener = open[openerIndex]
-				val consumed = minOf(run.available, opener.available)
-				opener.dropBack += consumed
-				run.dropFront += consumed
-
-				// Anything stacked above the matched opener can never close now.
-				while (open.size > openerIndex) open.removeAt(open.size - 1)
-				if (opener.available > 0) open.add(opener)
-			}
-		}
-		if (run.available > 0 && run.canOpen) open.add(run)
-	}
-}
-
-private fun render(markdown: String, runs: List<DelimiterRun>): String {
-	val sb = StringBuilder(markdown.length)
-	val length = markdown.length
-	var i = 0
-	var r = 0
-	var atLineStart = true
-	while (i < length) {
-		if (atLineStart) {
-			atLineStart = false
-			val afterPrefix = skipBlockPrefix(markdown, i)
-			if (afterPrefix > i) {
-				i = afterPrefix
-				while (r < runs.size && runs[r].start < i) r++
-				continue
-			}
-		}
-
-		if (r < runs.size && i == runs[r].start) {
-			val run = runs[r]
-			sb.append(markdown, run.start + run.dropFront, run.end - run.dropBack)
-			i = run.end
-			r++
-			continue
-		}
-
-		if (markdown[i] == '\n') atLineStart = true
-		i = sb.appendResolved(markdown, i)
-	}
-	return sb.toString()
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
@@ -1,0 +1,235 @@
+package com.darkrockstudios.apps.hammer.common.data.search
+
+private const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+
+/** Leading blockquote, heading, bullet and ordered-list markers, none of which read as prose. */
+private val BLOCK_PREFIX = Regex("""^\s*(?:>\s*)*(?:#{1,6}\s+|[-*+]\s+|\d{1,9}[.)]\s+)?""")
+
+/**
+ * Compared directly rather than via set or string membership: this runs once per character of every
+ * document scanned, and `in` on a CharSequence costs a call per character.
+ */
+private fun Char.isDelimiter(): Boolean = this == '*' || this == '_' || this == '`'
+
+private fun Char?.isBlankOrEdge(): Boolean = this == null || isWhitespace()
+
+private fun Char?.isPunctuation(): Boolean = this != null && this in ASCII_PUNCTUATION
+
+/**
+ * A maximal run of one delimiter character, plus how much of it the projection consumes. Emphasis
+ * pairs off from the end of the opener and the start of the closer, so the surviving characters are
+ * always the middle of the run.
+ */
+private class DelimiterRun(val char: Char, val start: Int, val end: Int) {
+	var canOpen = false
+	var canClose = false
+
+	/** Set for runs sitting inside a resolved code span, where emphasis does not apply. */
+	var inert = false
+	var dropFront = 0
+	var dropBack = 0
+
+	val available: Int get() = end - start - dropFront - dropBack
+}
+
+/**
+ * Flattens stored Markdown into the prose a reader sees, so a query can match across storage syntax.
+ * Backslash escapes resolve to their literal character (`well\-known` becomes `well-known`) and
+ * *paired* emphasis or code delimiters are dropped (`**Chapter** One` becomes `Chapter One`).
+ *
+ * Pairing follows CommonMark's flanking rules, which is what keeps literal markers intact:
+ * `user_name`, `2 * 3` and a bare `***` divider all survive because neither side of the delimiter
+ * can open or close emphasis. That matters for content the escaping editor did not write, such as
+ * imports, synced documents and hand-edited files.
+ *
+ * Known limits, accepted so a full-project scan stays inside the search debounce: link and image
+ * syntax is left intact, so imported content can show a URL in a snippet; punctuation is tested
+ * against ASCII only; and escapes resolve inside code spans, because everything the editor saves is
+ * escaped throughout. Parsing properly would cover all of these but costs roughly four times as
+ * much per scan, which only becomes affordable once projections are cached per document.
+ *
+ * Block structure is left alone; see [markdownTitleLine] for the leading-marker case.
+ */
+fun projectMarkdownToPlainText(markdown: String): String {
+	if (!containsDelimiter(markdown)) {
+		// The editor escapes punctuation on every save, so plain paragraphs still reach this far.
+		return if (containsEscape(markdown)) unescape(markdown) else markdown
+	}
+
+	val runs = scanDelimiterRuns(markdown)
+	resolveCodeSpans(runs)
+	resolveEmphasis(runs)
+	return render(markdown, runs)
+}
+
+/**
+ * The prose title for [markdown]: its first non-blank line with block markers stripped and inline
+ * markup flattened. A line that projects to nothing falls back to itself, so a marker-only line
+ * still yields a title rather than reading as an empty document.
+ */
+fun markdownTitleLine(markdown: String): String {
+	val line = markdown.lineSequence().firstOrNull { it.isNotBlank() } ?: return ""
+	val body = line.replaceFirst(BLOCK_PREFIX, "")
+	val projected = projectMarkdownToPlainText(body).trim()
+	return projected.ifBlank { line.trim() }
+}
+
+private fun containsDelimiter(text: String): Boolean {
+	var i = 0
+	val length = text.length
+	while (i < length) {
+		if (text[i].isDelimiter()) return true
+		i++
+	}
+	return false
+}
+
+private fun containsEscape(text: String): Boolean {
+	var i = 0
+	val length = text.length
+	while (i < length) {
+		if (text[i] == '\\') return true
+		i++
+	}
+	return false
+}
+
+/** Appends the character at [i], resolving a backslash escape, and returns the next index. */
+private fun StringBuilder.appendResolved(markdown: String, i: Int): Int {
+	val c = markdown[i]
+	if (c == '\\' && i + 1 < markdown.length && markdown[i + 1] in ASCII_PUNCTUATION) {
+		append(markdown[i + 1])
+		return i + 2
+	}
+	append(c)
+	return i + 1
+}
+
+/** Resolves escapes alone, for the common document that carries no emphasis at all. */
+private fun unescape(markdown: String): String {
+	val sb = StringBuilder(markdown.length)
+	var i = 0
+	while (i < markdown.length) i = sb.appendResolved(markdown, i)
+	return sb.toString()
+}
+
+private fun scanDelimiterRuns(markdown: String): List<DelimiterRun> {
+	val runs = mutableListOf<DelimiterRun>()
+	val length = markdown.length
+	var i = 0
+	while (i < length) {
+		val c = markdown[i]
+		if (c == '\\' && i + 1 < length && markdown[i + 1] in ASCII_PUNCTUATION) {
+			i += 2
+			continue
+		}
+		if (!c.isDelimiter()) {
+			i++
+			continue
+		}
+
+		val start = i
+		var end = start + 1
+		while (end < length && markdown[end] == c) end++
+		i = end
+
+		var canOpen = true
+		var canClose = true
+		if (c != '`') {
+			val prev = markdown.getOrNull(start - 1)
+			val next = markdown.getOrNull(end)
+			val leftFlanking = !next.isBlankOrEdge() &&
+				(!next.isPunctuation() || prev.isBlankOrEdge() || prev.isPunctuation())
+			val rightFlanking = !prev.isBlankOrEdge() &&
+				(!prev.isPunctuation() || next.isBlankOrEdge() || next.isPunctuation())
+			if (c == '*') {
+				canOpen = leftFlanking
+				canClose = rightFlanking
+			} else {
+				// Underscores cannot delimit emphasis inside a word, which is what saves `user_name`.
+				canOpen = leftFlanking && (!rightFlanking || prev.isPunctuation())
+				canClose = rightFlanking && (!leftFlanking || next.isPunctuation())
+			}
+			// A run that can do neither is literal text; leaving it out keeps it out of the render.
+			if (!canOpen && !canClose) continue
+		}
+
+		val run = DelimiterRun(c, start, end)
+		run.canOpen = canOpen
+		run.canClose = canClose
+		runs.add(run)
+	}
+	return runs
+}
+
+/** Code spans bind tighter than emphasis, so they claim their delimiters first. */
+private fun resolveCodeSpans(runs: List<DelimiterRun>) {
+	var i = 0
+	while (i < runs.size) {
+		val opener = runs[i]
+		if (opener.char != '`') {
+			i++
+			continue
+		}
+
+		val width = opener.end - opener.start
+		var j = i + 1
+		while (j < runs.size) {
+			val candidate = runs[j]
+			if (candidate.char == '`' && candidate.end - candidate.start == width) break
+			j++
+		}
+		if (j == runs.size) {
+			i++
+			continue
+		}
+
+		opener.dropBack = width
+		runs[j].dropFront = width
+		for (k in i + 1 until j) runs[k].inert = true
+		i = j + 1
+	}
+}
+
+private fun resolveEmphasis(runs: List<DelimiterRun>) {
+	val open = mutableListOf<DelimiterRun>()
+	for (run in runs) {
+		if (run.char == '`' || run.inert) continue
+
+		if (run.canClose) {
+			while (run.available > 0) {
+				val openerIndex = open.indexOfLast { it.char == run.char }
+				if (openerIndex < 0) break
+
+				val opener = open[openerIndex]
+				val consumed = minOf(run.available, opener.available)
+				opener.dropBack += consumed
+				run.dropFront += consumed
+
+				// Anything stacked above the matched opener can never close now.
+				while (open.size > openerIndex) open.removeAt(open.size - 1)
+				if (opener.available > 0) open.add(opener)
+			}
+		}
+		if (run.available > 0 && run.canOpen) open.add(run)
+	}
+}
+
+private fun render(markdown: String, runs: List<DelimiterRun>): String {
+	val sb = StringBuilder(markdown.length)
+	val length = markdown.length
+	var i = 0
+	var r = 0
+	while (i < length) {
+		if (r < runs.size && i == runs[r].start) {
+			val run = runs[r]
+			sb.append(markdown, run.start + run.dropFront, run.end - run.dropBack)
+			i = run.end
+			r++
+			continue
+		}
+
+		i = sb.appendResolved(markdown, i)
+	}
+	return sb.toString()
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
@@ -40,26 +40,8 @@ fun markdownTitleLine(markdown: String): String {
 }
 
 /**
- * True when [text] holds an inline marker the projection pairs off and removes.
- *
- * Gates the raw-source fallback, and deliberately excludes escapes and block markers. A query
- * spelling out `**Chapter**` is someone hunting for markup and wants the source searched; a query
- * holding a backslash or a dash is prose, and its storage form (`well\-known`) is not something a
- * reader ever types. One predicate over every removable character cannot tell those apart.
- */
-internal fun containsInlineMarkup(text: CharSequence): Boolean {
-	var i = 0
-	while (i < text.length) {
-		val c = text[i]
-		if (c == '*' || c == '_' || c == '`') return true
-		i++
-	}
-	return false
-}
-
-/**
- * True when [text] holds a character the projection can remove. A query without one that misses the
- * projection cannot match the raw source either, because the projection only ever deletes.
+ * True when [text] holds a character the projection can remove. Text without one projects to itself,
+ * so the scan can be skipped entirely.
  */
 internal fun containsMarkdownSyntax(text: CharSequence): Boolean {
 	var i = 0

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjection.kt
@@ -40,6 +40,24 @@ fun markdownTitleLine(markdown: String): String {
 }
 
 /**
+ * True when [text] holds an inline marker the projection pairs off and removes.
+ *
+ * Gates the raw-source fallback, and deliberately excludes escapes and block markers. A query
+ * spelling out `**Chapter**` is someone hunting for markup and wants the source searched; a query
+ * holding a backslash or a dash is prose, and its storage form (`well\-known`) is not something a
+ * reader ever types. One predicate over every removable character cannot tell those apart.
+ */
+internal fun containsInlineMarkup(text: CharSequence): Boolean {
+	var i = 0
+	while (i < text.length) {
+		val c = text[i]
+		if (c == '*' || c == '_' || c == '`') return true
+		i++
+	}
+	return false
+}
+
+/**
  * True when [text] holds a character the projection can remove. A query without one that misses the
  * projection cannot match the raw source either, because the projection only ever deletes.
  */

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjector.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjector.kt
@@ -114,28 +114,16 @@ class MarkdownProjector(initialCapacity: Int = INITIAL_OUT) : ScanBuffers {
 		return outLength
 	}
 
-	/** Length of the source the current projection came from. */
-	val sourceLength: Int get() = srcLength
-
 	/**
 	 * Index of [query] in the projected prose, or -1. Compares against the buffer directly so a scan
 	 * that finds nothing never builds a string.
 	 */
-	fun indexOf(query: String, ignoreCase: Boolean = true): Int =
-		indexOfIn(out, outLength, query, ignoreCase)
-
-	/**
-	 * Index of [query] in the unprojected source, or -1. Backs the fallback for queries that spell
-	 * out storage syntax, which the projection has by definition removed.
-	 */
-	fun indexOfInSource(query: String, ignoreCase: Boolean = true): Int =
-		indexOfIn(src, srcLength, query, ignoreCase)
-
-	private fun indexOfIn(buffer: CharArray, length: Int, query: String, ignoreCase: Boolean): Int {
+	fun indexOf(query: String, ignoreCase: Boolean = true): Int {
 		val queryLength = query.length
-		if (queryLength == 0 || queryLength > length) return -1
+		if (queryLength == 0 || queryLength > outLength) return -1
+		val buffer = out
 		val first = query[0]
-		val last = length - queryLength
+		val last = outLength - queryLength
 		var i = 0
 		outer@ while (i <= last) {
 			if (!buffer[i].equals(first, ignoreCase)) {
@@ -160,13 +148,6 @@ class MarkdownProjector(initialCapacity: Int = INITIAL_OUT) : ScanBuffers {
 		val from = startIndex.coerceIn(0, outLength)
 		val to = endIndex.coerceIn(from, outLength)
 		return out.concatToString(from, to)
-	}
-
-	/** The unprojected source as a String. Allocates, so reserve it for a hit. */
-	fun sourceSubstring(startIndex: Int, endIndex: Int): String {
-		val from = startIndex.coerceIn(0, srcLength)
-		val to = endIndex.coerceIn(from, srcLength)
-		return src.concatToString(from, to)
 	}
 
 	fun projected(): String = substring(0, outLength)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjector.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjector.kt
@@ -1,0 +1,490 @@
+package com.darkrockstudios.apps.hammer.common.data.search
+
+import com.darkrockstudios.apps.hammer.common.util.ScanBuffers
+
+private const val FLAG_CAN_OPEN = 1
+private const val FLAG_CAN_CLOSE = 2
+private const val FLAG_INERT = 4
+
+private const val INITIAL_OUT = 8 * 1024
+private const val INITIAL_RUNS = 256
+private const val MIN_RUNS = 16
+
+/**
+ * CommonMark's ASCII punctuation set, as the four contiguous ranges it actually is. Tested once per
+ * character of every document scanned, so the ranges beat a membership scan over a 32-char string.
+ */
+internal fun Char.isAsciiPunctuation(): Boolean =
+	this in '!'..'/' ||
+		this in ':'..'@' ||
+		this in '['..'`' ||
+		this in '{'..'~'
+
+private fun Char.isDelimiterChar(): Boolean = this == '*' || this == '_' || this == '`'
+
+private fun Char.isSpaceOrTabChar(): Boolean = this == ' ' || this == '\t'
+
+/**
+ * A reusable workspace for [projectMarkdownToPlainText]'s scan. Every buffer grows to the largest
+ * document it has seen and is then reused, so scanning a project a second time allocates nothing:
+ * the delimiter runs live in parallel primitive arrays rather than objects, and the projected prose
+ * lands in a char buffer that is matched against in place rather than being turned into a String.
+ *
+ * Not thread safe. A concurrent scan needs its own instance.
+ */
+class MarkdownProjector(initialCapacity: Int = INITIAL_OUT) : ScanBuffers {
+
+	/**
+	 * The source is copied in and then indexed as a flat array: the scan and the render each walk
+	 * every character, and going through `CharSequence` would pay an interface call on both passes.
+	 */
+	private var src = CharArray(initialCapacity)
+	private var srcLength = 0
+
+	private var rawBytes = ByteArray(0)
+
+	/** The projection only ever deletes, so it can never outgrow the source it came from. */
+	private var out = CharArray(initialCapacity)
+	private var outLength = 0
+
+	/**
+	 * Sized from the document rather than a fixed floor, so projecting one short note does not pay
+	 * for a novel's worth of run slots. Grows to whatever the widest document actually needs.
+	 */
+	private val initialRuns = (initialCapacity / 32).coerceIn(MIN_RUNS, INITIAL_RUNS)
+
+	private var runChar = CharArray(initialRuns)
+	private var runStart = IntArray(initialRuns)
+	private var runEnd = IntArray(initialRuns)
+	private var runParagraph = IntArray(initialRuns)
+	private var runDropFront = IntArray(initialRuns)
+	private var runDropBack = IntArray(initialRuns)
+	private var runFlags = IntArray(initialRuns)
+	private var runCount = 0
+
+	private var openStack = IntArray(initialRuns)
+	private var openCount = 0
+
+	/** Length of the projected prose currently held in the buffer. */
+	val length: Int get() = outLength
+
+	operator fun get(index: Int): Char = out[index]
+
+	/**
+	 * Projects [source] into this workspace and returns the projected length. The result stays valid
+	 * until the next call.
+	 */
+	fun project(source: CharSequence): Int {
+		val length = source.length
+		ensureSource(length)
+		var i = 0
+		while (i < length) {
+			src[i] = source[i]
+			i++
+		}
+		return projectSource(length)
+	}
+
+	/**
+	 * The source buffer, grown to hold at least [minCapacity] characters. Fill it directly and then
+	 * call [projectSource] to skip copying the document in at all.
+	 */
+	fun sourceBuffer(minCapacity: Int): CharArray {
+		ensureSource(minCapacity)
+		return src
+	}
+
+	override fun charBuffer(minCapacity: Int): CharArray = sourceBuffer(minCapacity)
+
+	/** Scratch for the raw bytes of a document being read in, before they are decoded into [src]. */
+	override fun byteBuffer(minCapacity: Int): ByteArray {
+		if (rawBytes.size < minCapacity) rawBytes = ByteArray(minCapacity)
+		return rawBytes
+	}
+
+	/** Projects the first [length] characters already sitting in [sourceBuffer]. */
+	fun projectSource(length: Int): Int {
+		srcLength = length
+		outLength = 0
+		ensureOut(length)
+		scanDelimiterRuns()
+		resolveCodeSpans()
+		resolveEmphasis()
+		render()
+		return outLength
+	}
+
+	/** Length of the source the current projection came from. */
+	val sourceLength: Int get() = srcLength
+
+	/**
+	 * Index of [query] in the projected prose, or -1. Compares against the buffer directly so a scan
+	 * that finds nothing never builds a string.
+	 */
+	fun indexOf(query: String, ignoreCase: Boolean = true): Int =
+		indexOfIn(out, outLength, query, ignoreCase)
+
+	/**
+	 * Index of [query] in the unprojected source, or -1. Backs the fallback for queries that spell
+	 * out storage syntax, which the projection has by definition removed.
+	 */
+	fun indexOfInSource(query: String, ignoreCase: Boolean = true): Int =
+		indexOfIn(src, srcLength, query, ignoreCase)
+
+	private fun indexOfIn(buffer: CharArray, length: Int, query: String, ignoreCase: Boolean): Int {
+		val queryLength = query.length
+		if (queryLength == 0 || queryLength > length) return -1
+		val first = query[0]
+		val last = length - queryLength
+		var i = 0
+		outer@ while (i <= last) {
+			if (!buffer[i].equals(first, ignoreCase)) {
+				i++
+				continue
+			}
+			var j = 1
+			while (j < queryLength) {
+				if (!buffer[i + j].equals(query[j], ignoreCase)) {
+					i++
+					continue@outer
+				}
+				j++
+			}
+			return i
+		}
+		return -1
+	}
+
+	/** The projected prose as a String. Allocates, so reserve it for a hit. */
+	fun substring(startIndex: Int, endIndex: Int): String {
+		val from = startIndex.coerceIn(0, outLength)
+		val to = endIndex.coerceIn(from, outLength)
+		return out.concatToString(from, to)
+	}
+
+	/** The unprojected source as a String. Allocates, so reserve it for a hit. */
+	fun sourceSubstring(startIndex: Int, endIndex: Int): String {
+		val from = startIndex.coerceIn(0, srcLength)
+		val to = endIndex.coerceIn(from, srcLength)
+		return src.concatToString(from, to)
+	}
+
+	fun projected(): String = substring(0, outLength)
+
+	/**
+	 * Up to [maxChars] of the projection with runs of whitespace collapsed to a single space, and an
+	 * ellipsis when prose remained. Walks the buffer, so previewing never materializes the whole
+	 * document just to throw most of it away.
+	 */
+	fun collapsedPreview(maxChars: Int): String {
+		val sb = StringBuilder(maxChars + 1)
+		var i = 0
+		var pendingSpace = false
+		while (i < outLength && sb.length <= maxChars) {
+			val c = out[i]
+			if (c.isWhitespace()) {
+				if (sb.isNotEmpty()) pendingSpace = true
+			} else {
+				if (pendingSpace) {
+					sb.append(' ')
+					pendingSpace = false
+				}
+				sb.append(c)
+			}
+			i++
+		}
+		// Anything left that is not whitespace means the preview is a truncation, not the whole text.
+		var more = false
+		while (i < outLength) {
+			if (!out[i].isWhitespace()) {
+				more = true
+				break
+			}
+			i++
+		}
+		if (sb.length > maxChars || more) {
+			while (sb.length > maxChars) sb.deleteAt(sb.length - 1)
+			while (sb.isNotEmpty() && sb.last().isWhitespace()) sb.deleteAt(sb.length - 1)
+			sb.append('…')
+		}
+		return sb.toString()
+	}
+
+	/** The first non-blank line of the projection, or "" when every line is blank. */
+	fun firstNonBlankLine(): String {
+		var i = 0
+		while (i < outLength) {
+			var end = i
+			while (end < outLength && out[end] != '\n') end++
+			var start = i
+			while (start < end && out[start].isWhitespace()) start++
+			var stop = end
+			while (stop > start && out[stop - 1].isWhitespace()) stop--
+			if (stop > start) return out.concatToString(start, stop)
+			i = end + 1
+		}
+		return ""
+	}
+
+	private fun ensureSource(needed: Int) {
+		if (src.size < needed) src = CharArray(needed)
+	}
+
+	private fun ensureOut(needed: Int) {
+		if (out.size < needed) out = CharArray(needed)
+	}
+
+	private fun ensureRuns(needed: Int) {
+		if (runChar.size >= needed) return
+		val size = needed * 2
+		runChar = runChar.copyOf(size)
+		runStart = runStart.copyOf(size)
+		runEnd = runEnd.copyOf(size)
+		runParagraph = runParagraph.copyOf(size)
+		runDropFront = runDropFront.copyOf(size)
+		runDropBack = runDropBack.copyOf(size)
+		runFlags = runFlags.copyOf(size)
+		openStack = openStack.copyOf(size)
+	}
+
+	private fun available(run: Int): Int =
+		runEnd[run] - runStart[run] - runDropFront[run] - runDropBack[run]
+
+	private fun addRun(char: Char, start: Int, end: Int, paragraph: Int, flags: Int) {
+		ensureRuns(runCount + 1)
+		runChar[runCount] = char
+		runStart[runCount] = start
+		runEnd[runCount] = end
+		runParagraph[runCount] = paragraph
+		runDropFront[runCount] = 0
+		runDropBack[runCount] = 0
+		runFlags[runCount] = flags
+		runCount++
+	}
+
+	private fun isBlankOrEdge(index: Int): Boolean =
+		index < 0 || index >= srcLength || src[index].isWhitespace()
+
+	private fun isPunctuationAt(index: Int): Boolean =
+		index >= 0 && index < srcLength && src[index].isAsciiPunctuation()
+
+	private fun scanDelimiterRuns() {
+		runCount = 0
+		val length = srcLength
+		var i = 0
+		var paragraph = 0
+		while (i < length) {
+			val c = src[i]
+			if (c == '\\' && i + 1 < length && src[i + 1].isAsciiPunctuation()) {
+				i += 2
+				continue
+			}
+			if (c == '\n') {
+				var k = i + 1
+				while (k < length && (src[k].isSpaceOrTabChar() || src[k] == '\r')) k++
+				if (k >= length || src[k] == '\n') paragraph++
+				i++
+				continue
+			}
+			if (!c.isDelimiterChar()) {
+				i++
+				continue
+			}
+
+			val start = i
+			var end = start + 1
+			while (end < length && src[end] == c) end++
+			i = end
+
+			var canOpen = true
+			var canClose = true
+			if (c != '`') {
+				val prevBlank = isBlankOrEdge(start - 1)
+				val nextBlank = isBlankOrEdge(end)
+				val prevPunct = isPunctuationAt(start - 1)
+				val nextPunct = isPunctuationAt(end)
+				val leftFlanking = !nextBlank && (!nextPunct || prevBlank || prevPunct)
+				val rightFlanking = !prevBlank && (!prevPunct || nextBlank || nextPunct)
+				if (c == '*') {
+					canOpen = leftFlanking
+					canClose = rightFlanking
+				} else {
+					// Underscores cannot delimit emphasis inside a word, which is what saves `user_name`.
+					canOpen = leftFlanking && (!rightFlanking || prevPunct)
+					canClose = rightFlanking && (!leftFlanking || nextPunct)
+				}
+				// A run that can do neither is literal text; leaving it out keeps it out of the render.
+				if (!canOpen && !canClose) continue
+			}
+
+			var flags = 0
+			if (canOpen) flags = flags or FLAG_CAN_OPEN
+			if (canClose) flags = flags or FLAG_CAN_CLOSE
+			addRun(c, start, end, paragraph, flags)
+		}
+	}
+
+	/** Code spans bind tighter than emphasis, so they claim their delimiters first. */
+	private fun resolveCodeSpans() {
+		var i = 0
+		while (i < runCount) {
+			if (runChar[i] != '`') {
+				i++
+				continue
+			}
+
+			val width = runEnd[i] - runStart[i]
+			var j = i + 1
+			var closer = -1
+			while (j < runCount && runParagraph[j] == runParagraph[i]) {
+				if (runChar[j] == '`' && runEnd[j] - runStart[j] == width) {
+					closer = j
+					break
+				}
+				j++
+			}
+			if (closer < 0) {
+				i++
+				continue
+			}
+
+			runDropBack[i] = width
+			runDropFront[closer] = width
+			for (k in i + 1 until closer) runFlags[k] = runFlags[k] or FLAG_INERT
+			i = closer + 1
+		}
+	}
+
+	private fun resolveEmphasis() {
+		openCount = 0
+		var paragraph = -1
+		for (run in 0 until runCount) {
+			if (runParagraph[run] != paragraph) {
+				openCount = 0
+				paragraph = runParagraph[run]
+			}
+			if (runChar[run] == '`' || runFlags[run] and FLAG_INERT != 0) continue
+
+			if (runFlags[run] and FLAG_CAN_CLOSE != 0) {
+				while (available(run) > 0) {
+					var openerSlot = -1
+					var s = openCount - 1
+					while (s >= 0) {
+						if (runChar[openStack[s]] == runChar[run]) {
+							openerSlot = s
+							break
+						}
+						s--
+					}
+					if (openerSlot < 0) break
+
+					val opener = openStack[openerSlot]
+					val consumed = minOf(available(run), available(opener))
+					runDropBack[opener] += consumed
+					runDropFront[run] += consumed
+
+					// Anything stacked above the matched opener can never close now.
+					openCount = openerSlot
+					if (available(opener) > 0) pushOpen(opener)
+				}
+			}
+			if (available(run) > 0 && runFlags[run] and FLAG_CAN_OPEN != 0) pushOpen(run)
+		}
+	}
+
+	private fun pushOpen(run: Int) {
+		ensureRuns(openCount + 1)
+		openStack[openCount] = run
+		openCount++
+	}
+
+	/**
+	 * The offset after any blockquote, heading or bullet marker opening the line at [start], or
+	 * [start] itself when the line opens with prose. Ordered-list markers are left alone: a single
+	 * line cannot distinguish "1. Draft opening" from "1984. The year everything changed".
+	 */
+	private fun skipBlockPrefix(start: Int): Int {
+		val length = srcLength
+		var i = start
+		var found = false
+
+		while (i < length && src[i].isSpaceOrTabChar()) i++
+
+		while (i < length && src[i] == '>') {
+			i++
+			found = true
+			while (i < length && src[i].isSpaceOrTabChar()) i++
+		}
+
+		if (i < length && src[i] == '#') {
+			var j = i
+			var hashes = 0
+			while (j < length && src[j] == '#') {
+				j++
+				hashes++
+			}
+			if (hashes <= 6 && j < length && src[j].isSpaceOrTabChar()) {
+				i = j
+				found = true
+			}
+		} else if (i < length && (src[i] == '-' || src[i] == '*' || src[i] == '+')) {
+			if (i + 1 < length && src[i + 1].isSpaceOrTabChar()) {
+				i++
+				found = true
+			}
+		}
+
+		if (!found) return start
+		while (i < length && src[i].isSpaceOrTabChar()) i++
+		return i
+	}
+
+	private fun appendOut(c: Char) {
+		out[outLength] = c
+		outLength++
+	}
+
+	private fun appendOut(from: Int, to: Int) {
+		var i = from
+		while (i < to) {
+			out[outLength] = src[i]
+			outLength++
+			i++
+		}
+	}
+
+	private fun render() {
+		val length = srcLength
+		var i = 0
+		var r = 0
+		var atLineStart = true
+		while (i < length) {
+			if (atLineStart) {
+				atLineStart = false
+				val afterPrefix = skipBlockPrefix(i)
+				if (afterPrefix > i) {
+					i = afterPrefix
+					while (r < runCount && runStart[r] < i) r++
+					continue
+				}
+			}
+
+			if (r < runCount && i == runStart[r]) {
+				appendOut(runStart[r] + runDropFront[r], runEnd[r] - runDropBack[r])
+				i = runEnd[r]
+				r++
+				continue
+			}
+
+			val c = src[i]
+			if (c == '\n') atLineStart = true
+			if (c == '\\' && i + 1 < length && src[i + 1].isAsciiPunctuation()) {
+				appendOut(src[i + 1])
+				i += 2
+			} else {
+				appendOut(c)
+				i++
+			}
+		}
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectorPool.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectorPool.kt
@@ -1,0 +1,31 @@
+package com.darkrockstudios.apps.hammer.common.data.search
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+private const val MAX_RETAINED = 8
+
+/**
+ * Lends [MarkdownProjector]s to concurrent scans and keeps them afterwards, so the buffers a scan
+ * grew are still there for the next keystroke rather than being rebuilt from scratch.
+ *
+ * A projector cannot be a plain field on the use case: cancelling a search is cooperative, so the
+ * outgoing scan can still be running when the next one starts, and the two would share a buffer.
+ * Borrowing serializes that without forcing the scans themselves to run one at a time.
+ */
+class MarkdownProjectorPool {
+
+	private val mutex = Mutex()
+	private val available = mutableListOf<MarkdownProjector>()
+
+	suspend fun <T> borrow(block: suspend (MarkdownProjector) -> T): T {
+		val projector = mutex.withLock { available.removeLastOrNull() } ?: MarkdownProjector()
+		try {
+			return block(projector)
+		} finally {
+			mutex.withLock {
+				if (available.size < MAX_RETAINED) available.add(projector)
+			}
+		}
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
@@ -39,18 +39,22 @@ fun parseQuery(query: String): ParsedQuery {
 }
 
 /**
- * True when [query] appears in [content] once the stored backslash escapes are resolved, so
- * `well-known` finds text stored as `well\-known`.
+ * True when [query] appears in the prose [content] displays as: escapes resolved and paired
+ * emphasis, code and block markers dropped, so `well-known` finds `well\-known` and `Chapter One`
+ * finds `**Chapter** One`.
  *
- * Only escapes are resolved. Emphasis, code and link markers are compared as stored, so a phrase
- * spanning them does not match; see #811. The query is taken literally, so the escaped storage form
- * of a phrase does not match either.
+ * The raw source is searched as a fallback only for a query spelling out emphasis or code markers,
+ * so hunting for `**Chapter**` works while the storage form of prose (`well\-known`) stays
+ * unsupported: readers type what they see.
  *
- * Global search needs offsets rather than a boolean, so it resolves and matches separately in
+ * Global search needs offsets rather than a boolean, so it projects and matches separately in
  * `SearchProjectUseCase.findMarkdownMatch`. `MarkdownContainsTest` pins the two to the same answer.
  */
-fun markdownContains(content: String, query: String): Boolean =
-	unescapeMarkdown(content).contains(query, ignoreCase = true)
+fun markdownContains(content: String, query: String): Boolean {
+	if (projectMarkdownToPlainText(content).contains(query, ignoreCase = true)) return true
+	if (containsInlineMarkup(query)) return content.contains(query, ignoreCase = true)
+	return false
+}
 
 /** True when every needle is contained (case-insensitively) in at least one tag. */
 fun Set<String>.matchesAllTags(needles: List<String>): Boolean {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
@@ -39,22 +39,21 @@ fun parseQuery(query: String): ParsedQuery {
 }
 
 /**
- * True when [query] appears in the prose [content] displays as: escapes resolved and paired
- * emphasis, code and block markers dropped, so `well-known` finds `well\-known` and `Chapter One`
- * finds `**Chapter** One`.
+ * True when [query] appears, as literal text, in the prose [content] displays as: escapes resolved
+ * and paired emphasis, code and block markers dropped. So `well-known` finds `well\-known`, and
+ * `Chapter One` finds `**Chapter** One`.
  *
- * The raw source is searched as a fallback only for a query spelling out emphasis or code markers,
- * so hunting for `**Chapter**` works while the storage form of prose (`well\-known`) stays
- * unsupported: readers type what they see.
+ * The query is never read as Markdown, and the storage form is never searched. `**Chapter**` finds
+ * nothing, because those asterisks are not on screen to be found; `well\-known` finds nothing for
+ * the same reason, while text stored as `well\\-known` renders a real backslash and is found by
+ * typing one. Markers the projection leaves alone, `5*4` and `user_name`, match where they sit,
+ * because there they are prose.
  *
  * Global search needs offsets rather than a boolean, so it projects and matches separately in
  * `SearchProjectUseCase.findMarkdownMatch`. `MarkdownContainsTest` pins the two to the same answer.
  */
-fun markdownContains(content: String, query: String): Boolean {
-	if (projectMarkdownToPlainText(content).contains(query, ignoreCase = true)) return true
-	if (containsInlineMarkup(query)) return content.contains(query, ignoreCase = true)
-	return false
-}
+fun markdownContains(content: String, query: String): Boolean =
+	projectMarkdownToPlainText(content).contains(query, ignoreCase = true)
 
 /** True when every needle is contained (case-insensitively) in at least one tag. */
 fun Set<String>.matchesAllTags(needles: List<String>): Boolean {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/util/CharBuffers.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/util/CharBuffers.kt
@@ -1,0 +1,100 @@
+package com.darkrockstudios.apps.hammer.common.util
+
+import okio.BufferedSource
+
+private const val REPLACEMENT = '�'
+
+/**
+ * Supplies the scratch a text scan reads into. Lets a reader fill buffers the caller owns and
+ * reuses, instead of handing back a freshly allocated string for every file.
+ */
+interface ScanBuffers {
+	/** A char buffer of at least [minCapacity]. May be larger, and may be the one from last time. */
+	fun charBuffer(minCapacity: Int): CharArray
+
+	/** A byte buffer of at least [minCapacity]. May be larger, and may be the one from last time. */
+	fun byteBuffer(minCapacity: Int): ByteArray
+}
+
+/**
+ * Reads up to [byteCount] bytes, decodes them as UTF-8 into [buffers]' char buffer, and returns how
+ * many chars landed there.
+ *
+ * The bytes are pulled in bulk and decoded from an array rather than a byte at a time: reading one
+ * byte at a time off a source costs more than the decode itself.
+ */
+fun BufferedSource.readUtf8Into(buffers: ScanBuffers, byteCount: Int): Int {
+	if (byteCount <= 0) return 0
+	val bytes = buffers.byteBuffer(byteCount)
+	var read = 0
+	while (read < byteCount) {
+		val n = read(bytes, read, byteCount - read)
+		if (n == -1) break
+		read += n
+	}
+	// UTF-8 never decodes to more UTF-16 chars than it has bytes, so this always fits.
+	return decodeUtf8(bytes, read, buffers.charBuffer(read))
+}
+
+/**
+ * Decodes the first [length] bytes of [bytes] as UTF-8 into [sink], returning the char count.
+ * Malformed input decodes to U+FFFD rather than throwing, matching how the rest of the app treats a
+ * damaged file: degraded, not fatal.
+ */
+internal fun decodeUtf8(bytes: ByteArray, length: Int, sink: CharArray): Int {
+	var i = 0
+	var out = 0
+	while (i < length && out < sink.size) {
+		val b0 = bytes[i].toInt() and 0xFF
+		i++
+
+		if (b0 < 0x80) {
+			sink[out++] = b0.toChar()
+			continue
+		}
+
+		val needed = when {
+			b0 and 0xE0 == 0xC0 -> 1
+			b0 and 0xF0 == 0xE0 -> 2
+			b0 and 0xF8 == 0xF0 -> 3
+			else -> -1
+		}
+		if (needed < 0 || i + needed > length) {
+			sink[out++] = REPLACEMENT
+			continue
+		}
+
+		var codePoint = when (needed) {
+			1 -> b0 and 0x1F
+			2 -> b0 and 0x0F
+			else -> b0 and 0x07
+		}
+		var malformed = false
+		for (k in 0 until needed) {
+			val b = bytes[i + k].toInt() and 0xFF
+			if (b and 0xC0 != 0x80) {
+				malformed = true
+				break
+			}
+			codePoint = (codePoint shl 6) or (b and 0x3F)
+		}
+		if (malformed) {
+			sink[out++] = REPLACEMENT
+			continue
+		}
+		i += needed
+
+		if (codePoint > 0x10FFFF) {
+			sink[out++] = REPLACEMENT
+		} else if (codePoint < 0x10000) {
+			sink[out++] = codePoint.toChar()
+		} else {
+			// Astral planes need a surrogate pair, the one case where a sequence yields two chars.
+			if (out + 1 >= sink.size) break
+			val v = codePoint - 0x10000
+			sink[out++] = (0xD800 + (v shr 10)).toChar()
+			sink[out++] = (0xDC00 + (v and 0x3FF)).toChar()
+		}
+	}
+	return out
+}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownContainsTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownContainsTest.kt
@@ -29,9 +29,17 @@ class MarkdownContainsTest {
 	}
 
 	@Test
-	fun `unescaped markup is matched as it is stored`() {
+	fun `markers that survive the projection are matched where they sit`() {
 		assertTrue(markdownContains("The cost is 5*4 today", "5*4"))
-		assertTrue(markdownContains("a **Chapter** heading", "**Chapter**"))
+		assertTrue(markdownContains("the user_name field", "user_name"))
+	}
+
+	@Test
+	fun `markers the projection removes are not findable by typing them`() {
+		// The query is literal text matched against the prose on screen, which has no asterisks in it.
+		assertFalse(markdownContains("a **Chapter** heading", "**Chapter**"))
+		assertFalse(markdownContains("a `code` span", "`code`"))
+		assertTrue(markdownContains("a **Chapter** heading", "Chapter heading"))
 	}
 
 	@Test

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectionTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectionTest.kt
@@ -1,0 +1,125 @@
+package com.darkrockstudios.apps.hammer.common.data.search
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class MarkdownProjectionTest {
+
+	@Test
+	fun `plain prose is returned unchanged and unallocated`() {
+		val input = "Alice went down the rabbit hole."
+		assertSame(input, projectMarkdownToPlainText(input))
+	}
+
+	@Test
+	fun `empty input is returned unchanged`() {
+		assertEquals("", projectMarkdownToPlainText(""))
+	}
+
+	@Test
+	fun `backslash escapes resolve to their literal character`() {
+		assertEquals("well-known", projectMarkdownToPlainText("well\\-known"))
+		assertEquals("1. not a list", projectMarkdownToPlainText("1\\. not a list"))
+		assertEquals("[brackets]", projectMarkdownToPlainText("\\[brackets\\]"))
+	}
+
+	@Test
+	fun `escaped backslash collapses to one backslash`() {
+		assertEquals("C:\\path", projectMarkdownToPlainText("C:\\\\path"))
+	}
+
+	@Test
+	fun `a backslash before a non-punctuation character is kept`() {
+		assertEquals("\\a", projectMarkdownToPlainText("\\a"))
+	}
+
+	@Test
+	fun `a trailing backslash is kept`() {
+		assertEquals("end\\", projectMarkdownToPlainText("end\\"))
+	}
+
+	@Test
+	fun `paired emphasis markers are dropped so phrases join up`() {
+		assertEquals("Chapter One", projectMarkdownToPlainText("**Chapter** One"))
+		assertEquals("quick brown", projectMarkdownToPlainText("_quick_ brown"))
+		assertEquals("run build now", projectMarkdownToPlainText("run `build` now"))
+	}
+
+	@Test
+	fun `nested emphasis is unwrapped`() {
+		assertEquals("very loud indeed", projectMarkdownToPlainText("**very _loud_ indeed**"))
+		assertEquals("shout", projectMarkdownToPlainText("***shout***"))
+	}
+
+	@Test
+	fun `escaped markers survive as literal characters`() {
+		assertEquals("_shape_", projectMarkdownToPlainText("\\_shape\\_"))
+		assertEquals("2 * 3", projectMarkdownToPlainText("2 \\* 3"))
+	}
+
+	@Test
+	fun `escaping is resolved before markers are dropped`() {
+		assertEquals("a_b and c", projectMarkdownToPlainText("a\\_b and _c_"))
+	}
+
+	@Test
+	fun `underscores inside a word are literal`() {
+		assertEquals("user_name", projectMarkdownToPlainText("user_name"))
+		assertEquals("my_table_name", projectMarkdownToPlainText("my_table_name"))
+		assertEquals("snake_case and emphasis", projectMarkdownToPlainText("snake_case and _emphasis_"))
+	}
+
+	@Test
+	fun `markers that cannot pair off are literal`() {
+		assertEquals("2 * 3 = 6", projectMarkdownToPlainText("2 * 3 = 6"))
+		assertEquals("***", projectMarkdownToPlainText("***"))
+		assertEquals("an *unclosed aside", projectMarkdownToPlainText("an *unclosed aside"))
+		assertEquals("a ` stray tick", projectMarkdownToPlainText("a ` stray tick"))
+	}
+
+	@Test
+	fun `emphasis markers inside a code span are literal`() {
+		assertEquals("call my_func now", projectMarkdownToPlainText("call `my_func` now"))
+	}
+
+	@Test
+	fun `block level markers are left alone`() {
+		assertEquals("# Chapter One", projectMarkdownToPlainText("# Chapter One"))
+		assertEquals("> a quote", projectMarkdownToPlainText("> a quote"))
+		assertEquals("- a bullet", projectMarkdownToPlainText("- a bullet"))
+	}
+
+	@Test
+	fun `a document with escapes but no emphasis still resolves them`() {
+		assertEquals(
+			"The well-known garden! (and its gate)",
+			projectMarkdownToPlainText("The well\\-known garden\\! \\(and its gate\\)"),
+		)
+	}
+
+	@Test
+	fun `title line strips block markers and inline markup`() {
+		assertEquals("Chapter One", markdownTitleLine("# **Chapter** One\n\nbody"))
+		assertEquals("A quoted thought", markdownTitleLine("> A quoted thought"))
+		assertEquals("First item", markdownTitleLine("- First item\n- Second"))
+		assertEquals("First item", markdownTitleLine("1. First item"))
+	}
+
+	@Test
+	fun `title line skips leading blank lines`() {
+		assertEquals("Actual title", markdownTitleLine("\n   \nActual title\nmore"))
+		assertEquals("", markdownTitleLine("   \n\n"))
+	}
+
+	@Test
+	fun `a title line of pure markup falls back to the raw line`() {
+		assertEquals("***", markdownTitleLine("***\nbody"))
+		assertEquals("#", markdownTitleLine("#\nbody"))
+	}
+
+	@Test
+	fun `an emphasized title keeps its words`() {
+		assertEquals("Once upon a time", markdownTitleLine("*Once upon a time*"))
+	}
+}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectionTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectionTest.kt
@@ -84,10 +84,44 @@ class MarkdownProjectionTest {
 	}
 
 	@Test
-	fun `block level markers are left alone`() {
-		assertEquals("# Chapter One", projectMarkdownToPlainText("# Chapter One"))
-		assertEquals("> a quote", projectMarkdownToPlainText("> a quote"))
-		assertEquals("- a bullet", projectMarkdownToPlainText("- a bullet"))
+	fun `leading block markers are stripped from each line`() {
+		assertEquals("Chapter One", projectMarkdownToPlainText("# Chapter One"))
+		assertEquals("a quote", projectMarkdownToPlainText("> a quote"))
+		assertEquals("a bullet", projectMarkdownToPlainText("- a bullet"))
+		assertEquals("Chapter One\n\nThe body", projectMarkdownToPlainText("# Chapter One\n\nThe body"))
+	}
+
+	@Test
+	fun `ordered list markers are left alone so years survive`() {
+		assertEquals("1984. The year everything changed", projectMarkdownToPlainText("1984. The year everything changed"))
+		assertEquals("3) Meet at the docks", projectMarkdownToPlainText("3) Meet at the docks"))
+	}
+
+	@Test
+	fun `a marker that is not followed by a space is prose`() {
+		assertEquals("-15 degrees", projectMarkdownToPlainText("-15 degrees"))
+		assertEquals("#hashtag here", projectMarkdownToPlainText("#hashtag here"))
+	}
+
+	@Test
+	fun `code delimiters do not pair across a paragraph break`() {
+		assertEquals(
+			"It`s here.\n\nThe Chapter One part.\n\nDon`t stop.",
+			projectMarkdownToPlainText("It`s here.\n\nThe **Chapter** One part.\n\nDon`t stop."),
+		)
+	}
+
+	@Test
+	fun `emphasis does not pair across a paragraph break`() {
+		assertEquals(
+			"See note *below\n\nThe rate is 5* higher",
+			projectMarkdownToPlainText("See note *below\n\nThe rate is 5* higher"),
+		)
+	}
+
+	@Test
+	fun `emphasis still pairs across a soft line break`() {
+		assertEquals("The long\ntitle here", projectMarkdownToPlainText("The **long\ntitle** here"))
 	}
 
 	@Test
@@ -103,7 +137,16 @@ class MarkdownProjectionTest {
 		assertEquals("Chapter One", markdownTitleLine("# **Chapter** One\n\nbody"))
 		assertEquals("A quoted thought", markdownTitleLine("> A quoted thought"))
 		assertEquals("First item", markdownTitleLine("- First item\n- Second"))
-		assertEquals("First item", markdownTitleLine("1. First item"))
+	}
+
+	@Test
+	fun `title line keeps a leading number`() {
+		assertEquals("1984. The year everything changed", markdownTitleLine("1984. The year everything changed"))
+	}
+
+	@Test
+	fun `title line pairs emphasis that closes on the next line`() {
+		assertEquals("The long", markdownTitleLine("The **long\ntitle** here"))
 	}
 
 	@Test

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectorTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectorTest.kt
@@ -1,0 +1,132 @@
+package com.darkrockstudios.apps.hammer.common.data.search
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MarkdownProjectorTest {
+
+	private val projector = MarkdownProjector()
+
+	@Test
+	fun `a reused projector gives the same answer as a fresh one`() {
+		val documents = listOf(
+			"The **big** dog barked.",
+			"a much longer document ".repeat(200) + "with *emphasis* at the end",
+			"short",
+			"# Heading\n\nBody text.",
+		)
+		documents.forEach { document ->
+			projector.project(document)
+			assertEquals(MarkdownProjector().also { it.project(document) }.projected(), projector.projected())
+		}
+	}
+
+	@Test
+	fun `a long document followed by a short one does not leak the tail of the long one`() {
+		projector.project("the quick brown fox ".repeat(100))
+		projector.project("short")
+		assertEquals("short", projector.projected())
+	}
+
+	@Test
+	fun `indexOf finds a phrase that spans dropped emphasis`() {
+		projector.project("the **big** dog")
+		assertEquals("the big dog", projector.projected())
+		assertEquals(4, projector.indexOf("big dog"))
+	}
+
+	@Test
+	fun `indexOf is case insensitive by default and reports a miss as -1`() {
+		projector.project("The Harbour At Dawn")
+		assertEquals(4, projector.indexOf("harbour"))
+		assertEquals(-1, projector.indexOf("mountain"))
+	}
+
+	@Test
+	fun `indexOf respects case when asked`() {
+		projector.project("The Harbour")
+		assertEquals(-1, projector.indexOf("harbour", ignoreCase = false))
+		assertEquals(4, projector.indexOf("Harbour", ignoreCase = false))
+	}
+
+	@Test
+	fun `an empty query never matches`() {
+		projector.project("anything")
+		assertEquals(-1, projector.indexOf(""))
+	}
+
+	@Test
+	fun `a query longer than the document never matches`() {
+		projector.project("hi")
+		assertEquals(-1, projector.indexOf("hello there"))
+	}
+
+	@Test
+	fun `substring returns the projected prose, not the source`() {
+		projector.project("the **big** dog")
+		assertEquals("big", projector.substring(4, 7))
+	}
+
+	@Test
+	fun `firstNonBlankLine skips blank lines and strips markers`() {
+		projector.project("\n\n# **Chapter** One\n\nBody")
+		assertEquals("Chapter One", projector.firstNonBlankLine())
+	}
+
+	@Test
+	fun `firstNonBlankLine is empty when every line is blank`() {
+		projector.project("\n   \n\t\n")
+		assertEquals("", projector.firstNonBlankLine())
+	}
+
+	@Test
+	fun `collapsedPreview flattens whitespace runs`() {
+		projector.project("the   quick\n\nbrown\tfox")
+		assertEquals("the quick brown fox", projector.collapsedPreview(100))
+	}
+
+	@Test
+	fun `collapsedPreview truncates with an ellipsis and stays within the cap`() {
+		projector.project("word ".repeat(100))
+		val preview = projector.collapsedPreview(20)
+		assertTrue(preview.endsWith("…"), "expected an ellipsis, got: $preview")
+		// The cap bounds the prose; trimming a trailing space before the ellipsis can leave it shorter.
+		assertTrue(preview.length <= 21, "expected at most 21 chars, got ${preview.length}: $preview")
+		assertEquals("word word word word…", preview)
+	}
+
+	@Test
+	fun `collapsedPreview does not add an ellipsis when the whole text fits`() {
+		projector.project("just this")
+		assertEquals("just this", projector.collapsedPreview(50))
+	}
+
+	@Test
+	fun `trailing whitespace does not count as more text to preview`() {
+		projector.project("just this   \n\n  ")
+		assertEquals("just this", projector.collapsedPreview(50))
+	}
+
+	@Test
+	fun `filling the source buffer directly projects the same as passing a string`() {
+		val document = "the **big** dog barked at the well\\-known man"
+		projector.project(document)
+		val viaString = projector.projected()
+
+		val buffer = projector.sourceBuffer(document.length)
+		document.forEachIndexed { i, c -> buffer[i] = c }
+		projector.projectSource(document.length)
+
+		assertEquals(viaString, projector.projected())
+	}
+
+	@Test
+	fun `the source buffer survives being grown for a longer document`() {
+		val long = "a *lot* of text ".repeat(50)
+		val buffer = projector.sourceBuffer(long.length)
+		long.forEachIndexed { i, c -> buffer[i] = c }
+		projector.projectSource(long.length)
+		assertEquals(projectMarkdownToPlainText(long), projector.projected())
+	}
+}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectorTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/search/MarkdownProjectorTest.kt
@@ -63,7 +63,7 @@ class MarkdownProjectorTest {
 	}
 
 	@Test
-	fun `substring returns the projected prose, not the source`() {
+	fun `substring returns the projected prose rather than the source`() {
 		projector.project("the **big** dog")
 		assertEquals("big", projector.substring(4, 7))
 	}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/util/CharBuffersTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/util/CharBuffersTest.kt
@@ -1,0 +1,91 @@
+package com.darkrockstudios.apps.hammer.common.util
+
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CharBuffersTest {
+
+	/** A fixed-size workspace, so a test can pin what happens when the sink runs out. */
+	private class FixedBuffers(sinkSize: Int) : ScanBuffers {
+		val chars = CharArray(sinkSize)
+		private var bytes = ByteArray(0)
+		override fun charBuffer(minCapacity: Int) = chars
+		override fun byteBuffer(minCapacity: Int): ByteArray {
+			if (bytes.size < minCapacity) bytes = ByteArray(minCapacity)
+			return bytes
+		}
+	}
+
+	private fun decode(text: String, sinkSize: Int = 256): String {
+		val source = Buffer().writeUtf8(text)
+		val byteCount = source.size.toInt()
+		val buffers = FixedBuffers(sinkSize)
+		val count = source.readUtf8Into(buffers, byteCount)
+		return buffers.chars.concatToString(0, count)
+	}
+
+	private fun decodeBytes(bytes: ByteArray, byteCount: Int = bytes.size, sinkSize: Int = 16): String {
+		val source = Buffer().write(bytes)
+		val buffers = FixedBuffers(sinkSize)
+		val count = source.readUtf8Into(buffers, byteCount)
+		return buffers.chars.concatToString(0, count)
+	}
+
+	@Test
+	fun `ascii decodes unchanged`() {
+		assertEquals("The quick brown fox", decode("The quick brown fox"))
+	}
+
+	@Test
+	fun `two byte sequences decode`() {
+		assertEquals("café naïve", decode("café naïve"))
+	}
+
+	@Test
+	fun `three byte sequences decode`() {
+		assertEquals("日本語のテキスト", decode("日本語のテキスト"))
+	}
+
+	@Test
+	fun `four byte sequences decode to a surrogate pair`() {
+		val emoji = "😀"
+		val decoded = decode("a${emoji}b")
+		assertEquals("a${emoji}b", decoded)
+		assertEquals(4, decoded.length)
+	}
+
+	@Test
+	fun `an empty source decodes to nothing`() {
+		assertEquals("", decode(""))
+	}
+
+	@Test
+	fun `decoding stops when the sink is full`() {
+		assertEquals("The q", decode("The quick brown fox", sinkSize = 5))
+	}
+
+	@Test
+	fun `a surrogate pair is not split across the end of the sink`() {
+		// Room for "a" plus one char: the pair needs two, so it is left out rather than half-written.
+		assertEquals("a", decode("a😀", sinkSize = 2))
+	}
+
+	@Test
+	fun `a truncated sequence decodes to the replacement character`() {
+		assertEquals("a�", decodeBytes(byteArrayOf(0x61, 0xC3.toByte())))
+	}
+
+	@Test
+	fun `a stray continuation byte decodes to the replacement character`() {
+		assertEquals("a�b", decodeBytes(byteArrayOf(0x61, 0x80.toByte(), 0x62)))
+	}
+
+	@Test
+	fun `reading fewer bytes than the source holds stops at the limit`() {
+		val source = Buffer().writeUtf8("abcdef")
+		val buffers = FixedBuffers(16)
+		val count = source.readUtf8Into(buffers, 3)
+		assertEquals("abc", buffers.chars.concatToString(0, count))
+	}
+}

--- a/common/src/desktopTest/kotlin/data/search/LegacyMarkdownProjection.kt
+++ b/common/src/desktopTest/kotlin/data/search/LegacyMarkdownProjection.kt
@@ -1,0 +1,283 @@
+// PR #821 implementation, kept verbatim in the test source set as a benchmark baseline.
+package data.search
+
+private const val ASCII_PUNCTUATION = "!\"#\$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+
+/**
+ * Compared directly rather than via set or string membership: this runs once per character of every
+ * document scanned, and `in` on a CharSequence costs a call per character.
+ */
+private fun Char.isDelimiter(): Boolean = this == '*' || this == '_' || this == '`'
+
+private fun Char.isSpaceOrTab(): Boolean = this == ' ' || this == '\t'
+
+private fun Char?.isBlankOrEdge(): Boolean = this == null || isWhitespace()
+
+private fun Char?.isPunctuation(): Boolean = this != null && this in ASCII_PUNCTUATION
+
+/**
+ * A maximal run of one delimiter character, plus how much of it the projection consumes. Emphasis
+ * pairs off from the end of the opener and the start of the closer, so the surviving characters are
+ * always the middle of the run.
+ */
+private class DelimiterRun(val char: Char, val start: Int, val end: Int, val paragraph: Int) {
+	var canOpen = false
+	var canClose = false
+
+	/** Set for runs sitting inside a resolved code span, where emphasis does not apply. */
+	var inert = false
+	var dropFront = 0
+	var dropBack = 0
+
+	val available: Int get() = end - start - dropFront - dropBack
+}
+
+/**
+ * Flattens stored Markdown into the prose a reader sees. Backslash escapes resolve to their literal
+ * character (`well\-known` becomes `well-known`), paired emphasis and code delimiters are dropped
+ * (`**Chapter** One` becomes `Chapter One`), and leading blockquote, heading and bullet markers are
+ * removed from each line.
+ *
+ * Delimiters pair only within a paragraph, and only where CommonMark's flanking rules allow, so
+ * literal markers survive: `user_name`, `2 * 3`, a bare `***` divider and a stray apostrophe-backtick
+ * are all left intact.
+ *
+ * Link and image syntax is left as written. Punctuation is tested against ASCII only, and escapes
+ * resolve inside code spans as well as outside them.
+ */
+fun legacyProjectMarkdownToPlainText(markdown: String): String {
+	if (!legacyContainsMarkdownSyntax(markdown)) return markdown
+
+	val runs = scanDelimiterRuns(markdown)
+	resolveCodeSpans(runs)
+	resolveEmphasis(runs)
+	return render(markdown, runs)
+}
+
+/**
+ * The prose title for [markdown]: the first non-blank line of its projection. Falls back to the raw
+ * first line when the projection of it is blank, so a marker-only line still yields a title rather
+ * than reading as an empty document.
+ */
+fun legacyMarkdownTitleLine(markdown: String): String {
+	val projected = legacyProjectMarkdownToPlainText(markdown)
+	val title = projected.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+	if (title.isNotEmpty()) return title
+	return markdown.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+}
+
+/**
+ * True when [text] holds a character the projection can remove. A query without one that misses the
+ * projection cannot match the raw source either, because the projection only ever deletes.
+ */
+fun legacyContainsMarkdownSyntax(text: String): Boolean {
+	var i = 0
+	while (i < text.length) {
+		val c = text[i]
+		if (c.isDelimiter() || c == '\\' || c == '#' || c == '>' || c == '-' || c == '+') return true
+		i++
+	}
+	return false
+}
+
+/**
+ * The offset after any blockquote, heading or bullet marker opening the line at [start], or [start]
+ * itself when the line opens with prose. Ordered-list markers are left alone: a single line cannot
+ * distinguish "1. Draft opening" from "1984. The year everything changed".
+ */
+private fun skipBlockPrefix(markdown: String, start: Int): Int {
+	val length = markdown.length
+	var i = start
+	var found = false
+
+	while (i < length && markdown[i].isSpaceOrTab()) i++
+
+	while (i < length && markdown[i] == '>') {
+		i++
+		found = true
+		while (i < length && markdown[i].isSpaceOrTab()) i++
+	}
+
+	if (i < length && markdown[i] == '#') {
+		var j = i
+		var hashes = 0
+		while (j < length && markdown[j] == '#') {
+			j++
+			hashes++
+		}
+		if (hashes <= 6 && j < length && markdown[j].isSpaceOrTab()) {
+			i = j
+			found = true
+		}
+	} else if (i < length && (markdown[i] == '-' || markdown[i] == '*' || markdown[i] == '+')) {
+		if (i + 1 < length && markdown[i + 1].isSpaceOrTab()) {
+			i++
+			found = true
+		}
+	}
+
+	if (!found) return start
+	while (i < length && markdown[i].isSpaceOrTab()) i++
+	return i
+}
+
+/** Appends the character at [i], resolving a backslash escape, and returns the next index. */
+private fun StringBuilder.appendResolved(markdown: String, i: Int): Int {
+	val c = markdown[i]
+	if (c == '\\' && i + 1 < markdown.length && markdown[i + 1] in ASCII_PUNCTUATION) {
+		append(markdown[i + 1])
+		return i + 2
+	}
+	append(c)
+	return i + 1
+}
+
+private fun scanDelimiterRuns(markdown: String): List<DelimiterRun> {
+	val runs = mutableListOf<DelimiterRun>()
+	val length = markdown.length
+	var i = 0
+	var paragraph = 0
+	while (i < length) {
+		val c = markdown[i]
+		if (c == '\\' && i + 1 < length && markdown[i + 1] in ASCII_PUNCTUATION) {
+			i += 2
+			continue
+		}
+		if (c == '\n') {
+			var k = i + 1
+			while (k < length && (markdown[k].isSpaceOrTab() || markdown[k] == '\r')) k++
+			if (k >= length || markdown[k] == '\n') paragraph++
+			i++
+			continue
+		}
+		if (!c.isDelimiter()) {
+			i++
+			continue
+		}
+
+		val start = i
+		var end = start + 1
+		while (end < length && markdown[end] == c) end++
+		i = end
+
+		var canOpen = true
+		var canClose = true
+		if (c != '`') {
+			val prev = markdown.getOrNull(start - 1)
+			val next = markdown.getOrNull(end)
+			val leftFlanking = !next.isBlankOrEdge() &&
+				(!next.isPunctuation() || prev.isBlankOrEdge() || prev.isPunctuation())
+			val rightFlanking = !prev.isBlankOrEdge() &&
+				(!prev.isPunctuation() || next.isBlankOrEdge() || next.isPunctuation())
+			if (c == '*') {
+				canOpen = leftFlanking
+				canClose = rightFlanking
+			} else {
+				// Underscores cannot delimit emphasis inside a word, which is what saves `user_name`.
+				canOpen = leftFlanking && (!rightFlanking || prev.isPunctuation())
+				canClose = rightFlanking && (!leftFlanking || next.isPunctuation())
+			}
+			// A run that can do neither is literal text; leaving it out keeps it out of the render.
+			if (!canOpen && !canClose) continue
+		}
+
+		val run = DelimiterRun(c, start, end, paragraph)
+		run.canOpen = canOpen
+		run.canClose = canClose
+		runs.add(run)
+	}
+	return runs
+}
+
+/** Code spans bind tighter than emphasis, so they claim their delimiters first. */
+private fun resolveCodeSpans(runs: List<DelimiterRun>) {
+	var i = 0
+	while (i < runs.size) {
+		val opener = runs[i]
+		if (opener.char != '`') {
+			i++
+			continue
+		}
+
+		val width = opener.end - opener.start
+		var j = i + 1
+		var closer = -1
+		while (j < runs.size && runs[j].paragraph == opener.paragraph) {
+			val candidate = runs[j]
+			if (candidate.char == '`' && candidate.end - candidate.start == width) {
+				closer = j
+				break
+			}
+			j++
+		}
+		if (closer < 0) {
+			i++
+			continue
+		}
+
+		opener.dropBack = width
+		runs[closer].dropFront = width
+		for (k in i + 1 until closer) runs[k].inert = true
+		i = closer + 1
+	}
+}
+
+private fun resolveEmphasis(runs: List<DelimiterRun>) {
+	val open = mutableListOf<DelimiterRun>()
+	var paragraph = -1
+	for (run in runs) {
+		if (run.paragraph != paragraph) {
+			open.clear()
+			paragraph = run.paragraph
+		}
+		if (run.char == '`' || run.inert) continue
+
+		if (run.canClose) {
+			while (run.available > 0) {
+				val openerIndex = open.indexOfLast { it.char == run.char }
+				if (openerIndex < 0) break
+
+				val opener = open[openerIndex]
+				val consumed = minOf(run.available, opener.available)
+				opener.dropBack += consumed
+				run.dropFront += consumed
+
+				// Anything stacked above the matched opener can never close now.
+				while (open.size > openerIndex) open.removeAt(open.size - 1)
+				if (opener.available > 0) open.add(opener)
+			}
+		}
+		if (run.available > 0 && run.canOpen) open.add(run)
+	}
+}
+
+private fun render(markdown: String, runs: List<DelimiterRun>): String {
+	val sb = StringBuilder(markdown.length)
+	val length = markdown.length
+	var i = 0
+	var r = 0
+	var atLineStart = true
+	while (i < length) {
+		if (atLineStart) {
+			atLineStart = false
+			val afterPrefix = skipBlockPrefix(markdown, i)
+			if (afterPrefix > i) {
+				i = afterPrefix
+				while (r < runs.size && runs[r].start < i) r++
+				continue
+			}
+		}
+
+		if (r < runs.size && i == runs[r].start) {
+			val run = runs[r]
+			sb.append(markdown, run.start + run.dropFront, run.end - run.dropBack)
+			i = run.end
+			r++
+			continue
+		}
+
+		if (markdown[i] == '\n') atLineStart = true
+		i = sb.appendResolved(markdown, i)
+	}
+	return sb.toString()
+}

--- a/common/src/desktopTest/kotlin/data/search/ProjectorBenchmark.kt
+++ b/common/src/desktopTest/kotlin/data/search/ProjectorBenchmark.kt
@@ -1,0 +1,111 @@
+package data.search
+
+import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjector
+import com.darkrockstudios.apps.hammer.common.data.search.projectMarkdownToPlainText
+import com.sun.management.ThreadMXBean
+import java.lang.management.ManagementFactory
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Cost of a full-project scan: PR #821's implementation against the reusable workspace. */
+class ProjectorBenchmark {
+
+	private val threads = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+	private inline fun measureAlloc(block: () -> Unit): Long {
+		val before = threads.getCurrentThreadAllocatedBytes()
+		block()
+		return threads.getCurrentThreadAllocatedBytes() - before
+	}
+
+	@Test
+	fun `the rewrite agrees with the implementation it replaces`() {
+		val corpus = buildCorpus(20_000)
+		val projector = MarkdownProjector()
+		corpus.forEach { scene ->
+			projector.project(scene)
+			assertEquals(legacyProjectMarkdownToPlainText(scene), projector.projected())
+		}
+	}
+
+	@Test
+	fun `full-project scan, legacy versus reusable workspace`() {
+		for (words in listOf(300_000, 1_250_000)) {
+			val corpus = buildCorpus(words)
+			val query = "gulls argue"
+			val projector = MarkdownProjector()
+
+			repeat(3) {
+				corpus.forEach { legacyProjectMarkdownToPlainText(it).indexOf(query, ignoreCase = true) }
+				corpus.forEach { projectMarkdownToPlainText(it).indexOf(query, ignoreCase = true) }
+				corpus.forEach { projector.project(it); projector.indexOf(query) }
+			}
+
+			val legacyTime = (0 until 3).minOf {
+				measureTimeMillis {
+					corpus.forEach { legacyProjectMarkdownToPlainText(it).indexOf(query, ignoreCase = true) }
+				}
+			}
+			val wrapperTime = (0 until 3).minOf {
+				measureTimeMillis {
+					corpus.forEach { projectMarkdownToPlainText(it).indexOf(query, ignoreCase = true) }
+				}
+			}
+			val reusedTime = (0 until 3).minOf {
+				measureTimeMillis {
+					corpus.forEach { projector.project(it); projector.indexOf(query) }
+				}
+			}
+
+			val legacyAlloc = measureAlloc {
+				corpus.forEach { legacyProjectMarkdownToPlainText(it).indexOf(query, ignoreCase = true) }
+			}
+			val wrapperAlloc = measureAlloc {
+				corpus.forEach { projectMarkdownToPlainText(it).indexOf(query, ignoreCase = true) }
+			}
+			val reusedAlloc = measureAlloc {
+				corpus.forEach { projector.project(it); projector.indexOf(query) }
+			}
+
+			println("=== ${words / 1000}k words, ${corpus.size} scenes ===")
+			println("  legacy (#821)      : ${legacyTime}ms, ${legacyAlloc.mb()}")
+			println("  new, workspace/call: ${wrapperTime}ms, ${wrapperAlloc.mb()}")
+			println("  new, reused        : ${reusedTime}ms, ${reusedAlloc.mb()}")
+		}
+	}
+
+	private fun Long.mb(): String =
+		"${(this / 1024.0 / 1024.0).let { kotlin.math.round(it * 100) / 100 }} MB"
+
+	private fun buildCorpus(totalWords: Int): List<String> {
+		val wordsPerScene = 2_000
+		val scenes = totalWords / wordsPerScene
+		val words = ("the quick brown fox jumps over a lazy dog while morning light spills across " +
+			"the harbour and gulls argue about nothing at all she thought of him again").split(" ")
+		return (0 until scenes).map { s ->
+			val sb = StringBuilder()
+			sb.append("# Scene $s\n\n")
+			var w = 0
+			while (w < wordsPerScene) {
+				val paragraph = StringBuilder()
+				repeat(120) {
+					val word = words[(w * 7 + it * 13 + s) % words.size]
+					if ((w + it) % 5 == 0) {
+						when ((w + it) % 15) {
+							0 -> paragraph.append("**").append(word).append("**")
+							5 -> paragraph.append("*").append(word).append("*")
+							else -> paragraph.append("well\\-known")
+						}
+					} else {
+						paragraph.append(word)
+					}
+					paragraph.append(' ')
+				}
+				w += 120
+				sb.append(paragraph.trimEnd()).append(".\n\n")
+			}
+			sb.toString()
+		}
+	}
+}

--- a/common/src/desktopTest/kotlin/data/search/ScanLoadPathBenchmark.kt
+++ b/common/src/desktopTest/kotlin/data/search/ScanLoadPathBenchmark.kt
@@ -1,0 +1,128 @@
+package data.search
+
+import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjector
+import com.darkrockstudios.apps.hammer.common.util.readUtf8Into
+import com.sun.management.ThreadMXBean
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+import java.lang.management.ManagementFactory
+import kotlin.io.path.createTempDirectory
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** End-to-end scan cost from disk: a string per scene against decoding into the scan buffer. */
+class ScanLoadPathBenchmark {
+
+	private val threads = ManagementFactory.getThreadMXBean() as ThreadMXBean
+
+	private inline fun measureAlloc(block: () -> Unit): Long {
+		val before = threads.getCurrentThreadAllocatedBytes()
+		block()
+		return threads.getCurrentThreadAllocatedBytes() - before
+	}
+
+	@Test
+	fun `both load paths read the same text`() {
+		val dir = createTempDirectory("scan-load-agree")
+		val fs = FileSystem.SYSTEM
+		val document = "The **big** dog barked at the well\\-known café 😀 日本語"
+		val path = dir.resolve("scene.md").toOkioPath()
+		fs.write(path) { writeUtf8(document) }
+
+		val viaString = fs.read(path) { readUtf8() }
+		assertEquals(document, viaString)
+
+		val projector = MarkdownProjector()
+		val byteCount = fs.metadata(path).size!!.toInt()
+		val chars = fs.read(path) { readUtf8Into(projector, byteCount) }
+		projector.projectSource(chars)
+
+		val expected = MarkdownProjector().also { it.project(document) }.projected()
+		assertEquals(expected, projector.projected())
+
+		fs.deleteRecursively(dir.toOkioPath())
+	}
+
+	@Test
+	fun `full-project scan from disk`() {
+		val dir = createTempDirectory("scan-load-bench")
+		val fs = FileSystem.SYSTEM
+		val corpus = buildCorpus(300_000)
+		val paths = corpus.mapIndexed { i, text ->
+			val p = dir.resolve("scene-$i.md").toOkioPath()
+			fs.write(p) { writeUtf8(text) }
+			p
+		}
+		val query = "gulls argue"
+		val projector = MarkdownProjector()
+
+		fun stringPerScene(): Int {
+			var hits = 0
+			paths.forEach { p ->
+				val text = fs.read(p) { readUtf8() }
+				if (legacyProjectMarkdownToPlainText(text).indexOf(query, ignoreCase = true) >= 0) hits++
+			}
+			return hits
+		}
+
+		fun intoScanBuffer(): Int {
+			var hits = 0
+			paths.forEach { p ->
+				val byteCount = (fs.metadata(p).size ?: 0L).toInt()
+				val chars = fs.read(p) { readUtf8Into(projector, byteCount) }
+				projector.projectSource(chars)
+				if (projector.indexOf(query) >= 0) hits++
+			}
+			return hits
+		}
+
+		repeat(3) { stringPerScene(); intoScanBuffer() }
+		assertEquals(stringPerScene(), intoScanBuffer())
+
+		val oldTime = (0 until 3).minOf { measureTimeMillis { stringPerScene() } }
+		val newTime = (0 until 3).minOf { measureTimeMillis { intoScanBuffer() } }
+		val oldAlloc = measureAlloc { stringPerScene() }
+		val newAlloc = measureAlloc { intoScanBuffer() }
+
+		println("=== 300k words, ${paths.size} scenes, read from disk ===")
+		println("  string per scene  : ${oldTime}ms, ${oldAlloc.mb()}")
+		println("  into scan buffer  : ${newTime}ms, ${newAlloc.mb()}")
+
+		fs.deleteRecursively(dir.toOkioPath())
+	}
+
+	private fun Long.mb(): String =
+		"${(this / 1024.0 / 1024.0).let { kotlin.math.round(it * 100) / 100 }} MB"
+
+	private fun buildCorpus(totalWords: Int): List<String> {
+		val wordsPerScene = 2_000
+		val scenes = totalWords / wordsPerScene
+		val words = ("the quick brown fox jumps over a lazy dog while morning light spills across " +
+			"the harbour and gulls argue about nothing at all she thought of him again").split(" ")
+		return (0 until scenes).map { s ->
+			val sb = StringBuilder()
+			sb.append("# Scene $s\n\n")
+			var w = 0
+			while (w < wordsPerScene) {
+				val paragraph = StringBuilder()
+				repeat(120) {
+					val word = words[(w * 7 + it * 13 + s) % words.size]
+					if ((w + it) % 5 == 0) {
+						when ((w + it) % 15) {
+							0 -> paragraph.append("**").append(word).append("**")
+							5 -> paragraph.append("*").append(word).append("*")
+							else -> paragraph.append("well\\-known")
+						}
+					} else {
+						paragraph.append(word)
+					}
+					paragraph.append(' ')
+				}
+				w += 120
+				sb.append(paragraph.trimEnd()).append(".\n\n")
+			}
+			sb.toString()
+		}
+	}
+}

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -380,6 +380,174 @@ class SearchProjectUseCaseTest : BaseTest() {
 		assertEquals(7, results.first().sceneItem.id)
 	}
 
+	private fun note(id: Int, content: String) =
+		NoteContainer(NoteContent(id = id, created = Clock.System.now(), content = content))
+
+	@Test
+	fun `search matches across a backslash escape`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "A well\\-known secret"))
+
+		val results = createUseCase().search("well-known", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+	}
+
+	@Test
+	fun `search matches a phrase spanning an emphasis boundary`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "**Chapter** One begins"))
+
+		val results = createUseCase().search("Chapter One", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+	}
+
+	@Test
+	fun `search matches a phrase spanning italics and code spans`() = runTest {
+		every { notes.getNotes() } returns listOf(
+			note(1, "the _quick_ brown fox"),
+			note(2, "run the `build` script"),
+		)
+
+		val italic = createUseCase().search("quick brown", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+		val code = createUseCase().search("the build script", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, italic.size)
+		assertEquals(1, code.size)
+	}
+
+	@Test
+	fun `snippets render prose without markdown syntax`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "A well\\-known **Chapter** One secret"))
+
+		val results = createUseCase().search("well-known", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		val snippet = results.first().snippet
+		assertEquals("A well-known Chapter One secret", snippet.text)
+		assertEquals("well-known", snippet.text.substring(snippet.matchStart, snippet.matchEnd))
+	}
+
+	@Test
+	fun `escaped literals survive the projection`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "the \\_shape\\_ of it"))
+
+		val results = createUseCase().search("_shape_", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertTrue(results.first().snippet.text.contains("_shape_"))
+	}
+
+	@Test
+	fun `searching for literal markdown syntax still finds it`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "raw **bold** marker"))
+
+		val results = createUseCase().search("**bold**", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+	}
+
+	@Test
+	fun `scene bodies match across an emphasis boundary`() = runTest {
+		val scene = SceneItem(
+			projectDef = projectDef,
+			type = SceneItem.Type.Scene,
+			id = 7,
+			name = "Opening",
+			order = 0,
+		)
+		every { sceneEditor.getScenes() } returns listOf(scene)
+		every { sceneContentRepository.getSceneBuffer(scene) } returns null
+		every { sceneEditor.loadSceneMarkdownRaw(scene, any()) } returns "**Chapter** One begins"
+
+		val results = createUseCase().search("Chapter One", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Scene>()
+
+		assertEquals(1, results.size)
+		assertEquals("Chapter One begins", results.first().snippet.text)
+	}
+
+	@Test
+	fun `literal underscores in imported content are left alone`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "the user_name field and my_table_name"))
+
+		val results = createUseCase().search("user_name", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertTrue(results.first().snippet.text.contains("my_table_name"))
+	}
+
+	@Test
+	fun `a body of only markdown markers still previews in a tag search`() = runTest {
+		every { notes.getNotes() } returns listOf(
+			NoteContainer(
+				NoteContent(
+					id = 1,
+					created = Clock.System.now(),
+					content = "***",
+					tags = setOf("fantasy"),
+				)
+			),
+		)
+
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertEquals("***", results.first().snippet.text)
+	}
+
+	@Test
+	fun `a note whose first line is only markers is not titled empty`() = runTest {
+		every { notes.getNotes() } returns listOf(note(1, "***\nThe real body text"))
+
+		val results = createUseCase().search("real body", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertEquals("***", results.first().title)
+	}
+
+	@Test
+	fun `timeline dates are not projected`() = runTest {
+		coEvery { timeLine.loadTimeline() } returns TimeLineContainer(
+			listOf(TimeLineEvent(id = 21, order = 0, date = "1990_2000", content = "A long war")),
+		)
+
+		val results = createUseCase().search("1990_2000", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.TimelineEvent>()
+
+		assertEquals(1, results.size)
+		assertTrue(results.first().snippet.text.contains("1990_2000"))
+	}
+
+	@Test
+	fun `tag-only search previews prose without markdown syntax`() = runTest {
+		every { notes.getNotes() } returns listOf(
+			NoteContainer(
+				NoteContent(
+					id = 1,
+					created = Clock.System.now(),
+					content = "A well\\-known **Chapter** One secret",
+					tags = setOf("fantasy"),
+				)
+			),
+		)
+
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertEquals("A well-known Chapter One secret", results.first().snippet.text)
+	}
+
 	@Test
 	fun `search matches across a backslash escape`() = runTest {
 		every { notes.getNotes() } returns listOf(note(1, "A well\\-known secret"))

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -19,6 +19,7 @@ import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteCont
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
+import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjector
 import com.darkrockstudios.apps.hammer.common.util.ScanBuffers
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.search.markdownContains
@@ -97,7 +98,7 @@ class SearchProjectUseCaseTest : BaseTest() {
 		for ((content, query) in cases) {
 			assertEquals(
 				markdownContains(content, query),
-				SearchProjectUseCase.findMarkdownMatch(content, query) != null,
+				SearchProjectUseCase.findMarkdownMatch(MarkdownProjector(), content, query) != null,
 				"disagreement on content=<$content> query=<$query>",
 			)
 		}
@@ -588,16 +589,6 @@ class SearchProjectUseCaseTest : BaseTest() {
 	}
 
 	@Test
-	fun `search matches across a backslash escape`() = runTest {
-		every { notes.getNotes() } returns listOf(note(1, "A well\\-known secret"))
-
-		val results = createUseCase().search("well-known", GlobalSearchFilter.All)
-			.filterIsInstance<SearchResult.Note>()
-
-		assertEquals(1, results.size)
-	}
-
-	@Test
 	fun `snippets render escaped text the way it reads on screen`() = runTest {
 		every { notes.getNotes() } returns listOf(note(1, "A well\\-known garden\\! at dusk"))
 
@@ -687,7 +678,7 @@ class SearchProjectUseCaseTest : BaseTest() {
 		)
 		every { sceneEditor.getScenes() } returns listOf(scene)
 		every { sceneContentRepository.getSceneBuffer(scene) } returns null
-		every { sceneEditor.loadSceneMarkdownRaw(scene, any()) } returns "A well\\-known road"
+		stubSceneMarkdown(scene, "A well\\-known road")
 
 		val results = createUseCase().search("well-known", GlobalSearchFilter.All)
 			.filterIsInstance<SearchResult.Scene>()
@@ -872,9 +863,6 @@ class SearchProjectUseCaseTest : BaseTest() {
 		assertEquals(1, results.size)
 		assertEquals(7, results.first().sceneItem.id)
 	}
-
-	private fun note(id: Int, content: String) =
-		NoteContainer(NoteContent(id = id, created = Clock.System.now(), content = content))
 
 	@Test
 	fun `search honors filter to a single source`() = runTest {

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -19,14 +19,14 @@ import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteCont
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
-import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjector
-import com.darkrockstudios.apps.hammer.common.util.ScanBuffers
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
+import com.darkrockstudios.apps.hammer.common.data.search.MarkdownProjector
 import com.darkrockstudios.apps.hammer.common.data.search.markdownContains
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineContainer
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEvent
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.util.ScanBuffers
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -459,13 +459,18 @@ class SearchProjectUseCaseTest : BaseTest() {
 	}
 
 	@Test
-	fun `searching for literal markdown syntax still finds it`() = runTest {
+	fun `typing markdown syntax does not find the markup it renders away`() = runTest {
+		// The query is literal text matched against the prose on screen; that prose reads "raw bold
+		// marker", so the asterisks are not there to be found.
 		every { notes.getNotes() } returns listOf(note(1, "raw **bold** marker"))
 
-		val results = createUseCase().search("**bold**", GlobalSearchFilter.All)
+		val asTyped = createUseCase().search("**bold**", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+		val asRead = createUseCase().search("raw bold marker", GlobalSearchFilter.All)
 			.filterIsInstance<SearchResult.Note>()
 
-		assertEquals(1, results.size)
+		assertEquals(0, asTyped.size)
+		assertEquals(1, asRead.size)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -19,6 +19,7 @@ import com.darkrockstudios.apps.hammer.common.data.notesrepository.note.NoteCont
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneContentRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneMetadataRepository
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneRepository
+import com.darkrockstudios.apps.hammer.common.util.ScanBuffers
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.search.markdownContains
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineContainer
@@ -183,8 +184,8 @@ class SearchProjectUseCaseTest : BaseTest() {
 			content = SceneContent(scene = scene, markdown = "Unsaved dragon attack"),
 			source = UpdateSource.Editor,
 		)
-		// loadSceneMarkdownRaw should not be consulted because buffer wins
-		every { sceneEditor.loadSceneMarkdownRaw(scene, any()) } returns "On-disk text"
+		// The on-disk read should not be consulted because the buffer wins
+		stubSceneMarkdown(scene, "On-disk text")
 
 		val results = createUseCase().search("dragon", GlobalSearchFilter.All)
 			.filterIsInstance<SearchResult.Scene>()
@@ -210,6 +211,19 @@ class SearchProjectUseCaseTest : BaseTest() {
 
 		assertEquals(1, results.size)
 		assertEquals(9, results.first().sceneItem.id)
+	}
+
+	/**
+	 * Stubs the on-disk read for [scene]. Search decodes a scene into a buffer it owns rather than
+	 * taking a string back, so the stub fills the buffer the use case handed in.
+	 */
+	private fun stubSceneMarkdown(scene: SceneItem, markdown: String) {
+		every { sceneEditor.readSceneMarkdownInto(eq(scene), any(), any()) } answers {
+			val sink = secondArg<ScanBuffers>()
+			val buffer = sink.charBuffer(markdown.length)
+			markdown.forEachIndexed { index, char -> buffer[index] = char }
+			markdown.length
+		}
 	}
 
 	@Test
@@ -464,7 +478,7 @@ class SearchProjectUseCaseTest : BaseTest() {
 		)
 		every { sceneEditor.getScenes() } returns listOf(scene)
 		every { sceneContentRepository.getSceneBuffer(scene) } returns null
-		every { sceneEditor.loadSceneMarkdownRaw(scene, any()) } returns "**Chapter** One begins"
+		stubSceneMarkdown(scene, "**Chapter** One begins")
 
 		val results = createUseCase().search("Chapter One", GlobalSearchFilter.All)
 			.filterIsInstance<SearchResult.Scene>()

--- a/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/usecases/globalsearch/SearchProjectUseCaseTest.kt
@@ -505,6 +505,27 @@ class SearchProjectUseCaseTest : BaseTest() {
 	}
 
 	@Test
+	fun `a heading does not leak into the title or the snippet`() = runTest {
+		every { notes.getNotes() } returns listOf(
+			NoteContainer(
+				NoteContent(
+					id = 1,
+					created = Clock.System.now(),
+					content = "# Chapter One\n\nThe body text",
+					tags = setOf("fantasy"),
+				)
+			),
+		)
+
+		val results = createUseCase().search("#fantasy", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.Note>()
+
+		assertEquals(1, results.size)
+		assertEquals("Chapter One", results.first().title)
+		assertEquals("Chapter One The body text", results.first().snippet.text)
+	}
+
+	@Test
 	fun `a note whose first line is only markers is not titled empty`() = runTest {
 		every { notes.getNotes() } returns listOf(note(1, "***\nThe real body text"))
 
@@ -518,14 +539,18 @@ class SearchProjectUseCaseTest : BaseTest() {
 	@Test
 	fun `timeline dates are not projected`() = runTest {
 		coEvery { timeLine.loadTimeline() } returns TimeLineContainer(
-			listOf(TimeLineEvent(id = 21, order = 0, date = "1990_2000", content = "A long war")),
+			listOf(TimeLineEvent(id = 21, order = 0, date = "1990 _to_ 2000", content = "A long war")),
 		)
 
-		val results = createUseCase().search("1990_2000", GlobalSearchFilter.All)
+		val verbatim = createUseCase().search("1990 _to_ 2000", GlobalSearchFilter.All)
+			.filterIsInstance<SearchResult.TimelineEvent>()
+		val projectedForm = createUseCase().search("1990 to 2000", GlobalSearchFilter.All)
 			.filterIsInstance<SearchResult.TimelineEvent>()
 
-		assertEquals(1, results.size)
-		assertTrue(results.first().snippet.text.contains("1990_2000"))
+		assertEquals(1, verbatim.size)
+		assertTrue(verbatim.first().snippet.text.contains("1990 _to_ 2000"))
+		// Projecting the date would make this hit and would show a date the event does not have.
+		assertEquals(0, projectedForm.size)
 	}
 
 	@Test

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/TextSummary.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/TextSummary.kt
@@ -1,7 +1,9 @@
 package com.darkrockstudios.apps.hammer.common.compose
 
-fun String.firstNonBlankLine(): String =
-	lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+import com.darkrockstudios.apps.hammer.common.data.search.markdownTitleLine
+
+/** Every caller summarizes stored Markdown, so the line is flattened to the prose behind it. */
+fun String.firstNonBlankLine(): String = markdownTitleLine(this)
 
 fun String.truncateWithEllipsis(limit: Int): String =
 	if (length > limit) take(limit - 1).trimEnd() + "…" else this

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/TextSummary.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/TextSummary.kt
@@ -1,9 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.compose
 
-import com.darkrockstudios.apps.hammer.common.data.search.markdownTitleLine
-
-/** Every caller summarizes stored Markdown, so the line is flattened to the prose behind it. */
-fun String.firstNonBlankLine(): String = markdownTitleLine(this)
+fun String.firstNonBlankLine(): String =
+	lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
 
 fun String.truncateWithEllipsis(limit: Int): String =
 	if (length > limit) take(limit - 1).trimEnd() + "…" else this

--- a/composeUi/src/desktopTest/kotlin/SearchFilterTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SearchFilterTest.kt
@@ -68,6 +68,8 @@ class SearchFilterTest {
 	fun `literal markup is not rewritten by any screen filter`() {
 		assertTrue(noteMatchesQuery(note("The cost is 5*4"), "5*4"))
 		assertTrue(eventMatchesQuery(event("the user_name field"), "user_name"))
-		assertTrue(ideaMatchesQuery(idea("a **Chapter** heading"), "**Chapter**"))
+		// Paired markers are gone from the prose on screen, so typing them finds nothing.
+		assertFalse(ideaMatchesQuery(idea("a **Chapter** heading"), "**Chapter**"))
+		assertTrue(ideaMatchesQuery(idea("a **Chapter** heading"), "Chapter heading"))
 	}
 }


### PR DESCRIPTION
Fixes #811. Supersedes #821, whose two commits are included here, rebased onto develop.

Global search compared queries against raw Markdown, so a phrase spanning an emphasis marker did not match and snippets rendered storage syntax back at the user. #821 fixed that with a prose projection. This carries that work the rest of the way: the scan no longer allocates, scenes are read straight into it, every surface shares the rule, and the rule itself is now one line.

## The rule

A query is literal text, matched against the prose a document renders as. It is never read as Markdown, and the storage form is never searched.

```kotlin
fun markdownContains(content: String, query: String): Boolean =
	projectMarkdownToPlainText(content).contains(query, ignoreCase = true)
```

| stored | renders as | `well-known` | `well\-known` |
|---|---|---|---|
| `well\-known` | `well-known` | match | no match |
| `well\-known` | `well\-known` | no match | match |

`**Chapter**` finds nothing, because those asterisks are not on screen. `Chapter One` finds `**Chapter** One`, because that is what the document reads. Markers the projection leaves alone, `5*4` and `user_name`, match where they sit, because there they are prose.

**This removes a capability:** you can no longer search for markup itself. Typing `**` to find every bolded word used to work via a raw-source fallback. That fallback was the query being interpreted as markup, and it is gone.

## Cost of the scan

A projection is more work than the raw `contains` it replaces, and the original objection to doing it at all was allocation, not time. So the scan was rebuilt to allocate nothing.

`MarkdownProjector` is a workspace that keeps its buffers. Delimiter runs live in parallel primitive arrays rather than one object each, the projected prose lands in a char buffer matched in place rather than turned into a String, and every buffer grows to the widest document seen and is then reused. Scenes are decoded off disk straight into that same workspace, so a scan takes no string per file either.

Measured over a full-project scan, markup on roughly a fifth of words:

| | 300k words | 1.25M words |
|---|---|---|
| #821 as written | 24 ms, 7.6 MB | 97 ms, 31.7 MB |
| this branch | 24 ms, **0 MB** | 104 ms, **0 MB** |

Including the read from disk, at 300k words: 36 ms / 11.5 MB becomes 37 ms / 0.4 MB. Steady-state search allocates essentially nothing, so the debounce budget is spent on the scan rather than on the collector.

Two incidental wins: the source is copied into a flat array so the scan and render index an array instead of paying a `CharSequence` call per character on both passes, and the ASCII punctuation test became four range checks instead of a scan over a 32-character string. The bytes are pulled in bulk and decoded from an array — reading a byte at a time off a `BufferedSource` was measurably slower than Okio's own `readUtf8`, and the decode was never the expensive part.

## Reconciling with #831

#831 landed while #821 was open and unified four surfaces on `markdownContains`, which resolves escapes only. Leaving it alone would have re-split the surfaces it had just joined, so it projects now too and Notes, Timeline and Story Ideas get the #811 fix as well.

The two PRs also disagreed on the raw-source fallback, and that disagreement is what the literal-text rule settles. Three assertions pinned the behaviour that has gone, one per surface, and each now states the opposite.

`matchOrPreview` keeps the fallback argument and empty-snippet chain from #833, which the projection commits had dropped; without it a tag-only search stops returning bodiless items.

## Notes for review

- `MarkdownProjector` is not thread safe by design. Cancelling a search is cooperative, so an outgoing scan can still be running when the next starts; `MarkdownProjectorPool` lends one per scan and keeps it afterwards, so buffers survive to the next keystroke without serialising the four scans.
- `SearchProjectUseCase` is no longer stateless — it holds the pool. That is the point, but it contradicts its own class doc, which is worth a look.
- `LegacyMarkdownProjection.kt` in `desktopTest` is #821's implementation kept verbatim as the benchmark baseline. It guards against regression but is dead weight if you would rather not carry it.
- `markdownTitleLine` now has no production callers.
- The UTF-8 decode is hand-written (`CharBuffers.kt`) because nothing in Okio decodes into a caller-owned `CharArray`. Malformed input yields U+FFFD rather than throwing.

## Tests

- `MarkdownProjectorTest`: 16 cases over the reusable workspace, including that a long document followed by a short one does not leak its tail.
- `CharBuffersTest`: 10 cases over the decoder — multibyte, surrogate pairs, truncated and stray-continuation bytes, sink exhaustion.
- `MarkdownProjectionTest` (26) and `SearchProjectUseCaseTest` unchanged in intent; the projection rewrite is internal and they passed throughout.
- `ProjectorBenchmark` / `ScanLoadPathBenchmark` produce the numbers above and assert the new path agrees with the old.

`:common:desktopTest` and `:composeUi:desktopTest` green (1669 tests). `:composeUi` and `:common:compileIosMainKotlinMetadata` compile.
