### PR TITLE
Migrate desktop window decoration to Nucleus 2.1.9 TAO backend

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ScreenCharacteristics.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ScreenCharacteristics.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.*
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import com.darkrockstudios.apps.hammer.common.uiNeedsExplicitCloseButtons
 
@@ -26,12 +29,28 @@ val LocalScreenCharacteristic = staticCompositionLocalOf {
 	)
 }
 
+/**
+ * Size classes come from the constraints of the space the UI occupies rather than from
+ * `calculateWindowSizeClass()`: the desktop implementation of that reads an AWT window,
+ * which does not exist under the Tao window backend.
+ */
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@Composable
+fun rememberWindowSizeClass(constraints: Constraints): WindowSizeClass {
+	val density = LocalDensity.current
+	return remember(constraints, density) {
+		WindowSizeClass.calculateFromSize(
+			size = Size(constraints.maxWidth.toFloat(), constraints.maxHeight.toFloat()),
+			density = density,
+		)
+	}
+}
+
 @Composable
 fun SetScreenCharacteristics(wideThreshold: Dp, content: @Composable BoxWithConstraintsScope.() -> Unit) {
 	BoxWithConstraints {
 		val isWide by remember(maxWidth) { derivedStateOf { maxWidth >= wideThreshold } }
-		val windowSizeClass = calculateWindowSizeClass()
+		val windowSizeClass = rememberWindowSizeClass(constraints)
 
 		CompositionLocalProvider(
 			LocalScreenCharacteristic provides ScreenCharacteristics(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ProjectSynchronizationUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ProjectSynchronizationUi.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import com.darkrockstudios.apps.hammer.common.compose.rememberWindowSizeClass
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -59,14 +59,15 @@ internal fun ProjectSynchronization(
 		onClosed = { component.endSync() },
 		properties = DialogProperties(usePlatformDefaultWidth = false),
 	) {
-		val screenCharacteristics = calculateWindowSizeClass()
-		ProjectSynchronizationContent(
-			component = component,
-			showSnackbar = showSnackbar,
-			screenCharacteristics = screenCharacteristics,
-			modifier = Modifier.predictiveBackTransform(),
-			onClose = requestClose,
-		)
+		BoxWithConstraints {
+			ProjectSynchronizationContent(
+				component = component,
+				showSnackbar = showSnackbar,
+				screenCharacteristics = rememberWindowSizeClass(constraints),
+				modifier = Modifier.predictiveBackTransform(),
+				onClose = requestClose,
+			)
+		}
 	}
 
 	if (confirmCancel) {

--- a/composeUi/src/desktopTest/kotlin/ScreenCharacteristicsTest.kt
+++ b/composeUi/src/desktopTest/kotlin/ScreenCharacteristicsTest.kt
@@ -1,0 +1,67 @@
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.hammer.common.compose.LocalScreenCharacteristic
+import com.darkrockstudios.apps.hammer.common.compose.ScreenCharacteristics
+import com.darkrockstudios.apps.hammer.common.compose.SetScreenCharacteristics
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+private val WideThreshold = 720.dp
+
+/**
+ * The size classes must come from the space the UI actually occupies. The desktop
+ * `calculateWindowSizeClass()` reads an AWT window, which no longer exists under the
+ * Tao backend, so every window reported Compact.
+ */
+class ScreenCharacteristicsTest {
+
+	@get:Rule
+	val compose = createComposeRule()
+
+	private fun characteristicsAt(width: Dp, height: Dp): ScreenCharacteristics {
+		lateinit var observed: ScreenCharacteristics
+		compose.setContent {
+			Box(modifier = Modifier.requiredSize(width, height)) {
+				SetScreenCharacteristics(WideThreshold) {
+					observed = LocalScreenCharacteristic.current
+				}
+			}
+		}
+		compose.waitForIdle()
+		return observed
+	}
+
+	@Test
+	fun `desktop sized window is expanded`() {
+		val screen = characteristicsAt(1280.dp, 900.dp)
+
+		assertEquals(WindowWidthSizeClass.Expanded, screen.windowWidthClass)
+		assertEquals(WindowHeightSizeClass.Expanded, screen.windowHeightClass)
+		assertEquals(true, screen.isWide)
+	}
+
+	@Test
+	fun `tablet sized window is medium`() {
+		val screen = characteristicsAt(700.dp, 600.dp)
+
+		assertEquals(WindowWidthSizeClass.Medium, screen.windowWidthClass)
+		assertEquals(WindowHeightSizeClass.Medium, screen.windowHeightClass)
+		assertEquals(false, screen.isWide)
+	}
+
+	@Test
+	fun `phone sized window is compact`() {
+		val screen = characteristicsAt(360.dp, 640.dp)
+
+		assertEquals(WindowWidthSizeClass.Compact, screen.windowWidthClass)
+		assertEquals(WindowHeightSizeClass.Medium, screen.windowHeightClass)
+		assertEquals(false, screen.isWide)
+	}
+}

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -60,12 +60,12 @@ kotlin {
 				implementation(compose.desktop.currentOs)
 				implementation(libs.clikt)
 				implementation(libs.nucleus.darkmode.detector)
-				implementation(libs.nucleus.decorated.window.jbr)
+				implementation(libs.nucleus.application)
+				implementation(libs.nucleus.decorated.window.tao)
 				implementation(libs.nucleus.decorated.window.material3)
 				implementation(libs.nucleus.launcher.windows)
 				implementation(libs.nucleus.launcher.linux)
 				implementation(libs.nucleus.launcher.macos)
-				implementation(libs.splashify)
 			}
 		}
 		val jvmTest by getting {
@@ -193,10 +193,15 @@ val extractMacosNativeLibs = tasks.register("extractMacosNativeLibs") {
 
 	val nativeLibs = listOf(
 		Triple("net.java.dev.jna", "jna", "com/sun/jna/darwin-aarch64/libjnidispatch.jnilib"),
-		Triple("io.github.kdroidfilter", "nucleus.launcher-macos", "nucleus/native/darwin-aarch64/libnucleus_launcher_macos.dylib"),
-		Triple("io.github.kdroidfilter", "nucleus.darkmode-detector", "nucleus/native/darwin-aarch64/libnucleus_darkmode.dylib"),
-		Triple("io.github.kdroidfilter", "nucleus.decorated-window-core", "nucleus/native/darwin-aarch64/libnucleus_layout_direction.dylib"),
-		Triple("io.github.kdroidfilter", "nucleus.decorated-window-jbr", "nucleus/native/darwin-aarch64/libnucleus_macos.dylib"),
+		Triple("dev.nucleusframework", "nucleus.launcher-macos", "nucleus/native/darwin-aarch64/libnucleus_launcher_macos.dylib"),
+		Triple("dev.nucleusframework", "nucleus.darkmode-detector", "nucleus/native/darwin-aarch64/libnucleus_darkmode.dylib"),
+		Triple("dev.nucleusframework", "nucleus.decorated-window-core", "nucleus/native/darwin-aarch64/libnucleus_layout_direction.dylib"),
+		Triple("dev.nucleusframework", "nucleus.decorated-window-tao", "nucleus/native/darwin-aarch64/libnucleus_tao.dylib"),
+		Triple("dev.nucleusframework", "nucleus.decorated-window-tao", "nucleus/native/darwin-aarch64/libnucleus_tao_dnd.dylib"),
+		Triple("dev.nucleusframework", "nucleus.decorated-window-tao", "nucleus/native/darwin-aarch64/libnucleus_tao_macos_deco.dylib"),
+		Triple("dev.nucleusframework", "nucleus.decorated-window-tao", "nucleus/native/darwin-aarch64/libnucleus_tao_macos_native_view.dylib"),
+		Triple("dev.nucleusframework", "nucleus.decorated-window-tao", "nucleus/native/darwin-aarch64/libnucleus_tao_macos_popup.dylib"),
+		Triple("dev.nucleusframework", "nucleus.decorated-window-tao", "nucleus/native/darwin-aarch64/libnucleus_tao_metal.dylib"),
 	)
 
 	val runtime = configurations.named("jvmRuntimeClasspath")

--- a/desktop/proguard-rules.pro
+++ b/desktop/proguard-rules.pro
@@ -58,14 +58,21 @@
 # NUCLEUS LAUNCHER (JNI bridge classes — JNI invokes static on*(...) callbacks)
 # Windows launcher ships its own keep rules via the Nucleus Gradle plugin.
 ################################################################################
--keep class io.github.kdroidfilter.nucleus.launcher.linux.NativeLinuxLauncherBridge {
+-keep class dev.nucleusframework.launcher.linux.NativeLinuxLauncherBridge {
     native <methods>;
     static ** on*(...);
 }
--keep class io.github.kdroidfilter.nucleus.launcher.macos.NativeMacOsDockMenuBridge {
+-keep class dev.nucleusframework.launcher.macos.NativeMacOsDockMenuBridge {
     native <methods>;
     static ** on*(...);
 }
+
+################################################################################
+# NUCLEUS TAO BACKEND (native window layer: JNI bridges call back into these,
+# and the Tao main dispatcher is discovered reflectively via ServiceLoader)
+################################################################################
+-keep class dev.nucleusframework.window.tao.** { *; }
+-keep class kotlinx.coroutines.internal.MainDispatcherFactory
 
 ################################################################################
 # LIBRARIES (Broad Keeps for Stability)

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
@@ -4,11 +4,12 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.window.ApplicationScope
-import androidx.compose.ui.window.application
+import androidx.compose.runtime.setValue
 import coil3.ImageLoader
 import coil3.compose.setSingletonImageLoaderFactory
+import com.arkivanov.decompose.DecomposeSettings
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.value.MutableValue
@@ -36,11 +37,13 @@ import com.darkrockstudios.apps.hammer.common.setInDevelopmentMode
 import com.darkrockstudios.apps.hammer.desktop.aboutlibraries.aboutLibrariesModule
 import com.darkrockstudios.apps.hammer.desktop.sandbox.SandboxStartup
 import com.darkrockstudios.apps.hammer.desktop.shortcuts.QuickShortcuts
+import dev.nucleusframework.application.NucleusApplicationScope
+import dev.nucleusframework.application.NucleusBackend
+import dev.nucleusframework.application.nucleusApplication
+import dev.nucleusframework.darkmodedetector.isSystemInDarkMode
+import dev.nucleusframework.window.NucleusDecoratedWindowTheme
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
-import io.github.kdroidfilter.nucleus.darkmodedetector.isSystemInDarkMode
-import io.github.kdroidfilter.nucleus.window.NucleusDecoratedWindowTheme
-import io.github.sudarshanmhasrup.splashify.SplashifyApp
 import io.github.vinceglb.filekit.FileKit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -175,8 +178,16 @@ fun main(args: Array<String>) {
 		}
 	}
 
+	// Decompose's ServiceLoader-provided checker only knows the AWT EDT, but the
+	// Tao backend drives the UI (and Dispatchers.Main) from Tao's own main thread.
+	DecomposeSettings.update { it.copy(mainThreadCheckEnabled = false) }
+
 	Napier.i("Startup: entering Compose application")
-	application {
+	nucleusApplication(
+		args = args,
+		backend = NucleusBackend.Tao,
+		enableSingleInstance = false,
+	) {
 		LaunchedEffect(Unit) { Napier.i("Startup: first composition") }
 		val applicationState = remember {
 			ApplicationState(
@@ -205,17 +216,26 @@ fun main(args: Array<String>) {
 			AppTheme(useDarkTheme = darkMode, settings = settingsState) {
 				when (val windowState = applicationState.windows.value) {
 					is WindowState.ProjectSectionWindow -> {
-						SplashifyApp(
-							splashScreen = { SplashScreen() }
-						) {
-							ProjectSelectionWindow { project ->
+						var showSplash by remember { mutableStateOf(true) }
+						if (showSplash) {
+							SplashWindow(onFinished = { showSplash = false })
+						} else {
+							ProjectSelectionWindow(
+								settings = settingsState,
+								darkMode = darkMode,
+							) { project ->
 								applicationState.openProject(project)
 							}
 						}
 					}
 
 					is WindowState.ProjectWindow -> {
-						ProjectEditorWindow(applicationState, windowState.projectDef)
+						ProjectEditorWindow(
+							app = applicationState,
+							projectDef = windowState.projectDef,
+							settings = settingsState,
+							darkMode = darkMode,
+						)
 					}
 				}
 			}
@@ -234,7 +254,7 @@ internal enum class ConfirmCloseResult {
 	Cancel
 }
 
-internal fun ApplicationScope.performClose(
+internal fun NucleusApplicationScope.performClose(
 	app: ApplicationState,
 	closeType: ApplicationState.CloseType
 ) {
@@ -250,7 +270,7 @@ internal fun ApplicationScope.performClose(
 	}
 }
 
-internal fun ApplicationScope.onRequestClose(
+internal fun NucleusApplicationScope.onRequestClose(
 	component: AppCloseManager,
 	app: ApplicationState,
 	closeType: ApplicationState.CloseType

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
@@ -217,15 +217,16 @@ fun main(args: Array<String>) {
 				when (val windowState = applicationState.windows.value) {
 					is WindowState.ProjectSectionWindow -> {
 						var showSplash by remember { mutableStateOf(true) }
+						// The splash is additive, never a gate: the real window exists from the
+						// start, so no way the splash can fail is a way the app fails to appear.
+						ProjectSelectionWindow(
+							settings = settingsState,
+							darkMode = darkMode,
+						) { project ->
+							applicationState.openProject(project)
+						}
 						if (showSplash) {
 							SplashWindow(onFinished = { showSplash = false })
-						} else {
-							ProjectSelectionWindow(
-								settings = settingsState,
-								darkMode = darkMode,
-							) { project ->
-								applicationState.openProject(project)
-							}
 						}
 					}
 

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
@@ -48,6 +48,7 @@ import io.github.vinceglb.filekit.FileKit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -217,16 +218,22 @@ fun main(args: Array<String>) {
 				when (val windowState = applicationState.windows.value) {
 					is WindowState.ProjectSectionWindow -> {
 						var showSplash by remember { mutableStateOf(true) }
-						// The splash is additive, never a gate: the real window exists from the
-						// start, so no way the splash can fail is a way the app fails to appear.
+						// The real window always exists, merely minimized behind the splash, and
+						// the hand-off is timed here rather than inside either window: a window
+						// that fails to render can neither stall it nor swallow the app.
+						LaunchedEffect(Unit) {
+							withContext(Dispatchers.Default) { delay(SplashDurationMs.toLong()) }
+							showSplash = false
+						}
 						ProjectSelectionWindow(
 							settings = settingsState,
 							darkMode = darkMode,
+							minimized = showSplash,
 						) { project ->
 							applicationState.openProject(project)
 						}
 						if (showSplash) {
-							SplashWindow(onFinished = { showSplash = false })
+							SplashWindow()
 						}
 					}
 

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.FrameWindowScope
 import androidx.compose.ui.window.MenuBar
 import com.arkivanov.decompose.DefaultComponentContext
@@ -48,8 +47,10 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
 import com.darkrockstudios.apps.hammer.common.compose.rememberMainDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.compose.theme.ProjectThemeOverride
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.projectroot.ProjectRootFab
 import com.darkrockstudios.apps.hammer.common.projectroot.ProjectRootUi
 import com.darkrockstudios.apps.hammer.common.projectroot.toHdNavRailDestination
@@ -57,8 +58,9 @@ import com.darkrockstudios.apps.hammer.project_window_menu_file
 import com.darkrockstudios.apps.hammer.project_window_menu_item_close
 import com.darkrockstudios.apps.hammer.project_window_menu_item_exit
 import com.darkrockstudios.apps.hammer.project_window_title
-import io.github.kdroidfilter.nucleus.window.material.MaterialDecoratedWindow
-import io.github.kdroidfilter.nucleus.window.material.MaterialTitleBar
+import dev.nucleusframework.application.NucleusApplicationScope
+import dev.nucleusframework.window.material.MaterialDecoratedWindow
+import dev.nucleusframework.window.material.MaterialTitleBar
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -67,9 +69,11 @@ import kotlinx.coroutines.withContext
 @ExperimentalDecomposeApi
 @ExperimentalMaterialApi
 @Composable
-internal fun ApplicationScope.ProjectEditorWindow(
+internal fun NucleusApplicationScope.ProjectEditorWindow(
 	app: ApplicationState,
 	projectDef: ProjectDef,
+	settings: GlobalSettings,
+	darkMode: Boolean,
 ) {
 	val backDispatcher = BackDispatcher()
 	val lifecycle = remember { LifecycleRegistry() }
@@ -146,78 +150,76 @@ internal fun ApplicationScope.ProjectEditorWindow(
 			)
 		}
 
-		// The old menu bar approach
-//		Column {
-//			EditorMenuBar(component, app, ::onRequestClose)
-//
-//			AppContent(component)
-//		}
-		AppContent(component)
+		// Tao windows are their own ComposeScene: locals provided outside the
+		// window (AppTheme in Main.kt) don't reach this content, so re-apply.
+		AppTheme(useDarkTheme = darkMode, settings = settings) {
+			AppContent(component)
 
-		LaunchedEffect(closeRequest) {
-			if (closeRequest != ApplicationState.CloseType.None) {
-				component.requestClose()
+			LaunchedEffect(closeRequest) {
+				if (closeRequest != ApplicationState.CloseType.None) {
+					component.requestClose()
+				}
 			}
-		}
 
-		if (shouldConfirmClose.isNotEmpty()) {
-			val item = shouldConfirmClose.first()
-			when (item) {
-				CloseConfirm.Scenes -> {
-					confirmCloseUnsavedScenesDialog(closeRequest) { result, closeType ->
-						scope.launch {
-							if (result == ConfirmCloseResult.SaveAll) {
-								component.storeDirtyBuffers()
-							}
+			if (shouldConfirmClose.isNotEmpty()) {
+				val item = shouldConfirmClose.first()
+				when (item) {
+					CloseConfirm.Scenes -> {
+						confirmCloseUnsavedScenesDialog(closeRequest) { result, closeType ->
+							scope.launch {
+								if (result == ConfirmCloseResult.SaveAll) {
+									component.storeDirtyBuffers()
+								}
 
-							withContext(mainDispatcher) {
-								if (result != ConfirmCloseResult.Cancel) {
-									component.closeRequestDealtWith(CloseConfirm.Scenes)
-								} else {
-									cancelClose()
+								withContext(mainDispatcher) {
+									if (result != ConfirmCloseResult.Cancel) {
+										component.closeRequestDealtWith(CloseConfirm.Scenes)
+									} else {
+										cancelClose()
+									}
 								}
 							}
 						}
 					}
-				}
 
-				CloseConfirm.Notes -> {
-					confirmCloseUnsavedNotesDialog(closeRequest) { result, closeType ->
-						when (result) {
-							ConfirmCloseResult.SaveAll -> error("Unhandled close type: $closeType")
-							ConfirmCloseResult.Discard -> component.closeRequestDealtWith(CloseConfirm.Notes)
-							ConfirmCloseResult.Cancel -> cancelClose()
+					CloseConfirm.Notes -> {
+						confirmCloseUnsavedNotesDialog(closeRequest) { result, closeType ->
+							when (result) {
+								ConfirmCloseResult.SaveAll -> error("Unhandled close type: $closeType")
+								ConfirmCloseResult.Discard -> component.closeRequestDealtWith(CloseConfirm.Notes)
+								ConfirmCloseResult.Cancel -> cancelClose()
+							}
 						}
 					}
-				}
 
-				CloseConfirm.Encyclopedia -> {
-					confirmCloseUnsavedEncyclopediaDialog(closeRequest) { result, closeType ->
-						when (result) {
-							ConfirmCloseResult.SaveAll -> error("Unhandled close type: $closeType")
-							ConfirmCloseResult.Discard -> component.closeRequestDealtWith(CloseConfirm.Encyclopedia)
-							ConfirmCloseResult.Cancel -> cancelClose()
+					CloseConfirm.Encyclopedia -> {
+						confirmCloseUnsavedEncyclopediaDialog(closeRequest) { result, closeType ->
+							when (result) {
+								ConfirmCloseResult.SaveAll -> error("Unhandled close type: $closeType")
+								ConfirmCloseResult.Discard -> component.closeRequestDealtWith(CloseConfirm.Encyclopedia)
+								ConfirmCloseResult.Cancel -> cancelClose()
+							}
 						}
 					}
-				}
 
-				CloseConfirm.Timeline -> {
-					confirmCloseUnsavedTimelineDialog(closeRequest) { result, closeType ->
-						when (result) {
-							ConfirmCloseResult.SaveAll -> error("Unhandled close type: $closeType")
-							ConfirmCloseResult.Discard -> component.closeRequestDealtWith(
-								CloseConfirm.Timeline
-							)
-							ConfirmCloseResult.Cancel -> cancelClose()
+					CloseConfirm.Timeline -> {
+						confirmCloseUnsavedTimelineDialog(closeRequest) { result, closeType ->
+							when (result) {
+								ConfirmCloseResult.SaveAll -> error("Unhandled close type: $closeType")
+								ConfirmCloseResult.Discard -> component.closeRequestDealtWith(
+									CloseConfirm.Timeline
+								)
+								ConfirmCloseResult.Cancel -> cancelClose()
+							}
 						}
 					}
-				}
 
-				CloseConfirm.Sync -> {
-					component.showProjectSync()
-				}
+					CloseConfirm.Sync -> {
+						component.showProjectSync()
+					}
 
-				CloseConfirm.Complete -> performClose(app, closeRequest)
+					CloseConfirm.Complete -> performClose(app, closeRequest)
+				}
 			}
 		}
 	}

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectSelectionWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectSelectionWindow.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -53,6 +54,7 @@ import dev.nucleusframework.window.material.MaterialTitleBar
 internal fun NucleusApplicationScope.ProjectSelectionWindow(
 	settings: GlobalSettings,
 	darkMode: Boolean,
+	minimized: Boolean = false,
 	onProjectSelected: (projectDef: ProjectDef) -> Unit
 ) {
 	val backDispatcher = BackDispatcher()
@@ -61,7 +63,14 @@ internal fun NucleusApplicationScope.ProjectSelectionWindow(
 	val windowState = rememberPersistedWindowState(
 		WindowGeometryStore.Window.ProjectSelect,
 		defaultSize = coerceWindowSize(900.dp, 800.dp),
+		startMinimized = minimized,
 	)
+
+	// Restore once the splash is done. One-way on purpose: a later user-initiated
+	// minimize must stick.
+	LaunchedEffect(minimized) {
+		if (!minimized) windowState.isMinimized = false
+	}
 	val component = remember {
 		ProjectSelectionComponent(
 			componentContext = compContext,

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectSelectionWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectSelectionWindow.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.ApplicationScope
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.lifecycle.LifecycleController
@@ -37,18 +36,23 @@ import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.projectselection.ProjectSelectionUi
 import com.darkrockstudios.apps.hammer.common.projectselection.toHdNavRailDestination
 import com.darkrockstudios.apps.hammer.common.util.getAppVersionString
-import io.github.kdroidfilter.nucleus.window.material.MaterialDecoratedWindow
-import io.github.kdroidfilter.nucleus.window.material.MaterialTitleBar
+import dev.nucleusframework.application.NucleusApplicationScope
+import dev.nucleusframework.window.material.MaterialDecoratedWindow
+import dev.nucleusframework.window.material.MaterialTitleBar
 
 @ExperimentalMaterialApi
 @ExperimentalComposeApi
 @ExperimentalDecomposeApi
 @Composable
-internal fun ApplicationScope.ProjectSelectionWindow(
+internal fun NucleusApplicationScope.ProjectSelectionWindow(
+	settings: GlobalSettings,
+	darkMode: Boolean,
 	onProjectSelected: (projectDef: ProjectDef) -> Unit
 ) {
 	val backDispatcher = BackDispatcher()
@@ -97,7 +101,11 @@ internal fun ApplicationScope.ProjectSelectionWindow(
 				modifier = Modifier.align(Alignment.CenterHorizontally),
 			)
 		}
-		Content(component)
+		// Tao windows are their own ComposeScene: locals provided outside the
+		// window (AppTheme in Main.kt) don't reach this content, so re-apply.
+		AppTheme(useDarkTheme = darkMode, settings = settings) {
+			Content(component)
+		}
 	}
 }
 

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/SplashScreen.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/SplashScreen.kt
@@ -44,35 +44,29 @@ private val TitleColor = Color(0xFFEDE0DB)
 private val SubtitleColor = Color(0xFFB9ACA6)
 private val TrackColor = Color(0x33FFFFFF)
 
-private const val SplashDurationMs = 600
+internal const val SplashDurationMs = 600
 
 /**
- * Borderless splash window shown while the main window spins up. Fills the
- * progress bar over [SplashDurationMs], then calls [onFinished].
+ * Borderless splash window shown over the main window while it spins up. Purely
+ * cosmetic: it owns no timer and gates nothing, so no way it can fail is a way the
+ * app fails to appear. The caller decides when it goes away.
  */
 @Composable
-internal fun NucleusApplicationScope.SplashWindow(onFinished: () -> Unit) {
+internal fun NucleusApplicationScope.SplashWindow() {
 	val windowState = rememberWindowState(
 		size = DpSize(600.dp, 380.dp),
 		position = WindowPosition(Alignment.Center),
 	)
 
 	DecoratedWindow(
-		onCloseRequest = onFinished,
+		onCloseRequest = {},
 		state = windowState,
 		title = "",
 		undecorated = true,
 		resizable = false,
 	) {
 		var filling by remember { mutableStateOf(false) }
-
-		// One wall-clock wait, timed off the UI thread: a stalled renderer must not be
-		// able to stretch the hand-off, and the hand-off must not ride the frame clock.
-		LaunchedEffect(Unit) {
-			filling = true
-			withContext(Dispatchers.Default) { delay(SplashDurationMs.toLong()) }
-			onFinished()
-		}
+		LaunchedEffect(Unit) { filling = true }
 
 		SplashScreen(if (filling) 1f else 0f)
 	}

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/SplashScreen.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/SplashScreen.kt
@@ -1,6 +1,8 @@
 package com.darkrockstudios.apps.hammer.desktop
 
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -9,7 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -27,7 +29,9 @@ import androidx.compose.ui.window.rememberWindowState
 import com.darkrockstudios.apps.hammer.*
 import dev.nucleusframework.application.DecoratedWindow
 import dev.nucleusframework.application.NucleusApplicationScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.Font
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -40,9 +44,11 @@ private val TitleColor = Color(0xFFEDE0DB)
 private val SubtitleColor = Color(0xFFB9ACA6)
 private val TrackColor = Color(0x33FFFFFF)
 
+private const val SplashDurationMs = 600
+
 /**
  * Borderless splash window shown while the main window spins up. Fills the
- * progress bar over roughly a second, then calls [onFinished].
+ * progress bar over [SplashDurationMs], then calls [onFinished].
  */
 @Composable
 internal fun NucleusApplicationScope.SplashWindow(onFinished: () -> Unit) {
@@ -58,17 +64,17 @@ internal fun NucleusApplicationScope.SplashWindow(onFinished: () -> Unit) {
 		undecorated = true,
 		resizable = false,
 	) {
-		var progress by remember { mutableFloatStateOf(0f) }
+		var filling by remember { mutableStateOf(false) }
 
+		// One wall-clock wait, timed off the UI thread: a stalled renderer must not be
+		// able to stretch the hand-off, and the hand-off must not ride the frame clock.
 		LaunchedEffect(Unit) {
-			repeat(100) {
-				progress += 0.01f
-				delay(10)
-			}
+			filling = true
+			withContext(Dispatchers.Default) { delay(SplashDurationMs.toLong()) }
 			onFinished()
 		}
 
-		SplashScreen(progress)
+		SplashScreen(if (filling) 1f else 0f)
 	}
 }
 
@@ -77,7 +83,10 @@ private fun SplashScreen(progress: Float) {
 	val typewriter = FontFamily(Font(Res.font.Kingthings_Trypewriter_2))
 	val mono = FontFamily(Font(Res.font.IBMPlexMono_SemiBold))
 
-	val animatedProgress by animateFloatAsState(targetValue = progress)
+	val animatedProgress by animateFloatAsState(
+		targetValue = progress,
+		animationSpec = tween(durationMillis = SplashDurationMs, easing = LinearEasing),
+	)
 
 	Box(
 		modifier = Modifier

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/SplashScreen.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/SplashScreen.kt
@@ -7,7 +7,11 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -15,12 +19,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.rememberWindowState
 import com.darkrockstudios.apps.hammer.*
-import io.github.sudarshanmhasrup.splashify.ui.config.SplashScreenSize
-import io.github.sudarshanmhasrup.splashify.ui.config.SplashScreenStyle
-import io.github.sudarshanmhasrup.splashify.ui.splashscreen.SimpleSplashScreen
+import dev.nucleusframework.application.DecoratedWindow
+import dev.nucleusframework.application.NucleusApplicationScope
+import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.Font
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -33,27 +40,51 @@ private val TitleColor = Color(0xFFEDE0DB)
 private val SubtitleColor = Color(0xFFB9ACA6)
 private val TrackColor = Color(0x33FFFFFF)
 
+/**
+ * Borderless splash window shown while the main window spins up. Fills the
+ * progress bar over roughly a second, then calls [onFinished].
+ */
 @Composable
-fun SplashScreen() {
-	val size = SplashScreenSize(
-		width = 600.dp,
-		height = 380.dp
+internal fun NucleusApplicationScope.SplashWindow(onFinished: () -> Unit) {
+	val windowState = rememberWindowState(
+		size = DpSize(600.dp, 380.dp),
+		position = WindowPosition(Alignment.Center),
 	)
 
-	val style = SplashScreenStyle(
-		backgroundColor = SplashBackground,
-		cornerRadius = 16.dp
-	)
+	DecoratedWindow(
+		onCloseRequest = onFinished,
+		state = windowState,
+		title = "",
+		undecorated = true,
+		resizable = false,
+	) {
+		var progress by remember { mutableFloatStateOf(0f) }
 
+		LaunchedEffect(Unit) {
+			repeat(100) {
+				progress += 0.01f
+				delay(10)
+			}
+			onFinished()
+		}
+
+		SplashScreen(progress)
+	}
+}
+
+@Composable
+private fun SplashScreen(progress: Float) {
 	val typewriter = FontFamily(Font(Res.font.Kingthings_Trypewriter_2))
 	val mono = FontFamily(Font(Res.font.IBMPlexMono_SemiBold))
 
-	SimpleSplashScreen(
-		size = size,
-		style = style
-	) { progress ->
-		val animatedProgress by animateFloatAsState(targetValue = progress)
+	val animatedProgress by animateFloatAsState(targetValue = progress)
 
+	Box(
+		modifier = Modifier
+			.fillMaxSize()
+			.background(SplashBackground),
+		contentAlignment = Alignment.Center,
+	) {
 		Column(
 			modifier = Modifier
 				.fillMaxWidth()

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowGeometryStore.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowGeometryStore.kt
@@ -61,12 +61,14 @@ class WindowGeometryStore(private val settings: Settings) {
 fun rememberPersistedWindowState(
 	window: WindowGeometryStore.Window,
 	defaultSize: DpSize,
+	startMinimized: Boolean = false,
 ): WindowState {
 	val store = remember { getKoin().get<WindowGeometryStore>() }
 	val initial = remember { store.load(window, defaultSize) }
 	val windowState = rememberWindowState(
 		size = initial.size,
 		placement = if (initial.maximized) WindowPlacement.Maximized else WindowPlacement.Floating,
+		isMinimized = startMinimized,
 	)
 
 	LaunchedEffect(windowState) {

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/shortcuts/LinuxQuicklist.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/shortcuts/LinuxQuicklist.kt
@@ -3,17 +3,17 @@ package com.darkrockstudios.apps.hammer.desktop.shortcuts
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import io.github.aakira.napier.Napier
-import io.github.kdroidfilter.nucleus.freedesktop.icons.FreedesktopIcon
-import io.github.kdroidfilter.nucleus.launcher.linux.DbusmenuItem
-import io.github.kdroidfilter.nucleus.launcher.linux.LauncherProperties
-import io.github.kdroidfilter.nucleus.launcher.linux.LinuxLauncherEntry
+import dev.nucleusframework.freedesktop.icons.FreedesktopIcon
+import dev.nucleusframework.launcher.linux.DbusmenuItem
+import dev.nucleusframework.launcher.linux.LauncherProperties
+import dev.nucleusframework.launcher.linux.LinuxLauncherEntry
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.CoroutineContext
-import io.github.kdroidfilter.nucleus.launcher.linux.LinuxQuicklist as NucleusQuicklist
+import dev.nucleusframework.launcher.linux.LinuxQuicklist as NucleusQuicklist
 
 class LinuxQuicklist(
 	private val projectsRepository: ProjectsRepository,

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/shortcuts/MacOsDockShortcuts.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/shortcuts/MacOsDockShortcuts.kt
@@ -3,9 +3,9 @@ package com.darkrockstudios.apps.hammer.desktop.shortcuts
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import io.github.aakira.napier.Napier
-import io.github.kdroidfilter.nucleus.launcher.macos.DockMenuItem
-import io.github.kdroidfilter.nucleus.launcher.macos.DockMenuListener
-import io.github.kdroidfilter.nucleus.launcher.macos.MacOsDockMenu
+import dev.nucleusframework.launcher.macos.DockMenuItem
+import dev.nucleusframework.launcher.macos.DockMenuListener
+import dev.nucleusframework.launcher.macos.MacOsDockMenu
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/shortcuts/WindowsJumpList.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/shortcuts/WindowsJumpList.kt
@@ -6,7 +6,7 @@ import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRe
 import com.darkrockstudios.apps.hammer.desktop.PROJECT_FLAG
 import com.darkrockstudios.apps.hammer.jump_list_recent_projects
 import io.github.aakira.napier.Napier
-import io.github.kdroidfilter.nucleus.launcher.windows.*
+import dev.nucleusframework.launcher.windows.*
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow

--- a/desktop/src/jvmMain/resources/aboutlibraries.json
+++ b/desktop/src/jvmMain/resources/aboutlibraries.json
@@ -199,10 +199,10 @@
         },
         {
             "uniqueId": "androidx.lifecycle:lifecycle-common-jvm",
-            "artifactVersion": "2.10.0",
+            "artifactVersion": "2.11.0",
             "name": "Lifecycle-Common",
             "description": "Android Lifecycle-Common",
-            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.11.0",
             "developers": [
                 {
                     "name": "The Android Open Source Project"
@@ -224,10 +224,10 @@
         },
         {
             "uniqueId": "androidx.lifecycle:lifecycle-runtime-compose-desktop",
-            "artifactVersion": "2.10.0",
+            "artifactVersion": "2.11.0",
             "name": "Lifecycle Runtime Compose",
             "description": "Compose integration with Lifecycle",
-            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.11.0",
             "developers": [
                 {
                     "name": "The Android Open Source Project"
@@ -249,10 +249,10 @@
         },
         {
             "uniqueId": "androidx.lifecycle:lifecycle-runtime-desktop",
-            "artifactVersion": "2.10.0",
+            "artifactVersion": "2.11.0",
             "name": "Lifecycle Runtime",
             "description": "Android Lifecycle Runtime",
-            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.11.0",
             "developers": [
                 {
                     "name": "The Android Open Source Project"
@@ -274,10 +274,10 @@
         },
         {
             "uniqueId": "androidx.lifecycle:lifecycle-viewmodel-desktop",
-            "artifactVersion": "2.10.0",
+            "artifactVersion": "2.11.0",
             "name": "Lifecycle ViewModel",
             "description": "Android Lifecycle ViewModel",
-            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.11.0",
             "developers": [
                 {
                     "name": "The Android Open Source Project"
@@ -299,10 +299,10 @@
         },
         {
             "uniqueId": "androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop",
-            "artifactVersion": "2.10.0",
+            "artifactVersion": "2.11.0",
             "name": "Lifecycle ViewModel with SavedState",
             "description": "Android Lifecycle ViewModel",
-            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.10.0",
+            "website": "https://developer.android.com/jetpack/androidx/releases/lifecycle#2.11.0",
             "developers": [
                 {
                     "name": "The Android Open Source Project"
@@ -537,7 +537,7 @@
         },
         {
             "uniqueId": "com.darkrockstudios:composetexteditor-desktop",
-            "artifactVersion": "2.3.1",
+            "artifactVersion": "2.4.0",
             "name": "Compose Text Editor",
             "description": "A Kotlin Multiplatform Text Editor.",
             "website": "https://github.com/Darkrock-Studios/ComposeTextEditor",
@@ -560,7 +560,7 @@
         },
         {
             "uniqueId": "com.darkrockstudios:composetexteditor-find-desktop",
-            "artifactVersion": "2.3.1",
+            "artifactVersion": "2.4.0",
             "name": "Compose Text Editor Find",
             "description": "Find functionality addon for Compose Text Editor.",
             "website": "https://github.com/Darkrock-Studios/ComposeTextEditor",
@@ -583,7 +583,7 @@
         },
         {
             "uniqueId": "com.darkrockstudios:composetexteditor-spellcheck-desktop",
-            "artifactVersion": "2.3.1",
+            "artifactVersion": "2.4.0",
             "name": "Compose Text Editor Spell Check",
             "description": "Spell checking addon for Compose Text Editor.",
             "website": "https://github.com/Darkrock-Studios/ComposeTextEditor",
@@ -629,19 +629,19 @@
         },
         {
             "uniqueId": "com.darkrockstudios:platform-spellcheckerkt-desktop",
-            "artifactVersion": "1.3.1",
+            "artifactVersion": "1.3.2",
             "name": "PlatformSpellChecker",
             "description": "A Kotlin Multiplatform library providing spell checking functionality for Android, iOS, and Desktop platforms",
-            "website": "https://github.com/Wavesonics/PlatformSpellCheckerKt",
+            "website": "https://github.com/Darkrock-Studios/PlatformSpellCheckerKt",
             "developers": [
                 {
                     "name": "Adam Brown"
                 }
             ],
             "scm": {
-                "connection": "scm:git:git://github.com/Wavesonics/PlatformSpellCheckerKt.git",
-                "developerConnection": "scm:git:ssh://github.com/Wavesonics/PlatformSpellCheckerKt.git",
-                "url": "https://github.com/Wavesonics/PlatformSpellCheckerKt"
+                "connection": "scm:git:git://github.com/Darkrock-Studios/PlatformSpellCheckerKt.git",
+                "developerConnection": "scm:git:ssh://github.com/Darkrock-Studios/PlatformSpellCheckerKt.git",
+                "url": "https://github.com/Darkrock-Studios/PlatformSpellCheckerKt"
             },
             "licenses": [
                 "MIT"
@@ -714,6 +714,72 @@
             },
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.fleeksoft.charset:charset-jvm",
+            "artifactVersion": "0.0.8",
+            "name": "charset",
+            "description": "Kotlin Multiplatform Charsets",
+            "website": "https://github.com/fleeksoft/charset",
+            "developers": [
+                {
+                    "name": "Sabeeh Ul Hussnain Anjum"
+                }
+            ],
+            "scm": {
+                "connection": "https://github.com/fleeksoft/charset.git",
+                "url": "https://github.com/fleeksoft/charset"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.fleeksoft.io:io-core-jvm",
+            "artifactVersion": "0.0.8",
+            "name": "io-core",
+            "description": "Kotlin Multiplatform IO",
+            "website": "https://github.com/fleeksoft/fleeksoft-io",
+            "developers": [
+                {
+                    "name": "Sabeeh Ul Hussnain Anjum"
+                }
+            ],
+            "scm": {
+                "connection": "https://github.com/fleeksoft/fleeksoft-io.git",
+                "url": "https://github.com/fleeksoft/fleeksoft-io"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "com.fleeksoft.ksoup:ksoup-jvm",
+            "artifactVersion": "0.2.6",
+            "name": "ksoup",
+            "description": "Ksoup is a Kotlin Multiplatform library for working with HTML and XML, and offers an easy-to-use API for URL fetching, data parsing, extraction, and manipulation using DOM and CSS selectors.",
+            "website": "https://github.com/fleeksoft/ksoup",
+            "developers": [
+                {
+                    "name": "Sabeeh Ul Hussnain Anjum"
+                }
+            ],
+            "scm": {
+                "connection": "https://github.com/fleeksoft/ksoup.git",
+                "url": "https://github.com/fleeksoft/ksoup"
+            },
+            "licenses": [
+                "MIT"
             ],
             "funding": [
                 
@@ -1299,19 +1365,19 @@
         },
         {
             "uniqueId": "com.squareup.okio:okio-jvm",
-            "artifactVersion": "3.17.0",
+            "artifactVersion": "3.18.1",
             "name": "okio",
             "description": "A modern I/O library for Android, Java, and Kotlin Multiplatform.",
-            "website": "https://github.com/square/okio/",
+            "website": "https://github.com/lysine-dev/okio/",
             "developers": [
                 {
                     "name": "Square, Inc."
                 }
             ],
             "scm": {
-                "connection": "scm:git:git://github.com/square/okio.git",
-                "developerConnection": "scm:git:ssh://git@github.com/square/okio.git",
-                "url": "https://github.com/square/okio/"
+                "connection": "scm:git:git://github.com/lysine-dev/okio.git",
+                "developerConnection": "scm:git:ssh://git@github.com/lysine-dev/okio.git",
+                "url": "https://github.com/lysine-dev/okio/"
             },
             "licenses": [
                 "Apache-2.0"
@@ -1428,6 +1494,328 @@
             },
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.aot-runtime",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus AOT Runtime",
+            "description": "AOT runtime library for the Nucleus Gradle plugin",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.core-runtime",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Core Runtime",
+            "description": "Core runtime library for the Nucleus Gradle plugin",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.darkmode-detector",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Dark Mode Detector",
+            "description": "Reactive dark mode detection for Compose Desktop across Windows, macOS and Linux",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.decorated-window-awt",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Decorated Window AWT",
+            "description": "AWT/Compose Desktop integration of Nucleus Decorated Window (consumed by JBR and JNI backends)",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.decorated-window-core",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Decorated Window Core",
+            "description": "Shared types, layout, styling, and resources for Nucleus Decorated Window",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.decorated-window-material3",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Material Decorated Window",
+            "description": "Material 3 integration for Nucleus Decorated Window",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.decorated-window-tao",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Decorated Window Tao",
+            "description": "Experimental no-AWT decorated window backend for Compose Desktop, powered by Tao via direct JNI for macOS, Windows, and Linux.",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.freedesktop-icons",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Freedesktop Icons",
+            "description": "Type-safe freedesktop icon naming specification constants for JVM desktop applications",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.graalvm-runtime",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus GraalVM Runtime",
+            "description": "GraalVM native-image runtime initialization and font manager substitutions",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.launcher-linux",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Launcher Linux",
+            "description": "Unity Launcher API (com.canonical.Unity.LauncherEntry) for JVM desktop applications via JNI",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.launcher-macos",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Launcher macOS",
+            "description": "macOS dock context menu for JVM desktop applications via JNI",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.launcher-windows",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Launcher Windows",
+            "description": "Windows Launcher API (Badge Notifications) for JVM desktop applications via JNI",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.linux-hidpi",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Linux HiDPI",
+            "description": "Native HiDPI scale factor detection for Compose Desktop on Linux (GSettings, GDK_SCALE, Xft.dpi)",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "dev.nucleusframework:nucleus.nucleus-application",
+            "artifactVersion": "2.1.9",
+            "name": "Nucleus Application",
+            "description": "Unified entry point picking the decorated-window backend (JBR/JNI AWT or no-AWT Tao) and exposing a backend-agnostic window handle.",
+            "website": "https://github.com/NucleusFramework/Nucleus",
+            "developers": [
+                {
+                    "name": "NucleusFramework"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:git://github.com/NucleusFramework/Nucleus.git",
+                "developerConnection": "scm:git:ssh://git@github.com/NucleusFramework/Nucleus.git",
+                "url": "https://github.com/NucleusFramework/Nucleus"
+            },
+            "licenses": [
+                "MIT"
             ],
             "funding": [
                 
@@ -1594,213 +1982,6 @@
             ]
         },
         {
-            "uniqueId": "io.github.kdroidfilter:nucleus.core-runtime",
-            "artifactVersion": "1.15.7",
-            "name": "Nucleus Core Runtime",
-            "description": "Core runtime library for the Nucleus Gradle plugin",
-            "website": "https://github.com/kdroidFilter/Nucleus",
-            "developers": [
-                {
-                    "name": "kdroidFilter"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:git://github.com/kdroidFilter/Nucleus.git",
-                "developerConnection": "scm:git:ssh://git@github.com/kdroidFilter/Nucleus.git",
-                "url": "https://github.com/kdroidFilter/Nucleus"
-            },
-            "licenses": [
-                "MIT"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
-            "uniqueId": "io.github.kdroidfilter:nucleus.darkmode-detector",
-            "artifactVersion": "1.15.7",
-            "name": "Nucleus Dark Mode Detector",
-            "description": "Reactive dark mode detection for Compose Desktop across Windows, macOS and Linux",
-            "website": "https://github.com/kdroidFilter/Nucleus",
-            "developers": [
-                {
-                    "name": "kdroidFilter"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:git://github.com/kdroidFilter/Nucleus.git",
-                "developerConnection": "scm:git:ssh://git@github.com/kdroidFilter/Nucleus.git",
-                "url": "https://github.com/kdroidFilter/Nucleus"
-            },
-            "licenses": [
-                "MIT"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
-            "uniqueId": "io.github.kdroidfilter:nucleus.decorated-window-core",
-            "artifactVersion": "1.15.7",
-            "name": "Nucleus Decorated Window Core",
-            "description": "Shared types, layout, styling, and resources for Nucleus Decorated Window",
-            "website": "https://github.com/kdroidFilter/Nucleus",
-            "developers": [
-                {
-                    "name": "kdroidFilter"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:git://github.com/kdroidFilter/Nucleus.git",
-                "developerConnection": "scm:git:ssh://git@github.com/kdroidFilter/Nucleus.git",
-                "url": "https://github.com/kdroidFilter/Nucleus"
-            },
-            "licenses": [
-                "MIT"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
-            "uniqueId": "io.github.kdroidfilter:nucleus.decorated-window-jbr",
-            "artifactVersion": "1.15.7",
-            "name": "Nucleus Decorated Window JBR",
-            "description": "JBR-based custom decorated window with native title bar for Compose Desktop",
-            "website": "https://github.com/kdroidFilter/Nucleus",
-            "developers": [
-                {
-                    "name": "kdroidFilter"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:git://github.com/kdroidFilter/Nucleus.git",
-                "developerConnection": "scm:git:ssh://git@github.com/kdroidFilter/Nucleus.git",
-                "url": "https://github.com/kdroidFilter/Nucleus"
-            },
-            "licenses": [
-                "MIT"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
-            "uniqueId": "io.github.kdroidfilter:nucleus.decorated-window-material3",
-            "artifactVersion": "1.15.7",
-            "name": "Nucleus Material Decorated Window",
-            "description": "Material 3 integration for Nucleus Decorated Window",
-            "website": "https://github.com/kdroidFilter/Nucleus",
-            "developers": [
-                {
-                    "name": "kdroidFilter"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:git://github.com/kdroidFilter/Nucleus.git",
-                "developerConnection": "scm:git:ssh://git@github.com/kdroidFilter/Nucleus.git",
-                "url": "https://github.com/kdroidFilter/Nucleus"
-            },
-            "licenses": [
-                "MIT"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
-            "uniqueId": "io.github.kdroidfilter:nucleus.freedesktop-icons",
-            "artifactVersion": "1.15.7",
-            "name": "Nucleus Freedesktop Icons",
-            "description": "Type-safe freedesktop icon naming specification constants for JVM desktop applications",
-            "website": "https://github.com/kdroidFilter/Nucleus",
-            "developers": [
-                {
-                    "name": "kdroidFilter"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:git://github.com/kdroidFilter/Nucleus.git",
-                "developerConnection": "scm:git:ssh://git@github.com/kdroidFilter/Nucleus.git",
-                "url": "https://github.com/kdroidFilter/Nucleus"
-            },
-            "licenses": [
-                "MIT"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
-            "uniqueId": "io.github.kdroidfilter:nucleus.launcher-linux",
-            "artifactVersion": "1.15.7",
-            "name": "Nucleus Launcher Linux",
-            "description": "Unity Launcher API (com.canonical.Unity.LauncherEntry) for JVM desktop applications via JNI",
-            "website": "https://github.com/kdroidFilter/Nucleus",
-            "developers": [
-                {
-                    "name": "kdroidFilter"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:git://github.com/kdroidFilter/Nucleus.git",
-                "developerConnection": "scm:git:ssh://git@github.com/kdroidFilter/Nucleus.git",
-                "url": "https://github.com/kdroidFilter/Nucleus"
-            },
-            "licenses": [
-                "MIT"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
-            "uniqueId": "io.github.kdroidfilter:nucleus.launcher-macos",
-            "artifactVersion": "1.15.7",
-            "name": "Nucleus Launcher macOS",
-            "description": "macOS dock context menu for JVM desktop applications via JNI",
-            "website": "https://github.com/kdroidFilter/Nucleus",
-            "developers": [
-                {
-                    "name": "kdroidFilter"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:git://github.com/kdroidFilter/Nucleus.git",
-                "developerConnection": "scm:git:ssh://git@github.com/kdroidFilter/Nucleus.git",
-                "url": "https://github.com/kdroidFilter/Nucleus"
-            },
-            "licenses": [
-                "MIT"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
-            "uniqueId": "io.github.kdroidfilter:nucleus.launcher-windows",
-            "artifactVersion": "1.15.7",
-            "name": "Nucleus Launcher Windows",
-            "description": "Windows Launcher API (Badge Notifications) for JVM desktop applications via JNI",
-            "website": "https://github.com/kdroidFilter/Nucleus",
-            "developers": [
-                {
-                    "name": "kdroidFilter"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:git://github.com/kdroidFilter/Nucleus.git",
-                "developerConnection": "scm:git:ssh://git@github.com/kdroidFilter/Nucleus.git",
-                "url": "https://github.com/kdroidFilter/Nucleus"
-            },
-            "licenses": [
-                "MIT"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
             "uniqueId": "io.github.koalaplot:koalaplot-core-desktop",
             "artifactVersion": "0.11.2",
             "name": "koalaplot-core",
@@ -1892,29 +2073,6 @@
             ]
         },
         {
-            "uniqueId": "io.github.sudarshanmhasrup.splashify:splashify-desktop",
-            "artifactVersion": "1.0.0-alpha1",
-            "name": "Splashify",
-            "description": "A Kotlin Multiplatform library for effortless, customizable splash screens in Compose Multiplatform desktop apps.",
-            "website": "https://github.com/sudarshanmhasrup/splashify",
-            "developers": [
-                {
-                    "name": "Sudarshan Mhasrup"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:https://github.com/sudarshanmhasrup/splashify.git",
-                "developerConnection": "scm:git:ssh://git@github.com/sudarshanmhasrup/splashify.git",
-                "url": "https://github.com/sudarshanmhasrup/splashify"
-            },
-            "licenses": [
-                "Apache-2.0"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
             "uniqueId": "io.github.vinceglb:filekit-core-jvm",
             "artifactVersion": "0.14.2",
             "name": "FileKit",
@@ -1961,7 +2119,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-auth-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-auth",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -1983,7 +2141,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-content-negotiation-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-content-negotiation",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2005,7 +2163,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-core-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-core",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2027,7 +2185,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-encoding-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-encoding",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2049,7 +2207,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-java-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-java",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2071,7 +2229,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-logging-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-logging",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2093,7 +2251,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-events-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-events",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2115,7 +2273,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-http-cio-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-http-cio",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2137,7 +2295,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-http-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-http",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2159,7 +2317,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-io-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-io",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2181,7 +2339,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-network-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-network",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2203,7 +2361,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-serialization-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-serialization",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2225,7 +2383,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-serialization-kotlinx-json-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-serialization-kotlinx-json",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2247,7 +2405,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-serialization-kotlinx-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-serialization-kotlinx",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2269,7 +2427,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-sse-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-sse",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2291,7 +2449,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-utils-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-utils",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2313,7 +2471,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-websocket-serialization-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-websocket-serialization",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2335,7 +2493,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-websockets-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-websockets",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -2780,11 +2938,11 @@
             ]
         },
         {
-            "uniqueId": "org.jetbrains.androidx.lifecycle:lifecycle-common",
-            "artifactVersion": "2.10.0",
+            "uniqueId": "org.jetbrains.androidx.lifecycle:lifecycle-common-jvm",
+            "artifactVersion": "2.11.0",
             "name": "Lifecycle-Common",
             "description": "Android Lifecycle-Common",
-            "website": "https://github.com/JetBrains/compose-jb",
+            "website": "https://github.com/JetBrains/compose-multiplatform",
             "developers": [
                 {
                     "name": "Compose Multiplatform Team",
@@ -2792,33 +2950,9 @@
                 }
             ],
             "scm": {
-                "connection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "developerConnection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "url": "https://github.com/JetBrains/compose-jb"
-            },
-            "licenses": [
-                "Apache-2.0"
-            ],
-            "funding": [
-                
-            ]
-        },
-        {
-            "uniqueId": "org.jetbrains.androidx.lifecycle:lifecycle-runtime",
-            "artifactVersion": "2.10.0",
-            "name": "Lifecycle Runtime",
-            "description": "Android Lifecycle Runtime",
-            "website": "https://github.com/JetBrains/compose-jb",
-            "developers": [
-                {
-                    "name": "Compose Multiplatform Team",
-                    "organisationUrl": "https://www.jetbrains.com"
-                }
-            ],
-            "scm": {
-                "connection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "developerConnection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "url": "https://github.com/JetBrains/compose-jb"
+                "connection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "developerConnection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "url": "https://github.com/JetBrains/compose-multiplatform"
             },
             "licenses": [
                 "Apache-2.0"
@@ -2829,10 +2963,10 @@
         },
         {
             "uniqueId": "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose-desktop",
-            "artifactVersion": "2.10.0",
+            "artifactVersion": "2.11.0",
             "name": "Lifecycle Runtime Compose",
             "description": "Compose integration with Lifecycle",
-            "website": "https://github.com/JetBrains/compose-jb",
+            "website": "https://github.com/JetBrains/compose-multiplatform",
             "developers": [
                 {
                     "name": "Compose Multiplatform Team",
@@ -2840,9 +2974,9 @@
                 }
             ],
             "scm": {
-                "connection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "developerConnection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "url": "https://github.com/JetBrains/compose-jb"
+                "connection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "developerConnection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "url": "https://github.com/JetBrains/compose-multiplatform"
             },
             "licenses": [
                 "Apache-2.0"
@@ -2852,11 +2986,35 @@
             ]
         },
         {
-            "uniqueId": "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel",
-            "artifactVersion": "2.10.0",
+            "uniqueId": "org.jetbrains.androidx.lifecycle:lifecycle-runtime-desktop",
+            "artifactVersion": "2.11.0",
+            "name": "Lifecycle Runtime",
+            "description": "Android Lifecycle Runtime",
+            "website": "https://github.com/JetBrains/compose-multiplatform",
+            "developers": [
+                {
+                    "name": "Compose Multiplatform Team",
+                    "organisationUrl": "https://www.jetbrains.com"
+                }
+            ],
+            "scm": {
+                "connection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "developerConnection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "url": "https://github.com/JetBrains/compose-multiplatform"
+            },
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "funding": [
+                
+            ]
+        },
+        {
+            "uniqueId": "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-desktop",
+            "artifactVersion": "2.11.0",
             "name": "Lifecycle ViewModel",
             "description": "Android Lifecycle ViewModel",
-            "website": "https://github.com/JetBrains/compose-jb",
+            "website": "https://github.com/JetBrains/compose-multiplatform",
             "developers": [
                 {
                     "name": "Compose Multiplatform Team",
@@ -2864,9 +3022,9 @@
                 }
             ],
             "scm": {
-                "connection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "developerConnection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "url": "https://github.com/JetBrains/compose-jb"
+                "connection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "developerConnection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "url": "https://github.com/JetBrains/compose-multiplatform"
             },
             "licenses": [
                 "Apache-2.0"
@@ -2876,11 +3034,11 @@
             ]
         },
         {
-            "uniqueId": "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate",
-            "artifactVersion": "2.9.6",
+            "uniqueId": "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop",
+            "artifactVersion": "2.11.0",
             "name": "Lifecycle ViewModel with SavedState",
             "description": "Android Lifecycle ViewModel",
-            "website": "https://github.com/JetBrains/compose-jb",
+            "website": "https://github.com/JetBrains/compose-multiplatform",
             "developers": [
                 {
                     "name": "Compose Multiplatform Team",
@@ -2888,9 +3046,9 @@
                 }
             ],
             "scm": {
-                "connection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "developerConnection": "scm:git:https://github.com/JetBrains/compose-jb.git",
-                "url": "https://github.com/JetBrains/compose-jb"
+                "connection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "developerConnection": "scm:git:https://github.com/JetBrains/compose-multiplatform.git",
+                "url": "https://github.com/JetBrains/compose-multiplatform"
             },
             "licenses": [
                 "Apache-2.0"
@@ -4000,7 +4158,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm",
-            "artifactVersion": "0.9.0",
+            "artifactVersion": "0.9.1",
             "name": "kotlinx-io-bytestring",
             "description": "IO support for Kotlin",
             "website": "https://github.com/Kotlin/kotlinx-io",
@@ -4022,7 +4180,7 @@
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-io-core-jvm",
-            "artifactVersion": "0.9.0",
+            "artifactVersion": "0.9.1",
             "name": "kotlinx-io-core",
             "description": "IO support for Kotlin",
             "website": "https://github.com/Kotlin/kotlinx-io",
@@ -4132,7 +4290,7 @@
         },
         {
             "uniqueId": "org.jetbrains.runtime:jbr-api",
-            "artifactVersion": "1.10.1",
+            "artifactVersion": "1.9.0",
             "name": "jbr-api",
             "description": "Interface for the functionality specific to https://github.com/JetBrains/JetBrainsRuntime",
             "website": "https://github.com/JetBrains/JetBrainsRuntimeApi",
@@ -4275,7 +4433,7 @@
         },
         {
             "uniqueId": "org.jetbrains:markdown-jvm",
-            "artifactVersion": "0.7.7",
+            "artifactVersion": "0.7.8",
             "name": "markdown",
             "description": "Markdown parser in Kotlin",
             "website": "https://github.com/JetBrains/markdown",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,7 +73,6 @@ ktor_i18n = "2.0.0"
 
 okio = "3.18.1"
 slf4jSimple = "2.0.18"
-splashify = "1.0.0-alpha1"
 turbine = "1.2.1"
 work-runtime-ktx = "2.11.2"
 
@@ -104,7 +103,7 @@ kotlinx-io-okio = "0.9.1"
 compose-texteditor = "2.4.0"
 kotlin-multiplatform-diff = "1.3.0"
 platform-spellcheckerkt = "1.3.2"
-nucleus = "1.15.7"
+nucleus = "2.1.9"
 colorpicker-compose = "1.2.0"
 material-kolor = "5.0.0"
 
@@ -228,7 +227,6 @@ koin_sl4j = { group = "io.insert-koin", name = "koin-logger-slf4j" }
 koin_ktor = { group = "io.insert-koin", name = "koin-ktor" }
 koin_compose = { group = "io.insert-koin", name = "koin-compose" }
 
-splashify = { module = "io.github.sudarshanmhasrup.splashify:splashify", version.ref = "splashify" }
 tomlkt = { group = "net.peanuuutz.tomlkt", name = "tomlkt", version.ref = "tomlkt" }
 
 ktor_client_core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
@@ -329,12 +327,13 @@ platform-spellcheckerkt = { module = "com.darkrockstudios:platform-spellcheckerk
 
 bouncycastle-bcpkix = { group = "org.bouncycastle", name = "bcpkix-jdk18on", version.ref = "bouncycastle" }
 
-nucleus_darkmode_detector = { module = "io.github.kdroidfilter:nucleus.darkmode-detector", version.ref = "nucleus" }
-nucleus_decorated_window_jbr = { module = "io.github.kdroidfilter:nucleus.decorated-window-jbr", version.ref = "nucleus" }
-nucleus_decorated_window_material3 = { module = "io.github.kdroidfilter:nucleus.decorated-window-material3", version.ref = "nucleus" }
-nucleus_launcher_windows = { module = "io.github.kdroidfilter:nucleus.launcher-windows", version.ref = "nucleus" }
-nucleus_launcher_linux = { module = "io.github.kdroidfilter:nucleus.launcher-linux", version.ref = "nucleus" }
-nucleus_launcher_macos = { module = "io.github.kdroidfilter:nucleus.launcher-macos", version.ref = "nucleus" }
+nucleus_darkmode_detector = { module = "dev.nucleusframework:nucleus.darkmode-detector", version.ref = "nucleus" }
+nucleus_application = { module = "dev.nucleusframework:nucleus.nucleus-application", version.ref = "nucleus" }
+nucleus_decorated_window_tao = { module = "dev.nucleusframework:nucleus.decorated-window-tao", version.ref = "nucleus" }
+nucleus_decorated_window_material3 = { module = "dev.nucleusframework:nucleus.decorated-window-material3", version.ref = "nucleus" }
+nucleus_launcher_windows = { module = "dev.nucleusframework:nucleus.launcher-windows", version.ref = "nucleus" }
+nucleus_launcher_linux = { module = "dev.nucleusframework:nucleus.launcher-linux", version.ref = "nucleus" }
+nucleus_launcher_macos = { module = "dev.nucleusframework:nucleus.launcher-macos", version.ref = "nucleus" }
 
 [plugins]
 kotlin_multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
Moves the desktop window decoration off Nucleus 1.15.7 `decorated-window-jbr` (AWT/JBR) onto 2.1.9 `decorated-window-tao` (native TAO). Nucleus 2.x also renamed the group and packages: `io.github.kdroidfilter:nucleus.*` / `io.github.kdroidfilter.nucleus.*` became `dev.nucleusframework:nucleus.*` / `dev.nucleusframework.*`. The APIs are otherwise identical.

## Changes

- Swap `decorated-window-jbr` for `nucleus-application` + `decorated-window-tao`.
- Launch via `nucleusApplication(backend = NucleusBackend.Tao) {}` instead of Compose's `application {}`. Window composables now take a `NucleusApplicationScope` receiver and content is `NucleusDecoratedWindowScope`.
- Re-apply `AppTheme` inside each window's content. Every Tao window is its own `ComposeScene`, so CompositionLocals set outside the window do not propagate in the way they did under AWT; `MaterialDecoratedWindow` re-provides only the Material colorScheme/typography/shapes, not `LocalHammerColors` or the markdown config.
- Disable Decompose's `SwingMainThreadChecker`. The tao jar service-loads `TaoMainDispatcherFactory`, so `Dispatchers.Main` is no longer the Swing EDT and the checker logs spurious `NotOnMainThread` errors.
- Pass `enableSingleInstance = false` (`nucleusApplication` defaults it to true) to preserve the existing multi-instance behavior that jump-list relaunches depend on.
- Drop Splashify. Its splash uses Compose's AWT `Window`, which cannot compose under the Tao applier. Replaced with `SplashWindow` in `SplashScreen.kt` built on `DecoratedWindow(undecorated = true)`. The corner radius is gone (no transparent-window support), which matches the square design system anyway.
- proguard: add keeps for `dev.nucleusframework.window.tao.**` and `MainDispatcherFactory`. The desktop proguard config ignores jar `META-INF` rules, so these have to be declared locally.
- `extractMacosNativeLibs` now pulls the six tao dylibs (`libnucleus_tao`, `_dnd`, `_macos_deco`, `_macos_native_view`, `_macos_popup`, `_metal`) instead of `libnucleus_macos` from jbr.

File drop needed no change: `event.awtTransferable` still works on TAO via synthetic `DropTargetDropEvent`s.

## Testing

Smoke-ran clean on Windows. **Untested and worth a look before merge:**

- **macOS** entirely. The AWT `Toolkit` calls in `WindowUtils.coerceWindowSize` may fight Tao's AppKit ownership.
- **Linux / Wayland.**
- **The proguard release build.** The keeps above are reasoned, not verified.
