### PR TITLE
About: promote Dark Rock Studios attribution, hoist Cairn overlay above nav

### DIFF
--- a/common/src/commonMain/composeResources/values-de/strings_about_app.xml
+++ b/common/src/commonMain/composeResources/values-de/strings_about_app.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="about_description">Ein einfaches Werkzeug zum Erstellen von Geschichten.</string>
-	<string name="about_description_line_two">Ein freies und quelloffenes Projekt.</string>
 	<string name="about_community_header">Community</string>
 	<string name="about_community_discord_link">Discord</string>
 	<string name="about_community_reddit_link">Reddit</string>

--- a/common/src/commonMain/composeResources/values-es/strings_about_app.xml
+++ b/common/src/commonMain/composeResources/values-es/strings_about_app.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="about_description">Una herramienta sencilla para crear historias.</string>
-	<string name="about_description_line_two">Un proyecto gratuito y de código abierto.</string>
 	<string name="about_community_header">Comunidad</string>
 	<string name="about_community_discord_link">Discord</string>
 	<string name="about_community_reddit_link">Reddit</string>

--- a/common/src/commonMain/composeResources/values-fr/strings_about_app.xml
+++ b/common/src/commonMain/composeResources/values-fr/strings_about_app.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="about_description">Un outil pour rédiger des histoires.</string>
-	<string name="about_description_line_two">Un projet libre et open source.</string>
 	<string name="about_community_header">Communauté</string>
 	<string name="about_community_discord_link">Discord</string>
 	<string name="about_community_reddit_link">Reddit</string>

--- a/common/src/commonMain/composeResources/values-it/strings_about_app.xml
+++ b/common/src/commonMain/composeResources/values-it/strings_about_app.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="about_description">Uno strumento semplice per costruire storie.</string>
-	<string name="about_description_line_two">Un progetto gratuito e open source.</string>
 	<string name="about_community_header">Community</string>
 	<string name="about_community_discord_link">Discord</string>
 	<string name="about_community_reddit_link">Reddit</string>

--- a/common/src/commonMain/composeResources/values-pt-rBR/strings_about_app.xml
+++ b/common/src/commonMain/composeResources/values-pt-rBR/strings_about_app.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="about_description">Uma ferramenta simples para construir histórias.</string>
-	<string name="about_description_line_two">Um projeto livre e de código aberto.</string>
 	<string name="about_community_header">Comunidades</string>
 	<string name="about_community_discord_link">Discord</string>
 	<string name="about_community_reddit_link">Reddit</string>

--- a/common/src/commonMain/composeResources/values-uk/strings_about_app.xml
+++ b/common/src/commonMain/composeResources/values-uk/strings_about_app.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="about_description">Простий інструмент для створення історій.</string>
-	<string name="about_description_line_two">Безкоштовний проєкт із відкритим кодом.</string>
 	<string name="about_community_header">Спільнота</string>
 	<string name="about_community_discord_link">Discord</string>
 	<string name="about_community_reddit_link">Reddit</string>

--- a/common/src/commonMain/composeResources/values/strings_about_app.xml
+++ b/common/src/commonMain/composeResources/values/strings_about_app.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <resources>
 	<string name="about_description">A simple tool for building stories.</string>
-	<string name="about_description_line_two">A free and open source project.</string>
+
+	<string name="about_studio_header">Studio</string>
+	<string name="about_community_studio_attribution">Hammer is made by Dark Rock Studios, alongside a family of other privacy-respecting, open source apps.</string>
 
 	<string name="about_community_header">Community</string>
 	<string name="about_community_discord_link">Discord</string>

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectSelectScaffold.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectSelectScaffold.kt
@@ -1,7 +1,9 @@
 package com.darkrockstudios.apps.hammer.common.projectselection
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -11,7 +13,9 @@ import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.common.components.projectselection.ProjectSelection
@@ -21,6 +25,9 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
 import com.darkrockstudios.apps.hammer.common.compose.rootElement
 import com.darkrockstudios.apps.hammer.common.util.getAppVersionString
