### PR TITLE
Trust proxy forwarding so a proxied server sees real client addresses

### DIFF
--- a/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
+++ b/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
@@ -61,6 +61,21 @@ To change the host-side binding or port:
 HAMMER_HTTP_BIND=0.0.0.0 HAMMER_HTTP_PORT=8090 docker compose up -d
 ```
 
+### Reverse proxy: set `behindProxy`
+
+With a proxy in front, every request reaches the container from the proxy's address, so the
+login rate limiter treats the whole server as one client and the login audit trail records one
+address for everyone. Setting `behindProxy = true` in `config.toml` makes Hammer read the real
+client from `X-Forwarded-For`. See
+[Behind a proxy](HOW-TO-RUN-A-SERVER.md#behind-a-proxy-every-request-looks-like-it-came-from-the-proxy)
+for the full picture and the warning that goes with it.
+
+That warning matters more in a container than anywhere else: the flag is only safe while the
+proxy is the *only* route in. Publishing the container port to `0.0.0.0` (above) reopens a
+direct path, and with `behindProxy` on, anything reaching it can forge a client address per
+request and walk through the rate limiter. Keep the publish on `127.0.0.1`, or on a Docker
+network only the proxy shares.
+
 ### A client that will not connect
 
 If a client reports that it could not make a secure connection, it reached the

--- a/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
+++ b/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
@@ -61,18 +61,19 @@ To change the host-side binding or port:
 HAMMER_HTTP_BIND=0.0.0.0 HAMMER_HTTP_PORT=8090 docker compose up -d
 ```
 
-### Reverse proxy: set `behindProxy`
+### Reverse proxy: set `trustProxyForwarding`
 
 With a proxy in front, every request reaches the container from the proxy's address, so the
 login rate limiter treats the whole server as one client and the login audit trail records one
