### PR TITLE
Give rendered stories real book typography

### DIFF
--- a/docs/WEB-DESIGN-SYSTEM.md
+++ b/docs/WEB-DESIGN-SYSTEM.md
@@ -513,6 +513,23 @@ h3 {
 }
 ```
 
+### Story Prose
+
+`.story-content` (in `story.css`) styles the sanitized HTML that `MarkdownService` produces from an
+author's scenes. It is the one place where the page renders text the site did not write, so every
+element markdown can emit has a rule:
+
+| Element      | Treatment                                                                       |
+|--------------|---------------------------------------------------------------------------------|
+| `p`          | 2em first-line indent, justified; flush left after a heading, rule, list or quote |
+| `ul` / `ol`  | 3.5em indent so markers sit inside the prose indent, 0.75em between items, accent markers |
+| `hr`         | Centered short rule with an amber diamond, 3rem of air above and below           |
+| `blockquote` | Tinted panel, amber left rule, italic, with `em` flipped upright inside          |
+| `br`         | The break `MarkdownService` emits for each blank line past the first             |
+
+Below 600px the column is too narrow to justify without opening rivers, so paragraphs go ragged
+right and hyphenation is off.
+
 ---
 
 ## Shared Animations

--- a/docs/WEB-DESIGN-SYSTEM.md
+++ b/docs/WEB-DESIGN-SYSTEM.md
@@ -521,7 +521,7 @@ element markdown can emit has a rule:
 
 | Element      | Treatment                                                                       |
 |--------------|---------------------------------------------------------------------------------|
-| `p`          | 2em first-line indent, justified; flush left after a heading, rule, list or quote |
+| `p`          | 2em first-line indent on every prose paragraph, justified                       |
 | `ul` / `ol`  | 3.5em indent so markers sit inside the prose indent, 0.75em between items, accent markers |
 | `hr`         | Centered short rule with an amber diamond, 3rem of air above and below           |
 | `blockquote` | Tinted panel, amber left rule, italic, with `em` flipped upright inside          |

--- a/docs/WEB-DESIGN-SYSTEM.md
+++ b/docs/WEB-DESIGN-SYSTEM.md
@@ -522,10 +522,19 @@ element markdown can emit has a rule:
 | Element      | Treatment                                                                       |
 |--------------|---------------------------------------------------------------------------------|
 | `p`          | 2em first-line indent on every prose paragraph, justified                       |
+| `h1`         | The story title, in Kingthings at 2rem                                          |
+| `h2`         | Chapter heading: centered, with a dashed rule above it and 4rem of air, dropped on the first one |
+| `h3` / `h4`  | Kingthings, stepping down in size, 2.5rem above                                 |
+| `h5` / `h6`  | Uppercase, letter-spaced and secondary-colored rather than larger               |
 | `ul` / `ol`  | 3.5em indent so markers sit inside the prose indent, 0.75em between items, accent markers |
 | `hr`         | Centered short rule with an amber diamond, 3rem of air above and below           |
 | `blockquote` | Tinted panel, amber left rule, italic, with `em` flipped upright inside          |
-| `br`         | The break `MarkdownService` emits for each blank line past the first             |
+| `pre`        | Tinted box that wraps rather than overflows the column                          |
+| `code`       | Courier; a tinted pill when it sits inline in a paragraph or list item          |
+| `a`          | Accent-colored, underlined with a softened amber rule                           |
+
+`br` needs no rule: it is the break `MarkdownService` emits for each blank line past the first, and
+it inherits the prose line height.
 
 Below 600px the column is too narrow to justify without opening rivers, so paragraphs go ragged
 right and hyphenation is off.

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
@@ -75,7 +75,7 @@ class StoryRenderCache(
 			.getOrNull()
 
 	companion object {
-		private const val RENDER_VERSION = "v1"
+		private const val RENDER_VERSION = "v2"
 
 		/**
 		 * Everything a render of this story depends on, collapsed to a string: the title heading

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
@@ -107,23 +107,26 @@ class StoryRendererService(
 		return builder.toString()
 	}
 
+	/** Appends every scene under [parentId], depth first, and returns their total word count. */
 	private fun writeGroupChildren(
 		builder: StringBuilder,
 		parentId: Int,
 		scenesByParent: Map<Int, List<ApiProjectEntity.SceneEntity>>
-	) {
-		val children = scenesByParent[parentId]?.sortedBy { it.order } ?: return
+	): Int {
+		val children = scenesByParent[parentId]?.sortedBy { it.order } ?: return 0
 
+		var wordCount = 0
 		for (child in children) {
 			if (child.sceneType == ApiSceneType.Scene) {
 				if (child.content.isNotBlank()) {
 					builder.appendScene(child.content)
+					wordCount += WordCountUtils.countWords(child.content)
 				}
 			} else {
-				// Recursively process nested groups
-				writeGroupChildren(builder, child.id, scenesByParent)
+				wordCount += writeGroupChildren(builder, child.id, scenesByParent)
 			}
 		}
+		return wordCount
 	}
 
 	/**
@@ -531,28 +534,10 @@ class StoryRendererService(
 		scenesByParent: Map<Int, List<ApiProjectEntity.SceneEntity>>
 	): Pair<String, Int> {
 		val builder = StringBuilder()
-		var totalWordCount = 0
-
 		builder.append("## ${group.name}\n\n")
+		val wordCount = writeGroupChildren(builder, group.id, scenesByParent)
 
-		fun collectGroupContent(parentId: Int) {
-			val children = scenesByParent[parentId]?.sortedBy { it.order } ?: return
-			for (child in children) {
-				if (child.sceneType == ApiSceneType.Scene) {
-					if (child.content.isNotBlank()) {
-						builder.appendScene(child.content)
-						totalWordCount += WordCountUtils.countWords(child.content)
-					}
-				} else {
-					// Recursively collect nested group content
-					collectGroupContent(child.id)
-				}
-			}
-		}
-
-		collectGroupContent(group.id)
-
-		return builder.toString() to totalWordCount
+		return builder.toString() to wordCount
 	}
 
 	companion object {

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
@@ -94,8 +94,7 @@ class StoryRendererService(
 			if (scene.sceneType == ApiSceneType.Scene) {
 				// Write scene content directly
 				if (scene.content.isNotBlank()) {
-					builder.append(scene.content)
-					builder.append("\n")
+					builder.appendScene(scene.content)
 				}
 			} else {
 				// It's a Group - write all child scenes' content
@@ -118,14 +117,23 @@ class StoryRendererService(
 		for (child in children) {
 			if (child.sceneType == ApiSceneType.Scene) {
 				if (child.content.isNotBlank()) {
-					builder.append(child.content)
-					builder.append("\n")
+					builder.appendScene(child.content)
 				}
 			} else {
 				// Recursively process nested groups
 				writeGroupChildren(builder, child.id, scenesByParent)
 			}
 		}
+	}
+
+	/**
+	 * Scenes are separate passages. Without the blank line the last paragraph of one scene and the
+	 * first of the next parse as a single paragraph; the trim keeps a scene that already ends in
+	 * newlines from gaining a spurious break.
+	 */
+	private fun StringBuilder.appendScene(content: String) {
+		append(content.trimEnd())
+		append("\n\n")
 	}
 
 	/**
@@ -354,8 +362,7 @@ class StoryRendererService(
 			if (scene.markdown.isNotBlank()) {
 				// Add scene name as chapter header
 				builder.append("## ${scene.scene.name}\n\n")
-				builder.append(scene.markdown)
-				builder.append("\n\n")
+				builder.appendScene(scene.markdown)
 			}
 		}
 
@@ -491,7 +498,7 @@ class StoryRendererService(
 			val (markdown, wordCount) = if (targetScene.sceneType == ApiSceneType.Scene) {
 				// Single scene - just its content
 				val content = if (targetScene.content.isNotBlank()) {
-					"## ${targetScene.name}\n\n${targetScene.content}\n"
+					"## ${targetScene.name}\n\n${targetScene.content.trimEnd()}\n"
 				} else {
 					"## ${targetScene.name}\n"
 				}
@@ -533,8 +540,7 @@ class StoryRendererService(
 			for (child in children) {
 				if (child.sceneType == ApiSceneType.Scene) {
 					if (child.content.isNotBlank()) {
-						builder.append(child.content)
-						builder.append("\n")
+						builder.appendScene(child.content)
 						totalWordCount += WordCountUtils.countWords(child.content)
 					}
 				} else {

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
@@ -52,7 +52,7 @@ class StoryRendererService(
 			}
 
 			val markdown = buildStoryMarkdown(projectDef.name, scenes)
-			val html = markdownService.markdownToSafeHtml(markdown)
+			val html = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
 
 			// Calculate total word count from scene content only (not group names)
 			val totalWordCount = scenes
@@ -89,7 +89,7 @@ class StoryRendererService(
 
 		var chapterNumber = 1
 		for (scene in rootScenes) {
-			builder.append("\n## $chapterNumber. ${scene.name}\n\n")
+			builder.append("## $chapterNumber. ${scene.name}\n\n")
 
 			if (scene.sceneType == ApiSceneType.Scene) {
 				// Write scene content directly
@@ -292,7 +292,7 @@ class StoryRendererService(
 
 		// Build markdown and HTML for current page only
 		val pageMarkdown = buildPaginatedMarkdown(projectDef.name, currentPageScenes, currentPage == 1)
-		val pageHtml = markdownService.markdownToSafeHtml(pageMarkdown)
+		val pageHtml = markdownService.markdownToSafeHtml(pageMarkdown, preserveBlankLines = true)
 
 		return StoryRender(
 			result = PaginatedStoryExportResult(
@@ -508,7 +508,7 @@ class StoryRendererService(
 				buildGroupMarkdown(targetScene, scenesByParent)
 			}
 
-			val html = markdownService.markdownToSafeHtml(markdown)
+			val html = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
 
 			SingleSceneExportResult.Success(
 				projectName = projectDef.name,

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
@@ -43,12 +43,15 @@ class MarkdownService {
 	 * All script tags, event handlers, and javascript: URLs are stripped.
 	 *
 	 * @param markdown The markdown text to convert
+	 * @param preserveBlankLines Keep runs of blank lines as visible space rather than letting
+	 * CommonMark collapse them. Prose opts in; anywhere the markdown is a short piece of writing
+	 * rather than a story, such as a bio or a policy page, wants the default collapsing.
 	 * @return Sanitized HTML string safe for rendering
 	 */
-	fun markdownToSafeHtml(markdown: String): String {
+	fun markdownToSafeHtml(markdown: String, preserveBlankLines: Boolean = false): String {
 		if (markdown.isBlank()) return ""
 
-		val source = preserveBlankLines(markdown)
+		val source = if (preserveBlankLines) expandBlankLines(markdown) else markdown
 		val parsedTree = markdownParser.buildMarkdownTreeFromString(source)
 		val unsafeHtml = HtmlGenerator(source, parsedTree, markdownFlavour).generateHtml()
 		return sanitizer.sanitize(unsafeHtml)
@@ -58,17 +61,23 @@ class MarkdownService {
 	 * CommonMark collapses any run of blank lines into a single paragraph break, which loses the
 	 * deliberate white space a writer put between passages. Each blank line past the first becomes
 	 * a `<br />` block so the rendered story keeps the author's spacing.
+	 *
+	 * Code is left exactly as written: a `<br />` landing inside a code block would both split the
+	 * block and show up as literal text. Fenced blocks are tracked by their delimiter, and a blank
+	 * run between two indented lines is assumed to sit inside an indented block.
 	 */
-	private fun preserveBlankLines(markdown: String): String {
+	private fun expandBlankLines(markdown: String): String {
 		val out = StringBuilder(markdown.length)
-		var inFence = false
+		var fence: Fence? = null
 		var blankRun = 0
 		var seenContent = false
+		var lastIndent = 0
 
 		for (line in markdown.lineSequence()) {
-			if (inFence) {
+			val openFence = fence
+			if (openFence != null) {
 				out.append(line).append('\n')
-				if (isFenceDelimiter(line)) inFence = false
+				if (closesFence(line, openFence)) fence = null
 				continue
 			}
 
@@ -77,29 +86,66 @@ class MarkdownService {
 				continue
 			}
 
+			val indent = indentWidth(line)
 			if (blankRun > 0) {
-				out.append('\n')
-				if (seenContent) {
+				val insideIndentedBlock = lastIndent > MAX_FENCE_INDENT && indent > MAX_FENCE_INDENT
+				if (seenContent && !insideIndentedBlock) {
+					out.append('\n')
 					repeat((blankRun - 1).coerceAtMost(MAX_CONSECUTIVE_BREAKS)) {
 						out.append(BREAK_BLOCK).append("\n\n")
 					}
+				} else {
+					repeat(blankRun) { out.append('\n') }
 				}
 				blankRun = 0
 			}
 
 			out.append(line).append('\n')
 			seenContent = true
-			if (isFenceDelimiter(line)) inFence = true
+			lastIndent = indent
+			fence = openingFence(line)
 		}
 
 		return out.toString()
 	}
 
-	private fun isFenceDelimiter(line: String): Boolean {
+	private fun openingFence(line: String): Fence? {
+		if (indentWidth(line) > MAX_FENCE_INDENT) return null
+
 		val trimmed = line.trimStart()
-		if (line.length - trimmed.length > MAX_FENCE_INDENT) return false
-		return trimmed.startsWith("```") || trimmed.startsWith("~~~")
+		val delimiter = trimmed.firstOrNull() ?: return null
+		if (delimiter != '`' && delimiter != '~') return null
+
+		val length = trimmed.takeWhile { it == delimiter }.length
+		if (length < MIN_FENCE_LENGTH) return null
+		// A backtick fence's info string may not itself contain a backtick.
+		if (delimiter == '`' && trimmed.drop(length).contains('`')) return null
+
+		return Fence(delimiter, length)
 	}
