### PR TITLE
Add create-admin-account form to the server setup page

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/SetupPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/SetupPage.kt
@@ -2,13 +2,22 @@ package com.darkrockstudios.apps.hammer.frontend
 
 import com.darkrockstudios.apps.hammer.ServerConfig
 import com.darkrockstudios.apps.hammer.account.AccountsRepository
+import com.darkrockstudios.apps.hammer.frontend.data.UserSession
+import com.darkrockstudios.apps.hammer.frontend.utils.msg
+import com.darkrockstudios.apps.hammer.plugins.LOGIN_RATE_LIMIT
+import com.darkrockstudios.apps.hammer.projects.ProjectsRepository
+import com.darkrockstudios.apps.hammer.utilities.isSuccess
 import io.ktor.server.mustache.*
+import io.ktor.server.plugins.ratelimit.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.server.sessions.*
 import org.koin.ktor.ext.inject
 
 fun Route.setupPage(serverConfig: ServerConfig) {
 	val accountsRepository: AccountsRepository by inject()
+	val projectsRepository: ProjectsRepository by inject()
 
 	route("/setup") {
 		get {
@@ -18,16 +27,72 @@ fun Route.setupPage(serverConfig: ServerConfig) {
 				return@get
 			}
 
-			val model = call.withDefaults()
-			model["page_stylesheet"] = "/assets/css/error.css"
+			call.respond(MustacheContent("setup.mustache", buildSetupModel(call, serverConfig)))
+		}
 
-			// Build the server address for display
-			val serverAddress = buildServerAddress(serverConfig)
-			model["serverAddress"] = serverAddress
+		rateLimit(RateLimitName(LOGIN_RATE_LIMIT)) {
+			post {
+				// Guards against races with app-side account creation and double-submits
+				if (accountsRepository.hasUsers()) {
+					call.respondRedirect("/login")
+					return@post
+				}
 
-			call.respond(MustacheContent("setup.mustache", model))
+				val params = call.receiveParameters()
+				val email = params["email"]?.trim() ?: ""
+				val password = params["password"] ?: ""
+				val confirmPassword = params["confirmPassword"] ?: ""
+
+				suspend fun respondWithError(message: String) {
+					val model = buildSetupModel(call, serverConfig)
+					model["error"] = message
+					model["email"] = email
+					call.respond(MustacheContent("setup.mustache", model))
+				}
+
+				if (email.isEmpty() || password.isEmpty() || confirmPassword.isEmpty()) {
+					respondWithError(call.msg("setup_error_fields_required"))
+					return@post
+				}
+				if (password != confirmPassword) {
+					respondWithError(call.msg("setup_error_password_mismatch"))
+					return@post
+				}
+
+				// ToS challenge is intentionally skipped for the first admin account,
+				// so this goes to the repository directly rather than AccountsComponent.
+				val result = accountsRepository.createAccount(
+					email = email,
+					installId = "web",
+					password = password,
+				)
+				if (isSuccess(result)) {
+					val token = result.data
+					projectsRepository.createUserData(token.userId)
+
+					// Read from the DB rather than assuming admin: a lost creation race
+					// means this account wasn't first and must not get an admin cookie.
+					val isAdmin = accountsRepository.isAdmin(token.userId)
+					val session = UserSession(
+						userId = token.userId,
+						username = email,
+						isAdmin = isAdmin,
+					)
+					call.sessions.set(session)
+					call.respondRedirect(if (isAdmin) "/admin" else "/dashboard")
+				} else {
+					respondWithError(result.displayMessageText(call) ?: call.msg("setup_error_generic"))
+				}
+			}
 		}
 	}
+}
+
+private suspend fun buildSetupModel(call: RoutingCall, serverConfig: ServerConfig): MutableMap<String, Any> {
+	val model = call.withDefaults()
+	model["page_stylesheet"] = "/assets/css/error.css"
+	model["serverAddress"] = buildServerAddress(serverConfig)
+	return model
 }
 
 private fun buildServerAddress(config: ServerConfig): String {

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/SetupModePlugin.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/SetupModePlugin.kt
@@ -12,7 +12,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Plugin that redirects frontend requests to the setup page when no users exist in the database.
- * This allows admins to see instructions for creating their first account via the Hammer app.
+ * The setup page lets the admin create the first account directly, or shows instructions for
+ * creating it via the Hammer app.
  *
  * API routes are NOT blocked - they must remain accessible so the Hammer app can create the first account.
  */

--- a/server/src/main/resources/assets/css/error.css
+++ b/server/src/main/resources/assets/css/error.css
@@ -499,9 +499,93 @@
 	}
 }
 
