### PR TITLE
Load scene content as markdown so block structure survives

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ComposeRichText.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ComposeRichText.kt
@@ -22,14 +22,6 @@ data class ComposeRichText(
 		}
 	}
 
-	fun getAnnotatedString(): AnnotatedString {
-		return when {
-			snapshot != null -> snapshot
-			state != null -> state.editorState.getAllText()
-			else -> error("ComposeRichText must contain non-null data ")
-		}
-	}
-
 	override fun stateCompare(text: PlatformRichText?): Boolean {
 		text as ComposeRichText
 		return (snapshot != null && text.snapshot === snapshot)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdown/updateMarkdownStyles.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdown/updateMarkdownStyles.kt
@@ -32,6 +32,10 @@ internal fun updateMarkdownStyles(
 ) {
 	if (state.textLines.isEmpty()) return
 
+	// Heading styles are deliberately absent: MarkdownExtension.markdownConfiguration's
+	// setter rebakes them from their HeaderSpanStyle spans. Remapping them here too
+	// leaves the rebake unable to find the old style to strip, so it appends a second
+	// copy to every heading on each config change.
 	val styleMapping = mapOf(
 		oldConfig.defaultTextStyle to newConfig.defaultTextStyle,
 		oldConfig.boldStyle to newConfig.boldStyle,
@@ -39,12 +43,6 @@ internal fun updateMarkdownStyles(
 		oldConfig.codeStyle to newConfig.codeStyle,
 		oldConfig.linkStyle to newConfig.linkStyle,
 		oldConfig.blockquoteStyle to newConfig.blockquoteStyle,
-		oldConfig.header1Style to newConfig.header1Style,
-		oldConfig.header2Style to newConfig.header2Style,
-		oldConfig.header3Style to newConfig.header3Style,
-		oldConfig.header4Style to newConfig.header4Style,
-		oldConfig.header5Style to newConfig.header5Style,
-		oldConfig.header6Style to newConfig.header6Style
 	)
 
 	state.processLines { _: Int, line: AnnotatedString ->
@@ -59,7 +57,6 @@ internal fun updateMarkdownStyles(
 						addStyle(newStyle, span.start, span.end)
 					} else {
 						// Keep the original style if it's not a markdown style
-						println("Skipping style update")
 						addStyle(span.item, span.start, span.end)
 					}
 				}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/drafts/DraftCompareUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/drafts/DraftCompareUi.kt
@@ -24,10 +24,14 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.markdown.updateMarkdownConfiguration
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
-import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.getInitialEditorContent
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.loadSceneContent
+import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.sceneDiffText
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.TextEditor
 import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
 import com.darkrockstudios.texteditor.markdown.withMarkdown
 import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
 import com.darkrockstudios.texteditor.richstyle.RichSpan
@@ -50,6 +54,17 @@ fun DraftCompareUi(component: DraftCompare) {
 	val screen = LocalScreenCharacteristic.current
 	val state by component.state.subscribeAsState()
 	val draftName = component.draftDef.draftName
+	val markdownConfig = LocalMarkdownConfig.current
+
+	// Hoisted above the width branch: the two layouts are separate composables, so building
+	// the editors inside them would discard the user's merge edits on a resize or rotate
+	// while component.mergedContent still pointed at the torn-down editor.
+	val draftMarkdown = key(state.draftContent) {
+		rememberSceneContentEditor(state.draftContent, markdownConfig)
+	}
+	val currentMarkdown = key(state.sceneContent) {
+		rememberSceneContentEditor(state.sceneContent, markdownConfig)
+	}
 
 	Column(modifier = Modifier.fillMaxSize()) {
 		HdMasthead(
@@ -69,35 +84,44 @@ fun DraftCompareUi(component: DraftCompare) {
 
 		when (screen.windowWidthClass) {
 			WindowWidthSizeClass.Compact, WindowWidthSizeClass.Medium -> {
-				CompactDraftCompareUi(Modifier.fillMaxSize(), component)
+				CompactDraftCompareUi(
+					modifier = Modifier.fillMaxSize(),
+					component = component,
+					draftMarkdown = draftMarkdown,
+					currentMarkdown = currentMarkdown,
+				)
 			}
 
 			else -> {
-				ExpandedDraftCompareUi(Modifier.fillMaxSize(), component)
+				ExpandedDraftCompareUi(
+					modifier = Modifier.fillMaxSize(),
+					component = component,
+					draftMarkdown = draftMarkdown,
+					currentMarkdown = currentMarkdown,
+				)
 			}
 		}
 	}
 }
 
 @Composable
-private fun CompactDraftCompareUi(modifier: Modifier, component: DraftCompare) {
+private fun CompactDraftCompareUi(
+	modifier: Modifier,
+	component: DraftCompare,
+	draftMarkdown: MarkdownExtension,
+	currentMarkdown: MarkdownExtension,
+) {
 	var pane by rememberSaveable { mutableIntStateOf(PANE_DRAFT) }
-	val state by component.state.subscribeAsState()
-	val markdownConfig = LocalMarkdownConfig.current
 	val draftLabel = Res.string.draft_compare_tab_title_draft.get()
 	val currentLabel = Res.string.draft_compare_tab_title_current.get()
 
-	val draftState = key(state.draftContent) {
-		rememberTextEditorState(getInitialEditorContent(state.draftContent, markdownConfig))
+	// Only one pane is composed at a time here, so the panes' own seeding effects can't
+	// be relied on to feed both sides of the diff.
+	LaunchedEffect(draftMarkdown) {
+		component.submitDraftText(sceneDiffText(draftMarkdown))
 	}
-	val currentState = key(state.sceneContent) {
-		rememberTextEditorState(getInitialEditorContent(state.sceneContent, markdownConfig))
-	}
-	LaunchedEffect(draftState) {
-		component.submitDraftText(draftState.getAllText().text)
-	}
-	LaunchedEffect(currentState) {
-		component.onCurrentTextChanged(currentState.getAllText().text)
+	LaunchedEffect(currentMarkdown) {
+		component.onCurrentTextChanged(sceneDiffText(currentMarkdown))
 	}
 
 	Column(modifier = modifier) {
@@ -116,32 +140,29 @@ private fun CompactDraftCompareUi(modifier: Modifier, component: DraftCompare) {
 				modifier = Modifier.fillMaxSize(),
 				sectionNumber = 1,
 				component = component,
-				textEditorState = draftState,
+				markdownExtension = draftMarkdown,
 			)
 		} else {
 			CurrentPane(
 				modifier = Modifier.fillMaxSize(),
 				sectionNumber = 1,
 				component = component,
-				textEditorState = currentState,
+				markdownExtension = currentMarkdown,
 			)
 		}
 	}
 }
 
 @Composable
-private fun ExpandedDraftCompareUi(modifier: Modifier, component: DraftCompare) {
+private fun ExpandedDraftCompareUi(
+	modifier: Modifier,
+	component: DraftCompare,
+	draftMarkdown: MarkdownExtension,
+	currentMarkdown: MarkdownExtension,
+) {
 	val state by component.state.subscribeAsState()
-	val markdownConfig = LocalMarkdownConfig.current
-
-	// Hoist both editor states here so we can wire synchronized scrolling between the panes.
-	// Each is keyed on its content so it rebuilds when the draft / scene finishes loading.
-	val draftState = key(state.draftContent) {
-		rememberTextEditorState(getInitialEditorContent(state.draftContent, markdownConfig))
-	}
-	val currentState = key(state.sceneContent) {
-		rememberTextEditorState(getInitialEditorContent(state.sceneContent, markdownConfig))
-	}
+	val draftState = draftMarkdown.editorState
+	val currentState = currentMarkdown.editorState
 
 	SyncScrolling(
 		leftState = draftState,
@@ -155,7 +176,7 @@ private fun ExpandedDraftCompareUi(modifier: Modifier, component: DraftCompare) 
 			modifier = Modifier.weight(1f).fillMaxHeight(),
 			sectionNumber = 1,
 			component = component,
-			textEditorState = draftState,
+			markdownExtension = draftMarkdown,
 		)
 		VerticalDivider(
 			color = MaterialTheme.colorScheme.outlineVariant,
@@ -165,7 +186,7 @@ private fun ExpandedDraftCompareUi(modifier: Modifier, component: DraftCompare) 
 			modifier = Modifier.weight(1f).fillMaxHeight(),
 			sectionNumber = 2,
 			component = component,
-			textEditorState = currentState,
+			markdownExtension = currentMarkdown,
 		)
 	}
 }
@@ -175,15 +196,16 @@ private fun DraftPane(
 	modifier: Modifier,
 	sectionNumber: Int,
 	component: DraftCompare,
-	textEditorState: TextEditorState,
+	markdownExtension: MarkdownExtension,
 ) {
 	val strRes = rememberStrRes()
 	val state by component.state.subscribeAsState()
 	val deletedHighlight = rememberDeletedHighlight()
+	val textEditorState = markdownExtension.editorState
 
 	// The draft is read-only, so its rendered text never changes — submit it once for the diff.
-	LaunchedEffect(textEditorState) {
-		component.submitDraftText(textEditorState.getAllText().text)
+	LaunchedEffect(markdownExtension) {
+		component.submitDraftText(sceneDiffText(markdownExtension))
 	}
 	val spans = if (state.showDiff) state.diffResult?.leftSpans.orEmpty() else emptyList()
 	DiffHighlightEffect(textEditorState, spans, deletedHighlight)
@@ -241,30 +263,24 @@ private fun CurrentPane(
 	modifier: Modifier,
 	sectionNumber: Int,
 	component: DraftCompare,
-	textEditorState: TextEditorState,
+	markdownExtension: MarkdownExtension,
 ) {
 	val state by component.state.subscribeAsState()
-	val markdownConfig = LocalMarkdownConfig.current
 	val insertedHighlight = rememberInsertedHighlight()
+	val textEditorState = markdownExtension.editorState
 
-	val markdownExtension = remember(textEditorState) { textEditorState.withMarkdown(markdownConfig) }
-
-	LaunchedEffect(markdownExtension, markdownConfig) {
-		markdownExtension.updateMarkdownConfiguration(markdownConfig)
-	}
-
-	LaunchedEffect(textEditorState) {
+	LaunchedEffect(markdownExtension) {
 		// Seed the diff with the initial text, then watch for edits. `collectLatest` cancels the
 		// previous lambda when a new edit arrives, so the `delay` acts as a per-keystroke debounce:
 		// the diff recompute only fires after the user stops typing for [DIFF_RECOMPUTE_DELAY_MS].
 		// The merged-content update runs synchronously before the delay so picking the current
 		// draft always uses the latest text. Submitting the editor's rendered text (not the
 		// markdown) keeps the diff in the same coordinate space the highlights are drawn in.
-		component.onCurrentTextChanged(textEditorState.getAllText().text)
+		component.onCurrentTextChanged(sceneDiffText(markdownExtension))
 		textEditorState.editOperations.collectLatest { _ ->
 			component.onMergedContentChanged(ComposeRichText(markdownExtension))
 			delay(DIFF_RECOMPUTE_DELAY_MS)
-			component.onCurrentTextChanged(textEditorState.getAllText().text)
+			component.onCurrentTextChanged(sceneDiffText(markdownExtension))
 		}
 	}
 
@@ -311,6 +327,24 @@ private fun CurrentPane(
 			)
 		}
 	}
+}
+
+/** An editor seeded with [content], keeping the block structure markdown carries. */
+@Composable
+private fun rememberSceneContentEditor(
+	content: SceneContent?,
+	markdownConfig: MarkdownConfiguration,
+): MarkdownExtension {
+	val editorState = rememberTextEditorState()
+	val markdownExtension = remember(editorState) {
+		editorState.withMarkdown(markdownConfig).also { loadSceneContent(it, content) }
+	}
+	// Both panes restyle together; the config is otherwise baked in at import time and
+	// the two would drift apart on a font size or theme change.
+	LaunchedEffect(markdownExtension, markdownConfig) {
+		markdownExtension.updateMarkdownConfiguration(markdownConfig)
+	}
+	return markdownExtension
 }
 
 @Composable

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
@@ -41,11 +41,13 @@ import com.darkrockstudios.apps.hammer.common.compose.ComposeRichText
 import com.darkrockstudios.apps.hammer.common.compose.LocalMarkdownConfig
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.findShortcutModifier
+import com.darkrockstudios.apps.hammer.common.compose.rememberDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.markdown.updateMarkdownConfiguration
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownFormatBar
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
-import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.getInitialEditorContent
+import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.loadSceneContent
+import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.sceneContentMarkdown
 import com.darkrockstudios.apps.hammer.common.utils.toEditorSpellChecker
 import com.darkrockstudios.apps.hammer.scene_editor_menu_item_close
 import com.darkrockstudios.texteditor.find.FindBar
@@ -54,22 +56,21 @@ import com.darkrockstudios.texteditor.rememberTextEditorStyle
 import com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor
 import com.darkrockstudios.texteditor.spellcheck.markdown.withMarkdown
 import com.darkrockstudios.texteditor.spellcheck.rememberSpellCheckState
+import kotlinx.coroutines.withContext
 
 @Composable
 fun FocusModeUi(component: FocusMode) {
 	val state by component.state.subscribeAsState()
 	val lastForceUpdate by component.lastForceUpdate.subscribeAsState()
 	val markdownConfig = LocalMarkdownConfig.current
+	val defaultDispatcher = rememberDefaultDispatcher()
 
 	val editorSpellChecker = remember(state.spellChecker) {
 		state.spellChecker.toEditorSpellChecker()
 	}
-	// Only read once, but unremembered it rebuilds the whole document's AnnotatedString on the UI
-	// thread every recomposition, and the buffer republishes every 500ms while typing.
-	val initialEditorContent = remember { getInitialEditorContent(state.sceneBuffer?.content, markdownConfig) }
 	val textEditorState = rememberSpellCheckState(
 		spellChecker = editorSpellChecker,
-		initialText = initialEditorContent,
+		initialText = null,
 		enableSpellChecking = state.spellCheckingEnabled,
 	)
 	val markdownExtension = remember { textEditorState.withMarkdown(markdownConfig) }
@@ -87,8 +88,13 @@ fun FocusModeUi(component: FocusMode) {
 		state.sceneBuffer?.let { buffer ->
 			// Always update on first buffer (initial load), or when external update occurs
 			if (!hasReceivedInitialBuffer || buffer.source != UpdateSource.Editor) {
-				val newContent = getInitialEditorContent(buffer.content, markdownConfig)
-				textEditorState.textState.setText(newContent)
+				val sceneMarkdown = withContext(defaultDispatcher) {
+					sceneContentMarkdown(buffer.content)
+				}
+				loadSceneContent(markdownExtension, sceneMarkdown)
+				// Importing emits no edit operations, so the incremental checker never
+				// sees this text. The one-shot check already ran against an empty document.
+				textEditorState.runFullSpellCheck()
 				hasReceivedInitialBuffer = true
 			}
 		}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneContentUtils.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneContentUtils.kt
@@ -1,26 +1,73 @@
 package com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor
 
-import androidx.compose.ui.text.AnnotatedString
-import com.darkrockstudios.apps.hammer.common.compose.ComposeRichText
 import com.darkrockstudios.apps.hammer.common.data.SceneContent
-import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
-import com.darkrockstudios.texteditor.markdown.toAnnotatedStringFromMarkdown
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
+import com.darkrockstudios.texteditor.richstyle.ImageBlockSpanStyle
 
-fun getInitialEditorContent(
-	sceneContent: SceneContent?,
-	markdownConfig: MarkdownConfiguration
-): AnnotatedString {
-	return if (sceneContent != null) {
-		val composeText = sceneContent.platformRepresentation as? ComposeRichText
-		val markdown = sceneContent.markdown
-		if (composeText != null) {
-			composeText.getAnnotatedString()
-		} else if (markdown != null) {
-			markdown.toAnnotatedStringFromMarkdown(markdownConfig)
-		} else {
-			error("Should be impossible to not have either platform rep or markdown")
-		}
-	} else {
-		AnnotatedString("")
-	}
+/** Private Use Area, so they can never collide with anything a writer types. */
+private val HR_MARKER = Char(0xE000)
+private val IMAGE_MARKER = Char(0xE001)
+
+/**
+ * Horizontal rules and code fences live in the editor's rich span manager, not in the
+ * AnnotatedString, so scene content has to travel as markdown and be imported.
+ * Round-tripping it as an AnnotatedString silently drops every block. Images need an
+ * ImageProvider the editors don't supply, so they import as literal text.
+ */
+fun loadSceneContent(markdown: MarkdownExtension, sceneContent: SceneContent?) {
+	loadSceneContent(markdown, sceneContentMarkdown(sceneContent))
 }
+
+fun loadSceneContent(markdown: MarkdownExtension, sceneMarkdown: String) {
+	markdown.importMarkdown(sceneMarkdown)
+}
+
+/**
+ * Serializing a buffer that holds a live editor walks its whole document, so callers on
+ * the main thread should do this off it first. [MarkdownExtension.exportAsMarkdown] reads
+ * a single immutable snapshot and is safe from any thread.
+ */
+fun sceneContentMarkdown(sceneContent: SceneContent?): String =
+	sceneContent?.coerceMarkdown() ?: ""
+
+/**
+ * The editor's rendered text with block placeholders swapped for distinct sentinels.
+ * Rules and images both render as a lone space, so a plain diff cannot tell a scene
+ * break from a blank line and silently drops one during a draft merge. The swap is
+ * length-preserving to keep the result in the editor's coordinate space, which is
+ * what the diff highlight spans are drawn in.
+ */
+fun sceneDiffText(markdown: MarkdownExtension): String {
+	val text = markdown.editorState.getAllText().text
+	val markers = blockMarkersByLine(markdown)
+	if (markers.isEmpty()) return text
+
+	val chars = StringBuilder(text)
+	var line = 0
+	var lineStart = 0
+	while (true) {
+		val newline = chars.indexOf("\n", lineStart)
+		val end = if (newline == -1) chars.length else newline
+		val marker = markers[line]
+		// Only a bare placeholder line is a block; anything longer is real prose.
+		if (marker != null && end - lineStart == 1) {
+			chars[lineStart] = marker
+		}
+		if (newline == -1) break
+		lineStart = newline + 1
+		line++
+	}
+	return chars.toString()
+}
+
+private fun blockMarkersByLine(markdown: MarkdownExtension): Map<Int, Char> =
+	markdown.editorState.richSpanManager.getAllRichSpans()
+		.mapNotNull { span ->
+			when (span.style) {
+				is HorizontalRuleSpanStyle -> span.range.start.line to HR_MARKER
+				is ImageBlockSpanStyle -> span.range.start.line to IMAGE_MARKER
+				else -> null
+			}
+		}
+		.toMap()

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -52,6 +52,7 @@ import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialog
 import com.darkrockstudios.apps.hammer.common.compose.ComposeRichText
 import com.darkrockstudios.apps.hammer.common.compose.LocalMarkdownConfig
 import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
+import com.darkrockstudios.apps.hammer.common.compose.rememberDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.Toaster
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.findShortcutModifier
@@ -70,6 +71,7 @@ import com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor
 import com.darkrockstudios.texteditor.spellcheck.markdown.withMarkdown
 import com.darkrockstudios.texteditor.spellcheck.rememberSpellCheckState
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 const val SCENE_EDITOR_TEXT_TAG = "scene-editor-text"
 const val SCENE_EDITOR_SAVE_TAG = "scene-editor-save"
@@ -86,16 +88,14 @@ fun SceneEditorUi(
 	val lastForceUpdate by component.lastForceUpdate.subscribeAsState()
 	val markdownConfig = LocalMarkdownConfig.current
 	val scope = rememberCoroutineScope()
+	val defaultDispatcher = rememberDefaultDispatcher()
 
 	val editorSpellChecker = remember(state.spellChecker) {
 		state.spellChecker.toEditorSpellChecker()
 	}
-	// Only read once, but unremembered it rebuilds the whole document's AnnotatedString on the UI
-	// thread every recomposition, and the buffer republishes every 500ms while typing.
-	val initialEditorContent = remember { getInitialEditorContent(state.sceneBuffer?.content, markdownConfig) }
 	val textEditorState = rememberSpellCheckState(
 		spellChecker = editorSpellChecker,
-		initialText = initialEditorContent,
+		initialText = null,
 		enableSpellChecking = state.spellCheckingEnabled,
 		spellCheckMode = SpellCheckMode.Word,
 	)
@@ -115,8 +115,13 @@ fun SceneEditorUi(
 		state.sceneBuffer?.let { buffer ->
 			// Always update on first buffer (initial load), or when external update occurs
 			if (!hasReceivedInitialBuffer || buffer.source != UpdateSource.Editor) {
-				val newContent = getInitialEditorContent(buffer.content, markdownConfig)
-				textEditorState.textState.setText(newContent)
+				val sceneMarkdown = withContext(defaultDispatcher) {
+					sceneContentMarkdown(buffer.content)
+				}
+				loadSceneContent(markdownExtension, sceneMarkdown)
+				// Importing emits no edit operations, so the incremental checker never
+				// sees this text. The one-shot check already ran against an empty document.
+				textEditorState.runFullSpellCheck()
 				hasReceivedInitialBuffer = true
 			}
 		}

--- a/composeUi/src/desktopTest/kotlin/MarkdownConfigRestyleTest.kt
+++ b/composeUi/src/desktopTest/kotlin/MarkdownConfigRestyleTest.kt
@@ -1,0 +1,45 @@
+import androidx.compose.ui.unit.sp
+import com.darkrockstudios.apps.hammer.common.compose.markdown.updateMarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class MarkdownConfigRestyleTest {
+
+	private fun TestScope.newEditor(config: MarkdownConfiguration): MarkdownExtension {
+		val state = TextEditorState(scope = this, measurer = mockk(relaxed = true))
+		return MarkdownExtension(state, config)
+	}
+
+	private fun configWithBodySize(size: Float) = MarkdownConfiguration.DEFAULT.copy(
+		defaultTextStyle = MarkdownConfiguration.DEFAULT.defaultTextStyle.copy(fontSize = size.sp),
+		header1Style = MarkdownConfiguration.DEFAULT.header1Style.copy(fontSize = (size * 2).sp),
+	)
+
+	@Test
+	fun `stepping the font size leaves one baked style per heading`() = runTest {
+		val editor = newEditor(configWithBodySize(16f))
+		editor.importMarkdown("# Chapter One\n\nSome body text.")
+		val before = editor.editorState.textLines[0].spanStyles.size
+
+		repeat(5) { step -> editor.updateMarkdownConfiguration(configWithBodySize(18f + step * 2)) }
+
+		assertEquals(before, editor.editorState.textLines[0].spanStyles.size)
+	}
+
+	@Test
+	fun `heading tracks the new font size`() = runTest {
+		val editor = newEditor(configWithBodySize(16f))
+		editor.importMarkdown("# Chapter One")
+
+		editor.updateMarkdownConfiguration(configWithBodySize(20f))
+
+		val sizes = editor.editorState.textLines[0].spanStyles.map { it.item.fontSize }
+		assertEquals(listOf(40f.sp), sizes.filter { it != 20f.sp })
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/SceneContentLoadTest.kt
+++ b/composeUi/src/desktopTest/kotlin/SceneContentLoadTest.kt
@@ -1,0 +1,111 @@
+import com.darkrockstudios.apps.hammer.common.compose.ComposeRichText
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.SceneItem
+import com.darkrockstudios.apps.hammer.common.fileio.HPath
+import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.loadSceneContent
+import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.sceneDiffText
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SceneContentLoadTest {
+
+	private val projectDef = ProjectDef(
+		name = "Test Project",
+		path = HPath(path = "/test", name = "Test Project", isAbsolute = true),
+	)
+
+	private val sceneItem = SceneItem(
+		projectDef = projectDef,
+		type = SceneItem.Type.Scene,
+		id = 1,
+		name = "Test Scene",
+		order = 0,
+	)
+
+	private fun TestScope.newEditor(): MarkdownExtension {
+		val state = TextEditorState(scope = this, measurer = mockk(relaxed = true))
+		return MarkdownExtension(state, MarkdownConfiguration.DEFAULT)
+	}
+
+	private fun MarkdownExtension.horizontalRuleLines(): List<Int> =
+		editorState.richSpanManager.getAllRichSpans()
+			.filter { it.style === HorizontalRuleSpanStyle }
+			.map { it.range.start.line }
+			.sorted()
+
+	@Test
+	fun `horizontal rule survives reloading a live editor buffer`() = runTest {
+		val original = "Before the break.\n\n---\n\nAfter the break."
+
+		val editing = newEditor()
+		editing.importMarkdown(original)
+		val buffered = SceneContent(
+			scene = sceneItem,
+			platformRepresentation = ComposeRichText(editing),
+		)
+
+		val reopened = newEditor()
+		loadSceneContent(reopened, buffered)
+
+		assertEquals(listOf(2), reopened.horizontalRuleLines())
+		assertEquals(original, reopened.exportAsMarkdown())
+	}
+
+	@Test
+	fun `horizontal rule survives loading markdown from disk`() = runTest {
+		val original = "Before the break.\n\n---\n\nAfter the break."
+		val onDisk = SceneContent(scene = sceneItem, markdown = original)
+
+		val reopened = newEditor()
+		loadSceneContent(reopened, onDisk)
+
+		assertEquals(listOf(2), reopened.horizontalRuleLines())
+		assertEquals(original, reopened.exportAsMarkdown())
+	}
+
+	@Test
+	fun `null content loads an empty document`() = runTest {
+		val editor = newEditor()
+		editor.importMarkdown("Some prior text")
+
+		loadSceneContent(editor, null)
+
+		assertEquals("", editor.exportAsMarkdown())
+	}
+
+	@Test
+	fun `diff text distinguishes a horizontal rule from a blank line`() = runTest {
+		val withRule = newEditor()
+		loadSceneContent(withRule, SceneContent(sceneItem, "Before.\n\n---\n\nAfter."))
+		val withoutRule = newEditor()
+		loadSceneContent(withoutRule, SceneContent(sceneItem, "Before.\n\n\n\nAfter."))
+
+		assertNotEquals(sceneDiffText(withRule), sceneDiffText(withoutRule))
+	}
+
+	@Test
+	fun `diff text stays in the editor coordinate space`() = runTest {
+		val editor = newEditor()
+		loadSceneContent(editor, SceneContent(sceneItem, "Before.\n\n---\n\nAfter."))
+
+		// The diff's offsets index back into the editor, so substitution must not resize.
+		assertEquals(editor.editorState.getAllText().text.length, sceneDiffText(editor).length)
+	}
+
+	@Test
+	fun `diff text leaves prose untouched`() = runTest {
+		val editor = newEditor()
+		loadSceneContent(editor, SceneContent(sceneItem, "Just prose.\n\nNo blocks here."))
+
+		assertEquals(editor.editorState.getAllText().text, sceneDiffText(editor))
+	}
+}


### PR DESCRIPTION
## What

Scene content no longer round-trips through an `AnnotatedString` on the way into the editor. Horizontal rules, images and code fences live in the editor's rich span manager rather than in the `AnnotatedString`, so `getInitialEditorContent` silently dropped every block. `loadSceneContent` imports the markdown instead.

## Why it grew past a one-liner

Routing through `importMarkdown` broke three things that were quietly leaning on the old seeding path.

**Spell check never ran on a loaded scene.** `rememberSpellCheckState` keys its one-shot `runFullSpellCheck()` on the spell checker alone, and `importMarkdown` emits no edit operations, so the incremental checker never sees imported text either. Once `ProjectSpellCheckRepository` has the dictionary cached, every subsequent scene composes with a non-null checker and the scan runs against a still-empty editor. The repro is the *second* scene opened in a session, not the first. Both editors now run a full check after loading.

**Heading spans accumulated.** `updateMarkdownStyles` remapped heading styles before `MarkdownExtension.markdownConfiguration`'s setter rebaked them, so `rebuildWithoutBlock` could no longer find the old style to strip and `rebuildWithBlock` appended a second copy. One duplicate span per heading per font-size step or theme flip, degrading layout for the rest of the session. Headings are now left to the library's rebake.

**The draft diff couldn't see block lines.** `HR_PLACEHOLDER` and `IMAGE_PLACEHOLDER` are both a single space, so a scene break added or removed between draft and current read as a blank line on both sides. `sceneDiffText()` swaps them for Private Use Area sentinels, length-preserving so the result stays in the editor's coordinate space that the highlight spans are drawn in.

## Also in here

- Draft Compare's editors are hoisted above the width breakpoint. `CompactDraftCompareUi` and `ExpandedDraftCompareUi` are separate composables, so crossing the boundary rebuilt the editable pane from `state.sceneContent` and discarded merge edits while `mergedContent` still pointed at the torn-down editor, meaning "accept current" saved the invisible text.
- Both panes get the markdown config effect, so they no longer drift apart on a font size or theme change.
- The markdown export runs on the default dispatcher. `exportAsMarkdown` reads a single immutable snapshot and is documented thread-safe.
- Removed a stray `println` that ran per span per line on every config change.

## Testing

`MarkdownConfigRestyleTest` is new and was confirmed failing before its fix. `SceneContentLoadTest` covers block survival from both a live buffer and on-disk markdown, plus the diff-text substitution. `:composeUi:desktopTest` and `:common:desktopTest` pass.

The spell-check fix was verified by hand in the desktop app: open one scene to warm the dictionary cache, then open a scene with misspellings and confirm underlines appear before typing.

## Known gaps

- **Images are still broken, unchanged from before this PR.** No call site supplies an `ImageProvider`, so `![alt](url)` imports as literal text and `exportAsMarkdown` escapes it to `\!\[alt\]\(url\)` on save. The KDoc that wrongly claimed images survive has been corrected. Fixing it properly means wiring a real provider into three editors.
- A horizontal rule difference is now *detected* by the diff (verified: it produces a `DELETED` span) but is not really *visible*, because the span is one character wide on a line rendered as a rule. Detection was the regression; making it legible is a design question.
- Loading a live buffer still does a full markdown re-parse on the main thread. Only the export half moved off. Removing the round trip entirely needs a document-transfer API, filed upstream as Darkrock-Studios/ComposeTextEditor#96.
