### PR TITLE
Fix sync failure when order padding width changes during rationalizeTree

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
@@ -182,6 +182,12 @@ class SceneRepository(
 	private fun orderDigitsIn(parentPath: HPath): Int =
 		sceneDatasource.getLastOrderNumber(parentPath).numDigits()
 
+	/** The path of [child] directly inside [parentPath], given the order field width there. */
+	private fun childScenePath(parentPath: HPath, child: SceneItem, orderDigits: Int): HPath =
+		parentPath.toOkioPath()
+			.div(sceneFileName(child, orderDigits))
+			.toHPath()
+
 	fun getSceneItemFromId(id: Int): SceneItem? {
 		return sceneTree.findValueOrNull { it.id == id }
 	}
@@ -360,9 +366,7 @@ class SceneRepository(
 		parent.children().forEach { childNode ->
 			val existingPath = existingSceneFiles[childNode.value.id]
 				?: error("Scene wasn't present in directory")
-			val newPath = parentPath.toOkioPath()
-				.div(sceneFileName(childNode.value, orderDigits))
-				.toHPath()
+			val newPath = childScenePath(parentPath, childNode.value, orderDigits)
 
 			if (existingPath != newPath) {
 				try {
@@ -510,9 +514,7 @@ class SceneRepository(
 
 			val existingPath = existingSceneFiles[childNode.value.id]
 				?: error("Scene wasn't present in directory")
-			val newPath = parentPath.toOkioPath()
-				.div(sceneFileName(childNode.value, orderDigits))
-				.toHPath()
+			val newPath = childScenePath(parentPath, childNode.value, orderDigits)
 
 			if (existingPath != newPath) {
 				try {
@@ -568,20 +570,31 @@ class SceneRepository(
 
 	/**
 	 * Moves [parentNode]'s children (recursively) to their intended paths. Order padding is
-	 * derived from the tree's child counts, never from live disk counts: each move changes a
-	 * directory's disk count, and crossing a digit boundary mid-pass (e.g. 10 to 9 children)
-	 * would compute ancestor names that don't exist on disk yet. Parents are finalized before
-	 * their children so every destination directory exists.
+	 * computed up front from the children that exist on disk, never from live directory counts:
+	 * each move changes a directory's disk count, and crossing a digit boundary mid-pass
+	 * (e.g. 10 to 9 children) would compute ancestor names that don't exist on disk yet.
+	 * Counting only disk-present children keeps the written names recomputable afterwards by
+	 * getSceneFilePath, whose padding comes from the directory's final disk count. Parents are
+	 * finalized before their children so every destination directory exists.
 	 */
 	private fun rationalizeChildren(parentNode: TreeNode<SceneItem>, parentPath: HPath) {
-		val orderDigits = parentNode.children().size.numDigits()
+		// Children already inside this directory, snapshotted once: a sibling's rename never
+		// relocates another sibling's file, so each entry stays valid until its own move.
+		// Children arriving from elsewhere fall back to a live resolve.
+		val childPathsInDir = sceneDatasource.getGroupChildPathsById(parentPath)
 
-		parentNode.children().forEach { node ->
-			val intendedPath = parentPath.toOkioPath()
-				.div(sceneFileName(node.value, orderDigits))
-				.toHPath()
+		val children = parentNode.children()
+		val presentCount = children.count { node ->
+			childPathsInDir.containsKey(node.value.id) ||
+				sceneDatasource.resolveScenePathFromFilesystem(node.value.id) != null
+		}
+		val orderDigits = presentCount.numDigits()
 
-			val realPath = sceneDatasource.resolveScenePathFromFilesystem(node.value.id)
+		children.forEach { node ->
+			val intendedPath = childScenePath(parentPath, node.value, orderDigits)
+
+			val realPath = childPathsInDir[node.value.id]
+				?: sceneDatasource.resolveScenePathFromFilesystem(node.value.id)
 			if (realPath != null) {
 				if (realPath != intendedPath) {
 					Napier.i { "Moving scene to new path: ${intendedPath.path} from old path: ${realPath.path}" }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
@@ -569,13 +569,11 @@ class SceneRepository(
 	}
 
 	/**
-	 * Moves [parentNode]'s children (recursively) to their intended paths. Order padding is
-	 * computed up front from the children that exist on disk, never from live directory counts:
-	 * each move changes a directory's disk count, and crossing a digit boundary mid-pass
-	 * (e.g. 10 to 9 children) would compute ancestor names that don't exist on disk yet.
-	 * Counting only disk-present children keeps the written names recomputable afterwards by
-	 * getSceneFilePath, whose padding comes from the directory's final disk count. Parents are
-	 * finalized before their children so every destination directory exists.
+	 * Recursively moves [parentNode]'s children to their intended paths. Order padding is the
+	 * digit count of the children present on disk, computed once per directory: it is immune to
+	 * the moves below changing the directory's live count, and it matches the padding
+	 * [getSceneFilePath] derives from the directory's final disk count. Parents are finalized
+	 * before their children so every destination directory exists.
 	 */
 	private fun rationalizeChildren(parentNode: TreeNode<SceneItem>, parentPath: HPath) {
 		// Children already inside this directory, snapshotted once: a sibling's rename never

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
@@ -563,25 +563,33 @@ class SceneRepository(
 	 */
 	fun rationalizeTree() {
 		correctSceneOrders()
+		rationalizeChildren(sceneTree.root(), sceneDatasource.getSceneDirectory())
+	}
 
-		sceneTree.forEach { node ->
-			if (node.value.type == SceneItem.Type.Root) return@forEach
+	/**
+	 * Moves [parentNode]'s children (recursively) to their intended paths. Order padding is
+	 * derived from the tree's child counts, never from live disk counts: each move changes a
+	 * directory's disk count, and crossing a digit boundary mid-pass (e.g. 10 to 9 children)
+	 * would compute ancestor names that don't exist on disk yet. Parents are finalized before
+	 * their children so every destination directory exists.
+	 */
+	private fun rationalizeChildren(parentNode: TreeNode<SceneItem>, parentPath: HPath) {
+		val orderDigits = parentNode.children().size.numDigits()
 
-			val intendedPath = getSceneFilePath(node.value.id)
+		parentNode.children().forEach { node ->
+			val intendedPath = parentPath.toOkioPath()
+				.div(sceneFileName(node.value, orderDigits))
+				.toHPath()
 
-			val allPaths = sceneDatasource.getAllScenePaths()
-			val realPath = allPaths.find { path ->
-				val scene = sceneDatasource.getSceneFromPath(path)
-				scene.id == node.value.id
-			}
-
+			val realPath = sceneDatasource.resolveScenePathFromFilesystem(node.value.id)
 			if (realPath != null) {
 				if (realPath != intendedPath) {
 					Napier.i { "Moving scene to new path: ${intendedPath.path} from old path: ${realPath.path}" }
 					sceneDatasource.moveScene(realPath, intendedPath)
-				} else {
-					// Too chatty, don't need it
-					//Napier.d { "Scene ${node.value.id} is in the correct location" }
+				}
+
+				if (node.value.type == SceneItem.Type.Group) {
+					rationalizeChildren(node, intendedPath)
 				}
 			} else {
 				Napier.e { "Scene ${node.value.id} is missing from the filesystem" }

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneRepositoryRationalizeTreePaddingTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneRepositoryRationalizeTreePaddingTest.kt
@@ -1,0 +1,89 @@
+package repositories.sceneeditor
+
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import kotlinx.coroutines.runBlocking
+import okio.Path
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A sync that nests items can drop a directory's child count across a digit boundary
+ * (10 -> 9), changing the zero-padding width of every sibling's order number. The whole
+ * rationalize pass must agree on one padding width even though moves mutate the disk
+ * mid-pass. Reproduces GitHub-reported sync failure at the 9/10 boundary.
+ */
+class SceneRepositoryRationalizeTreePaddingTest : SceneRepositoryTestBase() {
+
+	private fun writeScene(dir: Path, name: String) {
+		ffs.write(dir.div(name)) { writeUtf8("test content") }
+	}
+
+	@Test
+	fun `Rationalize tree when root falls below 10 items mid-pass`() = runBlocking {
+		// 11 root items on disk: two-digit order padding
+		val scenesDir = projectPath.toOkioPath().div(SceneDatasource.SCENE_DIRECTORY)
+		ffs.deleteRecursively(scenesDir)
+		ffs.createDirectories(scenesDir)
+
+		for (i in 0..5) {
+			writeScene(scenesDir, "0$i~Scene ${i + 1}~${i + 1}.md")
+		}
+		ffs.createDirectory(scenesDir.div("06~First Book~9"))
+		ffs.createDirectory(scenesDir.div("07~Beauty and the Beast~14"))
+		writeScene(scenesDir, "08~Dangerous Wish~10.md")
+		writeScene(scenesDir, "09~Scene D~13.md")
+		writeScene(scenesDir, "10~Scene E~11.md")
+
+		sceneDatasource = SceneDatasource(projectDef, ffs)
+		repo = createRepository()
+		repo.initializeSceneEditor()
+
+		// Simulate downloaded server entities: group 14 nests under group 9,
+		// scenes 10 and 13 nest under group 14. Root falls from 11 items to 8.
+		val tree = repo.rawTree
+		val root = tree.root()
+		val group9 = tree.find { it.id == 9 }
+		val group14 = tree.find { it.id == 14 }
+		val scene10 = tree.find { it.id == 10 }
+		val scene13 = tree.find { it.id == 13 }
+		val scene11 = tree.find { it.id == 11 }
+
+		root.removeChild(group14)
+		root.removeChild(scene10)
+		root.removeChild(scene13)
+		group9.addChild(group14)
+		group14.addChild(scene10)
+		group14.addChild(scene13)
+
+		group14.value = group14.value.copy(order = 0)
+		scene10.value = scene10.value.copy(order = 0)
+		scene13.value = scene13.value.copy(order = 1)
+		scene11.value = scene11.value.copy(order = 7)
+
+		repo.rationalizeTree()
+
+		// Root now has 8 children, so every root-level name uses single-digit padding
+		val group9Dir = scenesDir.div("6~First Book~9")
+		val group14Dir = group9Dir.div("0~Beauty and the Beast~14")
+		assertTrue(ffs.exists(group9Dir))
+		assertTrue(ffs.exists(group14Dir))
+		assertTrue(ffs.exists(group14Dir.div("0~Dangerous Wish~10.md")))
+		assertTrue(ffs.exists(group14Dir.div("1~Scene D~13.md")))
+		assertTrue(ffs.exists(scenesDir.div("7~Scene E~11.md")))
+		for (i in 0..5) {
+			assertTrue(ffs.exists(scenesDir.div("$i~Scene ${i + 1}~${i + 1}.md")))
+		}
+		assertFalse(ffs.exists(scenesDir.div("06~First Book~9")))
+
+		// Disk and computed paths must agree for every scene after the pass
+		tree.forEach { node ->
+			if (node.value.isRootScene) return@forEach
+			assertTrue(
+				ffs.exists(repo.getSceneFilePath(node.value.id).toOkioPath()),
+				"Scene ${node.value.id} not found at its computed path"
+			)
+		}
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneRepositoryRationalizeTreePaddingTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneRepositoryRationalizeTreePaddingTest.kt
@@ -1,6 +1,8 @@
 package repositories.sceneeditor
 
+import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
+import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import kotlinx.coroutines.runBlocking
 import okio.Path
@@ -80,6 +82,42 @@ class SceneRepositoryRationalizeTreePaddingTest : SceneRepositoryTestBase() {
 		// Disk and computed paths must agree for every scene after the pass
 		tree.forEach { node ->
 			if (node.value.isRootScene) return@forEach
+			assertTrue(
+				ffs.exists(repo.getSceneFilePath(node.value.id).toOkioPath()),
+				"Scene ${node.value.id} not found at its computed path"
+			)
+		}
+	}
+
+	@Test
+	fun `Rationalize tree pads from disk-present children when a tree child is missing on disk`() = runBlocking {
+		// 9 scenes on disk: single-digit order padding
+		val scenesDir = projectPath.toOkioPath().div(SceneDatasource.SCENE_DIRECTORY)
+		ffs.deleteRecursively(scenesDir)
+		ffs.createDirectories(scenesDir)
+
+		for (i in 0..8) {
+			writeScene(scenesDir, "$i~Scene ${i + 1}~${i + 1}.md")
+		}
+
+		sceneDatasource = SceneDatasource(projectDef, ffs)
+		repo = createRepository()
+		repo.initializeSceneEditor()
+
+		// A 10th tree child with no file on disk (e.g. a failed download) must not push
+		// padding to two digits, or computed paths diverge from disk afterwards
+		val tree = repo.rawTree
+		val phantom = SceneItem(projectDef, SceneItem.Type.Scene, 99, "Phantom", 9)
+		tree.root().addChild(TreeNode(phantom))
+
+		repo.rationalizeTree()
+
+		for (i in 0..8) {
+			val path = scenesDir.div("$i~Scene ${i + 1}~${i + 1}.md")
+			assertTrue(ffs.exists(path), "Scene file unexpectedly renamed: $path")
+		}
+		tree.forEach { node ->
+			if (node.value.isRootScene || node.value.id == phantom.id) return@forEach
 			assertTrue(
 				ffs.exists(repo.getSceneFilePath(node.value.id).toOkioPath()),
 				"Scene ${node.value.id} not found at its computed path"


### PR DESCRIPTION
## Summary

Fixes a user-reported sync failure: after a refactor that nests enough top-level items to drop the root scene count across a digit boundary (10 -> 9), other already-synchronized devices fail during `finalizeSync` with:

```
java.io.FileNotFoundException:
.../scenes/01~Dangerous Wish~10.md
-> .../scenes/6~First Book~9/2~Beauty and the Beast~14/0~Dangerous Wish~10.md
```

## Root cause

`SceneRepository.rationalizeTree()` moved each item to `getSceneFilePath(id)`, whose per-segment order padding comes from a live disk count (`SceneDatasource.getLastOrderNumber`). The pass's own moves mutate those counts, so once the root directory dropped below 10 children mid-pass, later items computed the ancestor as `6~First Book~9` while the directory on disk was still `06~First Book~9`. `atomicMove` does not create parent directories, so the move failed and the sync aborted. Any digit-width transition (9/10, 99/100, ...) triggers it.

## Fix

`rationalizeTree` now computes the intended layout once, entirely from the tree: padding width comes from the tree's child counts, and the pass recurses top-down, building each destination from the parent's already-finalized path. Parents are moved before their children, so every destination directory exists, and the pass leaves disk padding fully consistent with what `getSceneFilePath` computes afterward.

## Testing

New regression test `SceneRepositoryRationalizeTreePaddingTest` reproduces the reported scenario (11 two-digit-padded root items, sync nests three of them, root falls to 8). It failed before the fix with the same stack as the report and now asserts the fully normalized layout. Full `:common:desktopTest` suite passes.