+/* Setup Admin Account Form */
+.setup-form {
+	max-width: 400px;
+	margin: 0 auto 1.5rem;
+	text-align: left;
+}
+
+.setup-form__error {
+	background: rgba(239, 68, 68, 0.12);
+	border: 2px solid #ef4444;
+	border-radius: 0.5rem;
+	padding: 0.75rem 1rem;
+	margin-bottom: 1rem;
+}
+
+.setup-form__error p {
+	color: #991b1b;
+	font-weight: 500;
+	margin: 0;
+	font-size: 0.9375rem;
+}
+
+.setup-form__actions {
+	margin-top: 1.25rem;
+}
+
+.setup-form__submit {
+	width: 100%;
+	font-family: 'Kingthings Typewriter', monospace;
+	font-size: 1.125rem;
+	padding: 1rem 2rem;
+	background: #14532d;
+	color: white;
+	border: none;
+	border-radius: 0.5rem;
+	cursor: pointer;
+	transition: all var(--transition-base);
+	box-shadow: var(--shadow-md);
+}
+
+.setup-form__submit:hover {
+	background: #166534;
+	transform: translateY(-2px);
+	box-shadow: var(--shadow-lg);
+}
+
+.setup-form__submit:active {
+	transform: translateY(0);
+	box-shadow: var(--shadow-sm);
+}
+
+.setup-form__submit:focus-visible {
+	outline: 2px solid #22c55e;
+	outline-offset: 4px;
+}
+
+/* Secondary "set up from the app" section */
+.setup-alt {
+	margin-top: 1.5rem;
+	padding-top: 1.5rem;
+	border-top: 1px dashed rgba(20, 83, 45, 0.3);
+}
+
+.setup-alt__title {
+	font-family: 'Kingthings Typewriter', monospace;
+	font-size: 1rem;
+	color: #166534;
+	margin-bottom: 1rem;
+}
+
+@media only screen and (max-width: 600px) {
+	.setup-form__submit {
+		font-size: 1rem;
+		padding: 0.875rem 1.75rem;
+	}
+}
+
 /* Reduced motion for setup */
 @media (prefers-reduced-motion: reduce) {
 	.error-card.setup .error-icon {
 		animation: none;
+	}
+
+	.setup-form__submit,
+	.setup-form__submit:hover,
+	.setup-form__submit:active {
+		transition: none;
+		transform: none;
 	}
 }

--- a/server/src/main/resources/i18n/Messages_en.properties
+++ b/server/src/main/resources/i18n/Messages_en.properties
@@ -679,6 +679,13 @@ setup_step2=Go to Settings and enter this server address:
 setup_step3=Create your account to complete setup
 setup_admin_note=The first account created will become the administrator
 setup_return_note=After creating your account, refresh this page to continue.
+setup_form_password_label=Password
+setup_form_confirm_password_label=Confirm Password
+setup_form_submit=Create Admin Account
+setup_error_fields_required=Please fill in all fields
+setup_error_password_mismatch=Passwords do not match
+setup_error_generic=Account creation could not be completed. Please try again.
+setup_alt_title=Or set up from the Hammer app
 # Monitoring dashboard
 admin_nav_monitoring=Monitoring
 admin_mon_nav_overview=Overview

--- a/server/src/main/resources/templates/setup.mustache
+++ b/server/src/main/resources/templates/setup.mustache
@@ -13,29 +13,64 @@
 				<span>{{msg.setup_admin_note}}</span>
 			</div>
 
