### PR TITLE
Restore project-language string keys dropped by Crowdin sync

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -45,6 +45,13 @@
 	<string name="project_info_tags_label">Tags</string>
 	<string name="project_info_tags_hint">↵ to add</string>
 	<string name="project_info_tags_placeholder">fantasy, draft, nanowrimo…</string>
+	<string name="project_info_language_label">Language</string>
+	<string name="project_info_language_unset">Not set</string>
+	<string name="project_info_language_dialog_title">Choose a language</string>
+	<string name="project_info_language_dialog_close">Close</string>
+	<string name="project_info_language_search_hint">Search languages</string>
+	<string name="project_info_language_clear">Clear (not set)</string>
+	<string name="project_info_language_empty">No languages match</string>
 	<string name="project_info_color_picker_edit">Edit</string>
 	<string name="project_info_color_picker_cancel">Cancel</string>
 	<string name="project_info_color_picker_confirm">OK</string>
@@ -55,6 +62,7 @@
 	<string name="project_settings_hero_by">by %1$s</string>
 	<string name="project_settings_hero_no_author">by (no author set)</string>
 	<string name="project_settings_spellcheck_section_title">Spell checking</string>
+	<string name="project_settings_spellcheck_mismatch_caption">Spell check is off: the project language (%1$s) doesn’t match your dictionary (%2$s). Change either to re-enable it.</string>
 	<string name="project_settings_folio_caption">Project Settings · %1$s</string>
 	<string name="project_settings_folio_section_count">§§ %1$d</string>
 
@@ -64,6 +72,7 @@
 	<string name="sync_conflict_project_data_field_theme">Project Theme</string>
 	<string name="sync_conflict_project_data_field_word_goal">Word Count Goal</string>
 	<string name="sync_conflict_project_data_field_tags">Tags</string>
+	<string name="sync_conflict_project_data_field_language">Language</string>
 	<string name="sync_conflict_project_data_value_unset">(not set)</string>
 	<string name="sync_conflict_project_data_cadence_day">day</string>
 	<string name="sync_conflict_project_data_cadence_week">week</string>


### PR DESCRIPTION
## Summary
PR #838 added 7 English string keys to \`strings_sync.xml\` for the project-language feature (\`project_info_language_*\`, \`project_settings_spellcheck_mismatch_caption\`, \`sync_conflict_project_data_field_language\`). The very next merge, PR #847 (Crowdin sync), overwrote \`strings_sync.xml\` from Crowdin's stale copy that predated #838, silently deleting those 7 keys while the Kotlin code that references them (\`ProjectInfoSettingsUi.kt\`, \`ProjectSettingsUi.kt\`, \`ProjectDataConflict.kt\`) stayed in the codebase.

That's currently breaking every CI target on PR #848 (another Crowdin sync) with `Unresolved reference` compile errors, since Crowdin no longer has these keys as source strings to carry forward.

This restores the 7 keys so the source of truth is correct again; the next Crowdin cycle will pick them up and translations will follow.

## Test plan
- [x] Verified the restored block matches the original diff from #838 exactly
- [ ] CI green on this PR