-address for everyone. Setting `behindProxy = true` in `config.toml` makes Hammer read the real
-client from `X-Forwarded-For`. See
+address for everyone. Setting `trustProxyForwarding = true` in `config.toml` makes Hammer read
+the real client from `X-Forwarded-For`. See
 [Behind a proxy](HOW-TO-RUN-A-SERVER.md#behind-a-proxy-every-request-looks-like-it-came-from-the-proxy)
-for the full picture and the warning that goes with it.
+for the full picture, the warning that goes with it, and what to do when a CDN sits in front of
+your proxy.
 
 That warning matters more in a container than anywhere else: the flag is only safe while the
 proxy is the *only* route in. Publishing the container port to `0.0.0.0` (above) reopens a
-direct path, and with `behindProxy` on, anything reaching it can forge a client address per
+direct path, and with `trustProxyForwarding` on, anything reaching it can forge a client address per
 request and walk through the rate limiter. Keep the publish on `127.0.0.1`, or on a Docker
 network only the proxy shares.
 

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -458,16 +458,16 @@ Make sure to update your DNS with your desired URL to be able to use LetsEncrypt
 
 ### Behind a proxy, every request looks like it came from the proxy
 
-Hammer reads the connecting address to rate-limit logins, to record login attempts, and to count
-story readers. Behind a proxy that address is the proxy's, identically for every visitor, so:
+If nothing proxies your server, skip this section: Hammer already sees each visitor's real
+address, and nothing needs configuring.
 
-- the login rate limiter (10 attempts per minute) becomes **one bucket shared by the whole
-  server** instead of one per client, and a burst from anywhere locks everyone out
-- recorded login IPs are all the proxy's, so the audit trail says nothing
-- public story reader counts collapse to a single visitor
+Behind a proxy it sees the proxy instead, identically for every visitor. That breaks three
+things: the login rate limiter (10 attempts per minute) becomes one bucket shared by the whole
+server rather than one per client, so a burst from anywhere locks everyone out; recorded login
+IPs all read as the proxy; and public story reader counts collapse to a single visitor.
 
-The `X-Forwarded-For` and `X-Forwarded-Proto` headers your proxy already sends (both are in the
-Nginx config below) carry the real values. Tell Hammer to trust them:
+Your proxy already sends the real values in `X-Forwarded-For` and `X-Forwarded-Proto` (both are
+in the Nginx config below). Tell Hammer to trust them:
 
 ```toml
 # Default false. Only enable when clients cannot reach the server directly.
@@ -475,41 +475,23 @@ trustProxyForwarding = true
 ```
 
 > [!WARNING]
-> Only set this when the server is genuinely unreachable except through your proxy, which is
-> what `bindHosts = ["127.0.0.1", "::1"]` above ensures. `X-Forwarded-For` is just a request
-> header: anything that can connect to Hammer directly can invent one, and with
-> `trustProxyForwarding` on, that means inventing a fresh identity for every request and walking
-> straight through the login rate limiter.
->
-> So if your server is reachable *both* through the proxy and directly, leave this `false`.
-> Proxied visitors then share one bucket, which is worse than per-client but still bounded;
-> turning it on removes the bound entirely for anyone who finds the open port.
+> Only set this when the proxy is the *only* route to the server, which is what
+> `bindHosts = ["127.0.0.1", "::1"]` above ensures. `X-Forwarded-For` is just a request header:
+> anything that can reach Hammer directly can forge one, and with this on that means a fresh
+> identity per request and a free pass through the login rate limiter. If your server is
+> reachable both through the proxy and directly, leave it `false`.
 
-If nothing proxies your server at all, you do not need this setting. The address Hammer sees is
-already the visitor's, and everything above works correctly with it left `false`.
-
-#### Exactly one proxy
-
-`X-Forwarded-For` is a list, and proxies *append* to it rather than replacing it. So a request
-that arrives at Hammer carrying `9.9.9.9, 203.0.113.10` is telling you two different things: the
-last entry is the address your Nginx watched connect, and everything before it arrived with the
-request. A client that sends its own `X-Forwarded-For` gets it preserved verbatim at the front of
-the list.
-
-Hammer therefore reads the **last** entry, which assumes your proxy is the only one. If you put a
-CDN in front of Nginx (Cloudflare, Fastly), the last entry becomes the CDN's edge node rather
-than the visitor, and you would rate-limit per edge node. Fix that at the proxy by overwriting
-the header with the address the CDN reports, so Hammer sees one authoritative value:
+**One proxy only.** Hammer trusts the last `X-Forwarded-For` entry, which is the one your proxy
+added. Put a CDN in front of Nginx (Cloudflare, Fastly) and that entry becomes the CDN's edge
+node rather than the visitor, so have Nginx replace the header with the address the CDN reports:
 
 ```nginx
-# Cloudflare example. Restore the visitor's address, then send only that.
+# Cloudflare example. Keep set_real_ip_from restricted to the CDN's ranges,
+# or anything can supply its own CF-Connecting-IP.
 set_real_ip_from 173.245.48.0/20;   # ...and the rest of Cloudflare's published ranges
 real_ip_header CF-Connecting-IP;
 proxy_set_header X-Forwarded-For $remote_addr;
 ```
-
-Restricting `set_real_ip_from` to the CDN's ranges is what makes this safe: it stops anything
-that is not the CDN from supplying its own `CF-Connecting-IP`.
 
 ### Base Nginx Config
 

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -471,15 +471,45 @@ Nginx config below) carry the real values. Tell Hammer to trust them:
 
 ```toml
 # Default false. Only enable when clients cannot reach the server directly.
-behindProxy = true
+trustProxyForwarding = true
 ```
 
 > [!WARNING]
-> Only set this when the server is genuinely unreachable except through your proxy — which is
+> Only set this when the server is genuinely unreachable except through your proxy, which is
 > what `bindHosts = ["127.0.0.1", "::1"]` above ensures. `X-Forwarded-For` is just a request