-			<div class="setup-steps">
-				<div class="setup-step">
-					<span class="setup-step__number">1</span>
-					<span class="setup-step__text">{{msg.setup_step1}}</span>
+			<form action="/setup" method="post" class="setup-form">
+				<div class="form-field">
+					<label for="email" class="form-field__label">{{msg.login_email_label}}</label>
+					<input type="email" id="email" name="email" class="form-input" required autofocus
+						   value="{{email}}" placeholder="{{msg.login_email_placeholder}}" autocomplete="email">
 				</div>
-				<div class="setup-step">
-					<span class="setup-step__number">2</span>
-					<span class="setup-step__text">{{msg.setup_step2}}</span>
-				</div>
-				<div class="setup-step setup-step--highlight">
-					<span class="setup-step__number">
-						<i class="fa-solid fa-server"></i>
-					</span>
-					<span class="setup-step__text setup-step__address">{{serverAddress}}</span>
-				</div>
-				<div class="setup-step">
-					<span class="setup-step__number">3</span>
-					<span class="setup-step__text">{{msg.setup_step3}}</span>
-				</div>
-			</div>
 
-			<div class="error-note">
-				<p>{{msg.setup_return_note}}</p>
+				<div class="form-field">
+					<label for="password" class="form-field__label">{{msg.setup_form_password_label}}</label>
+					<input type="password" id="password" name="password" class="form-input" required
+						   placeholder="{{msg.login_password_placeholder}}" autocomplete="new-password">
+					<p class="form-field__help">{{msg.password_reset_requirements}}</p>
+				</div>
+
+				<div class="form-field">
+					<label for="confirmPassword" class="form-field__label">{{msg.setup_form_confirm_password_label}}</label>
+					<input type="password" id="confirmPassword" name="confirmPassword" class="form-input" required
+						   placeholder="{{msg.login_password_placeholder}}" autocomplete="new-password">
+				</div>
+
+				{{#error}}
+					<div class="setup-form__error">
+						<p>{{error}}</p>
+					</div>
+				{{/error}}
+
+				<div class="setup-form__actions">
+					<button type="submit" class="setup-form__submit">{{msg.setup_form_submit}}</button>
+				</div>
+			</form>
+
+			<div class="setup-alt">
+				<h2 class="setup-alt__title">{{msg.setup_alt_title}}</h2>
+
+				<div class="setup-steps">
+					<div class="setup-step">
+						<span class="setup-step__number">1</span>
+						<span class="setup-step__text">{{msg.setup_step1}}</span>
+					</div>
+					<div class="setup-step">
+						<span class="setup-step__number">2</span>
+						<span class="setup-step__text">{{msg.setup_step2}}</span>
+					</div>
+					<div class="setup-step setup-step--highlight">
+						<span class="setup-step__number">
+							<i class="fa-solid fa-server"></i>
+						</span>
+						<span class="setup-step__text setup-step__address">{{serverAddress}}</span>
+					</div>
+					<div class="setup-step">
+						<span class="setup-step__number">3</span>
+						<span class="setup-step__text">{{msg.setup_step3}}</span>
+					</div>
+				</div>
+
+				<div class="error-note">
+					<p>{{msg.setup_return_note}}</p>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/SetupFlowTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/SetupFlowTest.kt
@@ -1,0 +1,108 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.parameters
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SetupFlowTest : EndToEndTest() {
+
+	private fun webClient() = HttpClient {
+		install(HttpCookies)
+		followRedirects = false
+	}
+
+	private suspend fun HttpClient.postSetupForm(
+		email: String,
+		password: String,
+		confirmPassword: String,
+	) = submitForm(
+		url = route("setup"),
+		formParameters = parameters {
+			append("email", email)
+			append("password", password)
+			append("confirmPassword", confirmPassword)
+		}
+	)
+
+	@Test
+	fun `creating the first admin account from the setup page logs in and lands on the admin dashboard`() {
+		doStartServer()
+
+		runBlocking {
+			webClient().use { web ->
+				// With zero accounts the server is in setup mode: everything redirects to /setup
+				val dashboard = web.get(route("dashboard"))
+				assertEquals(HttpStatusCode.Found, dashboard.status)
+				assertEquals("/setup", dashboard.headers["Location"])
+
+				val response = web.postSetupForm("admin@test.com", "password123", "password123")
+				assertEquals(HttpStatusCode.Found, response.status)
+				assertEquals("/admin", response.headers["Location"])
+
+				val account = database().serverDatabase.accountQueries
+					.findAccount("admin@test.com").executeAsOne()
+				assertTrue(account.is_admin)
+
+				// The session cookie set by the POST authorizes the admin dashboard
+				val admin = web.get(route("admin"))
+				assertEquals(HttpStatusCode.OK, admin.status)
+			}
+		}
+	}
+
+	@Test
+	fun `setup mode ends after the first account is created`() {
+		doStartServer()
+
+		runBlocking {
+			webClient().use { web ->
+				val created = web.postSetupForm("admin@test.com", "password123", "password123")
+				assertEquals(HttpStatusCode.Found, created.status)
+
+				val setupAgain = web.get(route("setup"))
+				assertEquals(HttpStatusCode.Found, setupAgain.status)
+				assertEquals("/", setupAgain.headers["Location"])
+
+				// A stale or double-submitted form is bounced to login, not processed
+				webClient().use { fresh ->
+					val resubmit = fresh.postSetupForm("other@test.com", "password123", "password123")
+					assertEquals(HttpStatusCode.Found, resubmit.status)
+					assertEquals("/login", resubmit.headers["Location"])
+				}
+				assertNull(
+					database().serverDatabase.accountQueries
+						.findAccount("other@test.com").executeAsOneOrNull()
+				)
+			}
+		}
+	}
+
+	@Test
+	fun `mismatched passwords re-render the form with an error and create no account`() {
+		doStartServer()
+
+		runBlocking {
+			webClient().use { web ->
+				val response = web.postSetupForm("admin@test.com", "password123", "different456")
+
+				assertEquals(HttpStatusCode.OK, response.status)
+				assertContains(response.bodyAsText(), "Passwords do not match")
+				assertNull(
+					database().serverDatabase.accountQueries
+						.findAccount("admin@test.com").executeAsOneOrNull()
+				)
+			}
+		}
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/SetupPageTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/SetupPageTest.kt
@@ -1,0 +1,234 @@
+package com.darkrockstudios.apps.hammer.frontend
+
+import com.darkrockstudios.apps.hammer.ServerConfig
+import com.darkrockstudios.apps.hammer.account.AccountsRepository
+import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
+import com.darkrockstudios.apps.hammer.admin.ConfigRepository
+import com.darkrockstudios.apps.hammer.base.http.Token
+import com.darkrockstudios.apps.hammer.frontend.data.UserSession
+import com.darkrockstudios.apps.hammer.plugins.LOGIN_RATE_LIMIT
+import com.darkrockstudios.apps.hammer.plugins.configureLocalization
+import com.darkrockstudios.apps.hammer.plugins.configureTemplating
+import com.darkrockstudios.apps.hammer.projects.ProjectsRepository
+import com.darkrockstudios.apps.hammer.utilities.Msg
+import com.darkrockstudios.apps.hammer.utilities.SResult
+import com.darkrockstudios.apps.hammer.utils.BaseTest
+import com.darkrockstudios.apps.hammer.utils.setupKtorTestKoin
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.parameters
+import io.ktor.server.application.install
+import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.koin.dsl.module
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+
+class SetupPageTest : BaseTest() {
+
+	private val accountsRepository: AccountsRepository = mockk()
+	private val projectsRepository: ProjectsRepository = mockk()
+	private val configRepository: ConfigRepository = mockk()
+
+	private fun ApplicationTestBuilder.configureApp() {
+		application {
+			setupKtorTestKoin(
+				this@SetupPageTest,
+				module {
+					single { accountsRepository }
+					single { projectsRepository }
+					single { configRepository }
+				}
+			)
+			configureTemplating()
+			configureLocalization()
+			install(RateLimit) {
+				register(RateLimitName(LOGIN_RATE_LIMIT)) {
+					rateLimiter(limit = 1_000_000, refillPeriod = 1.seconds)
+				}
+			}
+			install(Sessions) {
+				cookie<UserSession>(COOKIE_USER_SESSION)
+			}
+			routing {
+				setupPage(ServerConfig())
+			}
+		}
+	}
+
+	private fun mockPageModelDependencies() {
+		coEvery { configRepository.get(AdminServerConfig.ABOUT_SERVER) } returns ""
+		coEvery { configRepository.get(AdminServerConfig.DEFAULT_LOCALE) } returns "en"
+	}
+
+	private suspend fun ApplicationTestBuilder.postSetupForm(
+		email: String,
+		password: String,
+		confirmPassword: String,
+	) = createClient { followRedirects = false }.submitForm(
+		url = "/setup",
+		formParameters = parameters {
+			append("email", email)
+			append("password", password)
+			append("confirmPassword", confirmPassword)
+		}
+	)
+
+	@Test
+	fun `GET renders the admin account form while no users exist`() = testApplication {
+		coEvery { accountsRepository.hasUsers() } returns false
+		mockPageModelDependencies()
+		configureApp()
+
+		val response = createClient { followRedirects = false }.get("/setup")
+
+		assertEquals(HttpStatusCode.OK, response.status)
+		val body = response.bodyAsText()
+		assertContains(body, "action=\"/setup\"")
+		assertContains(body, "name=\"email\"")
+		assertContains(body, "name=\"confirmPassword\"")
+	}
+
+	@Test
+	fun `GET redirects home once users exist`() = testApplication {
+		coEvery { accountsRepository.hasUsers() } returns true
+		configureApp()
+
+		val response = createClient { followRedirects = false }.get("/setup")
+
+		assertEquals(HttpStatusCode.Found, response.status)
+		assertEquals("/", response.headers["Location"])
+	}
+
+	@Test
+	fun `POST creates the admin account, sets a session, and redirects to the admin dashboard`() =
+		testApplication {
+			val token = Token(userId = 1, auth = "auth", refresh = "refresh")
+			coEvery { accountsRepository.hasUsers() } returns false
+			coEvery {
+				accountsRepository.createAccount("admin@test.com", "web", "password123")
+			} returns SResult.success(token)
+			coEvery { projectsRepository.createUserData(1) } returns Unit
+			coEvery { accountsRepository.isAdmin(1) } returns true
+			configureApp()
+
+			val response = postSetupForm("admin@test.com", "password123", "password123")
+
+			assertEquals(HttpStatusCode.Found, response.status)
+			assertEquals("/admin", response.headers["Location"])
+			val setCookie = response.headers["Set-Cookie"]
+			assertNotNull(setCookie)
+			assertContains(setCookie, COOKIE_USER_SESSION)
+			coVerify(exactly = 1) { accountsRepository.createAccount("admin@test.com", "web", "password123") }
+			coVerify(exactly = 1) { projectsRepository.createUserData(1) }
+		}
+
+	@Test
+	fun `POST with mismatched passwords re-renders with an error and never creates an account`() =
+		testApplication {
+			coEvery { accountsRepository.hasUsers() } returns false
+			mockPageModelDependencies()
+			configureApp()
+
+			val response = postSetupForm("admin@test.com", "password123", "different456")
+
+			assertEquals(HttpStatusCode.OK, response.status)
+			val body = response.bodyAsText()
+			assertContains(body, "Passwords do not match")
+			assertContains(body, "value=\"admin@test.com\"")
+			coVerify(exactly = 0) { accountsRepository.createAccount(any(), any(), any()) }
+		}
+
+	@Test
+	fun `POST with empty fields re-renders with an error`() = testApplication {
+		coEvery { accountsRepository.hasUsers() } returns false
+		mockPageModelDependencies()
+		configureApp()
+
+		val response = postSetupForm("", "", "")
+
+		assertEquals(HttpStatusCode.OK, response.status)
+		assertContains(response.bodyAsText(), "Please fill in all fields")
+		coVerify(exactly = 0) { accountsRepository.createAccount(any(), any(), any()) }
+	}
+
+	@Test
+	fun `POST surfaces the repository's invalid email message and skips user data creation`() =
+		testApplication {
+			coEvery { accountsRepository.hasUsers() } returns false
+			coEvery { accountsRepository.createAccount(any(), any(), any()) } returns SResult.failure(
+				"invalid email",
+				Msg.r("api_accounts_create_error_invalidemail"),
+			)
+			mockPageModelDependencies()
+			configureApp()
+
+			val response = postSetupForm("not-an-email", "password123", "password123")
+
+			assertEquals(HttpStatusCode.OK, response.status)
+			assertContains(response.bodyAsText(), "Invalid e-mail address")
+			coVerify(exactly = 0) { projectsRepository.createUserData(any()) }
+		}
+
+	@Test
+	fun `POST surfaces the repository's short password message`() = testApplication {
+		coEvery { accountsRepository.hasUsers() } returns false
+		coEvery { accountsRepository.createAccount(any(), any(), any()) } returns SResult.failure(
+			"password failure",
+			Msg.r("api_accounts_create_error_password_tooshort"),
+		)
+		mockPageModelDependencies()
+		configureApp()
+
+		val response = postSetupForm("admin@test.com", "short", "short")
+
+		assertEquals(HttpStatusCode.OK, response.status)
+		assertContains(response.bodyAsText(), "Password too short")
+	}
+
+	@Test
+	fun `POST after a user already exists redirects to login without creating anything`() =
+		testApplication {
+			coEvery { accountsRepository.hasUsers() } returns true
+			configureApp()
+
+			val response = postSetupForm("admin@test.com", "password123", "password123")
+
+			assertEquals(HttpStatusCode.Found, response.status)
+			assertEquals("/login", response.headers["Location"])
+			assertNull(response.headers["Set-Cookie"])
+			coVerify(exactly = 0) { accountsRepository.createAccount(any(), any(), any()) }
+		}
+
+	@Test
+	fun `POST that loses the creation race to another account does not grant an admin session`() =
+		testApplication {
+			val token = Token(userId = 2, auth = "auth", refresh = "refresh")
+			coEvery { accountsRepository.hasUsers() } returns false
+			coEvery {
+				accountsRepository.createAccount("second@test.com", "web", "password123")
+			} returns SResult.success(token)
+			coEvery { projectsRepository.createUserData(2) } returns Unit
+			coEvery { accountsRepository.isAdmin(2) } returns false
+			configureApp()
+
+			val response = postSetupForm("second@test.com", "password123", "password123")
+
+			assertEquals(HttpStatusCode.Found, response.status)
+			assertEquals("/dashboard", response.headers["Location"])
+		}
+}


### PR DESCRIPTION
## Summary

The first-run `/setup` page now hosts an email / password / confirm-password form that creates the initial admin account directly from the browser. On success the operator is signed into a web session and redirected to the admin dashboard at `/admin`. The existing "set up from the Hammer app" steps remain as a secondary section below the form.

## Details

- `POST /setup` sits behind the existing login rate limiter (every attempt costs a full Argon2 hash) and re-checks `hasUsers()` first, so double submits and races with app-side account creation bounce to `/login` instead of creating a second account.
- Creation goes through `AccountsRepository.createAccount` directly (ToS challenge intentionally skipped for the server operator's own first account), followed by `ProjectsRepository.createUserData` since `AccountsComponent` is bypassed.
- Admin status for the session cookie and redirect target is read back from the DB rather than assumed, so a lost creation race can never mint an admin cookie.
- Validation failures re-render the page with an inline error and preserve the entered email, following the password-reset page conventions.
- New `.setup-form*` / `.setup-alt*` styles in `error.css` follow the setup card's green palette; 7 new English message keys added.

## Testing

- New `SetupPageTest`: 9 route-level cases (form render, success redirect + cookie, each validation failure, users-already-exist bounce, lost-race lands on `/dashboard`).
- New `SetupFlowTest` e2e against real Jetty + Postgres: setup-mode redirect, form POST, `is_admin = true` row, `GET /admin` 200 on the new session, setup mode ends afterwards, mismatch creates nothing.
- Full `server:test` suite passes, including `MessageBundleParityTest`.
- Visually verified default and error states of the page.