+
+	private fun closesFence(line: String, fence: Fence): Boolean {
+		if (indentWidth(line) > MAX_FENCE_INDENT) return false
+
+		val trimmed = line.trimStart()
+		val length = trimmed.takeWhile { it == fence.delimiter }.length
+		return length >= fence.length && trimmed.drop(length).isBlank()
+	}
+
+	private fun indentWidth(line: String): Int {
+		var width = 0
+		for (character in line) {
+			when (character) {
+				' ' -> width++
+				'\t' -> width += TAB_WIDTH
+				else -> return width
+			}
+		}
+		return width
+	}
+
+	/** The delimiter that opened a code fence; only the same character, as long or longer, ends it. */
+	private data class Fence(val delimiter: Char, val length: Int)
 
 	companion object {
 		/** Upper bound on the breaks one run of blank lines can produce. */
@@ -109,5 +155,7 @@ class MarkdownService {
 		private const val BREAK_BLOCK = "<br />"
 
 		private const val MAX_FENCE_INDENT = 3
+		private const val MIN_FENCE_LENGTH = 3
+		private const val TAB_WIDTH = 4
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
@@ -48,8 +48,66 @@ class MarkdownService {
 	fun markdownToSafeHtml(markdown: String): String {
 		if (markdown.isBlank()) return ""
 
-		val parsedTree = markdownParser.buildMarkdownTreeFromString(markdown)
-		val unsafeHtml = HtmlGenerator(markdown, parsedTree, markdownFlavour).generateHtml()
+		val source = preserveBlankLines(markdown)
+		val parsedTree = markdownParser.buildMarkdownTreeFromString(source)
+		val unsafeHtml = HtmlGenerator(source, parsedTree, markdownFlavour).generateHtml()
 		return sanitizer.sanitize(unsafeHtml)
+	}
+
+	/**
+	 * CommonMark collapses any run of blank lines into a single paragraph break, which loses the
+	 * deliberate white space a writer put between passages. Each blank line past the first becomes
+	 * a `<br />` block so the rendered story keeps the author's spacing.
+	 */
+	private fun preserveBlankLines(markdown: String): String {
+		val out = StringBuilder(markdown.length)
+		var inFence = false
+		var blankRun = 0
+		var seenContent = false
+
+		for (line in markdown.lineSequence()) {
+			if (inFence) {
+				out.append(line).append('\n')
+				if (isFenceDelimiter(line)) inFence = false
+				continue
+			}
+
+			if (line.isBlank()) {
+				blankRun++
+				continue
+			}
+
+			if (blankRun > 0) {
+				out.append('\n')
+				if (seenContent) {
+					repeat((blankRun - 1).coerceAtMost(MAX_CONSECUTIVE_BREAKS)) {
+						out.append(BREAK_BLOCK).append("\n\n")
+					}
+				}
+				blankRun = 0
+			}
+
+			out.append(line).append('\n')
+			seenContent = true
+			if (isFenceDelimiter(line)) inFence = true
+		}
+
+		return out.toString()
+	}
+
+	private fun isFenceDelimiter(line: String): Boolean {
+		val trimmed = line.trimStart()
+		if (line.length - trimmed.length > MAX_FENCE_INDENT) return false
+		return trimmed.startsWith("```") || trimmed.startsWith("~~~")
+	}
+
+	companion object {
+		/** Upper bound on the breaks one run of blank lines can produce. */
+		const val MAX_CONSECUTIVE_BREAKS = 6
+
+		/** A blank line preceding this makes CommonMark pass it through as a raw HTML block. */
+		private const val BREAK_BLOCK = "<br />"
+
+		private const val MAX_FENCE_INDENT = 3
 	}
 }

--- a/server/src/main/resources/assets/css/story.css
+++ b/server/src/main/resources/assets/css/story.css
@@ -69,6 +69,11 @@
 	border-bottom: 3px solid var(--accent);
 }
 
+/* ========================================
+   Story Prose
+   Typography for author-written markdown
+   ======================================== */
+
 .story-content {
 	background: white;
 	padding: 3rem;
@@ -76,6 +81,7 @@
 	box-shadow: var(--shadow-lg);
 	line-height: 1.8;
 	font-size: 1.125rem;
+	color: var(--text-primary);
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 	word-break: normal;
@@ -108,36 +114,228 @@
 	padding-top: 0;
 }
 
+.story-content h3,
+.story-content h4,
+.story-content h5,
+.story-content h6 {
+	font-family: 'Kingthings Typewriter', monospace;
+	color: var(--text-primary);
+	margin-top: 2.5rem;
+	margin-bottom: 0.75rem;
+}
+
+.story-content h3 {
+	font-size: 1.375rem;
+}
+
+.story-content h4 {
+	font-size: 1.1875rem;
+}
+
+.story-content h5,
+.story-content h6 {
+	font-size: 1rem;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--text-secondary);
+}
+
 .story-content p {
 	margin-bottom: 0;
+	font-size: inherit;
+	color: inherit;
 	text-indent: 2em;
 	text-align: justify;
 }
 