-> header: anything that can connect to Hammer directly can invent one, and with `behindProxy`
-> on, that means inventing a fresh identity for every request and walking straight through the
-> login rate limiter. Directly-reachable server: leave it `false` and accept the shared bucket.
+> header: anything that can connect to Hammer directly can invent one, and with
+> `trustProxyForwarding` on, that means inventing a fresh identity for every request and walking
+> straight through the login rate limiter.
+>
+> So if your server is reachable *both* through the proxy and directly, leave this `false`.
+> Proxied visitors then share one bucket, which is worse than per-client but still bounded;
+> turning it on removes the bound entirely for anyone who finds the open port.
+
+If nothing proxies your server at all, you do not need this setting. The address Hammer sees is
+already the visitor's, and everything above works correctly with it left `false`.
+
+#### Exactly one proxy
+
+`X-Forwarded-For` is a list, and proxies *append* to it rather than replacing it. So a request
+that arrives at Hammer carrying `9.9.9.9, 203.0.113.10` is telling you two different things: the
+last entry is the address your Nginx watched connect, and everything before it arrived with the
+request. A client that sends its own `X-Forwarded-For` gets it preserved verbatim at the front of
+the list.
+
+Hammer therefore reads the **last** entry, which assumes your proxy is the only one. If you put a
+CDN in front of Nginx (Cloudflare, Fastly), the last entry becomes the CDN's edge node rather
+than the visitor, and you would rate-limit per edge node. Fix that at the proxy by overwriting
+the header with the address the CDN reports, so Hammer sees one authoritative value:
+
+```nginx
+# Cloudflare example. Restore the visitor's address, then send only that.
+set_real_ip_from 173.245.48.0/20;   # ...and the rest of Cloudflare's published ranges
+real_ip_header CF-Connecting-IP;
+proxy_set_header X-Forwarded-For $remote_addr;
+```
+
+Restricting `set_real_ip_from` to the CDN's ranges is what makes this safe: it stops anything
+that is not the CDN from supplying its own `CF-Connecting-IP`.
 
 ### Base Nginx Config
 

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -456,6 +456,31 @@ bindHosts = ["127.0.0.1", "::1"]
 
 Make sure to update your DNS with your desired URL to be able to use LetsEncrypt and the like.
 
