### PR TITLE
Keep the drop target live while the list autoscrolls

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
@@ -127,11 +127,13 @@ private fun Modifier.reorderableModifier(state: SceneTreeState): Modifier {
 	state.apply {
 		return pointerInput(Unit) {
 			detectDragGesturesAfterLongPress(
-				onDragStart = {
+				onDragStart = { offset ->
 					val id = pressedRowId
 					if (id != SceneTreeState.NO_SELECTION) {
 						hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
 						startDragging(id)
+						updateDragPosition(offset)
+						autoScrollForDrag()
 					}
 				},
 				onDragCancel = {
@@ -142,31 +144,8 @@ private fun Modifier.reorderableModifier(state: SceneTreeState): Modifier {
 				}
 			) { change, _ ->
 				change.consume()
-
-				val layoutInfo: LazyListLayoutInfo = listState.layoutInfo
-				val insertPosition = findInsertPosition(
-					dragOffset = change.position,
-					layouts = rowLayouts,
-					collapsedGroups = collapsedNodes,
-					tree = summary.sceneTree,
-					visibleNodes = visibleNodes,
-					selectedNode = selectedNode,
-				)
-
-				if (insertAt != insertPosition) {
-					insertAt = insertPosition
-				}
-
-				// Auto scroll
-				val height = layoutInfo.viewportSize.height - layoutInfo.viewportStartOffset
-				val bottomTenPercent: Float = height * .9f
-				val topTenPercent: Float = height * .1f
-
-				if (change.position.y >= bottomTenPercent) {
-					autoScroll(false)
-				} else if (change.position.y <= topTenPercent) {
-					autoScroll(true)
-				}
+				updateDragPosition(change.position)
+				autoScrollForDrag()
 			}
 		}
 	}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTreeState.kt
@@ -71,11 +71,32 @@ class SceneTreeState(
 	internal var summary by mutableStateOf(sceneSummary)
 	var selectedId by mutableStateOf(NO_SELECTION)
 	var selectedNode by mutableStateOf<TreeValue<SceneItem>?>(null)
-	var insertAt by mutableStateOf<InsertPosition?>(null)
 
 	/** The rows the tree renders, in display order — also the drag handler's id → node lookup. */
 	val visibleNodes: List<TreeValue<SceneItem>> by derivedStateOf {
 		visibleSceneNodes(summary.sceneTree, collapsedNodes)
+	}
+
+	var dragPosition by mutableStateOf<Offset?>(null)
+		private set
+
+	/**
+	 * Derived rather than assigned from the drag handler, because the pointer is only half of it:
+	 * autoscroll slides the rows out from under a finger that never moves and so never delivers
+	 * another event. Recomputing whenever either side changes keeps the drop target under the
+	 * finger, and [rowLayouts] re-reads on every placement pass to make that happen.
+	 */
+	val insertAt: InsertPosition? by derivedStateOf {
+		val position = dragPosition ?: return@derivedStateOf null
+
+		findInsertPosition(
+			dragOffset = position,
+			layouts = rowLayouts,
+			collapsedGroups = collapsedNodes,
+			tree = summary.sceneTree,
+			visibleNodes = visibleNodes,
+			selectedNode = selectedNode,
+		)
 	}
 
 	/**
@@ -157,7 +178,6 @@ class SceneTreeState(
 		rows.remove(id)
 	}
 
-
 	private var scrollJob by mutableStateOf<Job?>(null)
 	private var treeHash by mutableStateOf(sceneSummary.sceneTree.hashCode())
 
@@ -195,19 +215,42 @@ class SceneTreeState(
 		collapsedNodes.clear()
 	}
 
-	fun autoScroll(up: Boolean) {
+	/** True to scroll up, false to scroll down, null when the drag is clear of both edges. */
+	private fun dragScrollDirection(): Boolean? {
+		val position = dragPosition ?: return null
+		val layoutInfo = listState.layoutInfo
+		val height = layoutInfo.viewportSize.height - layoutInfo.viewportStartOffset
+		if (height <= 0) return null
+
+		return when {
+			position.y >= height * AUTO_SCROLL_ZONE_END -> false
+			position.y <= height * AUTO_SCROLL_ZONE_START -> true
+			else -> null
+		}
+	}
+
+	/**
+	 * Scrolls a row at a time while the drag is held near either edge.
+	 *
+	 * The job keeps stepping on its own until the pointer leaves the edge or the list runs out,
+	 * because a drag parked in the hot zone delivers no further pointer events to step it along.
+	 */
+	internal fun autoScrollForDrag() {
 		if (scrollJob?.isActive == true) return
+		if (dragScrollDirection() == null) return
 
 		scrollJob = coroutineScope.launch {
-			if (up) {
-				val targetIndex = (listState.firstVisibleItemIndex - 1).coerceAtLeast(0)
-				listState.animateScrollToItem(targetIndex)
-			} else {
-				val visibleItems = listState.layoutInfo.visibleItemsInfo
-				if (visibleItems.isNotEmpty()) {
-					val nextIndex = listState.firstVisibleItemIndex + 1
-					listState.animateScrollToItem(nextIndex)
+			while (true) {
+				val up = dragScrollDirection() ?: break
+				if (up && !listState.canScrollBackward) break
+				if (!up && !listState.canScrollForward) break
+
+				val target = if (up) {
+					(listState.firstVisibleItemIndex - 1).coerceAtLeast(0)
+				} else {
+					listState.firstVisibleItemIndex + 1
 				}
+				listState.animateScrollToItem(target)
 			}
 		}
 	}
@@ -217,6 +260,10 @@ class SceneTreeState(
 			selectedId = id
 			selectedNode = summary.sceneTree.findBy { it.id == id }
 		}
+	}
+
+	internal fun updateDragPosition(position: Offset) {
+		dragPosition = position
 	}
 
 	fun stopDragging() {
@@ -231,7 +278,8 @@ class SceneTreeState(
 
 		selectedId = NO_SELECTION
 		selectedNode = null
-		insertAt = null
+		dragPosition = null
+		scrollJob?.cancel()
 	}
 
 	fun toggleExpanded(nodeId: Int) {
@@ -241,5 +289,8 @@ class SceneTreeState(
 
 	companion object {
 		const val NO_SELECTION = -1
+
+		private const val AUTO_SCROLL_ZONE_START = .1f
+		private const val AUTO_SCROLL_ZONE_END = .9f
 	}
 }

--- a/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SceneTreeDragTest.kt
@@ -17,7 +17,9 @@ import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.data.MoveRequest
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
@@ -29,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 private const val TREE_TAG = "tree"
 private val RowHeight = 30.dp
@@ -77,7 +80,7 @@ class SceneTreeDragTest {
 	private lateinit var treeState: SceneTreeState
 	private var summary by mutableStateOf(buildSummary(camerasAtRoot = false))
 
-	private fun showTree() {
+	private fun showTree(height: Dp = 800.dp) {
 		compose.setContent {
 			val state = rememberReorderableLazyListState(
 				summary = summary,
@@ -86,7 +89,7 @@ class SceneTreeDragTest {
 			treeState = state
 			LaunchedEffect(summary) { state.updateSummary(summary) }
 
-			Box(modifier = Modifier.size(400.dp, 800.dp)) {
+			Box(modifier = Modifier.size(400.dp, height)) {
 				SceneTree(
 					state = state,
 					modifier = Modifier.fillMaxSize().testTag(TREE_TAG),
@@ -144,6 +147,36 @@ class SceneTreeDragTest {
 		longPressAt(visualCenterOf(Ids.VERIFICATION))
 
 		assertEquals(Ids.VERIFICATION, treeState.selectedId, "Grabbed the wrong row")
+	}
+
+	@Test
+	fun `the drop target follows the list when it scrolls under a still pointer`() {
+		showTree(height = 200.dp)
+
+		longPressAt(visualCenterOf(Ids.PREFACE))
+		val holdAt = visualCenterOf(Ids.CH2)
+		compose.onNodeWithTag(TREE_TAG).performMouseInput { moveTo(holdAt) }
+		compose.waitForIdle()
+
+		// Autoscroll moves the list without the pointer moving, so no drag event arrives.
+		compose.onNodeWithTag(TREE_TAG).performScrollToIndex(12)
+		compose.waitForIdle()
+
+		compose.onNodeWithTag(TREE_TAG).performMouseInput { release() }
+		compose.waitForIdle()
+
+		val request = moveRequest
+		assertNotNull(request, "No move was requested")
+		val anchorId = treeState.getTree()[request.toPosition.coords.globalIndex].value.id
+		val anchor = compose.onNodeWithTag(rowTag(anchorId)).getBoundsInRoot()
+		val top = with(compose.density) { anchor.top.toPx() }
+		val bottom = with(compose.density) { anchor.bottom.toPx() }
+
+		assertTrue(
+			holdAt.y in top..bottom,
+			"Anchored to a row that is not under the pointer: $anchorId spans $top..$bottom, " +
+				"pointer at ${holdAt.y}",
+		)
 	}
 
 	@Test


### PR DESCRIPTION
Follow-up to #842, fixing the auto-scroll wart that PR documented and left alone.

## The bug

Everything about a drag was driven by pointer events, but auto-scroll moves the list without the pointer moving. Hold a drag near the edge and two things go wrong:

1. **The drop target goes stale.** `insertAt` was computed only inside the drag callback, so as rows slid past a stationary finger, the insert line kept pointing at the row that *was* under the pointer. Releasing there filed the scene next to the wrong neighbour, with no on-screen hint that anything was off.
2. **Scrolling stalls.** `autoScroll` advanced the list by exactly one row per pointer event. With a finger genuinely still, it stepped once and stopped, so reaching anything past the edge meant jiggling the pointer to pump more events.

## The fix

`insertAt` becomes derived rather than assigned:

```kotlin
val insertAt: InsertPosition? by derivedStateOf {
    val position = dragPosition ?: return@derivedStateOf null
    findInsertPosition(dragOffset = position, layouts = rowLayouts, ...)
}
```

The drag callback now only records `dragPosition`. Because `rowLayouts` re-reads the row map on every placement pass (the invalidation fix from #842 is what makes this work), the drop target recomputes whenever *either* side moves: the pointer or the rows.

Auto-scroll becomes self-continuing instead of event-driven. The scroll job loops until the pointer leaves the hot zone or the list runs out, so holding at the edge keeps scrolling:

```kotlin
scrollJob = coroutineScope.launch {
    while (true) {
        val up = dragScrollDirection() ?: break
        if (up && !listState.canScrollBackward) break
        if (!up && !listState.canScrollForward) break
        listState.animateScrollToItem(target)
    }
}
```

The `canScroll*` guards matter: without them the loop spins at either end, since `animateScrollToItem` on an already-reached index returns immediately.

### One approach rejected

The obvious way to drive this is a per-frame loop while dragging:

```kotlin
LaunchedEffect(dragging) { while (isActive) { withFrameNanos { }; state.autoScrollForDrag() } }
```

Don't. An unbounded `withFrameNanos` loop means the composition never goes idle, which hung `:composeUi:desktopTest` outright (10 minutes, no progress) and would do the same to any Espresso/Compose test that waits for idle in the Android instrumented suite. Driving continuation from the scroll job itself keeps the work bounded to the time the list is actually scrolling.

## Tests

New: `the drop target follows the list when it scrolls under a still pointer`. It grabs a scene in a viewport short enough to scroll, parks the pointer over a row, scrolls the list without moving the pointer, and asserts on release that the anchor row is one whose *drawn bounds contain the pointer*, checked against the semantics tree rather than the same geometry the production code uses.

It fails when the derived value is made blind to geometry changes (`Snapshot.withoutReadObservation { rowLayouts }`), which is precisely the old behaviour. All 65 `composeUi` desktop tests pass.