-/* Standard typographic rule: don't indent the first paragraph after a heading */
+/* Standard typographic rule: a paragraph opening a passage, or resuming after an
+   interrupting block, sits flush left rather than indented */
 .story-content h1 + p,
 .story-content h2 + p,
-.story-content h3 + p {
+.story-content h3 + p,
+.story-content h4 + p,
+.story-content h5 + p,
+.story-content h6 + p,
+.story-content hr + p,
+.story-content ul + p,
+.story-content ol + p,
+.story-content pre + p,
+.story-content blockquote + p {
 	text-indent: 0;
 }
 
+/* ----------------------------------------
+   Lists
+   ---------------------------------------- */
+
+.story-content ul,
+.story-content ol {
+	margin: 1.5em 0;
+	padding-left: 3.5em;
+	text-align: left;
+	text-indent: 0;
+}
+
+.story-content li {
+	margin-bottom: 0.75em;
+	padding-left: 0.4em;
+}
+
+.story-content li:last-child {
+	margin-bottom: 0;
+}
+
+.story-content li::marker {
+	color: var(--accent);
+}
+
+.story-content ol > li::marker {
+	font-family: 'Kingthings Typewriter', monospace;
+	font-size: 0.95em;
+}
+
+.story-content li > p {
+	margin: 0;
+	text-indent: 0;
+	text-align: left;
+}
+
+.story-content li > p + p {
+	margin-top: 0.6em;
+}
+
+/* Nested lists tuck under their parent item instead of repeating the outer gap */
+.story-content li > ul,
+.story-content li > ol {
+	margin: 0.6em 0 0;
+	padding-left: 2em;
+}
+
+.story-content ul ul {
+	list-style-type: circle;
+}
+
+.story-content ul ul ul {
+	list-style-type: square;
+}
+
+.story-content ol ol {
+	list-style-type: lower-alpha;
+}
+
+.story-content ol ol ol {
+	list-style-type: lower-roman;
+}
+
+/* ----------------------------------------
+   Scene break
+   ---------------------------------------- */
+
+.story-content hr {
+	position: relative;
+	width: 45%;
+	max-width: 14rem;
+	height: 1px;
+	margin: 3rem auto;
+	border: none;
+	background: linear-gradient(90deg,
+	transparent 0%,
+	var(--neutral-300) 20%,
+	var(--neutral-300) 80%,
+	transparent 100%
+	);
+	overflow: visible;
+}
+
+.story-content hr::after {
+	content: '\25C6';
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	padding: 0 0.75rem;
+	background: white;
+	color: var(--accent);
+	font-size: 0.75rem;
+	line-height: 1;
+}
+
+/* ----------------------------------------
+   Quotes and code
+   ---------------------------------------- */
+
+.story-content blockquote {
+	margin: 2em 0 2em 1.5em;
+	padding: 1em 1.5em;
+	background: rgba(245, 245, 244, 0.7);
+	border-left: 3px solid rgba(217, 119, 6, 0.4);
+	border-radius: 0 0.375rem 0.375rem 0;
+	color: var(--text-secondary);
+	font-style: italic;
+}
+
+.story-content blockquote p {
+	margin: 0;
+	text-indent: 0;
+	text-align: left;
+	color: inherit;
+}
+
+.story-content blockquote p + p {
+	margin-top: 1em;
+}
+
+/* Emphasis inside already-italic type reads as upright */
+.story-content blockquote em {
+	font-style: normal;
+}
+
+.story-content blockquote blockquote {
+	margin-right: 0;
+	margin-bottom: 0;
+}
+
+.story-content blockquote > :last-child {
+	margin-bottom: 0;
+}
+
 .story-content pre {
+	margin: 1.5em 0;
+	padding: 1rem 1.25rem;
+	background: var(--neutral-100);
+	border: 1px solid var(--neutral-200);
+	border-radius: 0.375rem;
 	white-space: pre-wrap;
 	word-wrap: break-word;
 	overflow-x: auto;
 	max-width: 100%;
+	text-indent: 0;
 }
 
 .story-content code {
-	word-break: break-all;
+	font-family: 'Courier New', monospace;
+	font-size: 0.9375em;
+	word-break: normal;
+	overflow-wrap: anywhere;
 }
 
-.story-content blockquote {
-	margin: 1rem 0;
-	padding-left: 1rem;
-	border-left: 3px solid var(--neutral-300);
-	color: var(--text-secondary);
-	font-style: italic;
+.story-content p > code,
+.story-content li > code {
+	padding: 0.125em 0.375em;
+	background: var(--neutral-100);
+	border-radius: 0.25rem;
+}
+
+.story-content a {
+	color: var(--accent-dark);
+	text-decoration: underline;
+	text-decoration-color: rgba(217, 119, 6, 0.4);
+	text-underline-offset: 0.15em;
+}
+
+.story-content a:hover {
+	color: var(--accent);
+	text-decoration-color: var(--accent);
 }
 
 .story-empty {
@@ -316,6 +514,32 @@
 
 	.story-title {
 		font-size: 2rem;
+	}
+
+	.story-content ul,
+	.story-content ol {
+		padding-left: 2.25em;
+	}
+
+	.story-content blockquote {
+		margin-left: 0.5em;
+		padding: 0.875em 1.125em;
+	}
+
+	.story-content hr {
+		width: 60%;
+		margin: 2.25rem auto;
+	}
+}
+
+/* A column this narrow can't justify without opening rivers between words */
+@media only screen and (max-width: 600px) {
+	.story-content {
+		hyphens: none;
+	}
+
+	.story-content p {
+		text-align: left;
 	}
 }
 

--- a/server/src/main/resources/assets/css/story.css
+++ b/server/src/main/resources/assets/css/story.css
@@ -148,22 +148,6 @@
 	text-align: justify;
 }
 
-/* Standard typographic rule: a paragraph opening a passage, or resuming after an
-   interrupting block, sits flush left rather than indented */
-.story-content h1 + p,
-.story-content h2 + p,
-.story-content h3 + p,
-.story-content h4 + p,
-.story-content h5 + p,
-.story-content h6 + p,
-.story-content hr + p,
-.story-content ul + p,
-.story-content ol + p,
-.story-content pre + p,
-.story-content blockquote + p {
-	text-indent: 0;
-}
-
 /* ----------------------------------------
    Lists
    ---------------------------------------- */

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererServiceTest.kt
@@ -137,6 +137,20 @@ class StoryRendererServiceTest {
 	}
 
 	@Test
+	fun `chapter headings gain no break from the scene separator`() = runTest {
+		val scenes = listOf(
+			createScene(id = 1, name = "First", content = "Content 1", order = 0),
+			createScene(id = 2, name = "Second", content = "Content 2", order = 1),
+		)
+		setupMocksForScenes(scenes)
+
+		val result = service.renderStoryAsHtml(userId, projectId)
+
+		assertIs<StoryRenderResult.Success>(result)
+		assertFalse(result.html.contains("<br"), "Scene separation must not read as author spacing")
+	}
+
+	@Test
 	fun `sibling scenes in a group render as separate paragraphs`() = runTest {
 		val scenes = listOf(
 			createScene(id = 1, name = "Chapter 1", content = "", order = 0, sceneType = ApiSceneType.Group),

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererServiceTest.kt
@@ -137,6 +137,52 @@ class StoryRendererServiceTest {
 	}
 
 	@Test
+	fun `sibling scenes in a group render as separate paragraphs`() = runTest {
+		val scenes = listOf(
+			createScene(id = 1, name = "Chapter 1", content = "", order = 0, sceneType = ApiSceneType.Group),
+			createScene(id = 2, name = "Scene 1.1", content = "First child content.", order = 0, path = listOf(0, 1)),
+			createScene(id = 3, name = "Scene 1.2", content = "Second child content.", order = 1, path = listOf(0, 1)),
+		)
+		setupMocksForScenes(scenes)
+
+		val result = service.renderStoryAsHtml(userId, projectId)
+
+		assertIs<StoryRenderResult.Success>(result)
+		assertTrue(result.html.contains("<p>First child content.</p>"))
+		assertTrue(result.html.contains("<p>Second child content.</p>"))
+	}
+
+	@Test
+	fun `sibling scenes in an exported group render as separate paragraphs`() = runTest {
+		val scenes = listOf(
+			createScene(id = 1, name = "Chapter 1", content = "", order = 0, sceneType = ApiSceneType.Group),
+			createScene(id = 2, name = "Scene 1.1", content = "First child content.", order = 0, path = listOf(0, 1)),
+			createScene(id = 3, name = "Scene 1.2", content = "Second child content.", order = 1, path = listOf(0, 1)),
+		)
+		setupMocksForScenes(scenes)
+
+		val result = service.renderSceneAsHtml(userId, projectId, sceneId = 1)
+
+		assertIs<SingleSceneExportResult.Success>(result)
+		assertTrue(result.html.contains("<p>First child content.</p>"))
+		assertTrue(result.html.contains("<p>Second child content.</p>"))
+	}
+
+	@Test
+	fun `a scene keeps its own block structure`() = runTest {
+		val content = "A list follows:\n\n- one\n- two\n\nAnd prose after it."
+		val scene = createScene(id = 1, name = "Chapter One", content = content, order = 0)
+		setupMocksForScenes(listOf(scene))
+
+		val result = service.renderStoryAsHtml(userId, projectId)
+
+		assertIs<StoryRenderResult.Success>(result)
+		assertTrue(result.html.contains("<ul>"))
+		assertTrue(result.html.contains("<li>one</li>"))
+		assertTrue(result.html.contains("<p>And prose after it.</p>"))
+	}
+
+	@Test
 	fun `exports nested groups correctly`() = runTest {
 		val scenes = listOf(
 			createScene(id = 1, name = "Part 1", content = "", order = 0, sceneType = ApiSceneType.Group),

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
@@ -161,9 +161,19 @@ class MarkdownServiceTest {
 	}
 
 	@Test
+	fun `markdownToSafeHtml collapses extra blank lines unless asked to preserve them`() {
+		val markdown = "First paragraph.\n\n\n\nSecond paragraph."
+		val result = markdownService.markdownToSafeHtml(markdown)
+
+		assertEquals(0, countBreaks(result))
+		assertTrue(result.contains("First paragraph."))
+		assertTrue(result.contains("Second paragraph."))
+	}
+
+	@Test
 	fun `markdownToSafeHtml keeps a single blank line as a plain paragraph break`() {
 		val markdown = "First paragraph.\n\nSecond paragraph."
-		val result = markdownService.markdownToSafeHtml(markdown)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
 
 		assertEquals(0, countBreaks(result))
 		assertTrue(result.contains("First paragraph."))
@@ -173,7 +183,7 @@ class MarkdownServiceTest {
 	@Test
 	fun `markdownToSafeHtml renders each extra blank line as a break`() {
 		val markdown = "First paragraph.\n\n\n\nSecond paragraph."
-		val result = markdownService.markdownToSafeHtml(markdown)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
 
 		assertEquals(2, countBreaks(result))
 		assertTrue(result.contains("First paragraph."))
@@ -183,7 +193,7 @@ class MarkdownServiceTest {
 	@Test
 	fun `markdownToSafeHtml caps a runaway run of blank lines`() {
 		val markdown = "First paragraph." + "\n".repeat(40) + "Second paragraph."
-		val result = markdownService.markdownToSafeHtml(markdown)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
 
 		assertEquals(MarkdownService.MAX_CONSECUTIVE_BREAKS, countBreaks(result))
 	}
@@ -191,7 +201,7 @@ class MarkdownServiceTest {
 	@Test
 	fun `markdownToSafeHtml ignores blank lines before the first paragraph`() {
 		val markdown = "\n\n\n\nFirst paragraph."
-		val result = markdownService.markdownToSafeHtml(markdown)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
 
 		assertEquals(0, countBreaks(result))
 	}
@@ -199,7 +209,7 @@ class MarkdownServiceTest {
 	@Test
 	fun `markdownToSafeHtml ignores trailing blank lines`() {
 		val markdown = "First paragraph." + "\n".repeat(6)
-		val result = markdownService.markdownToSafeHtml(markdown)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
 
 		assertEquals(0, countBreaks(result))
 	}
@@ -207,7 +217,7 @@ class MarkdownServiceTest {
 	@Test
 	fun `markdownToSafeHtml leaves blank lines inside fenced code untouched`() {
 		val markdown = "```\nfirst\n\n\n\nsecond\n```"
-		val result = markdownService.markdownToSafeHtml(markdown)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
 
 		assertEquals(0, countBreaks(result))
 		assertTrue(result.contains("first"))
@@ -215,9 +225,49 @@ class MarkdownServiceTest {
 	}
 
 	@Test
+	fun `markdownToSafeHtml leaves blank lines inside an indented code block untouched`() {
+		val markdown = "Intro:\n\n    code line one\n\n\n    code line two\n\nOutro."
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+
+		assertEquals(0, countBreaks(result))
+		assertEquals(1, countTag(result, "pre"))
+	}
+
+	@Test
+	fun `markdownToSafeHtml leaves a fence nested in a list item untouched`() {
+		val markdown = "- item\n\n    ```\n    code\n\n\n    more\n    ```"
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+
+		assertEquals(0, countBreaks(result))
+		assertFalse(result.contains("&lt;br"))
+		assertTrue(result.contains("code"))
+		assertTrue(result.contains("more"))
+	}
+
+	@Test
+	fun `markdownToSafeHtml does not close a fence on a different delimiter`() {
+		val markdown = "```\nline one\n~~~\nline two\n\n\nline three\n```\n\nAfter."
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+
+		assertEquals(0, countBreaks(result))
+		assertFalse(result.contains("&lt;br"))
+		assertTrue(result.contains("After."))
+	}
+
+	@Test
+	fun `markdownToSafeHtml does not close a fence on a shorter delimiter`() {
+		val markdown = "````\nline one\n```\nline two\n\n\nline three\n````\n\nAfter."
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+
+		assertEquals(0, countBreaks(result))
+		assertFalse(result.contains("&lt;br"))
+		assertTrue(result.contains("After."))
+	}
+
+	@Test
 	fun `markdownToSafeHtml keeps a list intact when extra blank lines follow it`() {
 		val markdown = "- item 1\n- item 2\n\n\nAfter the list."
-		val result = markdownService.markdownToSafeHtml(markdown)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
 
 		assertTrue(result.contains("<ul>"))
 		assertEquals(1, countBreaks(result))
@@ -225,4 +275,6 @@ class MarkdownServiceTest {
 	}
 
 	private fun countBreaks(html: String) = Regex("<br\\s*/?>").findAll(html).count()
+
+	private fun countTag(html: String, tag: String) = Regex("<$tag[\\s>]").findAll(html).count()
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
@@ -159,4 +159,70 @@ class MarkdownServiceTest {
 
 		assertFalse(result.contains("data:"))
 	}
+
+	@Test
+	fun `markdownToSafeHtml keeps a single blank line as a plain paragraph break`() {
+		val markdown = "First paragraph.\n\nSecond paragraph."
+		val result = markdownService.markdownToSafeHtml(markdown)
+
+		assertEquals(0, countBreaks(result))
+		assertTrue(result.contains("First paragraph."))
+		assertTrue(result.contains("Second paragraph."))
+	}
+
+	@Test
+	fun `markdownToSafeHtml renders each extra blank line as a break`() {
+		val markdown = "First paragraph.\n\n\n\nSecond paragraph."
+		val result = markdownService.markdownToSafeHtml(markdown)
+
+		assertEquals(2, countBreaks(result))
+		assertTrue(result.contains("First paragraph."))
+		assertTrue(result.contains("Second paragraph."))
+	}
+
+	@Test
+	fun `markdownToSafeHtml caps a runaway run of blank lines`() {
+		val markdown = "First paragraph." + "\n".repeat(40) + "Second paragraph."
+		val result = markdownService.markdownToSafeHtml(markdown)
+
+		assertEquals(MarkdownService.MAX_CONSECUTIVE_BREAKS, countBreaks(result))
+	}
+
+	@Test
+	fun `markdownToSafeHtml ignores blank lines before the first paragraph`() {
+		val markdown = "\n\n\n\nFirst paragraph."
+		val result = markdownService.markdownToSafeHtml(markdown)
+
+		assertEquals(0, countBreaks(result))
+	}
+
+	@Test
+	fun `markdownToSafeHtml ignores trailing blank lines`() {
+		val markdown = "First paragraph." + "\n".repeat(6)
+		val result = markdownService.markdownToSafeHtml(markdown)
+
+		assertEquals(0, countBreaks(result))
+	}
+
+	@Test
+	fun `markdownToSafeHtml leaves blank lines inside fenced code untouched`() {
+		val markdown = "```\nfirst\n\n\n\nsecond\n```"
+		val result = markdownService.markdownToSafeHtml(markdown)
+
+		assertEquals(0, countBreaks(result))
+		assertTrue(result.contains("first"))
+		assertTrue(result.contains("second"))
+	}
+
+	@Test
+	fun `markdownToSafeHtml keeps a list intact when extra blank lines follow it`() {
+		val markdown = "- item 1\n- item 2\n\n\nAfter the list."
+		val result = markdownService.markdownToSafeHtml(markdown)
+
+		assertTrue(result.contains("<ul>"))
+		assertEquals(1, countBreaks(result))
+		assertTrue(result.contains("After the list."))
+	}
+
+	private fun countBreaks(html: String) = Regex("<br\\s*/?>").findAll(html).count()
 }


### PR DESCRIPTION
Styles the server-rendered story page so a published manuscript reads like a book rather than a wiki dump.

## Problem

Four things broke the reading experience on `/story/{project}` and `/a/{penName}/{project}`:

- Lists sat flush at the prose margin with their items packed together.
- Thematic breaks ran the full column width, reading as a divider rather than a scene break.
- Any run of blank lines an author deliberately typed collapsed to a single paragraph gap, losing intended pacing.
- Paragraphs had no first-line indent, so prose ran as undifferentiated blocks.

## Changes

- **`story.css`** styles every element markdown can emit: a 2em first-line indent on every prose paragraph, indented lists with accent markers and breathing room, a centered scene-break rule with an ornament, a tinted blockquote panel, code and links, `h3`–`h6`, and ragged-right prose below 600px where justification opens rivers.
- **`MarkdownService`** emits a break for each blank line past the first, so deliberate white space survives CommonMark's collapsing. Runs are capped so a runaway file can't blow up the page.
- **`StoryRendererService`** separates sibling scenes with a blank line. Without it the last paragraph of one scene and the first of the next parsed as a single paragraph.

Every paragraph is indented, including the one opening a chapter. The usual book convention leaves that one flush left, but the page breaks a story into pages that each open on a chapter heading, so the convention made the first line of every page look like a mistake.

## Review fixes

A review of the branch turned up four ways the blank-line work reached further than intended:

- Blank-line preservation is now opt-in: `markdownToSafeHtml(markdown, preserveBlankLines = true)`. Author bios, the About page, the privacy policy and the review frontend share this service and never wanted story spacing; they get CommonMark's collapsing back.
- A code fence is tracked by its delimiter and length, so a `~~~` line inside a ``` block no longer ends it and leaks a literal `<br />` into the code. A blank run between two indented lines is left alone, which covers indented code blocks and fences nested in list items.
- The chapter heading no longer carries a leading newline. Combined with the scene separator it made a run long enough to render a break above every heading.
- `StoryRenderCache.RENDER_VERSION` goes to `v2`. Its key derives only from the project name and scene hashes, so without the bump every already-cached public story page would keep serving pre-branch HTML until size eviction or the 30-day prune.

## Testing

`MarkdownServiceTest` covers blank-line preservation (single gap unchanged, extra lines become breaks, runs capped, leading and trailing runs ignored, lists intact) and the code cases the review found: fenced, indented, list-nested, mismatched delimiter, shorter delimiter, plus the default-collapsing path. `StoryRendererServiceTest` covers scene separation and asserts no break comes from it. Full `server:test` suite passes.

Rendered the real pipeline against the actual stylesheet in a browser across headings, lists, blockquote, thematic break, inline and fenced code, and multi-chapter separation.
