### PR TITLE
Keep block indents through a font size change

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdown/updateMarkdownStyles.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/markdown/updateMarkdownStyles.kt
@@ -48,6 +48,9 @@ internal fun updateMarkdownStyles(
 	state.processLines { _: Int, line: AnnotatedString ->
 		buildAnnotatedString {
 			append(line.text)
+			// Block lines carry their indent as a ParagraphStyle, which the raw text
+			// append above drops.
+			line.paragraphStyles.forEach { addStyle(it.item, it.start, it.end) }
 			if (line.spanStyles.isEmpty()) {
 				addStyle(newConfig.defaultTextStyle, 0, line.length)
 			} else {

--- a/composeUi/src/desktopTest/kotlin/MarkdownRestyleBlockIndentTest.kt
+++ b/composeUi/src/desktopTest/kotlin/MarkdownRestyleBlockIndentTest.kt
@@ -1,0 +1,44 @@
+import androidx.compose.ui.unit.sp
+import com.darkrockstudios.apps.hammer.common.compose.markdown.changeFontSize
+import com.darkrockstudios.apps.hammer.common.compose.markdown.updateMarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Changing the editor font size restyles every line in place, which must not cost
+ * block lines the ParagraphStyle their gutter markers are positioned against.
+ */
+class MarkdownRestyleBlockIndentTest {
+
+	private fun TestScope.newEditor(config: MarkdownConfiguration): MarkdownExtension =
+		MarkdownExtension(TextEditorState(scope = this, measurer = mockk(relaxed = true)), config)
+
+	@Test
+	fun `list indents survive a font size change`() = runTest {
+		val editor = newEditor(MarkdownConfiguration.DEFAULT)
+		editor.importMarkdown("A paragraph.\n\n1. one\n2. two\n\n- bullet\n\n> quoted")
+		val before = editor.editorState.textLines.map { it.paragraphStyles }
+
+		editor.updateMarkdownConfiguration(MarkdownConfiguration.DEFAULT.changeFontSize(24f))
+
+		assertEquals(before, editor.editorState.textLines.map { it.paragraphStyles })
+	}
+
+	@Test
+	fun `body text tracks the new font size`() = runTest {
+		val editor = newEditor(MarkdownConfiguration.DEFAULT)
+		editor.importMarkdown("A paragraph.\n\n1. one")
+
+		editor.updateMarkdownConfiguration(MarkdownConfiguration.DEFAULT.changeFontSize(24f))
+
+		editor.editorState.textLines.filter { it.text.isNotEmpty() }.forEach { line ->
+			assertEquals(listOf(24f.sp), line.spanStyles.map { it.item.fontSize })
+		}
+	}
+}


### PR DESCRIPTION
## The bug

`updateMarkdownStyles` restyles every line in place when the editor font size changes. It rebuilds each line with `append(line.text)`, which takes the raw string and leaves the line's `ParagraphStyle` behind.

That style is what indents lists and blockquotes, and the gutter markers (the bullet dot, the ordered-list numeral) position themselves against the resulting text-left. So every font size step flattened the indent and dropped the markers into the wrong place, until the scene was reloaded.

Found while chasing a separate report of list text rendering at the wrong size. That one turned out to be a library bug, fixed in [ComposeTextEditor#97](https://github.com/Darkrock-Studios/ComposeTextEditor/pull/97); this is an independent problem in our own restyle pass and needs no library bump.

## The fix

Carry the line's paragraph styles across the rebuild.

## Tests

`MarkdownRestyleBlockIndentTest` asserts that a document with an ordered list, a bullet list and a blockquote keeps its paragraph styles across a font size change, and that the body spans still track the new size.

Full `:composeUi:desktopTest` passes.
