### PR TITLE
Normalize tag needles for search and suggestions

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.data.search
 
 import com.darkrockstudios.apps.hammer.common.data.tagindex.isTagPrefix
+import com.darkrockstudios.apps.hammer.common.data.tagindex.isTagSeparator
 import com.darkrockstudios.apps.hammer.common.data.tagindex.normalizeTagNeedle
 
 /** Parsed search query: free text plus any `#tags` pulled out of it. */
@@ -21,23 +22,26 @@ data class ParsedQuery(
 }
 
 /**
- * A `#` starts a tag that runs to the next whitespace; everything else is free text. Tags come out
- * in the same normalized form they are stored in, so a needle typed decomposed still matches.
+ * A `#` opening a word starts a tag; everything else is free text. Tags are split and normalized
+ * the way tag input splits them on save, so a needle typed decomposed, or joined to the next by a
+ * comma, still matches what is stored. A `#` inside a word (`C#`) is part of the word.
  */
 fun parseQuery(query: String): ParsedQuery {
-	val tags = mutableListOf<String>()
+	val tags = LinkedHashSet<String>()
 	val textBuilder = StringBuilder()
 	var i = 0
 	while (i < query.length) {
 		val c = query[i]
-		if (c.isTagPrefix()) {
+		if (c.isTagPrefix() && (i == 0 || query[i - 1].isTagSeparator())) {
 			i++
-			val tagStart = i
-			while (i < query.length && !query[i].isWhitespace()) i++
-			if (i > tagStart) {
+			// A comma chains straight into the next tag; whitespace ends tag context entirely.
+			while (i < query.length) {
+				val tagStart = i
+				while (i < query.length && !query[i].isTagSeparator()) i++
 				normalizeTagNeedle(query.substring(tagStart, i))
 					.takeIf { it.isNotEmpty() }
 					?.let(tags::add)
+				if (i < query.length && !query[i].isWhitespace()) i++ else break
 			}
 		} else {
 			textBuilder.append(c)
@@ -45,7 +49,7 @@ fun parseQuery(query: String): ParsedQuery {
 		}
 	}
 	val text = textBuilder.toString().replace(Regex("\\s+"), " ").trim()
-	return ParsedQuery(text = text, tags = tags)
+	return ParsedQuery(text = text, tags = tags.toList())
 }
 
 /**

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/search/SearchQuery.kt
@@ -1,5 +1,8 @@
 package com.darkrockstudios.apps.hammer.common.data.search
 
+import com.darkrockstudios.apps.hammer.common.data.tagindex.isTagPrefix
+import com.darkrockstudios.apps.hammer.common.data.tagindex.normalizeTagNeedle
+
 /** Parsed search query: free text plus any `#tags` pulled out of it. */
 data class ParsedQuery(
 	val text: String,
@@ -17,18 +20,25 @@ data class ParsedQuery(
 	}
 }
 
-/** A `#` starts a tag that runs to the next whitespace; everything else is free text. */
+/**
+ * A `#` starts a tag that runs to the next whitespace; everything else is free text. Tags come out
+ * in the same normalized form they are stored in, so a needle typed decomposed still matches.
+ */
 fun parseQuery(query: String): ParsedQuery {
 	val tags = mutableListOf<String>()
 	val textBuilder = StringBuilder()
 	var i = 0
 	while (i < query.length) {
 		val c = query[i]
-		if (c == '#') {
+		if (c.isTagPrefix()) {
 			i++
 			val tagStart = i
 			while (i < query.length && !query[i].isWhitespace()) i++
-			if (i > tagStart) tags.add(query.substring(tagStart, i))
+			if (i > tagStart) {
+				normalizeTagNeedle(query.substring(tagStart, i))
+					.takeIf { it.isNotEmpty() }
+					?.let(tags::add)
+			}
 		} else {
 			textBuilder.append(c)
 			i++

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/AccountTagService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/AccountTagService.kt
@@ -64,7 +64,7 @@ class AccountTagService(
 		exclude: Set<String> = emptySet(),
 		limit: Int = MAX_SUGGESTIONS,
 	): List<TagCount> {
-		val needle = prefix.trim().removePrefix("#")
+		val needle = normalizeTagNeedle(prefix)
 		if (needle.isEmpty()) return emptyList()
 
 		val merged = ideaTagCounts.value.toMutableMap()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/BuildTagIndexUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/BuildTagIndexUseCase.kt
@@ -87,6 +87,8 @@ class BuildTagIndexUseCase(
 		)
 	}
 
+	// Normalized on the way in rather than trusting every writer to have called cleanTags: a tag
+	// that reached disk decomposed would otherwise be a key no typed needle can ever match.
 	private fun accumulate(
 		tagToEntities: MutableMap<String, MutableSet<TaggedEntityRef>>,
 		countsByType: MutableMap<TaggedEntityType, MutableMap<String, Int>>,
@@ -94,8 +96,10 @@ class BuildTagIndexUseCase(
 		tag: String,
 		ref: TaggedEntityRef,
 	) {
-		tagToEntities.getOrPut(tag) { mutableSetOf() }.add(ref)
+		val key = normalizeTagNeedle(tag)
+		if (key.isEmpty()) return
+		tagToEntities.getOrPut(key) { mutableSetOf() }.add(ref)
 		val perType = countsByType.getOrPut(type) { mutableMapOf() }
-		perType[tag] = (perType[tag] ?: 0) + 1
+		perType[key] = (perType[key] ?: 0) + 1
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagIndexService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagIndexService.kt
@@ -78,7 +78,7 @@ class TagIndexService(
 		_tagIndex.value.tagToEntities[tag].orEmpty()
 
 	fun suggest(prefix: String, limit: Int = 10): List<TagCount> {
-		val needle = prefix.trim()
+		val needle = normalizeTagNeedle(prefix)
 		if (needle.isEmpty()) return getRankedTags(limit)
 		return _tagIndex.value.tagToEntities
 			.filterKeys { it.startsWith(needle, ignoreCase = true) }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.kt
@@ -80,9 +80,16 @@ fun normalizeTagNeedle(text: String): String = normalizeTagForm(text.trim()).rem
 fun tagPrefixOf(input: String): String =
 	normalizeTagNeedle(input.takeLastWhile { !it.isTagSeparator() })
 
+/**
+ * [input] with the tag being typed at its end swapped for [tag], leaving any earlier tags in the
+ * field untouched. Pairs with [tagPrefixOf]: what that offers a suggestion for, this replaces.
+ */
+fun replaceTagPrefix(input: String, tag: String): String =
+	input.dropLast(input.takeLastWhile { !it.isTagSeparator() }.length) + tag
+
 fun cleanTags(tags: Set<String>): Set<String> =
 	tags.asSequence()
-		.map { normalizeTagForm(it.trim()).removeTagPrefix() }
+		.map(::normalizeTagNeedle)
 		.filter(::isValidTag)
 		.toSet()
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/tagindex/TagNormalizer.kt
@@ -16,6 +16,9 @@ internal expect fun normalizeTagForm(text: String): String
 /** True when the supplementary-plane [codePoint] is a letter or a digit. */
 internal expect fun isSupplementaryLetterOrDigit(codePoint: Int): Boolean
 
+/** Opens a `#tag`, in ASCII or fullwidth form. */
+fun Char.isTagPrefix(): Boolean = this == '#' || this == FULLWIDTH_NUMBER_SIGN
+
 /** Separates one tag from the next in free-form input, in any script's punctuation. */
 fun Char.isTagSeparator(): Boolean =
 	isWhitespace() ||
@@ -61,7 +64,21 @@ private fun codePointOf(high: Char, low: Char): Int =
 	0x10000 + ((high.code - 0xD800) shl 10) + (low.code - 0xDC00)
 
 private fun String.removeTagPrefix(): String =
-	if (startsWith('#') || startsWith(FULLWIDTH_NUMBER_SIGN)) substring(1) else this
+	if (isNotEmpty() && this[0].isTagPrefix()) substring(1) else this
+
+/**
+ * Put a tag the user typed into the form stored tags are held in, so searching and suggesting can
+ * compare the two: composed, trimmed, and without a leading `#`.
+ */
+fun normalizeTagNeedle(text: String): String = normalizeTagForm(text.trim()).removeTagPrefix()
+
+/**
+ * The tag the user is part-way through typing at the end of [input]: whatever follows the last
+ * separator, ready to match against stored tags. Splits on the same separators [parseTagInput]
+ * does, so the suggestions offered agree with the tags that would be saved.
+ */
+fun tagPrefixOf(input: String): String =
+	normalizeTagNeedle(input.takeLastWhile { !it.isTagSeparator() })
 
 fun cleanTags(tags: Set<String>): Set<String> =
 	tags.asSequence()

--- a/common/src/desktopTest/kotlin/data/search/SearchQueryTest.kt
+++ b/common/src/desktopTest/kotlin/data/search/SearchQueryTest.kt
@@ -34,6 +34,23 @@ class SearchQueryTest {
 		assertEquals("alice in wonderland", parsed.text)
 	}
 
+	/** Text entered on iOS/macOS can arrive decomposed: base letter plus a combining mark. */
+	@Test
+	fun `parseQuery composes decomposed accents in tags`() {
+		val parsed = parseQuery("#the\u0300me")
+
+		assertEquals(listOf("th\u00e8me"), parsed.tags)
+		assertTrue(setOf("th\u00e8me").matchesAllTags(parsed.tags))
+	}
+
+	@Test
+	fun `parseQuery starts a tag on a fullwidth hash`() {
+		val parsed = parseQuery("\uff03\u4eba\u7269")
+
+		assertEquals(listOf("\u4eba\u7269"), parsed.tags)
+		assertEquals("", parsed.text)
+	}
+
 	@Test
 	fun `isUsable requires a tag or two text chars`() {
 		assertFalse(parseQuery("a").isUsable())

--- a/common/src/desktopTest/kotlin/data/search/SearchQueryTest.kt
+++ b/common/src/desktopTest/kotlin/data/search/SearchQueryTest.kt
@@ -52,6 +52,32 @@ class SearchQueryTest {
 	}
 
 	@Test
+	fun `parseQuery drops duplicate tags`() {
+		assertEquals(listOf("epic"), parseQuery("##epic #epic").tags)
+		assertEquals(listOf("th\u00e8me"), parseQuery("#th\u00e8me #the\u0300me").tags)
+	}
+
+	/** A hash mid-word is part of the word: `C#` is a search term, not an empty tag. */
+	@Test
+	fun `parseQuery keeps a hash inside a word as free text`() {
+		val ascii = parseQuery("C#")
+		assertTrue(ascii.tags.isEmpty())
+		assertEquals("C#", ascii.text)
+
+		val fullwidth = parseQuery("\uff23\uff03")
+		assertTrue(fullwidth.tags.isEmpty())
+		assertEquals("\uff23\uff03", fullwidth.text)
+	}
+
+	@Test
+	fun `parseQuery splits a comma-joined tag run the way tag input does`() {
+		val parsed = parseQuery("#\u4eba\u7269\u3001\u9b54\u6cd5")
+
+		assertEquals(listOf("\u4eba\u7269", "\u9b54\u6cd5"), parsed.tags)
+		assertEquals("", parsed.text)
+	}
+
+	@Test
 	fun `isUsable requires a tag or two text chars`() {
 		assertFalse(parseQuery("a").isUsable())
 		assertTrue(parseQuery("ab").isUsable())

--- a/common/src/desktopTest/kotlin/repositories/tagindex/AccountTagServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/tagindex/AccountTagServiceTest.kt
@@ -108,6 +108,16 @@ class AccountTagServiceTest : BaseTest() {
 		assertEquals(listOf(TagCount("gothic", 1)), service.suggest("#go"))
 	}
 
+	/** Text entered on iOS/macOS can arrive decomposed: base letter plus a combining mark. */
+	@Test
+	fun `Prefix matching composes decomposed accents`() = runTest {
+		advanceUntilIdle()
+		ideasRepository.createIdea(content = "a", tags = setOf("th\u00e8me"))
+		advanceUntilIdle()
+
+		assertEquals(listOf(TagCount("th\u00e8me", 1)), service.suggest("the\u0300"))
+	}
+
 	@Test
 	fun `Blank prefix suggests nothing`() = runTest {
 		advanceUntilIdle()

--- a/common/src/desktopTest/kotlin/repositories/tagindex/TagIndexServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/tagindex/TagIndexServiceTest.kt
@@ -262,6 +262,31 @@ class TagIndexServiceTest : BaseTest() {
 			assertTrue(empty.isEmpty())
 		}
 
+	/** Text entered on iOS/macOS can arrive decomposed: base letter plus a combining mark. */
+	@Test
+	fun `suggest matches a decomposed accented prefix`() = runTest(mainTestDispatcher) {
+		stubNotes(note(1, "th\u00e8me"))
+		stubTimeline()
+		stubEntries()
+
+		val service = makeService()
+		advanceUntilIdle()
+
+		assertEquals(listOf("th\u00e8me" to 1), service.suggest("the\u0300").map { it.tag to it.count })
+	}
+
+	@Test
+	fun `suggest ignores a leading hash`() = runTest(mainTestDispatcher) {
+		stubNotes(note(1, "arwen"))
+		stubTimeline()
+		stubEntries()
+
+		val service = makeService()
+		advanceUntilIdle()
+
+		assertEquals(listOf("arwen" to 1), service.suggest("#ar").map { it.tag to it.count })
+	}
+
 	@Test
 	fun `rebuild fires when a content-changed signal is emitted`() = runTest(mainTestDispatcher) {
 		stubNotes(note(1, "alpha"))

--- a/common/src/desktopTest/kotlin/repositories/tagindex/TagIndexServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/tagindex/TagIndexServiceTest.kt
@@ -275,6 +275,24 @@ class TagIndexServiceTest : BaseTest() {
 		assertEquals(listOf("th\u00e8me" to 1), service.suggest("the\u0300").map { it.tag to it.count })
 	}
 
+	/** A tag can reach disk unnormalized (hand-edited project file, import); the index composes it. */
+	@Test
+	fun `index keys are normalized so an unnormalized stored tag is still found`() =
+		runTest(mainTestDispatcher) {
+			stubNotes(note(1, "the\u0300me"))
+			stubTimeline()
+			stubEntries()
+
+			val service = makeService()
+			advanceUntilIdle()
+
+			assertEquals(
+				setOf(TaggedEntityRef(TaggedEntityType.Note, 1)),
+				service.getEntitiesWithTag("th\u00e8me"),
+			)
+			assertEquals(listOf("th\u00e8me" to 1), service.suggest("th\u00e8me").map { it.tag to it.count })
+		}
+
 	@Test
 	fun `suggest ignores a leading hash`() = runTest(mainTestDispatcher) {
 		stubNotes(note(1, "arwen"))

--- a/common/src/desktopTest/kotlin/repositories/tagindex/TagNormalizerTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/tagindex/TagNormalizerTest.kt
@@ -2,6 +2,7 @@ package repositories.tagindex
 
 import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
 import com.darkrockstudios.apps.hammer.common.data.tagindex.parseTagInput
+import com.darkrockstudios.apps.hammer.common.data.tagindex.tagPrefixOf
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -95,6 +96,25 @@ class TagNormalizerTest {
 		val input = "\u4eba\u7269\u3000\u5834\u6240\u3001\u9b54\u6cd5"
 
 		assertEquals(setOf("\u4eba\u7269", "\u5834\u6240", "\u9b54\u6cd5"), parseTagInput(input))
+	}
+
+	@Test
+	fun `Tag prefix is the run after the last separator`() {
+		assertEquals("\u00e9t\u00e9", tagPrefixOf("guerre,\u00e9t\u00e9"))
+		assertEquals("\u9b54\u6cd5", tagPrefixOf("\u4eba\u7269\u3001\u9b54\u6cd5"))
+		assertEquals("\u5834\u6240", tagPrefixOf("\u4eba\u7269\u3000\u5834\u6240"))
+	}
+
+	@Test
+	fun `Tag prefix composes decomposed accents`() {
+		assertEquals("th\u00e8", tagPrefixOf("guerre #the\u0300"))
+	}
+
+	@Test
+	fun `Tag prefix is empty when the input ends on a separator`() {
+		assertEquals("", tagPrefixOf("guerre "))
+		assertEquals("", tagPrefixOf(""))
+		assertEquals("", tagPrefixOf("#"))
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/repositories/tagindex/TagNormalizerTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/tagindex/TagNormalizerTest.kt
@@ -2,6 +2,7 @@ package repositories.tagindex
 
 import com.darkrockstudios.apps.hammer.common.data.tagindex.cleanTags
 import com.darkrockstudios.apps.hammer.common.data.tagindex.parseTagInput
+import com.darkrockstudios.apps.hammer.common.data.tagindex.replaceTagPrefix
 import com.darkrockstudios.apps.hammer.common.data.tagindex.tagPrefixOf
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -115,6 +116,15 @@ class TagNormalizerTest {
 		assertEquals("", tagPrefixOf("guerre "))
 		assertEquals("", tagPrefixOf(""))
 		assertEquals("", tagPrefixOf("#"))
+	}
+
+	@Test
+	fun `Replace tag prefix swaps only the tag being typed`() {
+		assertEquals("alice bob", replaceTagPrefix("alice bo", "bob"))
+		assertEquals("alice,bob", replaceTagPrefix("alice,bo", "bob"))
+		assertEquals("alice bob", replaceTagPrefix("alice ", "bob"))
+		assertEquals("bob", replaceTagPrefix("", "bob"))
+		assertEquals("bob", replaceTagPrefix("#bo", "bob"))
 	}
 
 	@Test

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.compose.CollapseWhileTyping
 import com.darkrockstudios.apps.hammer.common.data.tagindex.isTagSeparator
 import com.darkrockstudios.apps.hammer.common.data.tagindex.parseTagInput
+import com.darkrockstudios.apps.hammer.common.data.tagindex.tagPrefixOf
 
 /**
  * Tag chip field — labeled hairline-underline input that keeps its
@@ -73,7 +74,7 @@ fun HdHairlineTagField(
 	}
 
 	val suggestions = remember(draft, tags, suggestTags) {
-		val prefix = draft.trim().removePrefix("#")
+		val prefix = tagPrefixOf(draft)
 		if (prefix.isEmpty()) emptyList()
 		else suggestTags(prefix).filter { it !in tags }
 	}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.compose.CollapseWhileTyping
 import com.darkrockstudios.apps.hammer.common.data.tagindex.isTagSeparator
 import com.darkrockstudios.apps.hammer.common.data.tagindex.parseTagInput
+import com.darkrockstudios.apps.hammer.common.data.tagindex.replaceTagPrefix
 import com.darkrockstudios.apps.hammer.common.data.tagindex.tagPrefixOf
 
 /**
@@ -73,11 +74,7 @@ fun HdHairlineTagField(
 		true
 	}
 
-	val suggestions = remember(draft, tags, suggestTags) {
-		val prefix = tagPrefixOf(draft)
-		if (prefix.isEmpty()) emptyList()
-		else suggestTags(prefix).filter { it !in tags }
-	}
+	val suggestions = rememberTagSuggestions(draft, tags, suggestTags)
 
 	val onSurface = MaterialTheme.colorScheme.onSurface
 	val muted = MaterialTheme.colorScheme.onSurfaceVariant
@@ -179,11 +176,26 @@ fun HdHairlineTagField(
 
 			HdTagSuggestionStrip(
 				suggestions = suggestions,
-				onSelect = { addTag(it) },
+				onSelect = { addTag(replaceTagPrefix(draft, it)) },
 				modifier = Modifier.padding(top = 6.dp),
 			)
 		}
 	}
+}
+
+/**
+ * Suggestions for the tag being typed at the end of [draft], minus the ones in [applied]. Pair the
+ * strip's `onSelect` with [replaceTagPrefix] so picking one keeps the tags typed before it.
+ */
+@Composable
+fun rememberTagSuggestions(
+	draft: String,
+	applied: Collection<String>,
+	suggestTags: (prefix: String) -> List<String>,
+): List<String> = remember(draft, applied, suggestTags) {
+	val prefix = tagPrefixOf(draft)
+	if (prefix.isEmpty()) emptyList()
+	else suggestTags(prefix).filter { it !in applied }
 }
 
 @OptIn(ExperimentalLayoutApi::class)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
@@ -52,6 +52,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryResult
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.tagindex.tagPrefixOf
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.FileKitType
@@ -1127,7 +1128,7 @@ private fun TagAddDialog(
 		var newTagsText by rememberSaveable { mutableStateOf("") }
 		val existingTags = state.content?.tags.orEmpty()
 		val suggestions = remember(newTagsText, existingTags) {
-			val prefix = newTagsText.substringAfterLast(' ').trim().removePrefix("#")
+			val prefix = tagPrefixOf(newTagsText)
 			if (prefix.isEmpty()) emptyList()
 			else component.suggestTags(prefix).filter { it !in existingTags }
 		}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
@@ -52,7 +52,7 @@ import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.Encycl
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryResult
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
-import com.darkrockstudios.apps.hammer.common.data.tagindex.tagPrefixOf
+import com.darkrockstudios.apps.hammer.common.data.tagindex.replaceTagPrefix
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.FileKitType
@@ -1127,11 +1127,7 @@ private fun TagAddDialog(
 	) {
 		var newTagsText by rememberSaveable { mutableStateOf("") }
 		val existingTags = state.content?.tags.orEmpty()
-		val suggestions = remember(newTagsText, existingTags) {
-			val prefix = tagPrefixOf(newTagsText)
-			if (prefix.isEmpty()) emptyList()
-			else component.suggestTags(prefix).filter { it !in existingTags }
-		}
+		val suggestions = rememberTagSuggestions(newTagsText, existingTags, component::suggestTags)
 		Column(verticalArrangement = Arrangement.spacedBy(Ui.Padding.L)) {
 			HdHairlineField(
 				label = Res.string.encyclopedia_create_entry_tags_label.get(),
@@ -1142,7 +1138,7 @@ private fun TagAddDialog(
 				suggestions = suggestions,
 				onSelect = { tag ->
 					scope.launch {
-						component.addTags(tag)
+						component.addTags(replaceTagPrefix(newTagsText, tag))
 						withContext(mainDispatcher) { newTagsText = "" }
 					}
 				},

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneMetadataPanelUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneMetadataPanelUi.kt
@@ -25,6 +25,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
+import com.darkrockstudios.apps.hammer.common.data.tagindex.tagPrefixOf
 import com.darkrockstudios.apps.hammer.common.encyclopedia.EntryRefChipLabel
 import com.darkrockstudios.apps.hammer.common.util.format
 import kotlinx.datetime.TimeZone
@@ -626,7 +627,7 @@ private fun AddTagDialog(
 	LaunchedEffect(visible) { if (!visible) draft = "" }
 
 	val suggestions = remember(draft, existingTags) {
-		val prefix = draft.substringAfterLast(' ').trim().removePrefix("#")
+		val prefix = tagPrefixOf(draft)
 		if (prefix.isEmpty()) emptyList()
 		else component.suggestTags(prefix).filter { it !in existingTags }
 	}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneMetadataPanelUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneMetadataPanelUi.kt
@@ -25,7 +25,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
-import com.darkrockstudios.apps.hammer.common.data.tagindex.tagPrefixOf
+import com.darkrockstudios.apps.hammer.common.data.tagindex.replaceTagPrefix
 import com.darkrockstudios.apps.hammer.common.encyclopedia.EntryRefChipLabel
 import com.darkrockstudios.apps.hammer.common.util.format
 import kotlinx.datetime.TimeZone
@@ -626,11 +626,7 @@ private fun AddTagDialog(
 	var draft by rememberSaveable { mutableStateOf("") }
 	LaunchedEffect(visible) { if (!visible) draft = "" }
 
-	val suggestions = remember(draft, existingTags) {
-		val prefix = tagPrefixOf(draft)
-		if (prefix.isEmpty()) emptyList()
-		else component.suggestTags(prefix).filter { it !in existingTags }
-	}
+	val suggestions = rememberTagSuggestions(draft, existingTags, component::suggestTags)
 
 	AnimatedDialog(
 		visible = visible,
@@ -659,7 +655,7 @@ private fun AddTagDialog(
 			HdTagSuggestionStrip(
 				suggestions = suggestions,
 				onSelect = { tag ->
-					component.addTags(tag)
+					component.addTags(replaceTagPrefix(draft, tag))
 					draft = ""
 				},
 			)


### PR DESCRIPTION
Fixes #836.

#829 made tags themselves Unicode-aware, but only on the save path. The read paths still compared raw input against the NFC-composed tags on disk, so a French user could create `thème` and then fail to find it again.

### What was broken

- **Search** — `parseQuery` handed needles through un-normalized. Text entered on iOS/macOS arrives decomposed (`e` + combining grave), so `#thème` matched a stored `thème` never.
- **Suggestions** — `TagIndexService.suggest` and `AccountTagService.suggest` did the same raw prefix comparison. `TagIndexService` also never stripped a leading `#`, unlike its sibling.
- **Prefix extraction** — three UI sites pulled the part-typed tag with `substringAfterLast(' ')`, splitting on the ASCII space alone. Typing `guerre,été` or `人物、魔法` offered no suggestions even though `parseTagInput` splits on all of those when saving.
- **Fullwidth hash** — `cleanTags` accepts `＃` as a tag prefix; `parseQuery` didn't.

### Changes

Two functions join the existing `Char.isTagSeparator()` vocabulary in `TagNormalizer`:

- `normalizeTagNeedle(text)` — trim, NFC-compose, drop a leading `#`/`＃`
- `tagPrefixOf(input)` — the run after the last separator, normalized

Wired into `parseQuery`, both `suggest()` implementations, and `HdHairlineTagField` / `ViewEntryUi.TagAddDialog` / `SceneMetadataPanelUi.AddTagDialog`. `Char.isTagPrefix()` replaces the two ad-hoc `#`/`＃` checks.

### Behavior changes worth a second look

- A query of `＃tag` now parses as a tag rather than free text, matching how the ASCII `#` already behaved.
- `TagIndexService.suggest("#")` now returns the ranked list (the needle normalizes to empty) rather than nothing.

### Testing

Per the repo's test-driven bug-fixing rule, the five reproducing tests were written first and confirmed failing, then three more added for `tagPrefixOf`. Non-ASCII test literals use `\uXXXX` escapes — a decomposed string written literally gets NFC-normalized in transit and would silently stop testing anything.

`:common:desktopTest` and `:composeUi:desktopTest` pass; desktop, Android and iOS metadata targets all compile.

### Not included

`MAX_TAG_SIZE` is checked with `String.length`, so supplementary-plane letters (rare kanji, Adlam) cost two units against the budget. Real, but it touches five repositories and doesn't affect accented Latin at all — `é` is one UTF-16 unit in NFC — so it belongs in its own PR.