+import com.darkrockstudios.cairn.CairnAboutOverlay
+import com.darkrockstudios.cairn.CairnAppId
+import com.darkrockstudios.cairn.CairnConfig
 
 @OptIn(
 	ExperimentalMaterial3WindowSizeClassApi::class,
@@ -30,17 +37,39 @@ import com.darkrockstudios.apps.hammer.common.util.getAppVersionString
 @Composable
 fun ProjectSelectScaffold(component: ProjectSelection) {
 	val windowSizeClass = calculateWindowSizeClass()
+	var showStudio by remember { mutableStateOf(false) }
 
-	when (windowSizeClass.widthSizeClass) {
-		WindowWidthSizeClass.Compact -> CompactNavigation(component)
-		WindowWidthSizeClass.Medium,
-		WindowWidthSizeClass.Expanded -> RailNavigation(component)
+	// The overlay is hoisted above the nav rail/bottom bar so its ceremony
+	// covers the whole window, not just the content pane.
+	Box(modifier = Modifier.fillMaxSize()) {
+		when (windowSizeClass.widthSizeClass) {
+			WindowWidthSizeClass.Compact -> CompactNavigation(
+				component = component,
+				onShowStudio = { showStudio = true },
+			)
+
+			WindowWidthSizeClass.Medium,
+			WindowWidthSizeClass.Expanded -> RailNavigation(
+				component = component,
+				onShowStudio = { showStudio = true },
+			)
+		}
+
+		CairnAboutOverlay(
+			visible = showStudio,
+			config = CairnConfig(
+				currentAppId = CairnAppId.Hammer,
+				// Cairn stamps its own "v", ours already carries one.
+				versionName = getAppVersionString().removePrefix("v"),
+			),
+			onDismissed = { showStudio = false },
+		)
 	}
 }
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalComposeApi::class)
 @Composable
-private fun CompactNavigation(component: ProjectSelection) {
+private fun CompactNavigation(component: ProjectSelection, onShowStudio: () -> Unit) {
 	val stackState by component.stack.subscribeAsState()
 	Scaffold(
 		modifier = Modifier.defaultScaffold(),
@@ -48,6 +77,7 @@ private fun CompactNavigation(component: ProjectSelection) {
 		content = { scaffoldPadding ->
 			ProjectSelectionUi(
 				component,
+				onShowStudio = onShowStudio,
 				modifier = Modifier.rootElement(scaffoldPadding),
 			)
 		},
@@ -64,7 +94,7 @@ private fun CompactNavigation(component: ProjectSelection) {
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalComposeApi::class)
 @Composable
-private fun RailNavigation(component: ProjectSelection) {
+private fun RailNavigation(component: ProjectSelection, onShowStudio: () -> Unit) {
 	val stackState by component.stack.subscribeAsState()
 	val navRailState by component.navRailState.subscribeAsState()
 	Scaffold(
@@ -88,7 +118,7 @@ private fun RailNavigation(component: ProjectSelection) {
 					},
 				)
 
-				ProjectSelectionUi(component)
+				ProjectSelectionUi(component, onShowStudio = onShowStudio)
 			}
 		},
 	)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectSelectionUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/ProjectSelectionUi.kt
@@ -66,6 +66,7 @@ fun ProjectSelection.Locations.toHdBottomBarDestination(): HdBottomBarDestinatio
 @Composable
 fun ProjectSelectionUi(
 	component: ProjectSelection,
+	onShowStudio: () -> Unit,
 	modifier: Modifier = Modifier
 ) {
 	// SetScreenCharacteristics only fires inside ProjectRootUi by default,
@@ -104,6 +105,7 @@ fun ProjectSelectionUi(
 
 					is ProjectSelection.Destination.AboutAppDestination -> AboutAppUi(
 						destination.component,
+						onShowStudio = onShowStudio,
 					)
 				}
 			}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/AboutAppUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/AboutAppUi.kt
@@ -45,8 +45,9 @@ import com.darkrockstudios.apps.hammer.about_community_discord_link
 import com.darkrockstudios.apps.hammer.about_community_github_link
 import com.darkrockstudios.apps.hammer.about_community_header
 import com.darkrockstudios.apps.hammer.about_community_reddit_link
+import com.darkrockstudios.apps.hammer.about_community_studio_attribution
 import com.darkrockstudios.apps.hammer.about_description
-import com.darkrockstudios.apps.hammer.about_description_line_two
+import com.darkrockstudios.apps.hammer.about_studio_header
 import com.darkrockstudios.apps.hammer.about_version_changes_button
 import com.darkrockstudios.apps.hammer.about_version_github_button
 import com.darkrockstudios.apps.hammer.app_name
@@ -66,17 +67,17 @@ import com.darkrockstudios.apps.hammer.common.compose.icons.Reddit
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 import com.darkrockstudios.apps.hammer.hammer_icon
-import com.darkrockstudios.cairn.CairnAboutOverlay
-import com.darkrockstudios.cairn.CairnAppId
-import com.darkrockstudios.cairn.CairnConfig
 import org.jetbrains.compose.resources.painterResource
 
 private val MaxColumnWidth = 880.dp
 
 @Composable
-fun AboutAppUi(component: AboutApp, modifier: Modifier = Modifier) {
+fun AboutAppUi(
+	component: AboutApp,
+	onShowStudio: () -> Unit,
+	modifier: Modifier = Modifier,
+) {
 	var showLibraries by remember { mutableStateOf(false) }
-	var showStudio by remember { mutableStateOf(false) }
 	val state by component.state.subscribeAsState()
 	val screen = LocalScreenCharacteristic.current
 	val isCompact = screen.windowWidthClass == WindowWidthSizeClass.Compact
@@ -117,13 +118,17 @@ fun AboutAppUi(component: AboutApp, modifier: Modifier = Modifier) {
 
 							HdHairlineSection(
 								section = 1,
-								title = "MANUSCRIPT",
-								contentSpacing = 12.dp,
+								title = Res.string.about_studio_header.get(),
+								contentSpacing = 14.dp,
 							) {
 								Text(
-									text = Res.string.about_description_line_two.get(),
+									text = Res.string.about_community_studio_attribution.get(),
 									style = MaterialTheme.typography.bodyLarge,
 									color = MaterialTheme.colorScheme.onSurface,
+								)
+								HdHairlineButton(
+									label = Res.string.about_attribution_studio_button.get(),
+									onClick = onShowStudio,
 								)
 							}
 
@@ -159,7 +164,6 @@ fun AboutAppUi(component: AboutApp, modifier: Modifier = Modifier) {
 
 							AttributionSection(
 								onShowLibraries = { showLibraries = true },
-								onShowStudio = { showStudio = true },
 							)
 
 							PlatformAboutSection(component, section = 5)
@@ -182,43 +186,22 @@ fun AboutAppUi(component: AboutApp, modifier: Modifier = Modifier) {
 		}
 
 		LibrariesUi(showLibraries) { showLibraries = false }
-
-		CairnAboutOverlay(
-			visible = showStudio,
-			config = CairnConfig(
-				currentAppId = CairnAppId.Hammer,
-				// Cairn stamps its own "v", ours already carries one.
-				versionName = state.currentVersion.removePrefix("v"),
-			),
-			onDismissed = { showStudio = false },
-		)
 	}
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun AttributionSection(
 	onShowLibraries: () -> Unit,
-	onShowStudio: () -> Unit,
 ) {
 	HdHairlineSection(
 		section = 4,
 		title = Res.string.about_attribution_header.get(),
 		contentSpacing = 14.dp,
 	) {
-		FlowRow(
-			horizontalArrangement = Arrangement.spacedBy(14.dp),
-			verticalArrangement = Arrangement.spacedBy(14.dp),
-		) {
-			HdHairlineButton(
-				label = Res.string.about_attribution_libraries_button.get(),
-				onClick = onShowLibraries,
-			)
-			HdHairlineButton(
-				label = Res.string.about_attribution_studio_button.get(),
-				onClick = onShowStudio,
-			)
-		}
+		HdHairlineButton(
+			label = Res.string.about_attribution_libraries_button.get(),
+			onClick = onShowLibraries,
+		)
 	}
 }
 

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/AboutAppUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/AboutAppUi.Preview.kt
@@ -15,7 +15,7 @@ import com.darkrockstudios.apps.hammer.common.preview.globalSettingsPreview
 @Composable
 fun ScreenAboutAppUiPreview() {
 	AppTheme(globalSettingsPreview) {
-		AboutAppUi(previewComponent)
+		AboutAppUi(previewComponent, onShowStudio = {})
 	}
 }
 
@@ -24,7 +24,7 @@ fun ScreenAboutAppUiPreview() {
 fun ScreenAboutAppUiTabletPreview() {
 	KoinApplicationPreview {
 		TabletPreviewSurface {
-			AboutAppUi(previewComponent)
+			AboutAppUi(previewComponent, onShowStudio = {})
 		}
 	}
 }

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -57,6 +57,7 @@ kotlin {
 				implementation(project(":composeUi"))
 				implementation(libs.jetbrains.compose.components.ui.tooling.preview)
 				implementation(compose.desktop.currentOs)
+				implementation(libs.cairn)
 				implementation(libs.clikt)
 				implementation(libs.nucleus.darkmode.detector)
 				implementation(libs.nucleus.application)

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -173,6 +173,17 @@ compose.desktop {
 	}
 }
 
+// Nucleus' Tao popup layer opens its placeholder surface at 1x1, which a
+// Wayland compositor on a scaled output rejects as a protocol violation and
+// kills the client. XWayland has no such rule.
+// https://github.com/NucleusFramework/Nucleus/issues/502
+// Respects an explicit GDK_BACKEND so the Wayland path stays testable.
+if (org.gradle.internal.os.OperatingSystem.current().isLinux && System.getenv("GDK_BACKEND") == null) {
+	tasks.withType<JavaExec>().configureEach {
+		environment("GDK_BACKEND", "x11")
+	}
+}
+
 aboutLibraries {
 	export {
 		prettyPrint = true

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectSelectionWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectSelectionWindow.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.desktop
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -12,7 +13,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
@@ -43,6 +46,9 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.projectselection.ProjectSelectionUi
 import com.darkrockstudios.apps.hammer.common.projectselection.toHdNavRailDestination
 import com.darkrockstudios.apps.hammer.common.util.getAppVersionString
+import com.darkrockstudios.cairn.CairnAboutOverlay
+import com.darkrockstudios.cairn.CairnAppId
+import com.darkrockstudios.cairn.CairnConfig
 import dev.nucleusframework.application.NucleusApplicationScope
 import dev.nucleusframework.window.material.MaterialDecoratedWindow
 import dev.nucleusframework.window.material.MaterialTitleBar
@@ -124,40 +130,56 @@ internal fun NucleusApplicationScope.ProjectSelectionWindow(
 fun Content(component: ProjectSelection) {
 	val stackState by component.stack.subscribeAsState()
 	val navRailState by component.navRailState.subscribeAsState()
+	var showStudio by remember { mutableStateOf(false) }
 
 	val destinations = ProjectSelection.Locations.entries.map { it.toHdNavRailDestination() }
 
-	Scaffold(
-		modifier = Modifier
-			.fillMaxSize()
-			.background(MaterialTheme.colorScheme.background),
-		content = { innerPadding ->
-			Row(
-				modifier = Modifier
-					.padding(innerPadding)
-					.fillMaxSize()
-					.background(MaterialTheme.colorScheme.background)
-			) {
-				HdNavRail(
-					destinations = destinations,
-					selectedId = stackState.active.configuration.location,
-					onSelect = { component.showLocation(it) },
-					expanded = navRailState.expanded,
-					onToggleExpanded = { component.toggleNavRailExpanded() },
-					footer = {
-						val versionText = remember { getAppVersionString() }
-						HdMonoLabel(
-							text = versionText,
-							color = MaterialTheme.colorScheme.onSurfaceVariant,
-						)
-					},
-				)
+	// The overlay is hoisted above the nav rail so its ceremony covers the
+	// whole window, not just the content pane.
+	Box(modifier = Modifier.fillMaxSize()) {
+		Scaffold(
+			modifier = Modifier
+				.fillMaxSize()
+				.background(MaterialTheme.colorScheme.background),
+			content = { innerPadding ->
+				Row(
+					modifier = Modifier
+						.padding(innerPadding)
+						.fillMaxSize()
+						.background(MaterialTheme.colorScheme.background)
+				) {
+					HdNavRail(
+						destinations = destinations,
+						selectedId = stackState.active.configuration.location,
+						onSelect = { component.showLocation(it) },
+						expanded = navRailState.expanded,
+						onToggleExpanded = { component.toggleNavRailExpanded() },
+						footer = {
+							val versionText = remember { getAppVersionString() }
+							HdMonoLabel(
+								text = versionText,
+								color = MaterialTheme.colorScheme.onSurfaceVariant,
+							)
+						},
+					)
 
-				ProjectSelectionUi(
-					component,
-					Modifier.padding(start = Ui.Padding.XL, top = Ui.Padding.XL)
-				)
-			}
-		},
-	)
+					ProjectSelectionUi(
+						component,
+						onShowStudio = { showStudio = true },
+						modifier = Modifier.padding(start = Ui.Padding.XL, top = Ui.Padding.XL),
+					)
+				}
+			},
+		)
+
+		CairnAboutOverlay(
+			visible = showStudio,
+			config = CairnConfig(
+				currentAppId = CairnAppId.Hammer,
+				// Cairn stamps its own "v", ours already carries one.
+				versionName = getAppVersionString().removePrefix("v"),
+			),
+			onDismissed = { showStudio = false },
+		)
+	}
 }


### PR DESCRIPTION
## Summary
- Replaces the About screen's "Manuscript" section with a "Studio" section (made-by attribution + button that opens the Cairn overlay), giving it top billing above Community.
- Hoists the Cairn overlay from `AboutAppUi` up to the nav shell (`ProjectSelectScaffold` for Android/iOS, `ProjectSelectionWindow`'s `Content` for desktop) so its full-screen ceremony covers the nav rail/bottom bar too, not just the About content pane.
- Adds `libs.cairn` directly to the `desktop` module since it now references Cairn types outside of `composeUi`.
- Drops the now-unused `about_description_line_two` string.
- Unrelated: forces `GDK_BACKEND=x11` for Nucleus' Tao popup layer on Linux until upstream fixes Wayland support.

## Test plan
- [x] `:composeUi:compileKotlinDesktop`, `:desktop:compileKotlinJvm`, `:composeUi:compileAndroidMain`, `:android:compileDebugKotlin`, `:composeUi:compileKotlinIosSimulatorArm64` all build clean
- [x] Ran the desktop app and visually confirmed the reworked About screen and the overlay covering the nav rail