### PR TITLE
Record web sign-ins in the security audit trail

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountRoutes.kt
@@ -3,7 +3,6 @@ package com.darkrockstudios.apps.hammer.account
 import com.darkrockstudios.apps.hammer.base.http.HTTP_STATUS_TERMS_OF_SERVICE
 import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
 import com.darkrockstudios.apps.hammer.base.http.INVALID_USER_ID
-import com.darkrockstudios.apps.hammer.monitoring.MonitoringState
 import com.darkrockstudios.apps.hammer.monitoring.SecurityRepository
 import com.darkrockstudios.apps.hammer.plugins.LOGIN_RATE_LIMIT
 import com.darkrockstudios.apps.hammer.plugins.ServerUserIdPrincipal
@@ -70,7 +69,6 @@ private fun Route.createAccount() {
 private fun Route.login() {
 	val accountsComponent: AccountsComponent = get()
 	val securityRepository: SecurityRepository = get()
-	val monitoringState: MonitoringState = get()
 
 	post("/login") {
 		val formParameters = call.receiveParameters()
@@ -79,12 +77,12 @@ private fun Route.login() {
 		val installId = formParameters["installId"].toString()
 
 		val result = accountsComponent.login(email = email, password = password, installId = installId)
-		val success = isSuccess(result)
 
-		if (monitoringState.loginTrackingEnabled) {
-			val ip = if (monitoringState.storeLoginIp) call.request.origin.remoteAddress else null
-			securityRepository.recordLoginAttempt(email = email, ipAddress = ip, success = success)
-		}
+		securityRepository.recordLoginAttempt(
+			email = email,
+			ipAddress = call.request.origin.remoteAddress,
+			success = isSuccess(result),
+		)
 
 		if (isSuccess(result)) {
 			val authToken = result.data

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -129,7 +129,7 @@ fun Route.frontend() {
 	termsOfServicePage()
 	privacyPolicyPage()
 	localeRoutes()
-	authRoutes(accountsRepository, whiteListRepository, configRepository, serverConfig)
+	authRoutes(accountsRepository, whiteListRepository, configRepository, serverConfig, securityRepository)
 	passwordResetRoutes(passwordResetRepository)
 	dashboardPage(
 		projectsRepository,

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/LoginPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/LoginPage.kt
@@ -6,10 +6,14 @@ import com.darkrockstudios.apps.hammer.admin.AdminServerConfig
 import com.darkrockstudios.apps.hammer.admin.ConfigRepository
 import com.darkrockstudios.apps.hammer.admin.WhiteListRepository
 import com.darkrockstudios.apps.hammer.frontend.data.UserSession
+import com.darkrockstudios.apps.hammer.monitoring.SecurityRepository
+import com.darkrockstudios.apps.hammer.plugins.LOGIN_RATE_LIMIT
 import com.darkrockstudios.apps.hammer.utilities.isSuccess
 import com.github.aymanizz.ktori18n.R
 import com.github.aymanizz.ktori18n.t
 import io.ktor.server.mustache.*
+import io.ktor.server.plugins.origin
+import io.ktor.server.plugins.ratelimit.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -19,9 +23,10 @@ fun Route.authRoutes(
 	accountsRepository: AccountsRepository,
 	whiteListRepository: WhiteListRepository,
 	configRepository: ConfigRepository,
-	serverConfig: ServerConfig
+	serverConfig: ServerConfig,
+	securityRepository: SecurityRepository,
 ) {
-	loginPage(accountsRepository, whiteListRepository, configRepository, serverConfig)
+	loginPage(accountsRepository, whiteListRepository, configRepository, serverConfig, securityRepository)
 	logout()
 	unauthorized()
 }
@@ -30,7 +35,8 @@ private fun Route.loginPage(
 	accountsRepository: AccountsRepository,
 	whiteListRepository: WhiteListRepository,
 	configRepository: ConfigRepository,
-	serverConfig: ServerConfig
+	serverConfig: ServerConfig,
+	securityRepository: SecurityRepository,
 ) {
 	route("/login") {
 		get {
@@ -46,40 +52,54 @@ private fun Route.loginPage(
 			}
 		}
 
-		post {
-			val params = call.receiveParameters()
-			val email = params["email"] ?: ""
-			val password = params["password"] ?: ""
+		rateLimit(RateLimitName(LOGIN_RATE_LIMIT)) {
+			post {
+				val params = call.receiveParameters()
+				val email = params["email"] ?: ""
+				val password = params["password"] ?: ""
 
-			val result = accountsRepository.login(
-				email = email,
-				password = password,
-				installId = "web"
-			)
-			if (isSuccess(result)) {
-				val token = result.data
-				val isAdmin = accountsRepository.isAdmin(token.userId)
-				val session = UserSession(
-					userId = token.userId,
-					username = email,
-					isAdmin = isAdmin
+				val result = accountsRepository.login(
+					email = email,
+					password = password,
+					installId = "web"
 				)
-				if (sessionIsAuthorized(session, accountsRepository, whiteListRepository)) {
+				val session: UserSession?
+				val credentialsError: String?
+				if (isSuccess(result)) {
+					val token = result.data
+					session = UserSession(
+						userId = token.userId,
+						username = email,
+						isAdmin = accountsRepository.isAdmin(token.userId)
+					)
+					credentialsError = null
+				} else {
+					session = null
+					credentialsError = result.displayMessageText(call) ?: "Login failed"
+				}
+
+				// A whitelist rejection is a denied sign-in, so it is audited as a failure
+				// to match what the API path records for the same credentials.
+				val authorized = session != null &&
+					sessionIsAuthorized(session, accountsRepository, whiteListRepository)
+
+				securityRepository.recordLoginAttempt(
+					email = email,
+					ipAddress = call.request.origin.remoteAddress,
+					success = authorized,
+				)
+
+				if (session != null && authorized) {
 					call.sessions.set(session)
 					call.respondRedirect("/dashboard")
 				} else {
-					// Credentials are valid but the user isn't whitelisted; don't set a
-					// session that /dashboard would reject (which would loop back here).
 					val model = buildLoginModel(call, whiteListRepository, configRepository, serverConfig)
 						.toMutableMap()
-					model["message"] = call.t(R("api_whitelist_rejected"))
+					// Valid credentials without a whitelist entry get no session, because
+					// /dashboard would reject it and loop back here.
+					model["message"] = credentialsError ?: call.t(R("api_whitelist_rejected"))
 					call.respond(MustacheContent("login.mustache", call.withDefaults(model)))
 				}
-			} else {
-				val message = result.displayMessageText(call) ?: "Login failed"
-				val model = buildLoginModel(call, whiteListRepository, configRepository, serverConfig).toMutableMap()
-				model["message"] = message
-				call.respond(MustacheContent("login.mustache", call.withDefaults(model)))
 			}
 		}
 	}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityRepository.kt
@@ -3,6 +3,8 @@ package com.darkrockstudios.apps.hammer.monitoring
 import com.darkrockstudios.apps.hammer.Login_attempt
 import com.darkrockstudios.apps.hammer.database.LoginAttemptDao
 import io.ktor.util.*
+import io.ktor.util.logging.Logger
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Clock
 import kotlin.time.Instant
 import org.koin.core.component.KoinComponent
@@ -10,20 +12,37 @@ import org.koin.core.component.KoinComponent
 /**
  * Records login attempts for brute-force visibility. Emails are stored
  * lower-cased so failure counts are stable regardless of how the attacker cased
- * the address. The IP is optional — callers pass null when storeLoginIp is off.
+ * the address, and blank ones as null so they stay out of the per-account
+ * queries. The monitoring toggles are honored here rather than at the call
+ * sites, so callers always pass the source address and no login route can
+ * record what an operator has switched off.
  */
 class SecurityRepository(
 	private val loginAttemptDao: LoginAttemptDao,
+	private val monitoringState: MonitoringState,
+	private val log: Logger,
 	private val clock: Clock,
 ) : KoinComponent {
 
+	/**
+	 * Recording is passive observation, so a failed write is logged and swallowed
+	 * rather than failing the sign-in that triggered it.
+	 */
 	suspend fun recordLoginAttempt(email: String?, ipAddress: String?, success: Boolean) {
-		loginAttemptDao.recordAttempt(
-			email = email?.cleaned(),
-			ipAddress = ipAddress,
-			success = success,
-			at = clock.now(),
-		)
+		if (monitoringState.loginTrackingEnabled.not()) return
+
+		try {
+			loginAttemptDao.recordAttempt(
+				email = email?.ifBlank { null }?.cleaned(),
+				ipAddress = ipAddress.takeIf { monitoringState.storeLoginIp },
+				success = success,
+				at = clock.now(),
+			)
+		} catch (e: CancellationException) {
+			throw e
+		} catch (e: Exception) {
+			log.error("Failed to record login attempt", e)
+		}
 	}
 
 	suspend fun countRecentFailures(email: String, since: Instant): Long =

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityRepository.kt
@@ -40,7 +40,7 @@ class SecurityRepository(
 			)
 		} catch (e: CancellationException) {
 			throw e
-		} catch (e: Exception) {
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
 			log.error("Failed to record login attempt", e)
 		}
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/LoginPageSecurityTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/LoginPageSecurityTest.kt
@@ -1,0 +1,100 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.e2e.util.WebEndToEndTest
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.net.URLEncoder
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The web login form feeds the same security audit trail as the API's
+ * `/account/login`, and it audits what the server actually allowed: a sign-in the
+ * whitelist turns away is a failure even though the password was right.
+ */
+class LoginPageSecurityTest : WebEndToEndTest() {
+
+	private val email = "author@test.com"
+	private val password = "password123!@#"
+
+	@Test
+	fun `the web login form records both a successful and a failed attempt`(): Unit = runBlocking {
+		doStartServer()
+		seedWhitelistedAccount(email, password, penName = "Test Author")
+
+		login(email, password)
+		val failed = postLogin(email, "wrong-password")
+
+		assertEquals(HttpStatusCode.OK, failed.status, "A rejected sign-in re-renders the login form")
+		assertContains(failed.bodyAsText(), "<form")
+
+		val attempts = recordedAttemptsFor(email)
+		assertEquals(2, attempts.size, "Both the successful and failed web sign-ins should be recorded")
+		assertTrue(attempts.any { it.success })
+		assertTrue(attempts.any { !it.success })
+	}
+
+	@Test
+	fun `a whitelist rejection is recorded as a failed attempt`(): Unit = runBlocking {
+		doStartServer()
+		seedWhitelistedAccount(email, password, penName = "Test Author")
+		database().serverDatabase.whiteListQueries.removeFromWhiteList(email)
+
+		val response = postLogin(email, password)
+
+		assertEquals(HttpStatusCode.OK, response.status, "A whitelist rejection must not hand out a session")
+
+		val attempts = recordedAttemptsFor(email)
+		assertEquals(1, attempts.size)
+		assertTrue(
+			attempts.none { it.success },
+			"Correct credentials the whitelist turned away are a denied sign-in, not a successful one",
+		)
+	}
+
+	@Test
+	fun `an attempt with no email is not recorded against an empty account`(): Unit = runBlocking {
+		doStartServer()
+		// Without an account the server is in setup mode and never reaches the login form.
+		seedWhitelistedAccount(email, password)
+
+		client().post(route("login")) {
+			contentType(ContentType.Application.FormUrlEncoded)
+			setBody("password=${URLEncoder.encode("whatever", "UTF-8")}")
+		}
+
+		val attempt = database().serverDatabase.loginAttemptQueries
+			.getRecentAttempts(10, 0)
+			.executeAsList()
+			.single()
+
+		assertNull(
+			attempt.email,
+			"A blank email must be null so it stays out of the per-account brute-force queries",
+		)
+	}
+
+	private suspend fun postLogin(email: String, password: String): HttpResponse =
+		client().post(route("login")) {
+			contentType(ContentType.Application.FormUrlEncoded)
+			setBody(
+				"email=${URLEncoder.encode(email, "UTF-8")}" +
+					"&password=${URLEncoder.encode(password, "UTF-8")}"
+			)
+		}
+
+	private fun recordedAttemptsFor(email: String) =
+		database().serverDatabase.loginAttemptQueries
+			.getRecentAttempts(10, 0)
+			.executeAsList()
+			.filter { it.email == email }
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringAlertTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringAlertTest.kt
@@ -54,7 +54,12 @@ class MonitoringAlertTest : BaseTest() {
 			configRepository = ConfigRepository(ServerConfigDao(db)),
 			metricsRepository = MetricsRepository(ApiMetricDao(db)),
 			errorRepository = errorRepository,
-			securityRepository = SecurityRepository(LoginAttemptDao(db), clock),
+			securityRepository = SecurityRepository(
+				LoginAttemptDao(db),
+				MonitoringState(),
+				LoggerFactory.getLogger("test"),
+				clock,
+			),
 			collector = MetricsCollector(clock),
 			userActivityCollector = UserActivityCollector(clock),
 			userActivityRepository = UserActivityRepository(UserActivityDao(db)),

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringMaintenanceJobLifecycleTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/MonitoringMaintenanceJobLifecycleTest.kt
@@ -111,7 +111,12 @@ class MonitoringMaintenanceJobLifecycleTest {
 			configRepository = configRepository,
 			metricsRepository = MetricsRepository(ApiMetricDao(db)),
 			errorRepository = ErrorRepository(ErrorLogDao(db), clock),
-			securityRepository = SecurityRepository(LoginAttemptDao(db), clock),
+			securityRepository = SecurityRepository(
+				LoginAttemptDao(db),
+				MonitoringState(),
+				LoggerFactory.getLogger("test"),
+				clock,
+			),
 			collector = MetricsCollector(clock),
 			userActivityCollector = UserActivityCollector(clock),
 			userActivityRepository = UserActivityRepository(UserActivityDao(db)),

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityAlertEmailTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityAlertEmailTest.kt
@@ -49,7 +49,12 @@ class SecurityAlertEmailTest : BaseTest() {
 	}
 
 	private fun job(email: FakeEmailService): Pair<MonitoringMaintenanceJob, SecurityRepository> {
-		val securityRepository = SecurityRepository(LoginAttemptDao(db), clock)
+		val securityRepository = SecurityRepository(
+			LoginAttemptDao(db),
+			MonitoringState(),
+			LoggerFactory.getLogger("test"),
+			clock,
+		)
 		val maintenance = MonitoringMaintenanceJob(
 			configRepository = ConfigRepository(ServerConfigDao(db)),
 			metricsRepository = MetricsRepository(ApiMetricDao(db)),

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/SecurityRepositoryTest.kt
@@ -1,0 +1,68 @@
+package com.darkrockstudios.apps.hammer.monitoring
+
+import com.darkrockstudios.apps.hammer.database.LoginAttemptDao
+import com.darkrockstudios.apps.hammer.e2e.util.SharedPostgresTestDatabase
+import com.darkrockstudios.apps.hammer.utils.BaseTest
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Clock
+
+/**
+ * The monitoring toggles are enforced by the repository, so every login route
+ * honors them without repeating the checks.
+ */
+class SecurityRepositoryTest : BaseTest() {
+
+	private lateinit var db: SharedPostgresTestDatabase
+	private val clock = Clock.System
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		db = SharedPostgresTestDatabase()
+		db.initialize()
+		setupKoin()
+	}
+
+	private fun repository(config: MonitoringConfig): SecurityRepository {
+		val state = MonitoringState().apply { update(config) }
+		return SecurityRepository(LoginAttemptDao(db), state, LoggerFactory.getLogger("test"), clock)
+	}
+
+	private fun recorded() = db.serverDatabase.loginAttemptQueries.getRecentAttempts(10, 0).executeAsList()
+
+	@Test
+	fun `login tracking off records nothing`() = runTest {
+		repository(MonitoringConfig(enabled = true, trackLoginAttempts = false))
+			.recordLoginAttempt("author@test.com", "203.0.113.7", success = false)
+
+		assertEquals(0, recorded().size)
+	}
+
+	@Test
+	fun `storing IPs off keeps the attempt but drops the address`() = runTest {
+		repository(MonitoringConfig(enabled = true, trackLoginAttempts = true, storeLoginIp = false))
+			.recordLoginAttempt("author@test.com", "203.0.113.7", success = false)
+
+		val attempt = recorded().single()
+		assertEquals("author@test.com", attempt.email)
+		assertNull(attempt.ip_address, "The operator disabled IP capture")
+	}
+
+	@Test
+	fun `emails are lower-cased and blank ones stored as null`() = runTest {
+		val repository = repository(MonitoringConfig(enabled = true, trackLoginAttempts = true))
+
+		repository.recordLoginAttempt("  Author@Test.com ", null, success = true)
+		repository.recordLoginAttempt("   ", null, success = false)
+
+		val attempts = recorded()
+		assertEquals(2, attempts.size)
+		assertEquals("author@test.com", attempts.single { it.success }.email)
+		assertNull(attempts.single { !it.success }.email, "Blank emails must not become an empty-string account")
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/UserActivityTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/monitoring/UserActivityTest.kt
@@ -159,7 +159,12 @@ class UserActivityTest : BaseTest() {
 			configRepository = configRepository,
 			metricsRepository = MetricsRepository(ApiMetricDao(db)),
 			errorRepository = ErrorRepository(ErrorLogDao(db), clock),
-			securityRepository = SecurityRepository(LoginAttemptDao(db), clock),
+			securityRepository = SecurityRepository(
+				LoginAttemptDao(db),
+				MonitoringState(),
+				LoggerFactory.getLogger("test"),
+				clock,
+			),
 			collector = MetricsCollector(clock),
 			userActivityCollector = collector,
 			userActivityRepository = repository,


### PR DESCRIPTION
## Problem

Failed sign-ins on hammer.ink never appeared on the admin Security monitoring page. The web login form (`POST /login`) never called `SecurityRepository.recordLoginAttempt` — only the API route `POST /account/login`, used by the desktop and mobile clients, was wired into the audit trail. Anyone signing in through the website was invisible to it.

This is unrelated to the recent `trustProxyForwarding` change; that fixed the recorded IP being `127.0.0.1`, not the missing rows.

## Changes

**`SecurityRepository` now owns the recording policy.** It checks `loginTrackingEnabled` itself, nulls the IP when `storeLoginIp` is off, stores blank emails as `null`, and logs rather than propagates a failed write. Both login routes just hand it the email, the source address, and the outcome — no call site can leak an IP or skip a gate by forgetting a check.

**`LoginPage.kt`**
- Records every web sign-in, success and failure.
- `success` is computed *after* the whitelist check, so a whitelist rejection audits as a failure the way the API path already records it. Auditing it as a success meant repeated valid-credential attempts against a blocked account produced zero failure rows and never tripped the brute-force alert.
- The `POST` is wrapped in `rateLimit(RateLimitName(LOGIN_RATE_LIMIT))`, matching `/account/login` and the setup page. The `GET` stays unlimited so page loads aren't throttled.

**Why blank emails matter:** `getBruteForceEmails` filters on `email IS NOT NULL`, so a scanner posting with no email field accumulated under an empty-string "account" and could fire an alert naming nobody.

**Why the write is guarded:** the audit insert sits between authentication and `sessions.set`, so an unguarded throw on a transient Postgres fault turned a valid sign-in into a 500. Recording is passive observation and shouldn't be able to deny a login.

## Tests

- `LoginPageSecurityTest` — success and failure both recorded (with response-status assertions), whitelist rejection recorded as a failure, blank email stored as `null`.
- `SecurityRepositoryTest` — tracking off records nothing, IP storage off keeps the row but drops the address, emails lower-cased and blanks nulled.
- Four existing monitoring tests updated for the new constructor.

421 tests across `e2e.*`, `frontend.*`, `monitoring.*` and `account.*` pass with no failures.

## Deployment note

The recorded IP is only meaningful when `trustProxyForwarding` is enabled in `config.toml`. hammer.ink already has it on; a fresh install behind a proxy will otherwise bucket every attempt under `127.0.0.1`.