+### Behind a proxy, every request looks like it came from the proxy
+
+Hammer reads the connecting address to rate-limit logins, to record login attempts, and to count
+story readers. Behind a proxy that address is the proxy's, identically for every visitor, so:
+
+- the login rate limiter (10 attempts per minute) becomes **one bucket shared by the whole
+  server** instead of one per client, and a burst from anywhere locks everyone out
+- recorded login IPs are all the proxy's, so the audit trail says nothing
+- public story reader counts collapse to a single visitor
+
+The `X-Forwarded-For` and `X-Forwarded-Proto` headers your proxy already sends (both are in the
+Nginx config below) carry the real values. Tell Hammer to trust them:
+
+```toml
+# Default false. Only enable when clients cannot reach the server directly.
+behindProxy = true
+```
+
+> [!WARNING]
+> Only set this when the server is genuinely unreachable except through your proxy — which is
+> what `bindHosts = ["127.0.0.1", "::1"]` above ensures. `X-Forwarded-For` is just a request
+> header: anything that can connect to Hammer directly can invent one, and with `behindProxy`
+> on, that means inventing a fresh identity for every request and walking straight through the
+> login rate limiter. Directly-reachable server: leave it `false` and accept the shared bucket.
+
 ### Base Nginx Config
 
 Create your base file. Make sure to change `hammer.example.com` to your domain!

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -262,6 +262,7 @@ ktor_server_mustache = { group = "io.ktor", name = "ktor-server-mustache", versi
 ktor_server_html_builder = { group = "io.ktor", name = "ktor-server-html-builder", version.ref = "ktor" }
 ktor_server_status_pages = { group = "io.ktor", name = "ktor-server-status-pages", version.ref = "ktor" }
 ktor_server_hsts = { group = "io.ktor", name = "ktor-server-hsts", version.ref = "ktor" }
+ktor_server_forwarded_header = { group = "io.ktor", name = "ktor-server-forwarded-header", version.ref = "ktor" }
 
 # HTMX for Ktor
 ktor_htmx = { group = "io.ktor", name = "ktor-htmx", version.ref = "ktor" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
 
 	implementation(libs.bundles.ktor.server)
 	implementation(libs.ktor.server.hsts)
+	implementation(libs.ktor.server.forwarded.header)
 	implementation(libs.ktor.network.tlscertificates)
 	implementation(libs.bouncycastle.bcpkix)
 	implementation(libs.jakarta.mail)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -30,18 +30,9 @@ data class ServerConfig(
 	 */
 	val publicUrl: String? = null,
 	/**
-	 * Trust the `X-Forwarded-*` headers for each request's client address and scheme, so the
-	 * login rate limiter, the login audit trail and story reader counts see real clients rather
-	 * than the proxy.
-	 *
-	 * The client address is read from the *last* `X-Forwarded-For` entry, which is the only one
-	 * the adjacent proxy wrote itself; earlier entries arrived with the request and are the
-	 * client's to invent. This means exactly one trusted proxy: with a second one in front
-	 * (a CDN), have the adjacent proxy overwrite the header with the address the CDN reports.
-	 *
-	 * Only enable this when clients cannot reach the server directly (pair it with
-	 * [bindHosts] on loopback). These are ordinary request headers: anything able to connect
-	 * directly can forge one, and a forged address per request defeats the rate limiter it feeds.
+	 * Trust the `X-Forwarded-*` headers for each request's client address and scheme. Only safe
+	 * when the proxy is the only route in, since anything reaching the server directly can forge
+	 * them. Assumes a single proxy: the address comes from the last `X-Forwarded-For` entry.
 	 */
 	val trustProxyForwarding: Boolean = false,
 	val additionalSitemaps: List<String> = emptyList(),

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -34,11 +34,16 @@ data class ServerConfig(
 	 * login rate limiter, the login audit trail and story reader counts see real clients rather
 	 * than the proxy.
 	 *
+	 * The client address is read from the *last* `X-Forwarded-For` entry, which is the only one
+	 * the adjacent proxy wrote itself; earlier entries arrived with the request and are the
+	 * client's to invent. This means exactly one trusted proxy: with a second one in front
+	 * (a CDN), have the adjacent proxy overwrite the header with the address the CDN reports.
+	 *
 	 * Only enable this when clients cannot reach the server directly (pair it with
 	 * [bindHosts] on loopback). These are ordinary request headers: anything able to connect
 	 * directly can forge one, and a forged address per request defeats the rate limiter it feeds.
 	 */
-	val behindProxy: Boolean = false,
+	val trustProxyForwarding: Boolean = false,
 	val additionalSitemaps: List<String> = emptyList(),
 	/**
 	 * Generate per-page social share images (OpenGraph) on the fly for author and story pages.

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -29,6 +29,16 @@ data class ServerConfig(
 	 * links are derived from each request's Host header.
 	 */
 	val publicUrl: String? = null,
+	/**
+	 * Trust the `X-Forwarded-*` headers for each request's client address and scheme, so the
+	 * login rate limiter, the login audit trail and story reader counts see real clients rather
+	 * than the proxy.
+	 *
+	 * Only enable this when clients cannot reach the server directly (pair it with
+	 * [bindHosts] on loopback). These are ordinary request headers: anything able to connect
+	 * directly can forge one, and a forged address per request defeats the rate limiter it feeds.
+	 */
+	val behindProxy: Boolean = false,
 	val additionalSitemaps: List<String> = emptyList(),
 	/**
 	 * Generate per-page social share images (OpenGraph) on the fly for author and story pages.

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
@@ -27,8 +27,13 @@ fun Application.configureHTTP(config: ServerConfig) {
 	// Off by default: X-Forwarded-* are client-supplied, so trusting them on a directly
 	// reachable server lets anyone forge a per-request identity and walk past the login
 	// rate limiter that keys on it.
-	if (config.behindProxy) {
-		install(XForwardedHeaders)
+	if (config.trustProxyForwarding) {
+		install(XForwardedHeaders) {
+			// Ktor defaults to the first X-Forwarded-For entry, which a client can supply:
+			// proxies append rather than replace, so only the last entry is the adjacent
+			// proxy's own observation of who connected.
+			useLastProxy()
+		}
 	}
 
 	val analyticsProvider = config.analytics.provider

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
@@ -17,12 +17,20 @@ import io.ktor.server.plugins.compression.gzip
 import io.ktor.server.plugins.compression.minimumSize
 import io.ktor.server.plugins.conditionalheaders.ConditionalHeaders
 import io.ktor.server.plugins.defaultheaders.DefaultHeaders
+import io.ktor.server.plugins.forwardedheaders.XForwardedHeaders
 import io.ktor.server.plugins.hsts.HSTS
 import io.ktor.server.plugins.httpsredirect.HttpsRedirect
 import io.ktor.server.request.path
 import io.ktor.server.routing.IgnoreTrailingSlash
 
 fun Application.configureHTTP(config: ServerConfig) {
+	// Off by default: X-Forwarded-* are client-supplied, so trusting them on a directly
+	// reachable server lets anyone forge a per-request identity and walk past the login
+	// rate limiter that keys on it.
+	if (config.behindProxy) {
+		install(XForwardedHeaders)
+	}
+
 	val analyticsProvider = config.analytics.provider
 	val analyticsScriptHosts = analyticsProvider?.scriptSrcHosts().orEmpty()
 	val analyticsConnectHosts = analyticsProvider?.connectSrcHosts().orEmpty()

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/HTTP.kt
@@ -24,14 +24,10 @@ import io.ktor.server.request.path
 import io.ktor.server.routing.IgnoreTrailingSlash
 
 fun Application.configureHTTP(config: ServerConfig) {
-	// Off by default: X-Forwarded-* are client-supplied, so trusting them on a directly
-	// reachable server lets anyone forge a per-request identity and walk past the login
-	// rate limiter that keys on it.
 	if (config.trustProxyForwarding) {
 		install(XForwardedHeaders) {
-			// Ktor defaults to the first X-Forwarded-For entry, which a client can supply:
-			// proxies append rather than replace, so only the last entry is the adjacent
-			// proxy's own observation of who connected.
+			// Ktor defaults to the first X-Forwarded-For entry, which the client supplies.
+			// Only the last is the adjacent proxy's own observation of who connected.
 			useLastProxy()
 		}
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/BehindProxyTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/BehindProxyTest.kt
@@ -17,13 +17,14 @@ import kotlin.test.assertEquals
 
 /**
  * The login rate limiter keys on the connecting address. Behind a proxy every request carries
- * the proxy's, so `behindProxy` decides whether one client can exhaust the bucket for everyone.
+ * the proxy's, so `trustProxyForwarding` decides whether one client can exhaust the bucket for
+ * everyone.
  */
 class BehindProxyTest : EndToEndTest() {
 
 	override val serverConfig = ServerConfig(
 		encryption = EncryptionConfig(EncryptionMode.AES),
-		behindProxy = true,
+		trustProxyForwarding = true,
 	)
 
 	@Test
@@ -50,6 +51,29 @@ class BehindProxyTest : EndToEndTest() {
 			HttpStatusCode.Unauthorized,
 			failedLogin(forwardedFor = "203.0.113.99").status,
 			"A different forwarded address must not inherit the first one's exhausted bucket",
+		)
+	}
+
+	@Test
+	fun `a client-supplied entry ahead of the proxy's cannot claim a fresh bucket`(): Unit = runBlocking {
+		createTestServer(SERVER_CONFIG_ONE, fileSystem, database())
+		doStartServer()
+
+		// The proxy appends what it saw to whatever arrived, so only the trailing entry is
+		// its own observation. Everything before it is the client's to invent.
+		repeat(RATE_LIMIT) { attempt ->
+			val response = failedLogin(forwardedFor = "9.9.9.$attempt, 203.0.113.10")
+			assertEquals(
+				HttpStatusCode.Unauthorized,
+				response.status,
+				"Attempt ${attempt + 1} should still be inside the window",
+			)
+		}
+
+		assertEquals(
+			HttpStatusCode.TooManyRequests,
+			failedLogin(forwardedFor = "1.1.1.1, 203.0.113.10").status,
+			"A forged leading entry must not escape the bucket the proxy's entry earned",
 		)
 	}
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/BehindProxyTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/BehindProxyTest.kt
@@ -1,0 +1,75 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.EncryptionConfig
+import com.darkrockstudios.apps.hammer.EncryptionMode
+import com.darkrockstudios.apps.hammer.ServerConfig
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
+import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
+import com.darkrockstudios.apps.hammer.utils.SERVER_CONFIG_ONE
+import com.darkrockstudios.apps.hammer.utils.createTestServer
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * The login rate limiter keys on the connecting address. Behind a proxy every request carries
+ * the proxy's, so `behindProxy` decides whether one client can exhaust the bucket for everyone.
+ */
+class BehindProxyTest : EndToEndTest() {
+
+	override val serverConfig = ServerConfig(
+		encryption = EncryptionConfig(EncryptionMode.AES),
+		behindProxy = true,
+	)
+
+	@Test
+	fun `a forwarded client address gets its own rate limit bucket`(): Unit = runBlocking {
+		createTestServer(SERVER_CONFIG_ONE, fileSystem, database())
+		doStartServer()
+
+		// Exhaust the window from one forwarded address.
+		repeat(RATE_LIMIT) { attempt ->
+			val response = failedLogin(forwardedFor = "203.0.113.10")
+			assertEquals(
+				HttpStatusCode.Unauthorized,
+				response.status,
+				"Attempt ${attempt + 1} should still be inside the window",
+			)
+		}
+		assertEquals(
+			HttpStatusCode.TooManyRequests,
+			failedLogin(forwardedFor = "203.0.113.10").status,
+			"The exhausted address must be limited",
+		)
+
+		assertEquals(
+			HttpStatusCode.Unauthorized,
+			failedLogin(forwardedFor = "203.0.113.99").status,
+			"A different forwarded address must not inherit the first one's exhausted bucket",
+		)
+	}
+
+	private suspend fun failedLogin(forwardedFor: String) = client().post(api("account/login")) {
+		headers {
+			append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+			append(HttpHeaders.XForwardedFor, forwardedFor)
+		}
+		setBody(
+			FormDataContent(
+				Parameters.build {
+					append("email", "test@example.com")
+					append("password", "definitely-not-the-password")
+					append("installId", "fake-install-id")
+				}
+			)
+		)
+	}
+
+	private companion object {
+		const val RATE_LIMIT = 10
+	}
+}


### PR DESCRIPTION
Adds `trustProxyForwarding`, a `config.toml` flag that makes Hammer read each request's client address and scheme from the `X-Forwarded-*` headers instead of the socket.

## Why

Hammer reads the connecting address in three places: the login rate limiter (`plugins/Security.kt:28`), the login audit trail (`account/AccountRoutes.kt:85`), and the story reader beacon (`frontend/PublicStoryPage.kt:321`).

Behind a reverse proxy all three see the proxy, identically for every visitor. The rate limiter is the one that matters: instead of one bucket per client it becomes one bucket for the whole server, so ten bad passwords a minute from anywhere locks every account out until the window refills. The audit trail is collateral, `getBruteForceIps` groups on a column where every row holds the same address.

## Reading the last entry, not the first

Ktor's `XForwardedHeaders` defaults to the **first** `X-Forwarded-For` entry. Proxies append rather than replace, so the first entry is the one value in the list that arrived with the request and that no proxy vouched for. With the Nginx config in our own docs (`proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`), a client sending `X-Forwarded-For: 9.9.9.9` reaches Hammer as `9.9.9.9, <real ip>`, and the forged value wins.

That defeats the entire point of the flag, on a loopback-bound server behind a correctly configured proxy. `useLastProxy()` reads the trailing entry, which is the only one the adjacent proxy observed and wrote itself.

This assumes exactly one proxy. A CDN in front makes the last entry the CDN's edge node, so the docs cover normalizing the header at the proxy (`set_real_ip_from` plus `real_ip_header`), which is the layer that has CIDR matching. No hop-count setting: a wrong count fails open silently, where the single-proxy assumption fails closed by over-grouping.

## Tests

`BehindProxyTest` covers both directions:

- distinct forwarded addresses get distinct buckets
- a forged leading entry cannot escape the bucket the proxy's entry earned

The second fails on the first-entry behaviour, where eleven requests from one address with rotating forged prefixes all return 401 and none are limited.

## Notes for deployment

Default is `false` and nothing changes until an operator opts in. The flag is only safe when the proxy is the sole route in, which is why the docs pair it with `bindHosts` on loopback and carry a warning.
