### PR TITLE
Bump ComposeTextEditor to 2.4.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,7 +100,7 @@ korge-core = "6.0.0"
 bouncycastle = "1.85"
 kotlinx-io-okio = "0.9.1"
 
-compose-texteditor = "2.4.0"
+compose-texteditor = "2.4.2"
 kotlin-multiplatform-diff = "1.3.0"
 platform-spellcheckerkt = "1.3.2"
 nucleus = "2.1.9"


### PR DESCRIPTION
## Why

2.4.2 carries [ComposeTextEditor#97](https://github.com/Darkrock-Studios/ComposeTextEditor/pull/97), which fixes typed text losing its body style when nothing neighbours the caret.

We pass `TextStyle.Default` as the editor style and carry the reader's chosen font size as a span on every character, so unstyled text falls back to the bare default size. Paragraphs are separated by a blank line, which means every paragraph after the first begins at column 0 with an empty line above it: no neighbouring character, no style, wrong size. Any newly typed paragraph or list came out visibly smaller than the loaded prose around it.

## Verified

Against 2.4.2, typing a list two lines below existing prose under a 24sp configuration now produces a `24.0.sp` span where it previously produced none.

`:composeUi:desktopTest` and `:common:desktopTest` pass.

## Related

[#863](https://github.com/Darkrock-Studios/hammer-editor/pull/863) fixes a second, independent problem found alongside this one: our own restyle pass dropping block indents on a font size change. The two are unrelated and can merge in either order.
