### PR TITLE
Fix the F3 sync and Ctrl+Alt+S shortcuts, and give them to Android and iOS

### DIFF
--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
@@ -30,6 +30,7 @@ import com.darkrockstudios.apps.hammer.android.shortcuts.ProjectShortcutsManager
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectDeepLink
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRootComponent
+import com.darkrockstudios.apps.hammer.common.compose.ProjectShortcutHost
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.closeProjectScope
@@ -70,6 +71,7 @@ class ProjectRootActivity : AppCompatActivity() {
 	private val viewModel: ProjectRootViewModel by viewModels()
 
 	private var projectRoot: ProjectRoot? = null
+	private val shortcutHost = ProjectShortcutHost()
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -185,14 +187,22 @@ class ProjectRootActivity : AppCompatActivity() {
 	}
 
 	override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-		if (event.action == KeyEvent.ACTION_DOWN &&
-			event.keyCode == KeyEvent.KEYCODE_F &&
-			event.isShiftPressed &&
-			event.isCtrlPressed
-		) {
-			projectRoot?.let {
-				it.showGlobalSearch()
-				return true
+		if (event.action == KeyEvent.ACTION_DOWN) {
+			if (event.keyCode == KeyEvent.KEYCODE_F && event.isShiftPressed && event.isCtrlPressed) {
+				projectRoot?.let {
+					it.showGlobalSearch()
+					return true
+				}
+			}
+
+			// hasModifiers matches exactly, so Ctrl+F3 and Ctrl+Alt+Shift+S fall through.
+			if (event.keyCode == KeyEvent.KEYCODE_F3 && event.hasNoModifiers()) {
+				if (shortcutHost.startProjectSync()) return true
+			}
+
+			val ctrlAlt = KeyEvent.META_CTRL_ON or KeyEvent.META_ALT_ON
+			if (event.keyCode == KeyEvent.KEYCODE_S && event.hasModifiers(ctrlAlt)) {
+				if (shortcutHost.saveAllBuffers()) return true
 			}
 		}
 		return super.dispatchKeyEvent(event)
@@ -214,7 +224,7 @@ class ProjectRootActivity : AppCompatActivity() {
 			component.requestClose()
 		}
 
-		ProjectRootScaffold(component, onCloseRequest = ::finish)
+		ProjectRootScaffold(component, onCloseRequest = ::finish, shortcutHost = shortcutHost)
 	}
 
 	companion object {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRoot.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRoot.kt
@@ -45,6 +45,9 @@ interface ProjectRoot : AppCloseManager, HammerComponent, BackHandlerOwner {
 	fun isAtRoot(): Boolean
 
 	fun showProjectSync()
+
+	/** Opens the sync modal only when this project is linked to a server. */
+	fun startProjectSync()
 	fun dismissProjectSync()
 
 	fun showGlobalSearch()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
@@ -234,6 +234,12 @@ class ProjectRootComponent(
 
 	override fun showProjectSync() = modalRouter.showProjectSync()
 
+	override fun startProjectSync() {
+		if (syncJournal.isServerSynchronized()) {
+			showProjectSync()
+		}
+	}
+
 	override fun dismissProjectSync() = modalRouter.dismissProjectSync()
 
 	override fun showGlobalSearch() = modalRouter.showGlobalSearch()

--- a/common/src/desktopTest/kotlin/components/projectroot/ProjectRootComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectroot/ProjectRootComponentTest.kt
@@ -282,6 +282,34 @@ class ProjectRootComponentTest : ComponentTest() {
 	}
 
 	@Test
+	fun `startProjectSync opens the modal for server synchronized projects`() = runTest(mainTestDispatcher) {
+		every { syncJournal.isServerSynchronized() } returns true
+
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.startProjectSync()
+		advanceUntilIdle()
+
+		assertIs<ProjectRoot.ModalDestination.ProjectSync>(comp.modalRouterState.value.child?.instance)
+	}
+
+	@Test
+	fun `startProjectSync does nothing for local-only projects`() = runTest(mainTestDispatcher) {
+		every { syncJournal.isServerSynchronized() } returns false
+
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.startProjectSync()
+		advanceUntilIdle()
+
+		assertIs<ProjectRoot.ModalDestination.None>(comp.modalRouterState.value.child?.instance)
+	}
+
+	@Test
 	fun `Global search modal opens and dismisses`() = runTest(mainTestDispatcher) {
 		val comp = newComponent()
 		context.resume()

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ProjectShortcutHost.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ProjectShortcutHost.kt
@@ -1,0 +1,38 @@
+package com.darkrockstudios.apps.hammer.common.compose
+
+import androidx.compose.runtime.Stable
+
+/**
+ * Lets a platform host (Activity, view controller, window) fire the project shortcuts from its
+ * own key handling. Compose's key modifiers only see events routed along the focus path, so a
+ * screen with nothing focused never receives them.
+ *
+ * Each action returns false when no project UI is bound, so the host can pass the key on.
+ */
+@Stable
+class ProjectShortcutHost {
+	private var startSync: (() -> Unit)? = null
+	private var saveAll: (() -> Unit)? = null
+
+	fun bind(startSync: () -> Unit, saveAll: () -> Unit) {
+		this.startSync = startSync
+		this.saveAll = saveAll
+	}
+
+	fun unbind() {
+		startSync = null
+		saveAll = null
+	}
+
+	fun startProjectSync(): Boolean {
+		val action = startSync ?: return false
+		action()
+		return true
+	}
+
+	fun saveAllBuffers(): Boolean {
+		val action = saveAll ?: return false
+		action()
+		return true
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ShortcutModifiers.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ShortcutModifiers.kt
@@ -30,12 +30,6 @@ fun Modifier.findShortcutModifier(showFindBar: () -> Unit): Modifier =
 fun Modifier.saveShortcutModifier(onSave: () -> Unit): Modifier =
 	onKeyShortcut(Key.S, ctrl = true, action = onSave)
 
-fun Modifier.saveAllShortcutModifier(onSaveAll: () -> Unit): Modifier =
-	onKeyShortcut(Key.S, ctrl = true, alt = true, action = onSaveAll)
-
-fun Modifier.syncShortcutModifier(onSync: () -> Unit): Modifier =
-	onKeyShortcut(Key.F3, action = onSync)
-
 fun Modifier.boldShortcutModifier(onBold: () -> Unit): Modifier =
 	onKeyShortcut(Key.B, ctrl = true, action = onBold)
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ShortcutModifiers.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ShortcutModifiers.kt
@@ -3,6 +3,21 @@ package com.darkrockstudios.apps.hammer.common.compose
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.*
 
+/** Matches a key-down with exactly these modifiers: extra ones do not count as a match. */
+fun KeyEvent.matchesShortcut(
+	key: Key,
+	ctrl: Boolean = false,
+	shift: Boolean = false,
+	alt: Boolean = false,
+): Boolean {
+	val ctrlOrMeta = isCtrlPressed || isMetaPressed
+	return type == KeyEventType.KeyDown &&
+		this.key == key &&
+		ctrlOrMeta == ctrl &&
+		isShiftPressed == shift &&
+		isAltPressed == alt
+}
+
 internal fun Modifier.onKeyShortcut(
 	key: Key,
 	ctrl: Boolean = false,
@@ -10,13 +25,7 @@ internal fun Modifier.onKeyShortcut(
 	alt: Boolean = false,
 	action: () -> Unit,
 ): Modifier = onPreviewKeyEvent { event ->
-	val ctrlOrMeta = event.isCtrlPressed || event.isMetaPressed
-	if (event.type == KeyEventType.KeyDown &&
-		event.key == key &&
-		ctrlOrMeta == ctrl &&
-		event.isShiftPressed == shift &&
-		event.isAltPressed == alt
-	) {
+	if (event.matchesShortcut(key, ctrl, shift, alt)) {
 		action()
 		true
 	} else {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootScaffold.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootScaffold.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSiz
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,7 +21,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
-import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.projectroot.CloseConfirm
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot
 import com.darkrockstudios.apps.hammer.common.compose.ProjectShortcutHost
@@ -33,12 +31,9 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
 import com.darkrockstudios.apps.hammer.common.compose.fab
 import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
-import com.darkrockstudios.apps.hammer.common.compose.rememberStrRes
 import com.darkrockstudios.apps.hammer.common.compose.rootElement
 import com.darkrockstudios.apps.hammer.common.compose.theme.ProjectThemeOverride
 import com.darkrockstudios.apps.hammer.common.util.getAppVersionString
-import com.darkrockstudios.apps.hammer.save_all_toast
-import kotlinx.coroutines.launch
 
 // Locale-independent nav testTags; values match "nav-${DestinationTypes.name}".
 const val NAV_HOME_TAG = "nav-Home"
@@ -58,29 +53,13 @@ fun ProjectRootScaffold(
 	val themeState by component.projectTheme.subscribeAsState()
 	val rootSnackbar = rememberRootSnackbarHostState()
 	val coroutineScope = rememberCoroutineScope()
-	val strRes = rememberStrRes()
-
-	if (shortcutHost != null) {
-		DisposableEffect(shortcutHost, component, rootSnackbar, coroutineScope, strRes) {
-			shortcutHost.bind(
-				startSync = { component.startProjectSync() },
-				saveAll = {
-					coroutineScope.launch {
-						component.storeDirtyBuffers()
-						rootSnackbar.showSnackbar(strRes.get(Res.string.save_all_toast))
-					}
-				},
-			)
-			onDispose { shortcutHost.unbind() }
-		}
-	}
 
 	ProjectThemeOverride(themeState.theme) {
 		val windowSizeClass = calculateWindowSizeClass()
 		when (windowSizeClass.widthSizeClass) {
-			WindowWidthSizeClass.Compact -> CompactNavigation(component, rootSnackbar)
+			WindowWidthSizeClass.Compact -> CompactNavigation(component, rootSnackbar, shortcutHost)
 			WindowWidthSizeClass.Medium,
-			WindowWidthSizeClass.Expanded -> RailNavigation(component, rootSnackbar)
+			WindowWidthSizeClass.Expanded -> RailNavigation(component, rootSnackbar, shortcutHost)
 		}
 
 		if (shouldConfirmClose.isNotEmpty()) {
@@ -100,6 +79,7 @@ fun ProjectRootScaffold(
 private fun CompactNavigation(
 	component: ProjectRoot,
 	rootSnackbar: RootSnackbarHostState,
+	shortcutHost: ProjectShortcutHost?,
 ) {
 	val router by component.routerState.subscribeAsState()
 	Scaffold(
@@ -112,6 +92,7 @@ private fun CompactNavigation(
 				rootSnackbar,
 				modifier = Modifier.rootElement(scaffoldPadding),
 				navWidth = 0.dp,
+				shortcutHost = shortcutHost,
 			)
 		},
 		bottomBar = {
@@ -133,6 +114,7 @@ private fun CompactNavigation(
 private fun RailNavigation(
 	component: ProjectRoot,
 	rootSnackbar: RootSnackbarHostState,
+	shortcutHost: ProjectShortcutHost?,
 ) {
 	val router by component.routerState.subscribeAsState()
 	val navRailState by component.navRailState.subscribeAsState()
@@ -164,7 +146,13 @@ private fun RailNavigation(
 					},
 				)
 
-				ProjectRootUi(component, rootSnackbar, navRailWidth, Modifier.padding(scaffoldPadding))
+				ProjectRootUi(
+					component,
+					rootSnackbar,
+					navRailWidth,
+					Modifier.padding(scaffoldPadding),
+					shortcutHost = shortcutHost,
+				)
 			}
 		},
 		floatingActionButton = {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootScaffold.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootScaffold.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSiz
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,8 +22,10 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.projectroot.CloseConfirm
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot
+import com.darkrockstudios.apps.hammer.common.compose.ProjectShortcutHost
 import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.defaultScaffold
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdBottomBar
@@ -30,9 +33,12 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
 import com.darkrockstudios.apps.hammer.common.compose.fab
 import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
+import com.darkrockstudios.apps.hammer.common.compose.rememberStrRes
 import com.darkrockstudios.apps.hammer.common.compose.rootElement
 import com.darkrockstudios.apps.hammer.common.compose.theme.ProjectThemeOverride
 import com.darkrockstudios.apps.hammer.common.util.getAppVersionString
+import com.darkrockstudios.apps.hammer.save_all_toast
+import kotlinx.coroutines.launch
 
 // Locale-independent nav testTags; values match "nav-${DestinationTypes.name}".
 const val NAV_HOME_TAG = "nav-Home"
@@ -46,11 +52,28 @@ const val NAV_TIMELINE_TAG = "nav-TimeLine"
 fun ProjectRootScaffold(
 	component: ProjectRoot,
 	onCloseRequest: () -> Unit,
+	shortcutHost: ProjectShortcutHost? = null,
 ) {
 	val shouldConfirmClose by component.closeRequestHandlers.subscribeAsState()
 	val themeState by component.projectTheme.subscribeAsState()
 	val rootSnackbar = rememberRootSnackbarHostState()
 	val coroutineScope = rememberCoroutineScope()
+	val strRes = rememberStrRes()
+
+	if (shortcutHost != null) {
+		DisposableEffect(shortcutHost, component, rootSnackbar, coroutineScope, strRes) {
+			shortcutHost.bind(
+				startSync = { component.startProjectSync() },
+				saveAll = {
+					coroutineScope.launch {
+						component.storeDirtyBuffers()
+						rootSnackbar.showSnackbar(strRes.get(Res.string.save_all_toast))
+					}
+				},
+			)
+			onDispose { shortcutHost.unbind() }
+		}
+	}
 
 	ProjectThemeOverride(themeState.theme) {
 		val windowSizeClass = calculateWindowSizeClass()

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootUi.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -25,6 +27,8 @@ import com.darkrockstudios.apps.hammer.common.compose.SetScreenCharacteristics
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdBottomBarDestination
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRailDestination
+import com.darkrockstudios.apps.hammer.common.compose.ProjectShortcutHost
+import com.darkrockstudios.apps.hammer.common.compose.rememberStrRes
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.encyclopedia.BrowseEntriesFab
 import com.darkrockstudios.apps.hammer.common.encyclopedia.EncyclopediaUi
@@ -44,6 +48,8 @@ import com.darkrockstudios.apps.hammer.ic_encyclopedia
 import com.darkrockstudios.apps.hammer.ic_home
 import com.darkrockstudios.apps.hammer.ic_notes
 import com.darkrockstudios.apps.hammer.ic_timeline
+import com.darkrockstudios.apps.hammer.save_all_toast
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
 
 private val WIDE_SCREEN_THRESHOLD = 650.dp
@@ -83,7 +89,26 @@ fun ProjectRootUi(
 	rootSnackbar: RootSnackbarHostState,
 	navWidth: Dp = Dp.Unspecified,
 	modifier: Modifier = Modifier,
+	shortcutHost: ProjectShortcutHost? = null,
 ) {
+	val scope = rememberCoroutineScope()
+	val strRes = rememberStrRes()
+
+	if (shortcutHost != null) {
+		DisposableEffect(shortcutHost, component, rootSnackbar, scope, strRes) {
+			shortcutHost.bind(
+				startSync = { component.startProjectSync() },
+				saveAll = {
+					scope.launch {
+						component.storeDirtyBuffers()
+						rootSnackbar.showSnackbar(strRes.get(Res.string.save_all_toast))
+					}
+				},
+			)
+			onDispose { shortcutHost.unbind() }
+		}
+	}
+
 	SetScreenCharacteristics(WIDE_SCREEN_THRESHOLD) {
 		FeatureContent(
 			modifier.fillMaxSize(),

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectroot/ProjectRootUi.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -26,10 +25,7 @@ import com.darkrockstudios.apps.hammer.common.compose.SetScreenCharacteristics
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdBottomBarDestination
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRailDestination
-import com.darkrockstudios.apps.hammer.common.compose.rememberStrRes
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
-import com.darkrockstudios.apps.hammer.common.compose.saveAllShortcutModifier
-import com.darkrockstudios.apps.hammer.common.compose.syncShortcutModifier
 import com.darkrockstudios.apps.hammer.common.encyclopedia.BrowseEntriesFab
 import com.darkrockstudios.apps.hammer.common.encyclopedia.EncyclopediaUi
 import com.darkrockstudios.apps.hammer.common.globalsearch.GlobalSearchUi
@@ -48,8 +44,6 @@ import com.darkrockstudios.apps.hammer.ic_encyclopedia
 import com.darkrockstudios.apps.hammer.ic_home
 import com.darkrockstudios.apps.hammer.ic_notes
 import com.darkrockstudios.apps.hammer.ic_timeline
-import com.darkrockstudios.apps.hammer.save_all_toast
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
 
 private val WIDE_SCREEN_THRESHOLD = 650.dp
@@ -90,20 +84,9 @@ fun ProjectRootUi(
 	navWidth: Dp = Dp.Unspecified,
 	modifier: Modifier = Modifier,
 ) {
-	val scope = rememberCoroutineScope()
-	val strRes = rememberStrRes()
-
 	SetScreenCharacteristics(WIDE_SCREEN_THRESHOLD) {
 		FeatureContent(
-			modifier
-				.fillMaxSize()
-				.saveAllShortcutModifier {
-					scope.launch {
-						component.storeDirtyBuffers()
-						rootSnackbar.showSnackbar(strRes.get(Res.string.save_all_toast))
-					}
-				}
-				.syncShortcutModifier { component.showProjectSync() },
+			modifier.fillMaxSize(),
 			component,
 			rootSnackbar,
 			navWidth,

--- a/composeUi/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/compose/MatchesShortcutTest.kt
+++ b/composeUi/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/compose/MatchesShortcutTest.kt
@@ -1,0 +1,91 @@
+package com.darkrockstudios.apps.hammer.common.compose
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.withKeyDown
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+class MatchesShortcutTest {
+
+	private fun shortcutFirings(
+		shortcut: Modifier.(onFired: () -> Unit) -> Modifier,
+		press: androidx.compose.ui.test.KeyInjectionScope.() -> Unit,
+	): Int {
+		var fired = 0
+		runComposeUiTest {
+			setContent {
+				val focusRequester = remember { FocusRequester() }
+				Box(
+					Modifier
+						.testTag("root")
+						.focusRequester(focusRequester)
+						.focusable()
+						.shortcut { fired++ }
+				)
+				LaunchedEffect(Unit) { focusRequester.requestFocus() }
+			}
+			onNodeWithTag("root").performKeyInput(press)
+		}
+		return fired
+	}
+
+	@Test
+	fun `bare F3 fires the sync shortcut`() {
+		assertEquals(1, shortcutFirings({ onKeyShortcut(Key.F3, action = it) }) { pressKey(Key.F3) })
+	}
+
+	@Test
+	fun `F3 with an extra modifier does not fire`() {
+		assertEquals(
+			0,
+			shortcutFirings({ onKeyShortcut(Key.F3, action = it) }) {
+				withKeyDown(Key.CtrlLeft) { pressKey(Key.F3) }
+			},
+		)
+		assertEquals(
+			0,
+			shortcutFirings({ onKeyShortcut(Key.F3, action = it) }) {
+				withKeyDown(Key.ShiftLeft) { pressKey(Key.F3) }
+			},
+		)
+	}
+
+	@Test
+	fun `ctrl alt S fires save all`() {
+		assertEquals(
+			1,
+			shortcutFirings({ onKeyShortcut(Key.S, ctrl = true, alt = true, action = it) }) {
+				withKeyDown(Key.CtrlLeft) { withKeyDown(Key.AltLeft) { pressKey(Key.S) } }
+			},
+		)
+	}
+
+	@Test
+	fun `ctrl alt shift S does not fire save all`() {
+		assertEquals(
+			0,
+			shortcutFirings({ onKeyShortcut(Key.S, ctrl = true, alt = true, action = it) }) {
+				withKeyDown(Key.CtrlLeft) {
+					withKeyDown(Key.AltLeft) {
+						withKeyDown(Key.ShiftLeft) { pressKey(Key.S) }
+					}
+				}
+			},
+		)
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/compose/ProjectShortcutHostTest.kt
+++ b/composeUi/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/compose/ProjectShortcutHostTest.kt
@@ -1,0 +1,41 @@
+package com.darkrockstudios.apps.hammer.common.compose
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProjectShortcutHostTest {
+
+	@Test
+	fun `unbound host reports the key as unhandled`() {
+		val host = ProjectShortcutHost()
+
+		assertFalse(host.startProjectSync())
+		assertFalse(host.saveAllBuffers())
+	}
+
+	@Test
+	fun `bound host runs the actions and claims the key`() {
+		var syncs = 0
+		var saves = 0
+		val host = ProjectShortcutHost()
+		host.bind(startSync = { syncs++ }, saveAll = { saves++ })
+
+		assertTrue(host.startProjectSync())
+		assertTrue(host.saveAllBuffers())
+		assertEquals(1, syncs)
+		assertEquals(1, saves)
+	}
+
+	@Test
+	fun `unbinding stops the actions running`() {
+		var syncs = 0
+		val host = ProjectShortcutHost()
+		host.bind(startSync = { syncs++ }, saveAll = {})
+		host.unbind()
+
+		assertFalse(host.startProjectSync())
+		assertEquals(0, syncs)
+	}
+}

--- a/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/MainViewController.kt
+++ b/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/MainViewController.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.window.ComposeUIViewController
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.common.components.iosroot.IosRoot
+import com.darkrockstudios.apps.hammer.common.compose.ProjectShortcutHost
 import com.darkrockstudios.apps.hammer.common.compose.rememberKoinInject
 import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
@@ -15,12 +16,15 @@ import com.darkrockstudios.apps.hammer.common.projectroot.ProjectRootScaffold
 import com.darkrockstudios.apps.hammer.common.projectselection.ProjectSelectScaffold
 import platform.UIKit.UIViewController
 
-fun MainViewController(root: IosRoot): UIViewController = ComposeUIViewController {
-	HammerApp(root)
-}
+// shortcutHost is owned by the Swift container: UIKit key commands are the only key hook that
+// does not depend on what Compose has focused, and Kotlin cannot override that category member.
+fun MainViewController(root: IosRoot, shortcutHost: ProjectShortcutHost): UIViewController =
+	ComposeUIViewController {
+		HammerApp(root, shortcutHost)
+	}
 
 @Composable
-private fun HammerApp(root: IosRoot) {
+private fun HammerApp(root: IosRoot, shortcutHost: ProjectShortcutHost) {
 	val globalSettingsStore: GlobalSettingsStore = rememberKoinInject()
 	val settingsState by globalSettingsStore.globalSettingsUpdates
 		.collectAsState(initial = globalSettingsStore.globalSettings)
@@ -42,6 +46,7 @@ private fun HammerApp(root: IosRoot) {
 				ProjectRootScaffold(
 					component = destination.component,
 					onCloseRequest = { root.closeProject() },
+					shortcutHost = shortcutHost,
 				)
 
 			null -> Unit

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
@@ -46,6 +45,7 @@ import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
+import com.darkrockstudios.apps.hammer.common.compose.matchesShortcut
 import com.darkrockstudios.apps.hammer.common.compose.rememberMainDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
@@ -117,6 +117,25 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 		state = windowState,
 		icon = painterResource("icon.png"),
 		onCloseRequest = { onRequestClose(component, app, ApplicationState.CloseType.Application) },
+		// These two run pre-focus so a focused editor can't swallow them.
+		onPreviewKeyEvent = { event ->
+			when {
+				event.matchesShortcut(Key.F3) -> {
+					component.startProjectSync()
+					true
+				}
+
+				event.matchesShortcut(Key.S, ctrl = true, alt = true) -> {
+					windowScope.launch {
+						component.storeDirtyBuffers()
+						rootSnackbar.showSnackbar(saveAllToast)
+					}
+					true
+				}
+
+				else -> false
+			}
+		},
 		onKeyEvent = { event ->
 			when {
 				event.key == Key.Escape && event.type == KeyEventType.KeyUp -> {
@@ -129,22 +148,6 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 					component.showGlobalSearch()
 					true
 				}
-				event.type == KeyEventType.KeyDown && event.key == Key.F3 -> {
-					component.startProjectSync()
-					true
-				}
-
-				event.type == KeyEventType.KeyDown &&
-					event.key == Key.S &&
-					event.isAltPressed &&
-					(event.isCtrlPressed || event.isMetaPressed) -> {
-					windowScope.launch {
-						component.storeDirtyBuffers()
-						rootSnackbar.showSnackbar(saveAllToast)
-					}
-					true
-				}
-
 				event.type == KeyEventType.KeyDown &&
 					event.key == Key.W &&
 					(event.isCtrlPressed || event.isMetaPressed) -> {

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
@@ -41,7 +41,7 @@ import com.darkrockstudios.apps.hammer.common.AppCloseManager
 import com.darkrockstudios.apps.hammer.common.components.projectroot.CloseConfirm
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRootComponent
-import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
+import com.darkrockstudios.apps.hammer.common.compose.ProjectShortcutHost
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
@@ -108,9 +108,7 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 	}
 
 	val windowTitle = Res.string.project_window_title.get(projectDef.name)
-	val saveAllToast = Res.string.save_all_toast.get()
-	val windowScope = rememberCoroutineScope()
-	val rootSnackbar = rememberRootSnackbarHostState()
+	val shortcutHost = remember { ProjectShortcutHost() }
 
 	MaterialDecoratedWindow(
 		title = windowTitle,
@@ -120,19 +118,8 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 		// These two run pre-focus so a focused editor can't swallow them.
 		onPreviewKeyEvent = { event ->
 			when {
-				event.matchesShortcut(Key.F3) -> {
-					component.startProjectSync()
-					true
-				}
-
-				event.matchesShortcut(Key.S, ctrl = true, alt = true) -> {
-					windowScope.launch {
-						component.storeDirtyBuffers()
-						rootSnackbar.showSnackbar(saveAllToast)
-					}
-					true
-				}
-
+				event.matchesShortcut(Key.F3) -> shortcutHost.startProjectSync()
+				event.matchesShortcut(Key.S, ctrl = true, alt = true) -> shortcutHost.saveAllBuffers()
 				else -> false
 			}
 		},
@@ -165,6 +152,7 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 			}
 		}
 	) {
+		val scope = rememberCoroutineScope()
 		val mainDispatcher = rememberMainDispatcher()
 
 		MaterialTitleBar {
@@ -178,7 +166,7 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 		// Tao windows are their own ComposeScene: locals provided outside the
 		// window (AppTheme in Main.kt) don't reach this content, so re-apply.
 		AppTheme(useDarkTheme = darkMode, settings = settings) {
-			AppContent(component, rootSnackbar)
+			AppContent(component, shortcutHost)
 
 			LaunchedEffect(closeRequest) {
 				if (closeRequest != ApplicationState.CloseType.None) {
@@ -191,7 +179,7 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 				when (item) {
 					CloseConfirm.Scenes -> {
 						confirmCloseUnsavedScenesDialog(closeRequest) { result, closeType ->
-							windowScope.launch {
+							scope.launch {
 								if (result == ConfirmCloseResult.SaveAll) {
 									component.storeDirtyBuffers()
 								}
@@ -288,10 +276,11 @@ private fun FrameWindowScope.EditorMenuBar(
 }
 
 @Composable
-private fun AppContent(component: ProjectRoot, rootSnackbar: RootSnackbarHostState) {
+private fun AppContent(component: ProjectRoot, shortcutHost: ProjectShortcutHost) {
 	val router by component.routerState.subscribeAsState()
 	val themeState by component.projectTheme.subscribeAsState()
 	val navRailState by component.navRailState.subscribeAsState()
+	val rootSnackbar = rememberRootSnackbarHostState()
 
 	val destinations = ProjectRoot.DestinationTypes.entries.map { it.toHdNavRailDestination() }
 
@@ -312,7 +301,7 @@ private fun AppContent(component: ProjectRoot, rootSnackbar: RootSnackbarHostSta
 					},
 				)
 
-				ProjectRootUi(component, rootSnackbar)
+				ProjectRootUi(component, rootSnackbar, shortcutHost = shortcutHost)
 			}
 
 			SnackbarHost(

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
@@ -41,6 +42,7 @@ import com.darkrockstudios.apps.hammer.common.AppCloseManager
 import com.darkrockstudios.apps.hammer.common.components.projectroot.CloseConfirm
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRoot
 import com.darkrockstudios.apps.hammer.common.components.projectroot.ProjectRootComponent
+import com.darkrockstudios.apps.hammer.common.compose.RootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
@@ -58,6 +60,7 @@ import com.darkrockstudios.apps.hammer.project_window_menu_file
 import com.darkrockstudios.apps.hammer.project_window_menu_item_close
 import com.darkrockstudios.apps.hammer.project_window_menu_item_exit
 import com.darkrockstudios.apps.hammer.project_window_title
+import com.darkrockstudios.apps.hammer.save_all_toast
 import dev.nucleusframework.application.NucleusApplicationScope
 import dev.nucleusframework.window.material.MaterialDecoratedWindow
 import dev.nucleusframework.window.material.MaterialTitleBar
@@ -105,6 +108,10 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 	}
 
 	val windowTitle = Res.string.project_window_title.get(projectDef.name)
+	val saveAllToast = Res.string.save_all_toast.get()
+	val windowScope = rememberCoroutineScope()
+	val rootSnackbar = rememberRootSnackbarHostState()
+
 	MaterialDecoratedWindow(
 		title = windowTitle,
 		state = windowState,
@@ -122,6 +129,22 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 					component.showGlobalSearch()
 					true
 				}
+				event.type == KeyEventType.KeyDown && event.key == Key.F3 -> {
+					component.startProjectSync()
+					true
+				}
+
+				event.type == KeyEventType.KeyDown &&
+					event.key == Key.S &&
+					event.isAltPressed &&
+					(event.isCtrlPressed || event.isMetaPressed) -> {
+					windowScope.launch {
+						component.storeDirtyBuffers()
+						rootSnackbar.showSnackbar(saveAllToast)
+					}
+					true
+				}
+
 				event.type == KeyEventType.KeyDown &&
 					event.key == Key.W &&
 					(event.isCtrlPressed || event.isMetaPressed) -> {
@@ -139,7 +162,6 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 			}
 		}
 	) {
-		val scope = rememberCoroutineScope()
 		val mainDispatcher = rememberMainDispatcher()
 
 		MaterialTitleBar {
@@ -153,7 +175,7 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 		// Tao windows are their own ComposeScene: locals provided outside the
 		// window (AppTheme in Main.kt) don't reach this content, so re-apply.
 		AppTheme(useDarkTheme = darkMode, settings = settings) {
-			AppContent(component)
+			AppContent(component, rootSnackbar)
 
 			LaunchedEffect(closeRequest) {
 				if (closeRequest != ApplicationState.CloseType.None) {
@@ -166,7 +188,7 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 				when (item) {
 					CloseConfirm.Scenes -> {
 						confirmCloseUnsavedScenesDialog(closeRequest) { result, closeType ->
-							scope.launch {
+							windowScope.launch {
 								if (result == ConfirmCloseResult.SaveAll) {
 									component.storeDirtyBuffers()
 								}
@@ -263,11 +285,10 @@ private fun FrameWindowScope.EditorMenuBar(
 }
 
 @Composable
-private fun AppContent(component: ProjectRoot) {
+private fun AppContent(component: ProjectRoot, rootSnackbar: RootSnackbarHostState) {
 	val router by component.routerState.subscribeAsState()
 	val themeState by component.projectTheme.subscribeAsState()
 	val navRailState by component.navRailState.subscribeAsState()
-	val rootSnackbar = rememberRootSnackbarHostState()
 
 	val destinations = ProjectRoot.DestinationTypes.entries.map { it.toHdNavRailDestination() }
 

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -17,10 +17,14 @@ macOS-specific `Cmd` bindings, they work with either key on every platform.
 
 ## Project (while a project is open)
 
-| Shortcut     | Action                                       | Source                                           |
-|--------------|----------------------------------------------|--------------------------------------------------|
-| `Ctrl+Alt+S` | Save all dirty buffers (scenes, notes, etc.) | `saveAllShortcutModifier` via `ProjectRootUi.kt` |
-| `F3`         | Start project sync                           | `syncShortcutModifier` via `ProjectRootUi.kt`    |
+Both are handled on the window, so they fire regardless of what is focused. Modifier
+shortcuts (the editor ones below) only fire when focus sits inside the composable they
+are attached to, because Compose routes key events along the focus path.
+
+| Shortcut     | Action                                       | Source                                  |
+|--------------|----------------------------------------------|-----------------------------------------|
+| `Ctrl+Alt+S` | Save all dirty buffers (scenes, notes, etc.) | `ProjectEditorWindow.kt` (`onKeyEvent`) |
+| `F3`         | Start project sync (server-linked only)      | `ProjectEditorWindow.kt` (`onKeyEvent`) |
 
 ## Editors (scene, note, timeline event, story idea)
 

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -17,14 +17,19 @@ macOS-specific `Cmd` bindings, they work with either key on every platform.
 
 ## Project (while a project is open)
 
-Both are handled on the window, so they fire regardless of what is focused. Modifier
-shortcuts (the editor ones below) only fire when focus sits inside the composable they
-are attached to, because Compose routes key events along the focus path.
+Both are handled on the window's `onPreviewKeyEvent`, which runs before the focus path,
+so a focused editor cannot swallow them. The application shortcuts above use the
+window's `onKeyEvent` instead and yield to a focused component that consumes the key.
+Modifier shortcuts (the editor ones below) only fire when focus sits inside the
+composable they are attached to, because Compose routes key events along the focus path.
 
-| Shortcut     | Action                                       | Source                                  |
-|--------------|----------------------------------------------|-----------------------------------------|
-| `Ctrl+Alt+S` | Save all dirty buffers (scenes, notes, etc.) | `ProjectEditorWindow.kt` (`onKeyEvent`) |
-| `F3`         | Start project sync (server-linked only)      | `ProjectEditorWindow.kt` (`onKeyEvent`) |
+Modifiers match exactly: `F3` means F3 with nothing held, so `Ctrl+F3` and `Shift+F3` do
+not start a sync.
+
+| Shortcut     | Action                                       | Source                                         |
+|--------------|----------------------------------------------|------------------------------------------------|
+| `Ctrl+Alt+S` | Save all dirty buffers (scenes, notes, etc.) | `ProjectEditorWindow.kt` (`onPreviewKeyEvent`) |
+| `F3`         | Start project sync (server-linked only)      | `ProjectEditorWindow.kt` (`onPreviewKeyEvent`) |
 
 ## Editors (scene, note, timeline event, story idea)
 

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -1,6 +1,7 @@
 # Keyboard Shortcuts
 
-Desktop-only. `Ctrl` and `Cmd` are interchangeable everywhere below: `onKeyShortcut`
+Desktop, plus the two project shortcuts on Android and iOS with a hardware keyboard.
+`Ctrl` and `Cmd` are interchangeable everywhere below: `onKeyShortcut`
 (
 `composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/ShortcutModifiers.kt`)
 treats `isCtrlPressed || isMetaPressed` as a single "ctrl" modifier, so these are not
@@ -17,19 +18,29 @@ macOS-specific `Cmd` bindings, they work with either key on every platform.
 
 ## Project (while a project is open)
 
-Both are handled on the window's `onPreviewKeyEvent`, which runs before the focus path,
-so a focused editor cannot swallow them. The application shortcuts above use the
-window's `onKeyEvent` instead and yield to a focused component that consumes the key.
-Modifier shortcuts (the editor ones below) only fire when focus sits inside the
-composable they are attached to, because Compose routes key events along the focus path.
+These two work on all three platforms, each through the host hook that does not depend on
+what Compose has focused. Compose routes key events along the focus path, so a screen with
+nothing focused never sees them, which is why none of these are `Modifier` shortcuts.
+
+| Platform | Hook                                                          |
+|----------|---------------------------------------------------------------|
+| Desktop  | `ProjectEditorWindow.kt` window `onPreviewKeyEvent`           |
+| Android  | `ProjectRootActivity.dispatchKeyEvent`                        |
+| iOS      | `ShortcutHostController.keyCommands` in `ComposeContainer.swift` |
+
+Android and iOS reach the shared action through `ProjectShortcutHost`, which
+`ProjectRootScaffold` binds while the project UI is composed. The application shortcuts
+above use the window's `onKeyEvent` instead and yield to a focused component that consumes
+the key. Modifier shortcuts (the editor ones below) only fire when focus sits inside the
+composable they are attached to.
 
 Modifiers match exactly: `F3` means F3 with nothing held, so `Ctrl+F3` and `Shift+F3` do
-not start a sync.
+not start a sync. On iOS the save-all chord is `Cmd+Opt+S` or `Ctrl+Opt+S`.
 
-| Shortcut     | Action                                       | Source                                         |
-|--------------|----------------------------------------------|------------------------------------------------|
-| `Ctrl+Alt+S` | Save all dirty buffers (scenes, notes, etc.) | `ProjectEditorWindow.kt` (`onPreviewKeyEvent`) |
-| `F3`         | Start project sync (server-linked only)      | `ProjectEditorWindow.kt` (`onPreviewKeyEvent`) |
+| Shortcut     | Action                                       |
+|--------------|----------------------------------------------|
+| `Ctrl+Alt+S` | Save all dirty buffers (scenes, notes, etc.) |
+| `F3`         | Start project sync (server-linked only)      |
 
 ## Editors (scene, note, timeline event, story idea)
 

--- a/ios/ios/ComposeContainer.swift
+++ b/ios/ios/ComposeContainer.swift
@@ -13,9 +13,64 @@ struct ComposeContainer: UIViewControllerRepresentable {
     let root: IosRoot
 
     func makeUIViewController(context: Context) -> UIViewController {
-        MainViewControllerKt.MainViewController(root: root)
+        let shortcutHost = ProjectShortcutHost()
+        let compose = MainViewControllerKt.MainViewController(root: root, shortcutHost: shortcutHost)
+        return ShortcutHostController(shortcutHost: shortcutHost, content: compose)
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+}
+
+/// Compose routes key events along the focus path, so a screen with nothing focused never sees
+/// them. UIKit key commands travel the responder chain instead and always reach this controller.
+final class ShortcutHostController: UIViewController {
+
+    /// UIKit reports function keys as these private-use characters (NSF3FunctionKey).
+    private static let f3Input = String(UnicodeScalar(0xF706)!)
+
+    private let shortcutHost: ProjectShortcutHost
+    private let content: UIViewController
+
+    init(shortcutHost: ProjectShortcutHost, content: UIViewController) {
+        self.shortcutHost = shortcutHost
+        self.content = content
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not used")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addChild(content)
+        content.view.frame = view.bounds
+        content.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(content.view)
+        content.didMove(toParent: self)
+    }
+
+    override var childForStatusBarStyle: UIViewController? { content }
+
+    override var childForStatusBarHidden: UIViewController? { content }
+
+    override var canBecomeFirstResponder: Bool { true }
+
+    override var keyCommands: [UIKeyCommand]? {
+        [
+            UIKeyCommand(input: Self.f3Input, modifierFlags: [], action: #selector(startSync)),
+            UIKeyCommand(input: "s", modifierFlags: [.command, .alternate], action: #selector(saveAll)),
+            UIKeyCommand(input: "s", modifierFlags: [.control, .alternate], action: #selector(saveAll)),
+        ]
+    }
+
+    @objc private func startSync() {
+        _ = shortcutHost.startProjectSync()
+    }
+
+    @objc private func saveAll() {
+        _ = shortcutHost.saveAllBuffers()
     }
 }


### PR DESCRIPTION
## What

`F3` (start project sync) and `Ctrl+Alt+S` (save all) did nothing unless focus happened to sit inside the project subtree. Both hung off `Modifier.onPreviewKeyEvent` in `ProjectRootUi`, and Compose only routes key events along the focus path, so pressing either from Project Home went nowhere. Before that, `F3` came from a desktop menu item that became a no-op when the menu moved in-UI.

Now each platform detects the keys through the hook that does not depend on focus, and they all run one shared action.

| Platform | Hook |
|----------|------|
| Desktop | window `onPreviewKeyEvent` in `ProjectEditorWindow.kt` |
| Android | `ProjectRootActivity.dispatchKeyEvent` |
| iOS | `ShortcutHostController.keyCommands` in `ComposeContainer.swift` |

`ProjectShortcutHost` holds the two actions; `ProjectRootUi` binds them while the project UI is composed and unbinds on dispose. Each action returns `false` when nothing is bound, so a host passes the key on instead of swallowing it.

Other behaviour:

- `F3` goes through the new `ProjectRoot.startProjectSync()`, which opens the sync modal only for server-linked projects. That restores the gate the old sync menu item had, and matches Project Home only offering Sync when a server is configured.
- Modifiers match exactly on every platform, so `Ctrl+F3` and `Ctrl+Alt+Shift+S` do nothing. The predicate is `KeyEvent.matchesShortcut(key, ctrl, shift, alt)`, extracted from `onKeyShortcut` so there is a single definition.
- On iOS the save-all chord is `Cmd+Opt+S` or `Ctrl+Opt+S`.

## Testing

- `MatchesShortcutTest` drives real key input through a focused node: bare `F3` fires, `F3` with an extra modifier does not, `Ctrl+Alt+S` fires, `Ctrl+Alt+Shift+S` does not.
- `ProjectShortcutHostTest` covers bound, unbound and unbind.
- `ProjectRootComponentTest` covers both branches of the server-linked gate.
- Desktop verified by hand: `F3` opens the sync modal from Project Home, which is the case that used to fail.

## Needs a Mac before merge

The iOS container is Swift because `keyCommands` is an Objective-C category member and Kotlin/Native cannot override those. It has never been compiled: there is no Xcode on the machine this was written on. `:composeUi:compileIosMainKotlinMetadata` type-checks the Kotlin side, but the Swift file and the runtime behaviour are both unverified, and exercising it needs an iPad with a hardware keyboard.

## Known gaps, deliberately left

- The shortcuts fire while a modal is open, so `F3` typed into global search swaps that modal for the sync one. The old modifiers were scoped to `FeatureContent`, a sibling of `ModalContent`; no host hook has that scoping.
- `F3` on a local-only project is consumed and silently discarded: no modal, no snackbar, no hint that sync needs an account.
- The sync `MenuDescriptor` still declares `KeyShortcut(0x72)` (VK_F3) with the same server-linked gate, so the binding is stated in two places.
