### PR TITLE
Resolve drop targets against drawn row geometry

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -61,7 +60,7 @@ fun SceneTree(
 				LazyColumn(
 					state = state.listState,
 					modifier = modifier.reorderableModifier(state)
-						.onGloballyPositioned { state.listTopInRoot = it.positionInRoot().y }
+						.onGloballyPositioned { state.setListCoordinates(it) }
 						.weight(1f),
 					contentPadding = contentPadding
 				) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
@@ -26,6 +27,8 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -58,6 +61,7 @@ fun SceneTree(
 				LazyColumn(
 					state = state.listState,
 					modifier = modifier.reorderableModifier(state)
+						.onGloballyPositioned { state.listTopInRoot = it.positionInRoot().y }
 						.weight(1f),
 					contentPadding = contentPadding
 				) {
@@ -68,6 +72,9 @@ fun SceneTree(
 					) { node ->
 						val nodeCollapsesChildren =
 							state.collapsedNodes[node.value.id] ?: false
+						val id = node.value.id
+
+						DisposableEffect(id) { onDispose { state.removeRowCoordinates(id) } }
 
 						SceneTreeNode(
 							node = node,
@@ -77,7 +84,8 @@ fun SceneTree(
 							modifier = Modifier.wrapContentHeight()
 								.fillMaxWidth()
 								.animateItem()
-								.pressCandidate(state, node.value.id),
+								.onGloballyPositioned { state.setRowCoordinates(id, it) }
+								.pressCandidate(state, id),
 							itemUi = itemUi
 						)
 					}
@@ -90,12 +98,11 @@ fun SceneTree(
 }
 
 /**
- * Records this row as the drag candidate while it is pressed.
+ * Claims this row as the drag target for as long as it is pressed.
  *
- * Thar be dragons: resolving the row from [LazyListLayoutInfo] instead looks equivalent but is
- * not. Its offsets are where items are headed, not where they are drawn, so a press landing
- * during a placement animation grabs whichever row now owns that target slot. Compose's own hit
- * test uses the drawn position, so it stays right mid-animation.
+ * The row is settled at touch-down, not when the long press expires, so a list still settling
+ * under a stationary finger hands back the row the user aimed at rather than whichever row has
+ * since slid beneath them.
  */
 private fun Modifier.pressCandidate(state: SceneTreeState, id: Int): Modifier =
 	pointerInput(id) {
@@ -140,7 +147,7 @@ private fun Modifier.reorderableModifier(state: SceneTreeState): Modifier {
 				val layoutInfo: LazyListLayoutInfo = listState.layoutInfo
 				val insertPosition = findInsertPosition(
 					dragOffset = change.position,
-					layouts = layoutInfo.visibleItemsInfo,
+					layouts = rowLayouts,
 					collapsedGroups = collapsedNodes,
 					tree = summary.sceneTree,
 					visibleNodes = visibleNodes,
@@ -196,17 +203,13 @@ private fun drawInsertLine(
 			return@Canvas
 		}
 
-		val visibleItems = state.listState.layoutInfo.visibleItemsInfo
-		val anchorLayout = visibleItems.find { it.key == node.value.id }
+		val visibleItems = state.rowLayouts
+		val anchorLayout = visibleItems.find { it.id == node.value.id }
 
-		val lineY: Int
+		val lineY: Float
 		val nestingDept: Int
 		if (anchorLayout != null) {
-			lineY = if (insertPos.before) {
-				anchorLayout.offset
-			} else {
-				anchorLayout.offset + anchorLayout.size
-			}
+			lineY = if (insertPos.before) anchorLayout.top else anchorLayout.bottom
 
 			val isGroup = node.value.type.isCollection
 			val isCollapsed = (state.collapsedNodes[node.value.id] == true)
@@ -224,8 +227,8 @@ private fun drawInsertLine(
 				.any { state.collapsedNodes[it.value.id] == true }
 			if (!hiddenByCollapse) return@Canvas
 			val parentNode = tree[node.parent]
-			val parentLayout = visibleItems.find { it.key == parentNode.value.id } ?: return@Canvas
-			lineY = parentLayout.offset + parentLayout.size
+			val parentLayout = visibleItems.find { it.id == parentNode.value.id } ?: return@Canvas
+			lineY = parentLayout.bottom
 			nestingDept = parentNode.depth + 1
 		}
 
@@ -233,8 +236,8 @@ private fun drawInsertLine(
 		val endX = size.width - NESTING_INSET.toPx()
 
 		drawLine(
-			start = Offset(x = insetSize, y = lineY.toFloat()),
-			end = Offset(x = endX, y = lineY.toFloat()),
+			start = Offset(x = insetSize, y = lineY),
+			end = Offset(x = endX, y = lineY),
 			color = color,
 			strokeWidth = 5f.dp.toPx(),
 			cap = StrokeCap.Round

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
@@ -14,9 +14,9 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.positionInRoot
 import com.darkrockstudios.apps.hammer.common.data.InsertPosition
 import com.darkrockstudios.apps.hammer.common.data.MoveRequest
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
@@ -106,37 +106,51 @@ class SceneTreeState(
 		pressedRowId = NO_SELECTION
 	}
 
-	private val rows = mutableStateMapOf<Int, LayoutCoordinates>()
+	private data class RowEntry(val coordinates: LayoutCoordinates, val placement: Int)
+
+	private val rows = mutableStateMapOf<Int, RowEntry>()
+	private var placementCount = 0
+	private var listCoordinates: LayoutCoordinates? = null
 
 	/**
-	 * Where the rows are actually drawn, which is what every drag decision must be made against.
+	 * Where the rows are actually drawn, in display order, which is what every drag decision has
+	 * to be made against.
 	 *
 	 * Thar be dragons: [LazyListLayoutInfo] looks like the obvious source and is not. Its offsets
 	 * are where items are headed, so while a placement animation runs it reports a row at a slot
 	 * it has not reached, and drags land on the neighbour instead (issue #837).
 	 */
-	internal val rowLayouts: Collection<RowLayout>
-		get() = rows.entries.mapNotNull { (id, coords) ->
-			if (!coords.isAttached) return@mapNotNull null
+	internal val rowLayouts: List<RowLayout>
+		get() {
+			val list = listCoordinates?.takeIf { it.isAttached } ?: return emptyList()
 
-			RowLayout(
-				id = id,
-				top = coords.positionInRoot().y - listTopInRoot,
-				height = coords.size.height.toFloat(),
-			)
+			return rows.entries.mapNotNull { (id, entry) ->
+				if (!entry.coordinates.isAttached) return@mapNotNull null
+
+				RowLayout(
+					id = id,
+					top = list.localPositionOf(entry.coordinates, Offset.Zero).y,
+					height = entry.coordinates.size.height.toFloat(),
+				)
+			}.sortedBy { it.top }
 		}
 
-	/** Root-space top of the list, so row positions share the drag gesture's coordinates. */
-	internal var listTopInRoot: Float = 0f
+	internal fun setListCoordinates(coordinates: LayoutCoordinates) {
+		listCoordinates = coordinates
+	}
 
 	/**
-	 * Held live rather than sampled: item placement animations move a row by translating its
-	 * layer every frame, without a new layout pass, so a position read during
-	 * [androidx.compose.ui.layout.onGloballyPositioned] is the row's destination. Asking the
-	 * coordinates where they are at the moment of the drag sees through that translation.
+	 * Coordinates are held live rather than sampled: item placement animations move a row by
+	 * translating its layer every frame, without a new layout pass, so a position read during
+	 * [androidx.compose.ui.layout.onGloballyPositioned] is the row's destination rather than
+	 * where it is drawn. Resolving them against the list at drag time sees through that.
+	 *
+	 * [RowEntry.placement] makes every call a distinct map value. Re-putting equal coordinates
+	 * is a no-op the snapshot system does not report, which would leave the insert line with
+	 * nothing to invalidate it as rows scroll.
 	 */
 	internal fun setRowCoordinates(id: Int, coordinates: LayoutCoordinates) {
-		rows[id] = coordinates
+		rows[id] = RowEntry(coordinates, placementCount++)
 	}
 
 	internal fun removeRowCoordinates(id: Int) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
@@ -15,6 +15,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.positionInRoot
 import com.darkrockstudios.apps.hammer.common.data.InsertPosition
 import com.darkrockstudios.apps.hammer.common.data.MoveRequest
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
@@ -77,8 +79,7 @@ class SceneTreeState(
 	}
 
 	/**
-	 * Row this press started on, recorded by the rows themselves so it reflects the drawn
-	 * position rather than a layout target.
+	 * Row this press started on, claimed by the row itself so it is the row the user aimed at.
 	 * Deliberately not snapshot state: it changes on every press and must not recompose the tree.
 	 */
 	internal var pressedRowId: Int = NO_SELECTION
@@ -104,6 +105,44 @@ class SceneTreeState(
 		pressedPointer = null
 		pressedRowId = NO_SELECTION
 	}
+
+	private val rows = mutableStateMapOf<Int, LayoutCoordinates>()
+
+	/**
+	 * Where the rows are actually drawn, which is what every drag decision must be made against.
+	 *
+	 * Thar be dragons: [LazyListLayoutInfo] looks like the obvious source and is not. Its offsets
+	 * are where items are headed, so while a placement animation runs it reports a row at a slot
+	 * it has not reached, and drags land on the neighbour instead (issue #837).
+	 */
+	internal val rowLayouts: Collection<RowLayout>
+		get() = rows.entries.mapNotNull { (id, coords) ->
+			if (!coords.isAttached) return@mapNotNull null
+
+			RowLayout(
+				id = id,
+				top = coords.positionInRoot().y - listTopInRoot,
+				height = coords.size.height.toFloat(),
+			)
+		}
+
+	/** Root-space top of the list, so row positions share the drag gesture's coordinates. */
+	internal var listTopInRoot: Float = 0f
+
+	/**
+	 * Held live rather than sampled: item placement animations move a row by translating its
+	 * layer every frame, without a new layout pass, so a position read during
+	 * [androidx.compose.ui.layout.onGloballyPositioned] is the row's destination. Asking the
+	 * coordinates where they are at the moment of the drag sees through that translation.
+	 */
+	internal fun setRowCoordinates(id: Int, coordinates: LayoutCoordinates) {
+		rows[id] = coordinates
+	}
+
+	internal fun removeRowCoordinates(id: Int) {
+		rows.remove(id)
+	}
+
 
 	private var scrollJob by mutableStateOf<Job?>(null)
 	private var treeHash by mutableStateOf(sceneSummary.sceneTree.hashCode())

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeUtils.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeUtils.kt
@@ -1,6 +1,5 @@
 package com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.scenetree
 
-import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.geometry.Offset
 import com.darkrockstudios.apps.hammer.common.data.InsertPosition
@@ -31,9 +30,14 @@ internal fun visibleSceneNodes(
 	return visible
 }
 
+/** A row as it is drawn, in coordinates shared with the drag gesture. */
+internal data class RowLayout(val id: Int, val top: Float, val height: Float) {
+	val bottom: Float get() = top + height
+}
+
 internal fun findInsertPosition(
 	dragOffset: Offset,
-	layouts: List<LazyListItemInfo>,
+	layouts: Collection<RowLayout>,
 	collapsedGroups: SnapshotStateMap<Int, Boolean>,
 	tree: ImmutableTree<SceneItem>,
 	visibleNodes: List<TreeValue<SceneItem>>,
@@ -45,9 +49,9 @@ internal fun findInsertPosition(
 	val selectedId = selectedNode.value.id
 	var foundItemId: InsertPosition? = null
 	for (layout in layouts) {
-		val id = layout.key as Int
-		val size = layout.size
-		val itemPos = layout.offset
+		val id = layout.id
+		val size = layout.height
+		val itemPos = layout.top
 
 		if (id != selectedId
 			&& dragY >= itemPos

--- a/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
@@ -147,6 +147,35 @@ class SceneTreeDragTest {
 	}
 
 	@Test
+	fun `dropping onto a settling list anchors to the row the user sees`() {
+		showTree()
+		compose.mainClock.autoAdvance = false
+
+		compose.onNodeWithTag(TREE_TAG)
+			.performMouseInput { moveTo(visualCenterOf(Ids.PREFACE)); press() }
+		compose.mainClock.advanceTimeBy(1_000)
+
+		// A sync re-flows the list while the drag is already under way.
+		summary = buildSummary(camerasAtRoot = true)
+		compose.mainClock.advanceTimeByFrame()
+		compose.mainClock.advanceTimeByFrame()
+
+		compose.onNodeWithTag(TREE_TAG)
+			.performMouseInput { moveTo(visualCenterOf(Ids.VERIFICATION)) }
+		compose.mainClock.advanceTimeByFrame()
+		compose.onNodeWithTag(TREE_TAG).performMouseInput { release() }
+		compose.mainClock.advanceTimeBy(1_000)
+
+		val request = moveRequest
+		assertNotNull(request, "No move was requested")
+		assertEquals(
+			Ids.VERIFICATION,
+			treeState.getTree()[request.toPosition.coords.globalIndex].value.id,
+			"Anchored to a row's destination instead of where it is drawn",
+		)
+	}
+
+	@Test
 	fun `a row disposed while pressed does not stay grabbable`() {
 		showTree()
 

--- a/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
@@ -147,6 +147,22 @@ class SceneTreeDragTest {
 	}
 
 	@Test
+	fun `rows are reported in display order`() {
+		// A tree whose display order is not ascending by id: "More Cameras" (9) sits near the
+		// bottom, so anything ordered by id or by hash disagrees with what is on screen.
+		summary = buildSummary(camerasAtRoot = true)
+		showTree()
+
+		// findInsertPosition takes the first row whose bounds contain the pointer, and row
+		// bounds share seams, so anything but display order makes a drop on a seam a coin toss.
+		assertEquals(
+			treeState.visibleNodes.map { it.value.id },
+			treeState.rowLayouts.map { it.id },
+			"Row order does not match the rendered tree",
+		)
+	}
+
+	@Test
 	fun `dropping onto a settling list anchors to the row the user sees`() {
 		showTree()
 		compose.mainClock.autoAdvance = false

--- a/composeUi/src/desktopTest/kotlin/SceneTreeInsertPositionTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SceneTreeInsertPositionTest.kt
@@ -1,6 +1,5 @@
 package com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.scenetree
 
-import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.geometry.Offset
@@ -25,15 +24,7 @@ import kotlin.test.assertNotNull
  */
 class SceneTreeInsertPositionTest {
 
-	private val rowHeight = 30
-
-	private class FakeItemInfo(
-		override val index: Int,
-		override val key: Any,
-		override val offset: Int,
-		override val size: Int,
-		override val contentType: Any? = null,
-	) : LazyListItemInfo
+	private val rowHeight = 30f
 
 	private fun dropAt(
 		tree: ImmutableTree<SceneItem>,
@@ -43,16 +34,15 @@ class SceneTreeInsertPositionTest {
 		fractionIntoRow: Float,
 	): InsertPosition? {
 		val visibleNodes = visibleSceneNodes(tree, collapsed)
-		val layouts: List<LazyListItemInfo> = visibleNodes.mapIndexed { index, node ->
-			FakeItemInfo(
-				index = index,
-				key = node.value.id,
-				offset = index * rowHeight,
-				size = rowHeight,
+		val layouts = visibleNodes.mapIndexed { index, node ->
+			RowLayout(
+				id = node.value.id,
+				top = index * rowHeight,
+				height = rowHeight,
 			)
 		}
-		val targetLayout = layouts.first { it.key == targetId }
-		val dragY = targetLayout.offset + (rowHeight * fractionIntoRow)
+		val targetLayout = layouts.first { it.id == targetId }
+		val dragY = targetLayout.top + (rowHeight * fractionIntoRow)
 		return findInsertPosition(
 			dragOffset = Offset(0f, dragY),
 			layouts = layouts,


### PR DESCRIPTION
Follow-up to #839, covering the drop-path finding that PR deliberately left open.

## What was still wrong

#839 fixed which row a drag *grabs*, but `findInsertPosition` and `drawInsertLine` still read `LazyListLayoutInfo`. Its offsets are where rows are headed, not where they are drawn, so if the list is still settling when a drop is computed, the scene anchors to whichever row owns that target slot and the insert line is painted at a position no row currently occupies.

## The fix

Rows now report their `LayoutCoordinates`, and the drop path asks those coordinates where the row is at the moment of the drag:

```kotlin
internal val rowLayouts: Collection<RowLayout>
    get() = rows.entries.mapNotNull { (id, coords) ->
        if (!coords.isAttached) return@mapNotNull null
        RowLayout(id, coords.positionInRoot().y - listTopInRoot, coords.size.height.toFloat())
    }
```

The coordinates are held live rather than sampled, and that distinction is the whole point. An item placement animation moves a row by translating its layer every frame *without a new layout pass*, so a position read inside `onGloballyPositioned` is the row's destination, not where it is drawn. Reading through the live coordinates sees past the translation. Measured mid-animation, with the row drawn at 270:

| source | reports |
| --- | --- |
| semantics `getBoundsInRoot()` | 270 |
| live `positionInRoot()` | 270 |
| `LazyListItemInfo.offset` | 240 |

`findInsertPosition` and `drawInsertLine` only ever read key/offset/size, so they take a small `RowLayout(id, top, height)` instead of `LazyListItemInfo`. That also drops the `FakeItemInfo` stub from `SceneTreeInsertPositionTest`.

## The grab still resolves at touch-down, on purpose

#839's review also suggested resolving the grabbed row when the long press expires rather than at touch-down. I implemented it and it is the wrong behaviour: it makes the #837 regression test fail again.

The reason is that it answers a different question. Press a row while the list is settling and hold still: 500 ms later the animation has finished and a *different* row genuinely occupies that point. Resolving at long-press expiry hands back whichever row slid under the stationary finger; resolving at touch-down hands back the row the user aimed at. The second is what people mean by pointing at something, so the press-claim from #839 stays, and the two mechanisms now split cleanly:

- **grab** = intent, fixed at touch-down (Compose's own hit test, via the per-row press claim)
- **drop** = geometry, live at the moment of the drag (`rowLayouts`)

## Tests

New: `dropping onto a settling list anchors to the row the user sees`. It grabs a scene, re-flows the list mid-drag (a sync landing during a drag), then drops on a row while it is still sliding. It fails when the drop path is pointed back at `layoutInfo`, and passes here. All 64 `composeUi` desktop tests pass.

## Review fixes

Three defects that the first cut of this PR introduced, all now fixed:

- **Row order.** Replacing the index-ordered `visibleItemsInfo` with a map meant `rowLayouts` came back in hash order, while `findInsertPosition` breaks on the first row containing the drag Y. Row rects share seams, so a drop on a seam resolved to whichever id hashed first. Now sorted by `top`. Worth noting the first test written for this was useless: the fixture's ids ascend in display order, so hash order coincided and it passed unsorted. It now uses a tree where "More Cameras" sits near the bottom, and it fails without the sort.
- **Insert line invalidation.** `positionInRoot()` is not snapshot state, and re-putting the same `LayoutCoordinates` instance is a no-op the snapshot system does not report, so nothing invalidated the draw phase when rows moved. Each map value now carries a monotonic placement counter, making every placement pass a real write and restoring the per-layout-pass invalidation that the old `layoutInfo` read provided.
- **Coordinate space.** Row tops were a live `positionInRoot()` minus a `listTopInRoot` sampled only on the list's own layout pass. An ancestor that animates by translating a layer (a Decompose stack slide, an IME inset animation) skews the two apart. The list's coordinates are now held live too, and rows resolve against them via `localPositionOf`, so both sides come from the same frame through the same transform chain.

## Known wart, unchanged

During auto-scroll the list moves under a stationary finger with no pointer event, so neither `insertAt` nor the insert line is recomputed until the finger moves. That predates this change and is not made worse by it.
