### PR TITLE
Render strikethrough on the web

### DIFF
--- a/server/src/jsTest/review-logic.test.js
+++ b/server/src/jsTest/review-logic.test.js
@@ -133,6 +133,43 @@ test('parseInlineMarkdown supports nesting and leaves unmatched or intraword mar
 	assert.equal(unclosed.map((r) => r.text).join(''), 'an *unclosed marker');
 });
 
+test('parseInlineMarkdown renders strikethrough without markers', () => {
+	const text = 'He was ~~dead~~ alive.';
+	const runs = logic.parseInlineMarkdown(text);
+	assert.deepEqual(runs.map((r) => [r.text, r.srcStart, r.strike]), [
+		['He was ', 0, false],
+		['dead', 9, true],
+		[' alive.', 15, false],
+	]);
+	for (const r of runs) {
+		assert.equal(text.slice(r.srcStart, r.srcStart + r.text.length), r.text);
+	}
+});
+
+test('parseInlineMarkdown nests strikethrough with other emphasis', () => {
+	const runs = logic.parseInlineMarkdown('*hello ~~there~~ now*');
+	assert.deepEqual(runs.map((r) => [r.text, r.italic, r.strike]), [
+		['hello ', true, false],
+		['there', true, true],
+		[' now', true, false],
+	]);
+});
+
+test('parseInlineMarkdown leaves a lone or unmatched tilde literal', () => {
+	const lone = logic.parseInlineMarkdown('about ~5 minutes');
+	assert.equal(lone.length, 1);
+	assert.equal(lone[0].strike, false);
+	assert.equal(lone[0].text, 'about ~5 minutes');
+
+	const unclosed = logic.parseInlineMarkdown('an ~~unclosed marker');
+	assert.equal(unclosed.map((r) => r.text).join(''), 'an ~~unclosed marker');
+	assert.equal(unclosed.some((r) => r.strike), false);
+
+	const escaped = logic.parseInlineMarkdown('not \\~\\~struck\\~\\~ here');
+	assert.equal(escaped.map((r) => r.text).join(''), 'not ~~struck~~ here');
+	assert.equal(escaped.some((r) => r.strike), false);
+});
+
 test('parseInlineMarkdown unescapes backslash-escaped punctuation, keeping source offsets', () => {
 	const text = 'Down the Rabbit\\-Hole \\(here\\) What\\!';
 	const runs = logic.parseInlineMarkdown(text);

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
@@ -75,7 +75,7 @@ class StoryRenderCache(
 			.getOrNull()
 
 	companion object {
-		private const val RENDER_VERSION = "v2"
+		private const val RENDER_VERSION = "v3"
 
 		/**
 		 * Everything a render of this story depends on, collapsed to a string: the title heading

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
@@ -1,6 +1,6 @@
 package com.darkrockstudios.apps.hammer.utilities
 
-import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
 import org.owasp.html.HtmlPolicyBuilder
@@ -12,9 +12,13 @@ import org.owasp.html.PolicyFactory
  * This service uses the JetBrains Markdown library for parsing and
  * OWASP HTML Sanitizer to prevent XSS attacks by only allowing
  * safe HTML elements and attributes.
+ *
+ * The flavour is GitHub Flavored Markdown, matching the editor that writes the
+ * content: CommonMark has no strikethrough, so `~~struck~~` reached the page as
+ * literal tildes.
  */
 class MarkdownService {
-	private val markdownFlavour = CommonMarkFlavourDescriptor()
+	private val markdownFlavour = GFMFlavourDescriptor()
 	private val markdownParser = MarkdownParser(markdownFlavour)
 
 	/**
@@ -25,7 +29,7 @@ class MarkdownService {
 	 */
 	private val sanitizer: PolicyFactory = HtmlPolicyBuilder()
 		.allowElements(
-			"p", "br", "strong", "em", "b", "i", "u",
+			"p", "br", "strong", "em", "b", "i", "u", "del",
 			"ul", "ol", "li",
 			"h1", "h2", "h3", "h4", "h5", "h6",
 			"blockquote", "code", "pre",
@@ -54,8 +58,16 @@ class MarkdownService {
 		val source = if (preserveBlankLines) expandBlankLines(markdown) else markdown
 		val parsedTree = markdownParser.buildMarkdownTreeFromString(source)
 		val unsafeHtml = HtmlGenerator(source, parsedTree, markdownFlavour).generateHtml()
-		return sanitizer.sanitize(unsafeHtml)
+		return sanitizer.sanitize(unsafeHtml.strikethroughAsDel())
 	}
+
+	/**
+	 * The GFM generator emits strikethrough as `<span class="user-del">`. Rewrite it
+	 * to `<del>` so the sanitizer, which allows no attributes on a `span` and so
+	 * would unwrap it, can keep the element.
+	 */
+	private fun String.strikethroughAsDel(): String =
+		replace(STRIKETHROUGH_SPAN, "<del>$1</del>")
 
 	/**
 	 * CommonMark collapses any run of blank lines into a single paragraph break, which loses the
@@ -157,5 +169,8 @@ class MarkdownService {
 		private const val MAX_FENCE_INDENT = 3
 		private const val MIN_FENCE_LENGTH = 3
 		private const val TAB_WIDTH = 4
+
+		private val STRIKETHROUGH_SPAN =
+			Regex("""<span class="user-del">(.*?)</span>""", RegexOption.DOT_MATCHES_ALL)
 	}
 }

--- a/server/src/main/resources/assets/css/story.css
+++ b/server/src/main/resources/assets/css/story.css
@@ -310,6 +310,13 @@
 	border-radius: 0.25rem;
 }
 
+/* Struck text is a revision the author left visible; it recedes but stays readable */
+.story-content del {
+	text-decoration: line-through;
+	text-decoration-thickness: 1px;
+	color: var(--text-secondary);
+}
+
 .story-content a {
 	color: var(--accent-dark);
 	text-decoration: underline;

--- a/server/src/main/resources/assets/js/review-logic.js
+++ b/server/src/main/resources/assets/js/review-logic.js
@@ -107,18 +107,18 @@ function applyAccepted(text, suggestions) {
  * at the punctuation's source offset, so the per-run source-slice invariant
  * holds), and an escaped marker can neither open nor close emphasis.
  *
- * @returns {Array<{text:string, srcStart:number, bold:boolean, italic:boolean}>}
+ * @returns {Array<{text:string, srcStart:number, bold:boolean, italic:boolean, strike:boolean}>}
  */
 function parseInlineMarkdown(text) {
 	const ESCAPABLE = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~';
 	const runs = [];
 
-	function emit(str, srcStart, bold, italic) {
+	function emit(str, srcStart, bold, italic, strike) {
 		if (str.length === 0) return;
-		runs.push({ text: str, srcStart: srcStart, bold: bold, italic: italic });
+		runs.push({ text: str, srcStart: srcStart, bold: bold, italic: italic, strike: strike });
 	}
 
-	function isFlankableBefore(ch) { return !ch || !/[\w*_]/.test(ch); }
+	function isFlankableBefore(ch) { return !ch || !/[\w*_~]/.test(ch); }
 
 	function findClose(marker, from, end) {
 		let i = from;
@@ -138,20 +138,22 @@ function parseInlineMarkdown(text) {
 		return -1;
 	}
 
-	function walk(start, end, bold, italic) {
+	function walk(start, end, bold, italic, strike) {
 		let plainFrom = start;
 		let i = start;
 		while (i < end) {
 			const ch = text[i];
 			if (ch === '\\' && i + 1 < end && ESCAPABLE.indexOf(text[i + 1]) !== -1) {
-				emit(text.slice(plainFrom, i), plainFrom, bold, italic);
-				emit(text[i + 1], i + 1, bold, italic);
+				emit(text.slice(plainFrom, i), plainFrom, bold, italic, strike);
+				emit(text[i + 1], i + 1, bold, italic, strike);
 				i += 2;
 				plainFrom = i;
 				continue;
 			}
-			if (ch !== '*' && ch !== '_') { i++; continue; }
+			if (ch !== '*' && ch !== '_' && ch !== '~') { i++; continue; }
 			const double = text[i + 1] === ch;
+			// GFM strikethrough is only the doubled form; a lone `~` is literal.
+			if (ch === '~' && !double) { i++; continue; }
 			const marker = double ? ch + ch : ch;
 			const contentFrom = i + marker.length;
 			const openOk = isFlankableBefore(text[i - 1]) &&
@@ -160,15 +162,21 @@ function parseInlineMarkdown(text) {
 			const close = findClose(marker, contentFrom + 1, end);
 			if (close === -1) { i++; continue; }
 
-			emit(text.slice(plainFrom, i), plainFrom, bold, italic);
-			walk(contentFrom, close, bold || double, italic || !double);
+			emit(text.slice(plainFrom, i), plainFrom, bold, italic, strike);
+			walk(
+				contentFrom,
+				close,
+				bold || (double && ch !== '~'),
+				italic || (!double && ch !== '~'),
+				strike || ch === '~',
+			);
 			i = close + marker.length;
 			plainFrom = i;
 		}
-		emit(text.slice(plainFrom, end), plainFrom, bold, italic);
+		emit(text.slice(plainFrom, end), plainFrom, bold, italic, strike);
 	}
 
-	walk(0, text.length, false, false);
+	walk(0, text.length, false, false, false);
 	return runs;
 }
 
@@ -188,6 +196,7 @@ function runsForRange(runs, start, end) {
 			srcStart: s,
 			bold: r.bold,
 			italic: r.italic,
+			strike: r.strike,
 		});
 	}
 	return out;

--- a/server/src/main/resources/assets/js/review.js
+++ b/server/src/main/resources/assets/js/review.js
@@ -78,15 +78,19 @@
 	function runNode(run) {
 		const tn = document.createTextNode(run.text);
 		nodeSrcStart.set(tn, run.srcStart);
-		if (!run.bold && !run.italic) return tn;
-		const span = el('span', {
-			style: {
-				fontWeight: run.bold ? '700' : '',
-				fontStyle: run.italic ? 'italic' : '',
-			},
-		});
+		if (!run.bold && !run.italic && !run.strike) return tn;
+		const span = el('span', { style: runStyle(run) });
 		span.appendChild(tn);
 		return span;
+	}
+
+	/** Inline styles for a parsed markdown run. */
+	function runStyle(run) {
+		return {
+			fontWeight: run.bold ? '700' : '',
+			fontStyle: run.italic ? 'italic' : '',
+			textDecoration: run.strike ? 'line-through' : '',
+		};
 	}
 
 	/** Append the styled display pieces for source range [start,end) of a paragraph. */
@@ -97,8 +101,11 @@
 	/** Append free text with its inline emphasis rendered (no source offsets — not manuscript text). */
 	function appendStyledText(parent, text) {
 		parseInlineMarkdown(text).forEach((run) => {
-			if (!run.bold && !run.italic) { parent.appendChild(document.createTextNode(run.text)); return; }
-			const span = el('span', { style: { fontWeight: run.bold ? '700' : '', fontStyle: run.italic ? 'italic' : '' } });
+			if (!run.bold && !run.italic && !run.strike) {
+				parent.appendChild(document.createTextNode(run.text));
+				return;
+			}
+			const span = el('span', { style: runStyle(run) });
 			span.appendChild(document.createTextNode(run.text));
 			parent.appendChild(span);
 		});

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
@@ -19,6 +19,41 @@ class MarkdownServiceTest {
 	}
 
 	@Test
+	fun `markdownToSafeHtml renders strikethrough`() {
+		val result = markdownService.markdownToSafeHtml("He was ~~dead~~ alive.")
+
+		assertTrue(result.contains("<del>dead</del>"), result)
+		assertFalse(result.contains("~~"), result)
+	}
+
+	@Test
+	fun `markdownToSafeHtml renders strikethrough alongside other emphasis`() {
+		val result = markdownService.markdownToSafeHtml("**bold** *italic* ~~struck~~")
+
+		assertTrue(result.contains("<strong>bold</strong>"), result)
+		assertTrue(result.contains("<em>italic</em>"), result)
+		assertTrue(result.contains("<del>struck</del>"), result)
+	}
+
+	@Test
+	fun `markdownToSafeHtml keeps strikethrough nested inside emphasis`() {
+		val result = markdownService.markdownToSafeHtml("He said *hello ~~there~~* now.")
+
+		assertTrue(result.contains("<del>there</del>"), result)
+		assertFalse(result.contains("~~"), result)
+	}
+
+	@Test
+	fun `markdownToSafeHtml does not let authored markup forge a del element`() {
+		val result = markdownService.markdownToSafeHtml(
+			"<span class=\"user-del\" onclick=\"alert('xss')\">x</span>"
+		)
+
+		assertFalse(result.contains("onclick"), result)
+		assertFalse(result.contains("alert"), result)
+	}
+
+	@Test
 	fun `markdownToSafeHtml renders headings`() {
 		val markdown = "# Heading 1\n## Heading 2"
 		val result = markdownService.markdownToSafeHtml(markdown)


### PR DESCRIPTION
Strikethrough reached every server rendered page as literal `~~` while bold and italic worked:

```
before: <p><strong>bold</strong> and <em>italic</em> and ~~struck~~</p>
after:  <p><strong>bold</strong> and <em>italic</em> and <del>struck</del></p>
```

Two independent causes, both fixed here.

## Story pages

`MarkdownService` used `CommonMarkFlavourDescriptor()`. Strikethrough is a GFM extension, so `~~` was never even tokenized. The editor that writes the content parses GFM, so client and server disagreed on what the markdown meant.

Now on `GFMFlavourDescriptor()`. GFM emits strikethrough as `<span class="user-del">`, which the sanitizer would unwrap for having no allowed attributes, so it is rewritten to `<del>` and `del` joins the allowlist. Added a `.story-content del` rule.

`RENDER_VERSION` goes to `v2`, per the contract on `StoryRenderCache`: cached pages were rendered by the old pipeline and have to regenerate.

## Review page

Same symptom, unrelated cause. `parseInlineMarkdown` in `review-logic.js` only branched on `*` and `_`, so `~~` fell through as literal text. It now handles the doubled form (a lone `~` stays literal, as in GFM), and the flag is threaded through `runsForRange` to both render sites.

## Note on the GFM switch

It turns on more than strikethrough:

- Bare URLs now autolink. Probably desirable, but it does change existing published stories.
- GFM tables would now parse, and the table elements are not in the sanitizer allowlist, so they would unwrap to run-together text rather than today's literal pipes. The editor cannot produce tables, so I left the allowlist alone. Easy to add if you would rather.

## Testing

Four new `MarkdownServiceTest` cases: basic strikethrough, alongside other emphasis, nested inside emphasis, and one confirming authored markup cannot forge a `del` past the sanitizer. Three new `review-logic.test.js` cases: rendering, nesting with other emphasis, and lone/unmatched/escaped tildes staying literal.

- `:server:test` 1071 tests, 0 failures
- `node --test src/jsTest` 46 tests, 0 failures

## Related

The desktop editor had a separate bug with the same symptom, where a style applied across part of an existing emphasis run serialized as crossing markers. That is fixed in ComposeTextEditor#98 and will need a version bump here once released.
