### PR TITLE
Recreate projects whose cached server id is dead

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -162,6 +162,7 @@
 	</string>
 
 	<string name="sync_log_client_data_computed">Client Entity data calculated</string>
+	<string name="sync_log_project_id_stale">The server no longer has this project. It will be recreated the next time you sync.</string>
 	<string name="sync_log_server_data_loaded">Server data received</string>
 	<string name="sync_log_client_data_loaded">Client data loaded</string>
 	<string name="sync_log_backup_made">Local Backup made: %1$s</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/projectslist/ProjectsListComponent.kt
@@ -313,6 +313,8 @@ class ProjectsListComponent(
 			Napier.i("Project deleted: ${projectDef.name}")
 			if (syncedProject != null) {
 				projectsSynchronizer.deleteProject(syncedProject)
+			} else if (projectsSynchronizer.isServerSynchronized()) {
+				projectsSynchronizer.deleteUnsyncedProject(projectDef.name)
 			}
 
 			loadProjectList()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -478,7 +478,9 @@ class ClientAccountSynchronizer(
 	}
 
 	/**
-	 * Create projects on the server which this client has created locally
+	 * Create projects on the server which this client has created locally. A cached [ProjectId] the
+	 * server neither holds nor has tombstoned is dead (the client last synced against a different or
+	 * since-reset server): recreate it, or per-project sync gets an id it can only 410 on.
 	 */
 	private suspend fun createProjectsOnServer(
 		localProjectsWithIds: List<Pair<ProjectDef, ProjectId?>>,
@@ -487,8 +489,11 @@ class ClientAccountSynchronizer(
 		onLog: OnSyncLog,
 		onUnauthorized: suspend () -> Unit = {},
 	) {
+		val serverKnownIds = serverSyncData.projects.mapTo(mutableSetOf()) { it.uuid } +
+			serverSyncData.deletedProjects
+
 		val localOnly = localProjectsWithIds.filter { (_, uuid) ->
-			uuid == null
+			uuid == null || uuid !in serverKnownIds
 		}.map { it.first.name }
 
 		val newLocalProjects = clientSyncData.projectsToCreate + localOnly

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -81,10 +81,11 @@ class ClientAccountSynchronizer(
 				syncId = serverSyncData.syncId
 
 				val clientSyncData = loadSyncData()
+				val serverKnownIds = serverSyncData.knownProjectIds()
 
 				yield()
 
-				syncRenamedProjects(clientSyncData, serverSyncData, onLog, onUnauthorized)
+				syncRenamedProjects(clientSyncData, serverSyncData, serverKnownIds, onLog, onUnauthorized)
 
 				yield()
 
@@ -98,7 +99,7 @@ class ClientAccountSynchronizer(
 				syncCreatedProjects(
 					clientSyncData,
 					updatedServerSyncData,
-					serverSyncData.knownProjectIds(),
+					serverKnownIds,
 					localProjects,
 					onLog,
 					onUnauthorized,
@@ -280,11 +281,20 @@ class ClientAccountSynchronizer(
 	private suspend fun syncRenamedProjects(
 		clientSyncData: ProjectsSynchronizationData,
 		serverSyncData: BeginProjectsSyncResponse,
+		serverKnownIds: Set<ProjectId>,
 		onLog: OnSyncLog,
 		onUnauthorized: suspend () -> Unit = {},
 	) {
 		// Rename projects on the server
 		clientSyncData.projectsToRename.forEach { (projectId, newName) ->
+			// The server can't rename an id it never issued, and would fail this every session
+			// forever. Recreation covers the rename anyway: it creates under the local name,
+			// which a local rename has already updated.
+			if (projectId !in serverKnownIds) {
+				dropQueuedRename(projectId)
+				return@forEach
+			}
+
 			val result = serverProjectsApi.renameProject(projectId, serverSyncData.syncId, newName)
 			if (result.isSuccess) {
 				onLog(
@@ -295,12 +305,7 @@ class ClientAccountSynchronizer(
 						)
 					)
 				)
-				updateSyncData { syncData ->
-					syncData.copy(
-						projectsToRename = syncData.projectsToRename
-							.filterNot { it.projectId == projectId }.toSet(),
-					)
-				}
+				dropQueuedRename(projectId)
 			} else {
 				val exception = result.exceptionOrNull()
 				Napier.e("Failed to rename project: $projectId", exception)
@@ -318,6 +323,15 @@ class ClientAccountSynchronizer(
 					onUnauthorized()
 				}
 			}
+		}
+	}
+
+	private fun dropQueuedRename(projectId: ProjectId) {
+		updateSyncData { syncData ->
+			syncData.copy(
+				projectsToRename = syncData.projectsToRename
+					.filterNot { it.projectId == projectId }.toSet(),
+			)
 		}
 	}
 
@@ -509,7 +523,18 @@ class ClientAccountSynchronizer(
 			uuid == null || uuid !in serverKnownIds
 		}.map { it.first.name }
 
-		val newLocalProjects = clientSyncData.projectsToCreate + localOnly
+		// A queued name with no local project was deleted before it ever reached the server.
+		// Creating it would push an empty project to every device, and resolving its definition
+		// would point at a directory that is gone, so drop it instead.
+		val localNames = localProjectsWithIds.mapTo(mutableSetOf()) { it.first.name }
+		val staleCreates = clientSyncData.projectsToCreate - localNames
+		if (staleCreates.isNotEmpty()) {
+			updateSyncData { syncData ->
+				syncData.copy(projectsToCreate = syncData.projectsToCreate - staleCreates)
+			}
+		}
+
+		val newLocalProjects = (clientSyncData.projectsToCreate - staleCreates) + localOnly
 		// Create projects on the server
 		newLocalProjects.forEach { projectName ->
 			val result = serverProjectsApi.createProject(projectName, serverSyncData.syncId)
@@ -639,6 +664,19 @@ class ClientAccountSynchronizer(
 		updateSyncData { syncData ->
 			syncData.copy(
 				projectsToCreate = syncData.projectsToCreate + projectName,
+			)
+		}
+	}
+
+	/**
+	 * A project deleted before it ever synced has no id to tombstone, only a queued creation to
+	 * withdraw. Left queued, the next sync would create it on the server and push it back to
+	 * every device.
+	 */
+	fun deleteUnsyncedProject(projectName: String) {
+		updateSyncData { syncData ->
+			syncData.copy(
+				projectsToCreate = syncData.projectsToCreate - projectName,
 			)
 		}
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -95,7 +95,14 @@ class ClientAccountSynchronizer(
 				val updatedServerSyncData = processProjectSyncData(serverSyncData, clientSyncData)
 
 				val localProjects = projectsRepository.getProjects()
-				syncCreatedProjects(clientSyncData, updatedServerSyncData, localProjects, onLog, onUnauthorized)
+				syncCreatedProjects(
+					clientSyncData,
+					updatedServerSyncData,
+					serverSyncData.knownProjectIds(),
+					localProjects,
+					onLog,
+					onUnauthorized,
+				)
 
 				yield()
 
@@ -402,6 +409,7 @@ class ClientAccountSynchronizer(
 	private suspend fun syncCreatedProjects(
 		clientSyncData: ProjectsSynchronizationData,
 		serverSyncData: BeginProjectsSyncResponse,
+		serverKnownIds: Set<ProjectId>,
 		localProjects: List<ProjectDef>,
 		onLog: OnSyncLog,
 		onUnauthorized: suspend () -> Unit = {},
@@ -425,7 +433,14 @@ class ClientAccountSynchronizer(
 			onLog
 		)
 
-		createProjectsOnServer(localProjectsWithIds, clientSyncData, serverSyncData, onLog, onUnauthorized)
+		createProjectsOnServer(
+			localProjectsWithIds,
+			clientSyncData,
+			serverSyncData,
+			serverKnownIds,
+			onLog,
+			onUnauthorized,
+		)
 
 		createLocalProjectsFromServer(newServerProjects, onLog)
 	}
@@ -478,20 +493,18 @@ class ClientAccountSynchronizer(
 	}
 
 	/**
-	 * Create projects on the server which this client has created locally. A cached [ProjectId] the
-	 * server neither holds nor has tombstoned is dead (the client last synced against a different or
+	 * Create projects on the server which this client has created locally. A cached [ProjectId]
+	 * absent from [serverKnownIds] is dead (the client last synced against a different or
 	 * since-reset server): recreate it, or per-project sync gets an id it can only 410 on.
 	 */
 	private suspend fun createProjectsOnServer(
 		localProjectsWithIds: List<Pair<ProjectDef, ProjectId?>>,
 		clientSyncData: ProjectsSynchronizationData,
 		serverSyncData: BeginProjectsSyncResponse,
+		serverKnownIds: Set<ProjectId>,
 		onLog: OnSyncLog,
 		onUnauthorized: suspend () -> Unit = {},
 	) {
-		val serverKnownIds = serverSyncData.projects.mapTo(mutableSetOf()) { it.uuid } +
-			serverSyncData.deletedProjects
-
 		val localOnly = localProjectsWithIds.filter { (_, uuid) ->
 			uuid == null || uuid !in serverKnownIds
 		}.map { it.first.name }
@@ -714,3 +727,11 @@ private data class ProjectPair(
 
 private fun Throwable?.isAuthenticationFailure(): Boolean =
 	(this is HttpFailureException && statusCode == HttpStatusCode.Unauthorized)
+
+/**
+ * Every project id the server accounted for, live or tombstoned. Must be read from the raw
+ * begin_sync response: `processProjectSyncData` drops projects this client has queued for
+ * deletion, and a project missing for that reason is still known to the server, not dead.
+ */
+private fun BeginProjectsSyncResponse.knownProjectIds(): Set<ProjectId> =
+	projects.mapTo(mutableSetOf()) { it.uuid } + deletedProjects

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchServerDataOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchServerDataOperation.kt
@@ -6,10 +6,14 @@ import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
+import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.util.StrRes
+import com.darkrockstudios.apps.hammer.sync_log_project_id_stale
 import com.darkrockstudios.apps.hammer.sync_log_server_data_loaded
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.flow.first
 
 class FetchServerDataOperation(
@@ -17,6 +21,7 @@ class FetchServerDataOperation(
 	private val globalSettingsStore: GlobalSettingsStore,
 	private val serverProjectApi: ServerProjectApi,
 	private val projectMetadataDatasource: ProjectMetadataDatasource,
+	private val projectsRepository: ProjectsRepository,
 	private val strRes: StrRes,
 ) : SyncOperation(projectDef) {
 
@@ -55,9 +60,18 @@ class FetchServerDataOperation(
 
 			CResult.success(fetchServerDataStateState)
 		} else {
-			CResult.failure(
+			val exception =
 				serverSyncDataResult.exceptionOrNull() ?: IllegalStateException("No exception")
-			)
+
+			// 410 means the server has no record of this id, so it can never succeed. Drop it and
+			// EnsureProjectIdOperation creates the project fresh next sync, instead of this
+			// failing forever.
+			if (exception is HttpFailureException && exception.statusCode == HttpStatusCode.Gone) {
+				projectsRepository.removeProjectId(projectDef)
+				onLog(syncLogW(strRes.get(Res.string.sync_log_project_id_stale), projectDef))
+			}
+
+			CResult.failure(exception)
 		}
 	}
 

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -534,9 +534,47 @@ class ClientAccountSynchronizerTest {
 	}
 
 	@Test
+	fun `syncProjects drops a rename queued against an id the server never knew`() = runTest {
+		val deadId = ProjectId.randomUUID()
+		writeSyncData(emptySyncData().copy(projectsToRename = setOf(RenamedProject(deadId, "NewName"))))
+		every { projectsRepository.getProjects(any()) } returns emptyList()
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		// Attempting it would fail every session forever and log an error each time.
+		coVerify(exactly = 0) { serverProjectsApi.renameProject(any(), any(), any()) }
+		assertTrue(readSyncData().projectsToRename.isEmpty())
+	}
+
+	@Test
+	fun `syncProjects withdraws a queued creation whose local project is gone`() = runTest {
+		writeSyncData(emptySyncData().copy(projectsToCreate = setOf("DeletedBeforeSync")))
+		every { projectsRepository.getProjects(any()) } returns emptyList()
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		coVerify(exactly = 0) { serverProjectsApi.createProject(any(), any()) }
+		assertTrue(readSyncData().projectsToCreate.isEmpty())
+	}
+
+	@Test
+	fun `deleteUnsyncedProject withdraws the queued creation`() {
+		writeSyncData(emptySyncData().copy(projectsToCreate = setOf("Draft", "Keeper")))
+
+		createSynchronizer().deleteUnsyncedProject("Draft")
+
+		assertEquals(setOf("Keeper"), readSyncData().projectsToCreate)
+	}
+
+	@Test
 	fun `syncProjects renames a project on the server`() = runTest {
 		val id = ProjectId.randomUUID()
 		writeSyncData(emptySyncData().copy(projectsToRename = setOf(RenamedProject(id, "NewName"))))
+		coEvery { serverProjectsApi.beginProjectsSync() } returns Result.success(
+			emptyServerResponse().copy(projects = setOf(ApiProjectDefinition("OldName", id)))
+		)
 		every { projectsRepository.getProjects(any()) } returns emptyList()
 		coEvery { serverProjectsApi.renameProject(id, "sync-1", "NewName") } returns Result.success("ok")
 

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -461,6 +461,47 @@ class ClientAccountSynchronizerTest {
 	}
 
 	@Test
+	fun `syncProjects does not recreate a project whose cached id the server still lists`() = runTest {
+		writeSyncData(emptySyncData())
+		val id = ProjectId.randomUUID()
+		val def = projectDef("KnownNovel")
+
+		coEvery { serverProjectsApi.beginProjectsSync() } returns Result.success(
+			emptyServerResponse().copy(projects = setOf(ApiProjectDefinition("KnownNovel", id)))
+		)
+		every { projectsRepository.getProjects(any()) } returns listOf(def)
+		every { projectsRepository.getProjectId(def) } returns id
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		coVerify(exactly = 0) { serverProjectsApi.createProject(any(), any()) }
+	}
+
+	@Test
+	fun `syncProjects does not resurrect a project queued for deletion that is still on disk`() = runTest {
+		val id = ProjectId.randomUUID()
+		val def = projectDef("DoomedNovel")
+		writeSyncData(emptySyncData().copy(projectsToDelete = setOf(id)))
+
+		// processProjectSyncData strips a queued-for-deletion project out of the server list, so
+		// liveness has to be judged against the raw begin_sync response. The local folder is still
+		// present here (restored by a file-sync tool), which is what puts it back in getProjects.
+		coEvery { serverProjectsApi.beginProjectsSync() } returns Result.success(
+			emptyServerResponse().copy(projects = setOf(ApiProjectDefinition("DoomedNovel", id)))
+		)
+		coEvery { serverProjectsApi.deleteProject(id, "sync-1") } returns Result.success("ok")
+		every { projectsRepository.getProjects(any()) } returns listOf(def)
+		every { projectsRepository.getProjectId(def) } returns id
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		coVerify { serverProjectsApi.deleteProject(id, "sync-1") }
+		coVerify(exactly = 0) { serverProjectsApi.createProject(any(), any()) }
+	}
+
+	@Test
 	fun `syncProjects deletes a server project this client marked for deletion`() = runTest {
 		val id = ProjectId.randomUUID()
 		writeSyncData(emptySyncData().copy(projectsToDelete = setOf(id)))

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -439,6 +439,28 @@ class ClientAccountSynchronizerTest {
 	}
 
 	@Test
+	fun `syncProjects recreates a project whose cached id the server neither holds nor tombstoned`() = runTest {
+		writeSyncData(emptySyncData())
+		val staleId = ProjectId.randomUUID()
+		val freshId = ProjectId.randomUUID()
+		val def = projectDef("ResetServerNovel")
+
+		// The server has no record of this id at all: not a live project, not a tombstone.
+		// This is what a client sees after syncing against a different or since-reset server.
+		every { projectsRepository.getProjects(any()) } returns listOf(def)
+		every { projectsRepository.getProjectId(def) } returns staleId
+		every { projectsRepository.getProjectDefinition("ResetServerNovel") } returns def
+		coEvery { serverProjectsApi.createProject("ResetServerNovel", "sync-1") } returns
+			Result.success(CreateProjectResponse(freshId, alreadyExisted = false))
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		coVerify { serverProjectsApi.createProject("ResetServerNovel", "sync-1") }
+		verify { projectsRepository.setProjectId(def, freshId) }
+	}
+
+	@Test
 	fun `syncProjects deletes a server project this client marked for deletion`() = runTest {
 		val id = ProjectId.randomUUID()
 		writeSyncData(emptySyncData().copy(projectsToDelete = setOf(id)))

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FetchServerDataOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FetchServerDataOperationTest.kt
@@ -2,22 +2,27 @@ package synchronizer.operations
 
 import PROJECT_2_NAME
 import com.darkrockstudios.apps.hammer.base.http.ApiProjectEntity
+import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.*
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.operations.FetchServerDataOperation
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import getProjectDef
+import io.ktor.http.HttpStatusCode
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -44,6 +49,9 @@ class FetchServerDataOperationTest : BaseTest() {
 
 	@MockK(relaxed = true)
 	private lateinit var serverProjectApi: ServerProjectApi
+
+	@MockK(relaxed = true)
+	private lateinit var projectsRepository: ProjectsRepository
 
 	private lateinit var strRes: TestStrRes
 
@@ -73,6 +81,7 @@ class FetchServerDataOperationTest : BaseTest() {
 			strRes = strRes,
 			projectMetadataDatasource = projectMetadataDatasource,
 			globalSettingsStore = globalSettingsStore,
+			projectsRepository = projectsRepository,
 			serverProjectApi = serverProjectApi,
 		)
 	}
@@ -177,4 +186,67 @@ class FetchServerDataOperationTest : BaseTest() {
 
 		assertFalse(isSuccess(result))
 	}
+
+	@Test
+	fun `A generic failure leaves the cached project id alone`() = runTest {
+		val projectDef = getProjectDef(PROJECT_2_NAME)
+		val op = createOperation(projectDef)
+
+		stubSettingsAndMetadata()
+		coEvery { serverProjectApi.beginProjectSync(any(), any(), any(), any()) } returns
+			Result.failure(Exception("Test Failure"))
+
+		val result = execute(op)
+
+		assertFalse(isSuccess(result))
+		// Only a 410 proves the id is dead; a transient failure must not discard it.
+		verify(exactly = 0) { projectsRepository.removeProjectId(any()) }
+	}
+
+	@Test
+	fun `A 410 Gone drops the dead project id so the next sync can recreate it`() = runTest {
+		val projectDef = getProjectDef(PROJECT_2_NAME)
+		val op = createOperation(projectDef)
+
+		stubSettingsAndMetadata()
+		coEvery { serverProjectApi.beginProjectSync(any(), any(), any(), any()) } returns
+			Result.failure(
+				HttpFailureException(
+					statusCode = HttpStatusCode.Gone,
+					error = HttpResponseError(
+						error = "Project Not Found",
+						displayMessage = "Project does not exist",
+					),
+				)
+			)
+
+		val result = execute(op)
+
+		assertFalse(isSuccess(result))
+		verify { projectsRepository.removeProjectId(projectDef) }
+	}
+
+	private suspend fun stubSettingsAndMetadata() {
+		coEvery { globalSettingsStore.serverSettingsUpdates } returns sharedFlow {
+			emit(
+				mockk<ServerSettings>().apply {
+					every { userId } returns 1L
+				}
+			)
+		}
+		coEvery { projectMetadataDatasource.loadMetadata(any()) } returns metadata
+	}
+
+	private suspend fun execute(op: FetchServerDataOperation) = op.execute(
+		state = FetchLocalDataState(
+			onlyNew = false,
+			clientSyncData = projectData,
+			entityState = entityState,
+			serverProjectId = projId,
+		),
+		onProgress = mockk(relaxed = true),
+		onLog = mockk(relaxed = true),
+		onConflict = mockk(relaxed = true),
+		onComplete = mockk(relaxed = true),
+	)
 }

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -35,6 +35,15 @@ deletion is filtered out of the working copy of that list, but it is still known
 judging it against the filtered list would recreate what the user just deleted. A tombstoned ID is
 likewise not dead: it means a real server-side delete, which propagates as a local deletion instead.
 
+Replacing an ID strands anything else queued against the old one, so the queues are withdrawn
+rather than retried:
+
+- A **rename** queued against an ID the server does not know is dropped without being sent. The
+  server cannot rename an ID it never issued, so retrying only logs an error every session;
+  recreation already covers it, because the project is created under its current local name.
+- A **creation** queued for a name with no local project is dropped. The project was deleted before
+  it ever reached the server, so creating it would push an empty project out to every device.
+
 Any given user account may only have one sync in progress at a time. Attempting to start a sync when
 one is already in progress will result in a failure to begin the sync (`400 Bad Request`).
 

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -23,6 +23,18 @@ parity with each other.
 Additionally, it will find or create a `projectId` for the client's local projects. These are the
 key to being able to sync a local project with the server.
 
+### Stale project IDs
+
+A local project caches the `projectId` it was assigned, so a client that last synced against a
+different server (or one whose database has since been reset) holds IDs that server never issued.
+Account sync therefore treats a cached ID the server neither lists in `begin_sync` nor reports in
+`deletedProjects` as **dead**, and recreates the project as though it had no ID at all.
+
+Liveness is judged against the raw `begin_sync` response. A project the client has queued for
+deletion is filtered out of the working copy of that list, but it is still known to the server, and
+judging it against the filtered list would recreate what the user just deleted. A tombstoned ID is
+likewise not dead: it means a real server-side delete, which propagates as a local deletion instead.
+
 Any given user account may only have one sync in progress at a time. Attempting to start a sync when
 one is already in progress will result in a failure to begin the sync (`400 Bad Request`).
 
@@ -306,6 +318,19 @@ The install is identified server-side from the authenticated bearer token (never
   after 2 minutes without activity (sliding — refreshed each time the `syncID` is used).
 
 The client also fires `end_sync` even when its sync is cancelled, so sessions are normally released cleanly; reclaim is the safety net for the cases where that request can't be delivered.
+
+#### Unknown project (`410 Gone`)
+
+A project endpoint called with a `projectId` the user doesn't own answers **`410 Gone`**, not `404`.
+The distinction matters: `download_entity` maps a `404` to "entity deleted on the server" and, for
+an entity it doesn't already hold, silently marks it deleted. A project-level `404` would therefore
+make a client abandon undownloaded entities when a project vanishes mid-sync.
+
+`410` is terminal for that ID: retrying can never succeed. On receiving it from `begin_sync` the
+client discards the cached `projectId`, which drops the project back to the never-synced state, and
+the next sync recreates it on the server. Without that the project would fail every sync forever,
+because the only other repair path (account sync, above) is not run when syncing a single project
+from inside the project itself.
 
 You may however have `syncID`s for multiple different projects simultaneously.
 


### PR DESCRIPTION
## Problem

A local project keeps the server project id it was assigned on a previous sync. Account sync only created a project on the server when that id was **missing**, so a project holding an id the server has no record of was skipped entirely. Per-project sync then went straight to `begin_sync` with the dead id and failed:

```
Sync failed with error: HTTP 410 Gone Project Not Found: Project does not exist
```

There was no path back: every subsequent sync repeated the same failure, and the trailing `endSync` compounded it with `IllegalStateException: No sync ID` because the session never opened.

This is what a client sees when it last synced against a different server, or against one whose database has since been reset. The server is correct to answer 410 (a project-level 404 would make `download_entity` mark undownloaded entities deleted), so the fix belongs on the client.

## Fix

Treat a cached id that the server neither lists nor has tombstoned as dead, and recreate the project alongside the ones that never had an id.

A tombstoned id is deliberately still excluded: that means a real server-side delete, which `deletedProjects` already handles by deleting the project locally. Only ids the server has genuinely never heard of are recreated.

## Testing

Added `syncProjects recreates a project whose cached id the server neither holds nor tombstoned`, which reproduces the reported failure. Confirmed it fails against the unfixed code and passes with the fix; the rest of `ClientAccountSynchronizerTest` stays green.
