### PR TITLE
Render story prose the way the editor shows it, on the web and in every export

### DIFF
--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/markdown/ProseHtml.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/markdown/ProseHtml.kt
@@ -1,0 +1,138 @@
+package com.darkrockstudios.apps.hammer.base.markdown
+
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.LeafASTNode
+import org.intellij.markdown.ast.accept
+import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
+import org.intellij.markdown.html.GeneratingProvider
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.html.SimpleTagProvider
+import org.intellij.markdown.html.TrimmingInlineHolderProvider
+import org.intellij.markdown.parser.LinkMap
+
+/**
+ * How a story's markdown becomes HTML, shared by every surface that renders prose for a reader: the
+ * web pages the server serves and the EPUB the client exports.
+ *
+ * CommonMark reflows prose. A run of single-newline lines collapses into one block and any run of
+ * blank lines collapses to one paragraph break, so a page of dialogue arrives as a wall of text that
+ * looks nothing like what the writer sees in the editor. These providers lay the text out as it was
+ * typed instead: every newline starts a new line, and every blank line is a blank line.
+ *
+ * Only prose is touched. Lists, tables, code and headings keep markdown's own layout, and blank
+ * lines next to them add nothing — those blocks carry their own spacing already.
+ */
+object ProseHtml {
+
+	/** Upper bound on the breaks one run of blank lines can produce. */
+	const val MAX_CONSECUTIVE_BREAKS = 6
+
+	/**
+	 * The generating providers [flavour] would use, with prose layout applied. Pass the result to
+	 * [HtmlGenerator].
+	 */
+	fun providers(
+		flavour: MarkdownFlavourDescriptor,
+		linkMap: LinkMap,
+	): Map<IElementType, GeneratingProvider> =
+		flavour.createHtmlGeneratingProviders(linkMap, null) + mapOf(
+			MarkdownElementTypes.PARAGRAPH to ProseParagraphProvider,
+			MarkdownElementTypes.MARKDOWN_FILE to ProseContainerProvider("body"),
+			MarkdownElementTypes.BLOCK_QUOTE to ProseContainerProvider("blockquote"),
+		)
+
+	/**
+	 * The parser only ends a line on `\n`. Content written on Windows, or imported from a file that
+	 * was, arrives with `\r\n` and would otherwise parse as one run-on paragraph.
+	 */
+	fun normalizeLineEndings(markdown: String): String = markdown.replace(CARRIAGE_RETURN, "\n")
+
+	private val CARRIAGE_RETURN = Regex("\r\n?")
+}
+
+/**
+ * A paragraph of prose keeps the lines the author typed: each becomes its own paragraph.
+ *
+ * This relies on the reader's stylesheet giving paragraph siblings no vertical margin, so
+ * consecutive lines sit directly under one another and each picks up the first-line indent, exactly
+ * as the editor draws them.
+ */
+private object ProseParagraphProvider : TrimmingInlineHolderProvider() {
+	override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+		visitor.consumeTagOpen(node, "p")
+	}
+
+	override fun closeTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+		visitor.consumeTagClose("p")
+	}
+
+	override fun processNode(
+		visitor: HtmlGenerator.HtmlGeneratingVisitor,
+		text: String,
+		node: ASTNode,
+	) {
+		val children = childrenToRender(node)
+		openTag(visitor, text, node)
+
+		children.forEachIndexed { index, child ->
+			when {
+				// An edge newline would only open or close an empty paragraph.
+				child.type == MarkdownTokenTypes.EOL -> {
+					if (index != 0 && index != children.lastIndex) {
+						closeTag(visitor, text, node)
+						openTag(visitor, text, node)
+					}
+				}
+
+				// The trailing spaces of a hard break are redundant: the newline itself breaks here.
+				child.type == MarkdownTokenTypes.HARD_LINE_BREAK -> Unit
+
+				child is LeafASTNode -> visitor.visitLeaf(child)
+				else -> child.accept(visitor)
+			}
+		}
+
+		closeTag(visitor, text, node)
+	}
+}
+
+/** Emits a break for each blank line the author left between two paragraphs. */
+private class ProseContainerProvider(tag: String) : SimpleTagProvider(tag) {
+	override fun processNode(
+		visitor: HtmlGenerator.HtmlGeneratingVisitor,
+		text: String,
+		node: ASTNode,
+	) {
+		openTag(visitor, text, node)
+
+		var newlines = 0
+		var afterParagraph = false
+		for (child in node.children) {
+			when (child.type) {
+				MarkdownTokenTypes.EOL -> newlines++
+				// A quote's own '>' markers sit between the lines they mark, and neither they nor
+				// stray indentation say anything about how far apart two passages are.
+				MarkdownTokenTypes.WHITE_SPACE, MarkdownTokenTypes.BLOCK_QUOTE -> Unit
+				else -> {
+					val isParagraph = child.type == MarkdownElementTypes.PARAGRAPH
+					if (afterParagraph && isParagraph) {
+						val breaks = (newlines - 1).coerceIn(0, ProseHtml.MAX_CONSECUTIVE_BREAKS)
+						repeat(breaks) { visitor.consumeHtml(BREAK) }
+					}
+					child.accept(visitor)
+					afterParagraph = isParagraph
+					newlines = 0
+				}
+			}
+		}
+
+		closeTag(visitor, text, node)
+	}
+
+	private companion object {
+		const val BREAK = "<br />"
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/DocxStoryRenderer.kt
@@ -512,9 +512,16 @@ private class MarkdownDocxWriter(
 	private val ctx: DocxRenderContext,
 ) {
 	fun render(markdown: String) {
-		for (block in parseProseMarkdown(markdown)) {
+		val blocks = parseProseMarkdown(markdown)
+		blocks.forEachIndexed { index, block ->
+			// Prose runs tight: the indent parts one line from the next, and the space a passage
+			// break wants is a blank line the author typed. Space after is for leaving prose behind.
+			val runsOn = blocks.getOrNull(index + 1)?.isProseLine == true
 			when (block) {
-				is ProseBlock.Paragraph -> paragraph(style = null, numId = null) { runs(block.spans) }
+				is ProseBlock.Paragraph ->
+					paragraph(style = null, numId = null, tight = runsOn) { runs(block.spans) }
+
+				ProseBlock.Blank -> paragraph(style = null, numId = null, tight = runsOn) {}
 				is ProseBlock.Heading -> paragraph(style = "Heading${block.level}", numId = null) { runs(block.spans) }
 				is ProseBlock.Listing -> {
 					val numbering = DocxListNumbering(ctx)
@@ -619,11 +626,17 @@ private class MarkdownDocxWriter(
 		}
 	}
 
-	private fun paragraph(style: String?, numId: Int?, ilvl: Int = 0, body: () -> Unit) {
+	private fun paragraph(
+		style: String?,
+		numId: Int?,
+		ilvl: Int = 0,
+		tight: Boolean = false,
+		body: () -> Unit,
+	) {
 		// Plain prose gets the first-line-indented body style; numbered paragraphs control their own indent.
 		val effectiveStyle = style ?: if (numId == null) "BodyText" else null
 		writer.w("p") {
-			if (effectiveStyle != null || numId != null) {
+			if (effectiveStyle != null || numId != null || tight) {
 				w("pPr") {
 					effectiveStyle?.let { wVal("pStyle", it) }
 					if (numId != null) {
@@ -632,6 +645,8 @@ private class MarkdownDocxWriter(
 							wVal("numId", numId.toString())
 						}
 					}
+					// Overrides the document default, which would otherwise gap every line of prose.
+					if (tight) w("spacing") { wAttr("after", "0") }
 				}
 			}
 			body()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/EpubStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/EpubStoryRenderer.kt
@@ -7,8 +7,10 @@ import io.documentnode.epub4kmp.epub.EpubWriter
 import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
 import okio.BufferedSink
+import com.darkrockstudios.apps.hammer.base.markdown.ProseHtml
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkdownParser
 
 private data class TocEntry(val title: String, val href: String)
@@ -84,6 +86,8 @@ private fun buildStylesheet(theme: ProjectTheme?): Stylesheet = stylesheet {
 	// Title page presentation — applies even without a theme.
 	raw(
 		"""
+		/* Each authored line is its own paragraph, so the indent has to be the only separator */
+		p { margin: 0; }
 		body.title-page { text-align: center; margin: 0; }
 		.title-page-inner { margin-top: 30%; padding: 0 2em; }
 		h1.book-title { font-size: 2.5em; margin: 0 0 0.4em 0; page-break-before: auto; }
@@ -172,8 +176,10 @@ private fun BODY.titlePageBody(projectName: String, authorName: String?) {
 private fun BODY.chapterBody(chapterTitle: String, markdown: String) {
 	h1(classes = "chapter-title") { +chapterTitle }
 	val flavour = GFMFlavourDescriptor()
-	val parsed = MarkdownParser(flavour).buildMarkdownTreeFromString(markdown)
-	val htmlBody = HtmlGenerator(markdown, parsed, flavour).generateHtml()
+	val source = ProseHtml.normalizeLineEndings(markdown)
+	val parsed = MarkdownParser(flavour).buildMarkdownTreeFromString(source)
+	val providers = ProseHtml.providers(flavour, LinkMap.buildLinkMap(parsed, source))
+	val htmlBody = HtmlGenerator(source, parsed, providers).generateHtml()
 	val xhtmlBody = htmlBody.selfCloseHtmlVoidTags()
 	unsafe { +xhtmlBody }
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfProseMarkdown.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/PdfProseMarkdown.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.components.projecthome
 
 import com.conamobile.pdfkmp.dsl.ContainerScope
+import com.darkrockstudios.apps.hammer.base.markdown.ProseHtml
 import com.darkrockstudios.apps.hammer.common.data.search.unescapeMarkdown
 import com.conamobile.pdfkmp.dsl.TextScope
 import com.conamobile.pdfkmp.geometry.Padding
@@ -52,14 +53,15 @@ internal fun ContainerScope.proseMarkdown(markdown: String, colors: ProseColors 
 			if (index > 0) {
 				val previous = blocks[index - 1]
 				when {
-					// Consecutive paragraphs carry their own separation via the indent.
-					previous is ProseBlock.Paragraph && block is ProseBlock.Paragraph -> Unit
+					// Prose carries its own separation: the indent, and the author's blank lines.
+					previous.isProseLine && block.isProseLine -> Unit
 					previous is ProseBlock.Heading -> spacer(height = HEADING_SPACING)
 					else -> spacer(height = BLOCK_SPACING)
 				}
 			}
 			when (block) {
 				is ProseBlock.Paragraph -> renderParagraph(block.spans, base, colors)
+				ProseBlock.Blank -> spacer(height = Dp(TextStyle().fontSize.value * BODY_LEADING))
 				is ProseBlock.Heading -> renderHeading(block, base, colors)
 				is ProseBlock.Listing -> renderListing(block, base, colors)
 				is ProseBlock.Quote -> renderQuote(block, base, colors)
@@ -94,7 +96,12 @@ internal data class ProseListItem(
 
 /** A block-level markdown element, reduced to what the prose layout renders. */
 internal sealed interface ProseBlock {
+	/** One line of prose as the author typed it. */
 	data class Paragraph(val spans: List<ProseSpan>) : ProseBlock
+
+	/** A blank line the author left between two passages. */
+	data object Blank : ProseBlock
+
 	data class Heading(val level: Int, val spans: List<ProseSpan>) : ProseBlock
 	data class Listing(val ordered: Boolean, val items: List<ProseListItem>) : ProseBlock
 	data class Quote(val paragraphs: List<List<ProseSpan>>) : ProseBlock
@@ -106,11 +113,20 @@ internal sealed interface ProseBlock {
 /**
  * Parses [markdown] into renderable blocks using the GFM flavour, so `~~strike~~`, pipe tables, and
  * autolinks are recognized. Unknown syntax degrades to paragraph text.
+ *
+ * Prose keeps the shape the author gave it, which is what the editor shows them: every newline
+ * starts a new [ProseBlock.Paragraph] and every blank line becomes a [ProseBlock.Blank]. CommonMark
+ * would reflow both away, turning a page of dialogue into one packed block.
  */
 internal fun parseProseMarkdown(markdown: String): List<ProseBlock> {
-	val root = MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(markdown)
-	return ProseWalker(markdown).blocks(root)
+	val source = ProseHtml.normalizeLineEndings(markdown)
+	val root = MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(source)
+	return ProseWalker(source).blocks(root)
 }
+
+/** True for the block kinds that make up running prose, as opposed to a structural block. */
+internal val ProseBlock.isProseLine: Boolean
+	get() = this is ProseBlock.Paragraph || this is ProseBlock.Blank
 
 // ---------------------------------------------------------------------------
 // AST walking
@@ -129,37 +145,99 @@ private val HEADING_LEVELS: Map<IElementType, Int> = mapOf(
 
 private class ProseWalker(private val source: String) {
 
-	fun blocks(root: ASTNode): List<ProseBlock> = root.children.mapNotNull { block(it) }
+	/**
+	 * Walks the top level, keeping the blank lines between prose passages. A run of newlines
+	 * separating two paragraphs is one more than the blank lines it contains; only prose gets them,
+	 * because a heading, list or rule carries its own spacing already.
+	 */
+	fun blocks(root: ASTNode): List<ProseBlock> {
+		val out = mutableListOf<ProseBlock>()
+		var newlines = 0
+		var afterProse = false
 
-	private fun block(node: ASTNode): ProseBlock? = when (node.type) {
-		MarkdownElementTypes.PARAGRAPH ->
-			inline(node).ifEmpty { null }?.let { ProseBlock.Paragraph(it) }
+		for (child in root.children) {
+			if (child.type == MarkdownTokenTypes.EOL) {
+				newlines++
+				continue
+			}
+			if (child.type == MarkdownTokenTypes.WHITE_SPACE) continue
 
-		in HEADING_LEVELS -> heading(node)
+			val produced = block(child)
+			if (produced.isEmpty()) continue
+
+			if (afterProse && produced.first().isProseLine) {
+				val blanks = (newlines - 1).coerceIn(0, ProseHtml.MAX_CONSECUTIVE_BREAKS)
+				repeat(blanks) { out += ProseBlock.Blank }
+			}
+			out += produced
+			afterProse = produced.last().isProseLine
+			newlines = 0
+		}
+
+		return out
+	}
+
+	private fun block(node: ASTNode): List<ProseBlock> = when (node.type) {
+		MarkdownElementTypes.PARAGRAPH -> paragraphs(node)
+
+		in HEADING_LEVELS -> listOfNotNull(heading(node))
 
 		MarkdownElementTypes.UNORDERED_LIST ->
-			ProseBlock.Listing(ordered = false, items = listItems(node, level = 0, ordered = false))
+			listOf(ProseBlock.Listing(ordered = false, items = listItems(node, level = 0, ordered = false)))
 
 		MarkdownElementTypes.ORDERED_LIST ->
-			ProseBlock.Listing(ordered = true, items = listItems(node, level = 0, ordered = true))
+			listOf(ProseBlock.Listing(ordered = true, items = listItems(node, level = 0, ordered = true)))
 
 		MarkdownElementTypes.BLOCK_QUOTE ->
-			quoteParagraphs(node).ifEmpty { null }?.let { ProseBlock.Quote(it) }
+			listOfNotNull(quoteParagraphs(node).ifEmpty { null }?.let { ProseBlock.Quote(it) })
 
-		MarkdownElementTypes.CODE_FENCE -> ProseBlock.CodeBlock(fenceContent(node))
-		MarkdownElementTypes.CODE_BLOCK -> ProseBlock.CodeBlock(indentedCode(node))
+		MarkdownElementTypes.CODE_FENCE -> listOf(ProseBlock.CodeBlock(fenceContent(node)))
+		MarkdownElementTypes.CODE_BLOCK -> listOf(ProseBlock.CodeBlock(indentedCode(node)))
 
-		MarkdownTokenTypes.HORIZONTAL_RULE -> ProseBlock.Rule
+		MarkdownTokenTypes.HORIZONTAL_RULE -> listOf(ProseBlock.Rule)
 
-		GFMElementTypes.TABLE -> table(node)
+		GFMElementTypes.TABLE -> listOfNotNull(table(node))
 
-		// Reference-link definitions and inter-block whitespace produce no output.
-		MarkdownElementTypes.LINK_DEFINITION,
-		MarkdownTokenTypes.EOL,
-		MarkdownTokenTypes.WHITE_SPACE,
-		-> null
+		// Reference-link definitions produce no output.
+		MarkdownElementTypes.LINK_DEFINITION -> emptyList()
 
-		else -> inline(node).ifEmpty { null }?.let { ProseBlock.Paragraph(it) }
+		else -> paragraphs(node)
+	}
+
+	/** A paragraph node, split into one block per line the author typed. */
+	private fun paragraphs(node: ASTNode): List<ProseBlock.Paragraph> =
+		if (node.children.isEmpty()) {
+			listOfNotNull(inline(node).ifEmpty { null }?.let { ProseBlock.Paragraph(it) })
+		} else {
+			lines(node).map { ProseBlock.Paragraph(it) }
+		}
+
+	/** The inline content of [holder], cut at every newline the author typed. */
+	private fun lines(holder: ASTNode): List<List<ProseSpan>> {
+		val lines = mutableListOf<List<ProseSpan>>()
+		var current = mutableListOf<ProseSpan>()
+
+		fun endLine() {
+			normalise(current).ifEmpty { null }?.let { lines += it }
+			current = mutableListOf()
+		}
+
+		for (child in holder.children) {
+			when (child.type) {
+				MarkdownTokenTypes.EOL -> endLine()
+
+				// The trailing spaces of a hard break are redundant: the newline itself breaks here.
+				MarkdownTokenTypes.HARD_LINE_BREAK -> Unit
+
+				// A quote's own '>' markers sit inside the paragraph, on every line but the first.
+				MarkdownTokenTypes.BLOCK_QUOTE -> Unit
+
+				else -> collect(child, Flags(), current)
+			}
+		}
+		endLine()
+
+		return lines
 	}
 
 	private fun heading(node: ASTNode): ProseBlock? {
@@ -214,7 +292,8 @@ private class ProseWalker(private val source: String) {
 				MarkdownTokenTypes.WHITE_SPACE,
 				-> Unit
 
-				else -> inline(child).ifEmpty { null }?.let { paragraphs += it }
+				// A quoted passage keeps its lines, the same as prose outside the quote.
+				else -> paragraphs += lines(child)
 			}
 		}
 		return paragraphs

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRenderer.kt
@@ -183,9 +183,15 @@ private fun themeColor(argb: String?): RtfColor? {
  */
 private fun renderMarkdownRtf(markdown: String, primary: RtfColor?, secondary: RtfColor?): List<RtfBlock> {
 	val blocks = mutableListOf<RtfBlock>()
-	for (block in parseProseMarkdown(markdown)) {
+	val parsed = parseProseMarkdown(markdown)
+	parsed.forEachIndexed { index, block ->
+		// Prose runs tight: the indent parts one line from the next, and the space a passage break
+		// wants is a blank line the author actually typed. Space after is for leaving prose behind.
+		val runsOn = parsed.getOrNull(index + 1)?.isProseLine == true
+		val proseSpaceAfter = if (runsOn) 0 else PARAGRAPH_SPACE_AFTER
 		when (block) {
-			is ProseBlock.Paragraph -> blocks += bodyParagraph(block.spans, primary)
+			is ProseBlock.Paragraph -> blocks += bodyParagraph(block.spans, primary, proseSpaceAfter)
+			ProseBlock.Blank -> blocks += bodyParagraph(emptyList(), primary, proseSpaceAfter)
 			is ProseBlock.Heading -> blocks += headingParagraph(block, primary, secondary)
 			is ProseBlock.Listing -> {
 				val numbering = RtfListNumbering()
@@ -201,9 +207,16 @@ private fun renderMarkdownRtf(markdown: String, primary: RtfColor?, secondary: R
 	return blocks
 }
 
-private fun bodyParagraph(spans: List<ProseSpan>, primary: RtfColor?): RtfParagraph = RtfParagraph(
+private fun bodyParagraph(
+	spans: List<ProseSpan>,
+	primary: RtfColor?,
+	spaceAfterTwips: Int = PARAGRAPH_SPACE_AFTER,
+): RtfParagraph = RtfParagraph(
 	content = coalesceRuns(spansToInlines(spans, RtfSpanStyle.Default, primary)),
-	style = RtfParagraphStyle(firstLineIndentTwips = BODY_FIRST_LINE_INDENT, spaceAfterTwips = PARAGRAPH_SPACE_AFTER),
+	style = RtfParagraphStyle(
+		firstLineIndentTwips = BODY_FIRST_LINE_INDENT,
+		spaceAfterTwips = spaceAfterTwips,
+	),
 )
 
 private fun headingParagraph(block: ProseBlock.Heading, primary: RtfColor?, secondary: RtfColor?): RtfParagraph {

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/RtfStoryRendererTest.kt
@@ -30,6 +30,42 @@ class RtfStoryRendererTest {
 		return buffer.readByteArray().decodeToString()
 	}
 
+	@Test
+	fun `every authored line becomes its own paragraph`() {
+		val rtf = render(listOf(StoryChapter("Alpha", "line one\nline two")))
+
+		// \fi360 opens a body paragraph; two lines means two of them.
+		assertEquals(2, Regex("""\\fi360""").findAll(rtf).count(), rtf)
+		assertTrue(rtf.contains("line one"), rtf)
+		assertTrue(rtf.contains("line two"), rtf)
+	}
+
+	@Test
+	fun `lines that run on into each other lose the gaps between them`() {
+		val chapter = render(listOf(StoryChapter("Alpha", "line one\nline two\nline three")))
+		// Isolate the chapter body: the front matter has paragraphs of its own.
+		val rtf = chapter.substring(chapter.indexOf("line one"))
+
+		// Only the last line leaves prose behind and so earns a gap after it.
+		assertEquals(
+			1,
+			Regex("""\\sa[1-9]""").findAll(rtf).count(),
+			"Prose that runs on into more prose must not push the next line down: $rtf",
+		)
+	}
+
+	@Test
+	fun `a blank line between passages becomes an empty paragraph`() {
+		val tight = render(listOf(StoryChapter("Alpha", "First passage.\nSecond passage.")))
+		val parted = render(listOf(StoryChapter("Alpha", "First passage.\n\nSecond passage.")))
+
+		assertEquals(
+			Regex("""\\fi360""").findAll(tight).count() + 1,
+			Regex("""\\fi360""").findAll(parted).count(),
+			"A blank line should add one empty body paragraph",
+		)
+	}
+
 	/** Counts brace nesting, ignoring the backslash-escaped `\{` and `\}` that appear in body text. */
 	private fun braceBalance(rtf: String): Int {
 		var depth = 0

--- a/common/src/desktopTest/kotlin/components/projecthome/DocxStoryRendererTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/DocxStoryRendererTest.kt
@@ -334,13 +334,36 @@ class DocxStoryRendererTest {
 	}
 
 	@Test
-	fun `soft line breaks within a paragraph stay in one paragraph`() {
+	fun `every authored line becomes its own paragraph`() {
 		val doc = render(listOf(StoryChapter("Alpha", "line one\nline two")))
 
 		val texts = doc.bodyParagraphs().map { it.text }
 		assertTrue(
-			texts.any { it.contains("line one") && it.contains("line two") },
-			"Soft-wrapped lines should join into a single paragraph, got $texts",
+			texts.contains("line one") && texts.contains("line two"),
+			"Authored lines should each stand alone, got $texts",
 		)
+	}
+
+	@Test
+	fun `a line that runs on into another loses the gap between them`() {
+		val doc = render(listOf(StoryChapter("Alpha", "line one\nline two")))
+
+		val first = doc.bodyParagraphs().first { it.text == "line one" }
+		assertEquals(
+			0,
+			(first.ctp.pPr?.spacing?.after as? java.math.BigInteger)?.toInt(),
+			"A line followed by more prose must not push the next line down",
+		)
+	}
+
+	@Test
+	fun `a blank line between passages becomes an empty paragraph`() {
+		val doc = render(listOf(StoryChapter("Alpha", "First passage.\n\nSecond passage.")))
+
+		val texts = doc.bodyParagraphs().map { it.text }
+		val first = texts.indexOf("First passage.")
+		val second = texts.indexOf("Second passage.")
+		assertEquals(first + 2, second, "Expected one empty paragraph between the passages, got $texts")
+		assertEquals("", texts[first + 1])
 	}
 }

--- a/common/src/desktopTest/kotlin/components/projecthome/EpubStoryRendererTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/EpubStoryRendererTest.kt
@@ -42,6 +42,30 @@ class EpubStoryRendererTest {
 	}
 
 	@Test
+	fun `every authored line becomes its own paragraph`() {
+		val content = render(listOf(StoryChapter("Alpha", "line one\nline two")))
+
+		assertTrue("<p>line one</p><p>line two</p>" in content, "Authored lines should each stand alone")
+	}
+
+	@Test
+	fun `a blank line between passages survives as a break`() {
+		val content = render(listOf(StoryChapter("Alpha", "First passage.\n\nSecond passage.")))
+
+		assertTrue(
+			"<p>First passage.</p><br /><p>Second passage.</p>" in content,
+			"The author's blank line should reach the reader",
+		)
+	}
+
+	@Test
+	fun `paragraphs carry no margin so the indent parts the lines`() {
+		val content = render(listOf(StoryChapter("Alpha", "Body.")))
+
+		assertTrue("p { margin: 0; }" in content, "Prose lines must not be gapped by a paragraph margin")
+	}
+
+	@Test
 	fun `contents page carries the localized title`() {
 		val content = render(listOf(StoryChapter("Alpha", "Body.")))
 		assertTrue("Contents" in content, "The TOC title should appear in the EPUB")

--- a/common/src/desktopTest/kotlin/components/projecthome/PdfProseMarkdownTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/PdfProseMarkdownTest.kt
@@ -23,12 +23,45 @@ class PdfProseMarkdownTest {
 	}
 
 	@Test
-	fun `paragraphs are split on blank lines and soft wraps become spaces`() {
-		val blocks = parseProseMarkdown("First line\ncontinues here.\n\nSecond paragraph.")
+	fun `every authored line becomes its own paragraph`() {
+		val blocks = parseProseMarkdown("First line.\nSecond line.\nThird line.")
 
-		assertEquals(2, blocks.size)
-		assertEquals("First line continues here.", paragraph(blocks[0]).spans.plain())
-		assertEquals("Second paragraph.", paragraph(blocks[1]).spans.plain())
+		assertEquals(3, blocks.size)
+		assertEquals("First line.", paragraph(blocks[0]).spans.plain())
+		assertEquals("Second line.", paragraph(blocks[1]).spans.plain())
+		assertEquals("Third line.", paragraph(blocks[2]).spans.plain())
+	}
+
+	@Test
+	fun `a blank line between passages survives as a blank block`() {
+		val blocks = parseProseMarkdown("First passage.\n\nSecond passage.")
+
+		assertEquals(3, blocks.size)
+		assertEquals("First passage.", paragraph(blocks[0]).spans.plain())
+		assertIs<ProseBlock.Blank>(blocks[1])
+		assertEquals("Second passage.", paragraph(blocks[2]).spans.plain())
+	}
+
+	@Test
+	fun `each blank line of a run counts`() {
+		val blocks = parseProseMarkdown("First passage.\n\n\n\nSecond passage.")
+
+		assertEquals(3, blocks.count { it is ProseBlock.Blank })
+	}
+
+	@Test
+	fun `a blank line beside a heading is left to the heading's own spacing`() {
+		val blocks = parseProseMarkdown("## Chapter One\n\nThe prose.\n\n\n## Chapter Two")
+
+		assertEquals(0, blocks.count { it is ProseBlock.Blank })
+	}
+
+	@Test
+	fun `Windows line endings lay out like any other`() {
+		val unix = parseProseMarkdown("First line.\nSecond line.\n\nAfter a blank line.")
+		val windows = parseProseMarkdown("First line.\r\nSecond line.\r\n\r\nAfter a blank line.")
+
+		assertEquals(unix, windows)
 	}
 
 	@Test
@@ -152,10 +185,22 @@ class PdfProseMarkdownTest {
 	}
 
 	@Test
-	fun `hard line break becomes a newline within the paragraph`() {
+	fun `hard line break parts the lines just as a plain newline does`() {
 		val blocks = parseProseMarkdown("line one  \nline two")
 
-		assertEquals("line one\nline two", paragraph(blocks.single()).spans.plain())
+		assertEquals(2, blocks.size)
+		assertEquals("line one", paragraph(blocks[0]).spans.plain())
+		assertEquals("line two", paragraph(blocks[1]).spans.plain())
+	}
+
+	@Test
+	fun `a quoted passage keeps its lines`() {
+		val blocks = parseProseMarkdown("> quote line one\n> quote line two")
+
+		val quote = assertIs<ProseBlock.Quote>(blocks.single())
+		assertEquals(2, quote.paragraphs.size)
+		assertEquals("quote line one", quote.paragraphs[0].plain())
+		assertEquals("quote line two", quote.paragraphs[1].plain())
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/components/projecthome/PdfProseVisualCheck.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/PdfProseVisualCheck.kt
@@ -17,17 +17,27 @@ class PdfProseVisualCheck {
 	@EnabledIfEnvironmentVariable(named = "PDF_VISUAL_CHECK", matches = "1")
 	fun `render sample pdf`() {
 		val markdown = """
-			The opening paragraph of a chapter sits flush against the margin, as is the convention in book typesetting. It runs long enough to wrap across several lines so the wrapping behaviour around the indent can be seen clearly on the page.
+			The opening paragraph of a chapter carries a first-line indent, as does every other. It runs long enough to wrap across several lines so the wrapping behaviour around the indent can be seen clearly on the page.
 
-			The second paragraph begins with a first-line indent, marking the paragraph break without a blank line. It also runs long enough to wrap, which shows that only the first line is indented and continuation lines return to the margin.
+			The second paragraph sits one blank line below, because that is the blank line the author typed. It also runs long enough to wrap, which shows that only the first line is indented and continuation lines return to the margin.
 
-			A third paragraph continues the prose with the same indent, with **bold**, *italic*, and ~~struck~~ words along the way to confirm inline styling still works.
+			A third paragraph continues the prose with **bold**, *italic*, and ~~struck~~ words along the way to confirm inline styling still works.
+
+			– Good evening, madame. I did not mean to disturb you.
+			– Think nothing of it, she said. I am only doing my work.
+			– Then perhaps you can tell me where the old medicines are kept, said the visitor, whose question ran on long enough to wrap onto a second line.
+
+			These lines of dialogue each stand on their own, exactly as they do in the editor.
+
+
+			Two blank lines above this one open a wider gap, the way the author asked for it.
 
 			---
 
-			After a scene break the next paragraph is flush again, signalling a fresh section to the reader.
+			After a scene break the prose continues.
 
-			And the one after it is indented once more.
+			> A quoted passage keeps its lines,
+			> one under the next.
 
 			## A Secondary Heading
 

--- a/docs/WEB-DESIGN-SYSTEM.md
+++ b/docs/WEB-DESIGN-SYSTEM.md
@@ -521,7 +521,7 @@ element markdown can emit has a rule:
 
 | Element      | Treatment                                                                       |
 |--------------|---------------------------------------------------------------------------------|
-| `p`          | 2em first-line indent on every prose paragraph, justified                       |
+| `p`          | One authored line: 2em first-line indent, justified, no margin between siblings |
 | `h1`         | The story title, in Kingthings at 2rem                                          |
 | `h2`         | Chapter heading: centered, with a dashed rule above it and 4rem of air, dropped on the first one |
 | `h3` / `h4`  | Kingthings, stepping down in size, 2.5rem above                                 |
@@ -533,8 +533,17 @@ element markdown can emit has a rule:
 | `code`       | Courier; a tinted pill when it sits inline in a paragraph or list item          |
 | `a`          | Accent-colored, underlined with a softened amber rule                           |
 
-`br` needs no rule: it is the break `MarkdownService` emits for each blank line past the first, and
-it inherits the prose line height.
+`br` needs no rule: it is the break `MarkdownService` emits for each blank line between two
+paragraphs, and it inherits the prose line height.
+
+Prose is laid out as the author typed it, which is what they see in the editor: every newline starts
+a new paragraph and every blank line is a blank line. Paragraph siblings carry no margin, so
+consecutive lines sit directly under one another and each takes the first-line indent. Headings,
+lists, quotes and rules keep their own spacing; blank lines next to them add nothing.
+
+The prose element declares the story's language (`lang` on `.story-content`) on both the author's
+page and the public reader page, so the browser hyphenates by the story's rules rather than the
+reader's UI locale.
 
 Below 600px the column is too narrow to justify without opening rivers, so paragraphs go ragged
 right and hyphenation is off.

--- a/docs/WEB-DESIGN-SYSTEM.md
+++ b/docs/WEB-DESIGN-SYSTEM.md
@@ -527,6 +527,7 @@ element markdown can emit has a rule:
 | `h3` / `h4`  | Kingthings, stepping down in size, 2.5rem above                                 |
 | `h5` / `h6`  | Uppercase, letter-spaced and secondary-colored rather than larger               |
 | `ul` / `ol`  | 3.5em indent so markers sit inside the prose indent, 0.75em between items, accent markers |
+| `table`      | Centered, hairline-ruled, scrolls inside itself; header row in Kingthings on a tint |
 | `hr`         | Centered short rule with an amber diamond, 3rem of air above and below           |
 | `blockquote` | Tinted panel, amber left rule, italic, with `em` flipped upright inside          |
 | `pre`        | Tinted box that wraps rather than overflows the column                          |
@@ -536,10 +537,15 @@ element markdown can emit has a rule:
 `br` needs no rule: it is the break `MarkdownService` emits for each blank line between two
 paragraphs, and it inherits the prose line height.
 
-Prose is laid out as the author typed it, which is what they see in the editor: every newline starts
-a new paragraph and every blank line is a blank line. Paragraph siblings carry no margin, so
-consecutive lines sit directly under one another and each takes the first-line indent. Headings,
-lists, quotes and rules keep their own spacing; blank lines next to them add nothing.
+Prose is laid out as the author typed it, which is what they see in the editor: every newline in a
+paragraph starts a new line and every blank line is a blank line. Paragraph siblings carry no
+margin, so consecutive lines sit directly under one another and each takes the first-line indent.
+Headings, lists, quotes and rules keep their own spacing; blank lines next to them add nothing, and
+a list keeps markdown's own layout rather than the author's line breaks.
+
+An element the sanitizer drops keeps its text, so anything the parser can emit needs either a rule
+here or a deliberate exclusion. Images and task-list checkboxes are excluded: a remote image on a
+public page is a tracking pixel, and a checkbox is a form control.
 
 The prose element declares the story's language (`lang` on `.story-content`) on both the author's
 page and the public reader page, so the browser hyphenates by the story's rules rather than the

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -156,7 +156,7 @@ fun Route.frontend() {
 		projectsRepository,
 		accountsRepository,
 		reviewRepository,
-		storyReaderRepository, projectDao, clock,
+		storyReaderRepository, serverProjectDataRepository, projectDao, clock,
 	)
 	reviewFrontend(
 		reviewRepository = reviewRepository,

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PublicStoryPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/PublicStoryPage.kt
@@ -201,6 +201,7 @@ fun Route.publicStoryPage(
 							)
 							if (storyLanguage != null) {
 								model["locale"] = storyLanguage
+								model["storyLanguage"] = storyLanguage
 							}
 
 							model.putAll(

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/StoryPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/StoryPage.kt
@@ -14,6 +14,8 @@ import com.darkrockstudios.apps.hammer.frontend.utils.msg
 import com.darkrockstudios.apps.hammer.frontend.utils.requireUser
 import com.darkrockstudios.apps.hammer.frontend.utils.respondTemplateWithToast
 import com.darkrockstudios.apps.hammer.monitoring.StoryReaderRepository
+import com.darkrockstudios.apps.hammer.project.ProjectDefinition
+import com.darkrockstudios.apps.hammer.project.ServerProjectDataRepository
 import com.darkrockstudios.apps.hammer.project.access.ProjectAccessRepository
 import com.darkrockstudios.apps.hammer.projects.ProjectsRepository
 import com.darkrockstudios.apps.hammer.story.SceneHierarchyResult
@@ -48,6 +50,7 @@ fun Route.storyPage(
 	accountsRepository: AccountsRepository,
 	reviewRepository: com.darkrockstudios.apps.hammer.review.ReviewRepository,
 	storyReaderRepository: StoryReaderRepository,
+	serverProjectDataRepository: ServerProjectDataRepository,
 	projectDao: ProjectDao,
 	clock: kotlin.time.Clock,
 ) {
@@ -140,9 +143,18 @@ fun Route.storyPage(
 
 						val reviewModels = call.reviewCards(reviewRepository, session.userId, projectId)
 
+						// The public reader page declares the story's language on the prose; the
+						// author's own view has to as well, or the browser hyphenates a French
+						// story by the rules of whatever locale the author reads Hammer in.
+						val storyLanguage = serverProjectDataRepository.loadProjectLanguage(
+							userId = session.userId,
+							projectDef = ProjectDefinition(name = project.name, uuid = projectId),
+						)
+
 						val model = call.withDefaults(
 							mapOf(
 								"page_stylesheet" to "/assets/css/story.css",
+								"storyLanguage" to storyLanguage.orEmpty(),
 								"page_script" to "/assets/js/story.js",
 								"page_pre_script" to "/assets/js/review-form-logic.js",
 								"reviews" to reviewModels,

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
@@ -18,7 +18,8 @@ import kotlin.time.Duration
  * Keys are built from the render's inputs — the project name and every scene's stored content hash
  * — so a synced edit, rename, reorder, or deletion lands on a different key and renders fresh. The
  * superseded entry is simply orphaned, then reclaimed by size eviction or [prune]. Bump
- * [RENDER_VERSION] to invalidate everything after a change to how markdown becomes HTML.
+ * [RENDER_VERSION] after a change to how markdown becomes HTML: it sits in [fingerprint], so it
+ * invalidates the readers' ETags along with the cached pages.
  */
 class StoryRenderCache(
 	fileSystem: TouchableFileSystem,
@@ -64,7 +65,7 @@ class StoryRenderCache(
 		wordsPerPage: Int,
 		sceneHashes: List<EntityHash>,
 	): String =
-		"story-html:$RENDER_VERSION:${projectId.id}:$page:$wordsPerPage:${fingerprint(projectName, sceneHashes)}"
+		"story-html:${projectId.id}:$page:$wordsPerPage:${fingerprint(projectName, sceneHashes)}"
 
 	private fun encode(result: PaginatedStoryExportResult): ByteArray =
 		json.encodeToString(result).toByteArray(Charsets.UTF_8)
@@ -78,13 +79,16 @@ class StoryRenderCache(
 		private const val RENDER_VERSION = "v4"
 
 		/**
-		 * Everything a render of this story depends on, collapsed to a string: the title heading
-		 * and every scene's stored content hash. Doubles as the HTTP validator for story pages.
+		 * Everything a render of this story depends on, collapsed to a string: the renderer itself,
+		 * the title heading and every scene's stored content hash. Doubles as the HTTP validator for
+		 * story pages, so [RENDER_VERSION] has to be in here as well as in the cache key — otherwise
+		 * a reader holding the old ETag is answered 304 with the old markup.
 		 *
 		 * The name is length-prefixed so one containing the delimiters can't imitate a scene list.
 		 */
 		fun fingerprint(projectName: String, sceneHashes: List<EntityHash>): String =
-			"${projectName.length}:$projectName|" + sceneHashes.joinToString(",") { "${it.id}:${it.hash}" }
+			"$RENDER_VERSION|${projectName.length}:$projectName|" +
+				sceneHashes.joinToString(",") { "${it.id}:${it.hash}" }
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
@@ -75,7 +75,7 @@ class StoryRenderCache(
 			.getOrNull()
 
 	companion object {
-		private const val RENDER_VERSION = "v3"
+		private const val RENDER_VERSION = "v4"
 
 		/**
 		 * Everything a render of this story depends on, collapsed to a string: the title heading

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
@@ -52,7 +52,7 @@ class StoryRendererService(
 			}
 
 			val markdown = buildStoryMarkdown(projectDef.name, scenes)
-			val html = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+			val html = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
 			// Calculate total word count from scene content only (not group names)
 			val totalWordCount = scenes
@@ -295,7 +295,7 @@ class StoryRendererService(
 
 		// Build markdown and HTML for current page only
 		val pageMarkdown = buildPaginatedMarkdown(projectDef.name, currentPageScenes, currentPage == 1)
-		val pageHtml = markdownService.markdownToSafeHtml(pageMarkdown, preserveBlankLines = true)
+		val pageHtml = markdownService.markdownToSafeHtml(pageMarkdown, preserveLineBreaks = true)
 
 		return StoryRender(
 			result = PaginatedStoryExportResult(
@@ -511,7 +511,7 @@ class StoryRendererService(
 				buildGroupMarkdown(targetScene, scenesByParent)
 			}
 
-			val html = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+			val html = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
 			SingleSceneExportResult.Success(
 				projectName = projectDef.name,

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
@@ -15,6 +15,7 @@ import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkdownParser
 import org.owasp.html.HtmlPolicyBuilder
 import org.owasp.html.PolicyFactory
+import java.util.regex.Pattern
 
 /**
  * Service for converting Markdown to sanitized HTML.
@@ -36,6 +37,10 @@ class MarkdownService {
 	 * - Strips all script tags and event handlers
 	 * - Only allows http/https URLs in links
 	 * - Adds rel="nofollow" to all links for security
+	 *
+	 * An element the parser can produce but the policy drops does not vanish: its text survives
+	 * unwrapped, so a stripped table reads as its cells run together. Everything GFM emits is
+	 * either allowed here or, like an image or a task-list checkbox, deliberately left out.
 	 */
 	private val sanitizer: PolicyFactory = HtmlPolicyBuilder()
 		.allowElements(
@@ -43,10 +48,14 @@ class MarkdownService {
 			"ul", "ol", "li",
 			"h1", "h2", "h3", "h4", "h5", "h6",
 			"blockquote", "code", "pre",
+			"table", "thead", "tbody", "tr", "th", "td",
 			"a", "hr"
 		)
 		.allowUrlProtocols("http", "https")
 		.allowAttributes("href").onElements("a")
+		// A list that starts at 5 has to say so, or it renders as 1.
+		.allowAttributes("start").matching(ORDERED_LIST_START).onElements("ol")
+		.allowAttributes("align").matching(COLUMN_ALIGNMENT).onElements("th", "td")
 		.requireRelNofollowOnLinks()
 		.toFactory()
 
@@ -66,13 +75,16 @@ class MarkdownService {
 	fun markdownToSafeHtml(markdown: String, preserveLineBreaks: Boolean = false): String {
 		if (markdown.isBlank()) return ""
 
-		val parsedTree = markdownParser.buildMarkdownTreeFromString(markdown)
+		// The parser only ends a line on '\n'. Content written on Windows, or imported from a file
+		// that was, arrives with '\r\n' and would otherwise parse as one run-on paragraph.
+		val source = markdown.replace(CARRIAGE_RETURN, "\n")
+		val parsedTree = markdownParser.buildMarkdownTreeFromString(source)
 		val providers = markdownFlavour.createHtmlGeneratingProviders(
-			LinkMap.buildLinkMap(parsedTree, markdown),
+			LinkMap.buildLinkMap(parsedTree, source),
 			null,
 		) + if (preserveLineBreaks) PROSE_PROVIDERS else emptyMap()
 
-		val unsafeHtml = HtmlGenerator(markdown, parsedTree, providers).generateHtml()
+		val unsafeHtml = HtmlGenerator(source, parsedTree, providers).generateHtml()
 		return sanitizer.sanitize(unsafeHtml.strikethroughAsDel())
 	}
 
@@ -96,6 +108,11 @@ class MarkdownService {
 
 		private val STRIKETHROUGH_SPAN =
 			Regex("""<span class="user-del">(.*?)</span>""", RegexOption.DOT_MATCHES_ALL)
+
+		private val CARRIAGE_RETURN = Regex("\r\n?")
+
+		private val ORDERED_LIST_START: Pattern = Pattern.compile("[0-9]{1,9}")
+		private val COLUMN_ALIGNMENT: Pattern = Pattern.compile("left|center|right")
 	}
 }
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
@@ -1,7 +1,17 @@
 package com.darkrockstudios.apps.hammer.utilities
 
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.LeafASTNode
+import org.intellij.markdown.ast.accept
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.html.GeneratingProvider
 import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.html.SimpleTagProvider
+import org.intellij.markdown.html.TrimmingInlineHolderProvider
+import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkdownParser
 import org.owasp.html.HtmlPolicyBuilder
 import org.owasp.html.PolicyFactory
@@ -47,17 +57,22 @@ class MarkdownService {
 	 * All script tags, event handlers, and javascript: URLs are stripped.
 	 *
 	 * @param markdown The markdown text to convert
-	 * @param preserveBlankLines Keep runs of blank lines as visible space rather than letting
-	 * CommonMark collapse them. Prose opts in; anywhere the markdown is a short piece of writing
-	 * rather than a story, such as a bio or a policy page, wants the default collapsing.
+	 * @param preserveLineBreaks Lay the text out the way the author typed it: every newline starts a
+	 * new line and every blank line is a blank line, which is what the editor shows them. Story prose
+	 * opts in; anywhere the markdown is a short piece of writing rather than a story, such as a bio or
+	 * a policy page, wants CommonMark's usual reflowing.
 	 * @return Sanitized HTML string safe for rendering
 	 */
-	fun markdownToSafeHtml(markdown: String, preserveBlankLines: Boolean = false): String {
+	fun markdownToSafeHtml(markdown: String, preserveLineBreaks: Boolean = false): String {
 		if (markdown.isBlank()) return ""
 
-		val source = if (preserveBlankLines) expandBlankLines(markdown) else markdown
-		val parsedTree = markdownParser.buildMarkdownTreeFromString(source)
-		val unsafeHtml = HtmlGenerator(source, parsedTree, markdownFlavour).generateHtml()
+		val parsedTree = markdownParser.buildMarkdownTreeFromString(markdown)
+		val providers = markdownFlavour.createHtmlGeneratingProviders(
+			LinkMap.buildLinkMap(parsedTree, markdown),
+			null,
+		) + if (preserveLineBreaks) PROSE_PROVIDERS else emptyMap()
+
+		val unsafeHtml = HtmlGenerator(markdown, parsedTree, providers).generateHtml()
 		return sanitizer.sanitize(unsafeHtml.strikethroughAsDel())
 	}
 
@@ -69,108 +84,109 @@ class MarkdownService {
 	private fun String.strikethroughAsDel(): String =
 		replace(STRIKETHROUGH_SPAN, "<del>$1</del>")
 
-	/**
-	 * CommonMark collapses any run of blank lines into a single paragraph break, which loses the
-	 * deliberate white space a writer put between passages. Each blank line past the first becomes
-	 * a `<br />` block so the rendered story keeps the author's spacing.
-	 *
-	 * Code is left exactly as written: a `<br />` landing inside a code block would both split the
-	 * block and show up as literal text. Fenced blocks are tracked by their delimiter, and a blank
-	 * run between two indented lines is assumed to sit inside an indented block.
-	 */
-	private fun expandBlankLines(markdown: String): String {
-		val out = StringBuilder(markdown.length)
-		var fence: Fence? = null
-		var blankRun = 0
-		var seenContent = false
-		var lastIndent = 0
-
-		for (line in markdown.lineSequence()) {
-			val openFence = fence
-			if (openFence != null) {
-				out.append(line).append('\n')
-				if (closesFence(line, openFence)) fence = null
-				continue
-			}
-
-			if (line.isBlank()) {
-				blankRun++
-				continue
-			}
-
-			val indent = indentWidth(line)
-			if (blankRun > 0) {
-				val insideIndentedBlock = lastIndent > MAX_FENCE_INDENT && indent > MAX_FENCE_INDENT
-				if (seenContent && !insideIndentedBlock) {
-					out.append('\n')
-					repeat((blankRun - 1).coerceAtMost(MAX_CONSECUTIVE_BREAKS)) {
-						out.append(BREAK_BLOCK).append("\n\n")
-					}
-				} else {
-					repeat(blankRun) { out.append('\n') }
-				}
-				blankRun = 0
-			}
-
-			out.append(line).append('\n')
-			seenContent = true
-			lastIndent = indent
-			fence = openingFence(line)
-		}
-
-		return out.toString()
-	}
-
-	private fun openingFence(line: String): Fence? {
-		if (indentWidth(line) > MAX_FENCE_INDENT) return null
-
-		val trimmed = line.trimStart()
-		val delimiter = trimmed.firstOrNull() ?: return null
-		if (delimiter != '`' && delimiter != '~') return null
-
-		val length = trimmed.takeWhile { it == delimiter }.length
-		if (length < MIN_FENCE_LENGTH) return null
-		// A backtick fence's info string may not itself contain a backtick.
-		if (delimiter == '`' && trimmed.drop(length).contains('`')) return null
-
-		return Fence(delimiter, length)
-	}
-
-	private fun closesFence(line: String, fence: Fence): Boolean {
-		if (indentWidth(line) > MAX_FENCE_INDENT) return false
-
-		val trimmed = line.trimStart()
-		val length = trimmed.takeWhile { it == fence.delimiter }.length
-		return length >= fence.length && trimmed.drop(length).isBlank()
-	}
-
-	private fun indentWidth(line: String): Int {
-		var width = 0
-		for (character in line) {
-			when (character) {
-				' ' -> width++
-				'\t' -> width += TAB_WIDTH
-				else -> return width
-			}
-		}
-		return width
-	}
-
-	/** The delimiter that opened a code fence; only the same character, as long or longer, ends it. */
-	private data class Fence(val delimiter: Char, val length: Int)
-
 	companion object {
 		/** Upper bound on the breaks one run of blank lines can produce. */
 		const val MAX_CONSECUTIVE_BREAKS = 6
 
-		/** A blank line preceding this makes CommonMark pass it through as a raw HTML block. */
-		private const val BREAK_BLOCK = "<br />"
-
-		private const val MAX_FENCE_INDENT = 3
-		private const val MIN_FENCE_LENGTH = 3
-		private const val TAB_WIDTH = 4
+		private val PROSE_PROVIDERS: Map<IElementType, GeneratingProvider> = mapOf(
+			MarkdownElementTypes.PARAGRAPH to ProseParagraphProvider,
+			MarkdownElementTypes.MARKDOWN_FILE to ProseContainerProvider("body"),
+			MarkdownElementTypes.BLOCK_QUOTE to ProseContainerProvider("blockquote"),
+		)
 
 		private val STRIKETHROUGH_SPAN =
 			Regex("""<span class="user-del">(.*?)</span>""", RegexOption.DOT_MATCHES_ALL)
+	}
+}
+
+/**
+ * A paragraph of prose keeps the lines the author typed. CommonMark reflows a run of single-newline
+ * lines into one block, which turns a page of dialogue into a wall of text that looks nothing like
+ * what the writer sees in the editor; each line becomes its own paragraph instead.
+ *
+ * Paragraph siblings carry no vertical margin in the story stylesheet, so consecutive lines sit
+ * directly under one another and each picks up the first-line indent, exactly as the editor draws
+ * them.
+ */
+private object ProseParagraphProvider : TrimmingInlineHolderProvider() {
+	override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+		visitor.consumeTagOpen(node, "p")
+	}
+
+	override fun closeTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+		visitor.consumeTagClose("p")
+	}
+
+	override fun processNode(
+		visitor: HtmlGenerator.HtmlGeneratingVisitor,
+		text: String,
+		node: ASTNode,
+	) {
+		val children = childrenToRender(node)
+		openTag(visitor, text, node)
+
+		children.forEachIndexed { index, child ->
+			when {
+				// An edge newline would only open or close an empty paragraph.
+				child.type == MarkdownTokenTypes.EOL -> {
+					if (index != 0 && index != children.lastIndex) {
+						closeTag(visitor, text, node)
+						openTag(visitor, text, node)
+					}
+				}
+
+				// The trailing spaces of a hard break are redundant: the newline itself breaks here.
+				child.type == MarkdownTokenTypes.HARD_LINE_BREAK -> Unit
+
+				child is LeafASTNode -> visitor.visitLeaf(child)
+				else -> child.accept(visitor)
+			}
+		}
+
+		closeTag(visitor, text, node)
+	}
+}
+
+/**
+ * Blank lines an author left between passages are deliberate white space, but CommonMark treats any
+ * run of them as a single paragraph break. Each one becomes a break element so the spacing survives.
+ *
+ * Only prose gets them. Headings, lists and rules carry their own margins, and stacking blank lines
+ * on top of those margins opens a gap the author never asked for.
+ */
+private class ProseContainerProvider(tag: String) : SimpleTagProvider(tag) {
+	override fun processNode(
+		visitor: HtmlGenerator.HtmlGeneratingVisitor,
+		text: String,
+		node: ASTNode,
+	) {
+		openTag(visitor, text, node)
+
+		var newlines = 0
+		var afterParagraph = false
+		for (child in node.children) {
+			when (child.type) {
+				MarkdownTokenTypes.EOL -> newlines++
+				// A quote's own '>' markers sit between the lines they mark, and neither they nor
+				// stray indentation say anything about how far apart two passages are.
+				MarkdownTokenTypes.WHITE_SPACE, MarkdownTokenTypes.BLOCK_QUOTE -> Unit
+				else -> {
+					val isParagraph = child.type == MarkdownElementTypes.PARAGRAPH
+					if (afterParagraph && isParagraph) {
+						val breaks = (newlines - 1).coerceIn(0, MarkdownService.MAX_CONSECUTIVE_BREAKS)
+						repeat(breaks) { visitor.consumeHtml(BREAK) }
+					}
+					child.accept(visitor)
+					afterParagraph = isParagraph
+					newlines = 0
+				}
+			}
+		}
+
+		closeTag(visitor, text, node)
+	}
+
+	private companion object {
+		const val BREAK = "<br />"
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownService.kt
@@ -1,16 +1,8 @@
 package com.darkrockstudios.apps.hammer.utilities
 
-import org.intellij.markdown.IElementType
-import org.intellij.markdown.MarkdownElementTypes
-import org.intellij.markdown.MarkdownTokenTypes
-import org.intellij.markdown.ast.ASTNode
-import org.intellij.markdown.ast.LeafASTNode
-import org.intellij.markdown.ast.accept
+import com.darkrockstudios.apps.hammer.base.markdown.ProseHtml
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
-import org.intellij.markdown.html.GeneratingProvider
 import org.intellij.markdown.html.HtmlGenerator
-import org.intellij.markdown.html.SimpleTagProvider
-import org.intellij.markdown.html.TrimmingInlineHolderProvider
 import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkdownParser
 import org.owasp.html.HtmlPolicyBuilder
@@ -75,14 +67,14 @@ class MarkdownService {
 	fun markdownToSafeHtml(markdown: String, preserveLineBreaks: Boolean = false): String {
 		if (markdown.isBlank()) return ""
 
-		// The parser only ends a line on '\n'. Content written on Windows, or imported from a file
-		// that was, arrives with '\r\n' and would otherwise parse as one run-on paragraph.
-		val source = markdown.replace(CARRIAGE_RETURN, "\n")
+		val source = ProseHtml.normalizeLineEndings(markdown)
 		val parsedTree = markdownParser.buildMarkdownTreeFromString(source)
-		val providers = markdownFlavour.createHtmlGeneratingProviders(
-			LinkMap.buildLinkMap(parsedTree, source),
-			null,
-		) + if (preserveLineBreaks) PROSE_PROVIDERS else emptyMap()
+		val linkMap = LinkMap.buildLinkMap(parsedTree, source)
+		val providers = if (preserveLineBreaks) {
+			ProseHtml.providers(markdownFlavour, linkMap)
+		} else {
+			markdownFlavour.createHtmlGeneratingProviders(linkMap, null)
+		}
 
 		val unsafeHtml = HtmlGenerator(source, parsedTree, providers).generateHtml()
 		return sanitizer.sanitize(unsafeHtml.strikethroughAsDel())
@@ -97,113 +89,10 @@ class MarkdownService {
 		replace(STRIKETHROUGH_SPAN, "<del>$1</del>")
 
 	companion object {
-		/** Upper bound on the breaks one run of blank lines can produce. */
-		const val MAX_CONSECUTIVE_BREAKS = 6
-
-		private val PROSE_PROVIDERS: Map<IElementType, GeneratingProvider> = mapOf(
-			MarkdownElementTypes.PARAGRAPH to ProseParagraphProvider,
-			MarkdownElementTypes.MARKDOWN_FILE to ProseContainerProvider("body"),
-			MarkdownElementTypes.BLOCK_QUOTE to ProseContainerProvider("blockquote"),
-		)
-
 		private val STRIKETHROUGH_SPAN =
 			Regex("""<span class="user-del">(.*?)</span>""", RegexOption.DOT_MATCHES_ALL)
 
-		private val CARRIAGE_RETURN = Regex("\r\n?")
-
 		private val ORDERED_LIST_START: Pattern = Pattern.compile("[0-9]{1,9}")
 		private val COLUMN_ALIGNMENT: Pattern = Pattern.compile("left|center|right")
-	}
-}
-
-/**
- * A paragraph of prose keeps the lines the author typed. CommonMark reflows a run of single-newline
- * lines into one block, which turns a page of dialogue into a wall of text that looks nothing like
- * what the writer sees in the editor; each line becomes its own paragraph instead.
- *
- * Paragraph siblings carry no vertical margin in the story stylesheet, so consecutive lines sit
- * directly under one another and each picks up the first-line indent, exactly as the editor draws
- * them.
- */
-private object ProseParagraphProvider : TrimmingInlineHolderProvider() {
-	override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
-		visitor.consumeTagOpen(node, "p")
-	}
-
-	override fun closeTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
-		visitor.consumeTagClose("p")
-	}
-
-	override fun processNode(
-		visitor: HtmlGenerator.HtmlGeneratingVisitor,
-		text: String,
-		node: ASTNode,
-	) {
-		val children = childrenToRender(node)
-		openTag(visitor, text, node)
-
-		children.forEachIndexed { index, child ->
-			when {
-				// An edge newline would only open or close an empty paragraph.
-				child.type == MarkdownTokenTypes.EOL -> {
-					if (index != 0 && index != children.lastIndex) {
-						closeTag(visitor, text, node)
-						openTag(visitor, text, node)
-					}
-				}
-
-				// The trailing spaces of a hard break are redundant: the newline itself breaks here.
-				child.type == MarkdownTokenTypes.HARD_LINE_BREAK -> Unit
-
-				child is LeafASTNode -> visitor.visitLeaf(child)
-				else -> child.accept(visitor)
-			}
-		}
-
-		closeTag(visitor, text, node)
-	}
-}
-
-/**
- * Blank lines an author left between passages are deliberate white space, but CommonMark treats any
- * run of them as a single paragraph break. Each one becomes a break element so the spacing survives.
- *
- * Only prose gets them. Headings, lists and rules carry their own margins, and stacking blank lines
- * on top of those margins opens a gap the author never asked for.
- */
-private class ProseContainerProvider(tag: String) : SimpleTagProvider(tag) {
-	override fun processNode(
-		visitor: HtmlGenerator.HtmlGeneratingVisitor,
-		text: String,
-		node: ASTNode,
-	) {
-		openTag(visitor, text, node)
-
-		var newlines = 0
-		var afterParagraph = false
-		for (child in node.children) {
-			when (child.type) {
-				MarkdownTokenTypes.EOL -> newlines++
-				// A quote's own '>' markers sit between the lines they mark, and neither they nor
-				// stray indentation say anything about how far apart two passages are.
-				MarkdownTokenTypes.WHITE_SPACE, MarkdownTokenTypes.BLOCK_QUOTE -> Unit
-				else -> {
-					val isParagraph = child.type == MarkdownElementTypes.PARAGRAPH
-					if (afterParagraph && isParagraph) {
-						val breaks = (newlines - 1).coerceIn(0, MarkdownService.MAX_CONSECUTIVE_BREAKS)
-						repeat(breaks) { visitor.consumeHtml(BREAK) }
-					}
-					child.accept(visitor)
-					afterParagraph = isParagraph
-					newlines = 0
-				}
-			}
-		}
-
-		closeTag(visitor, text, node)
-	}
-
-	private companion object {
-		const val BREAK = "<br />"
 	}
 }

--- a/server/src/main/resources/assets/css/story.css
+++ b/server/src/main/resources/assets/css/story.css
@@ -265,10 +265,6 @@
 	color: inherit;
 }
 
-.story-content blockquote p + p {
-	margin-top: 1em;
-}
-
 /* Emphasis inside already-italic type reads as upright */
 .story-content blockquote em {
 	font-style: normal;

--- a/server/src/main/resources/assets/css/story.css
+++ b/server/src/main/resources/assets/css/story.css
@@ -212,6 +212,49 @@
 }
 
 /* ----------------------------------------
+   Tables
+   ---------------------------------------- */
+
+.story-content table {
+	display: block;
+	width: fit-content;
+	max-width: 100%;
+	margin: 2em auto;
+	overflow-x: auto;
+	border-collapse: collapse;
+	font-size: 0.9375em;
+	text-indent: 0;
+}
+
+.story-content th,
+.story-content td {
+	padding: 0.5em 1em;
+	border: 1px solid var(--neutral-200);
+	text-align: left;
+	vertical-align: top;
+}
+
+/* Author CSS outranks the align attribute markdown's column alignment produces, so honour it here */
+.story-content th[align="center"],
+.story-content td[align="center"] {
+	text-align: center;
+}
+
+.story-content th[align="right"],
+.story-content td[align="right"] {
+	text-align: right;
+}
+
+.story-content th {
+	font-family: 'Kingthings Typewriter', monospace;
+	font-size: 0.9375em;
+	font-weight: 500;
+	color: var(--text-secondary);
+	background: rgba(245, 245, 244, 0.7);
+	border-bottom-color: var(--neutral-300);
+}
+
+/* ----------------------------------------
    Scene break
    ---------------------------------------- */
 

--- a/server/src/main/resources/templates/partials/story-page-content.mustache
+++ b/server/src/main/resources/templates/partials/story-page-content.mustache
@@ -1,4 +1,4 @@
-<article class="story-content">{{{storyHtml}}}</article>
+<article class="story-content"{{#storyLanguage}} lang="{{storyLanguage}}"{{/storyLanguage}}>{{{storyHtml}}}</article>
 
 {{#hasPagination}}
 	<nav class="story-pagination">

--- a/server/src/main/resources/templates/story.mustache
+++ b/server/src/main/resources/templates/story.mustache
@@ -41,7 +41,8 @@
 				{{/hasScenes}}
 
 				<!-- Story Content -->
-				<article class="story-content" id="story-content-area">
+				<article class="story-content"{{#storyLanguage}} lang="{{storyLanguage}}"{{/storyLanguage}}
+						 id="story-content-area">
 					{{#hasContent}}
 						{{{storyHtml}}}
 					{{/hasContent}}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererServiceTest.kt
@@ -167,6 +167,23 @@ class StoryRendererServiceTest {
 	}
 
 	@Test
+	fun `sibling scenes in a group are parted by one blank line`() = runTest {
+		val scenes = listOf(
+			createScene(id = 1, name = "Chapter 1", content = "", order = 0, sceneType = ApiSceneType.Group),
+			createScene(id = 2, name = "Scene 1.1", content = "First child content.", order = 0, path = listOf(0, 1)),
+			createScene(id = 3, name = "Scene 1.2", content = "Second child content.", order = 1, path = listOf(0, 1)),
+		)
+		setupMocksForScenes(scenes)
+
+		val result = service.renderStoryAsHtml(userId, projectId)
+
+		assertIs<StoryRenderResult.Success>(result)
+		// Nothing else marks the seam between two scenes of a chapter, and without it the last line
+		// of one and the first of the next read as consecutive lines of the same passage.
+		assertEquals(1, Regex("<br\\s*/?>").findAll(result.html).count(), result.html)
+	}
+
+	@Test
 	fun `sibling scenes in an exported group render as separate paragraphs`() = runTest {
 		val scenes = listOf(
 			createScene(id = 1, name = "Chapter 1", content = "", order = 0, sceneType = ApiSceneType.Group),

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.utilities
 
+import com.darkrockstudios.apps.hammer.base.markdown.ProseHtml
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -281,7 +282,7 @@ class MarkdownServiceTest {
 		val markdown = "First paragraph." + "\n".repeat(40) + "Second paragraph."
 		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
-		assertEquals(MarkdownService.MAX_CONSECUTIVE_BREAKS, countBreaks(result))
+		assertEquals(ProseHtml.MAX_CONSECUTIVE_BREAKS, countBreaks(result))
 	}
 
 	@Test

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
@@ -375,7 +375,47 @@ class MarkdownServiceTest {
 		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
 		assertEquals(0, countBreaks(result))
+		assertEquals(1, countTag(result, "table"))
+		assertEquals(2, countTag(result, "th"))
+		assertEquals(2, countTag(result, "td"))
 		assertTrue(result.contains("After."))
+	}
+
+	@Test
+	fun `markdownToSafeHtml keeps a table's column alignment`() {
+		val markdown = "| a | b | c |\n| :--- | :---: | ---: |\n| 1 | 2 | 3 |"
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertTrue(result.contains("""align="center""""), result)
+		assertTrue(result.contains("""align="right""""), result)
+	}
+
+	@Test
+	fun `markdownToSafeHtml keeps the number an ordered list starts at`() {
+		val markdown = "5. Fifth\n6. Sixth"
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertTrue(result.contains("""<ol start="5">"""), result)
+	}
+
+	@Test
+	fun `markdownToSafeHtml lays out Windows line endings like any other`() {
+		val unix = "First line.\nSecond line.\n\nAfter a blank line."
+		val windows = unix.replace("\n", "\r\n")
+
+		assertEquals(
+			markdownService.markdownToSafeHtml(unix, preserveLineBreaks = true),
+			markdownService.markdownToSafeHtml(windows, preserveLineBreaks = true),
+		)
+	}
+
+	@Test
+	fun `markdownToSafeHtml keeps blocks apart across Windows line endings`() {
+		val markdown = "- one\r\n- two\r\n\r\nAfter the list."
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertEquals(2, countTag(result, "li"))
+		assertTrue(result.contains("<p>After the list.</p>"), result)
 	}
 
 	private fun countBreaks(html: String) = Regex("<br\\s*/?>").findAll(html).count()

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/MarkdownServiceTest.kt
@@ -196,6 +196,15 @@ class MarkdownServiceTest {
 	}
 
 	@Test
+	fun `markdownToSafeHtml reflows single newlines unless asked to preserve them`() {
+		val markdown = "First line.\nSecond line."
+		val result = markdownService.markdownToSafeHtml(markdown)
+
+		assertEquals(1, countTag(result, "p"))
+		assertEquals(0, countBreaks(result))
+	}
+
+	@Test
 	fun `markdownToSafeHtml collapses extra blank lines unless asked to preserve them`() {
 		val markdown = "First paragraph.\n\n\n\nSecond paragraph."
 		val result = markdownService.markdownToSafeHtml(markdown)
@@ -206,21 +215,63 @@ class MarkdownServiceTest {
 	}
 
 	@Test
-	fun `markdownToSafeHtml keeps a single blank line as a plain paragraph break`() {
-		val markdown = "First paragraph.\n\nSecond paragraph."
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+	fun `markdownToSafeHtml gives every authored line its own paragraph`() {
+		// An en dash: French dialogue opens with one, and unlike "- " it is not a list marker.
+		val dash = "–"
+		val markdown = "$dash Bonsoir madame.\n$dash Ne vous inquietez pas.\n$dash Tres bien."
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
+		assertEquals(3, countTag(result, "p"))
+		assertTrue(result.contains("<p>$dash Bonsoir madame.</p>"), result)
+		assertTrue(result.contains("<p>$dash Ne vous inquietez pas.</p>"), result)
+		assertTrue(result.contains("<p>$dash Tres bien.</p>"), result)
+	}
+
+	@Test
+	fun `markdownToSafeHtml keeps emphasis whole when it spans an authored line break`() {
+		val markdown = "He said *hello\nthere* now."
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		// Splitting mid-emphasis would cross the tags; the line stays joined instead.
+		assertEquals(1, countTag(result, "p"))
+		assertTrue(result.contains("<em>hello"), result)
+		assertFalse(result.contains("*"), result)
+	}
+
+	@Test
+	fun `markdownToSafeHtml splits a line that is emphasized end to end`() {
+		val markdown = "*First line.*\n*Second line.*"
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertEquals(2, countTag(result, "p"))
+		assertEquals(2, countTag(result, "em"))
+	}
+
+	@Test
+	fun `markdownToSafeHtml renders a hard line break as a single line break`() {
+		val markdown = "First line.  \nSecond line."
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertEquals(2, countTag(result, "p"))
 		assertEquals(0, countBreaks(result))
+	}
+
+	@Test
+	fun `markdownToSafeHtml renders a single blank line as a break`() {
+		val markdown = "First paragraph.\n\nSecond paragraph."
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertEquals(1, countBreaks(result))
 		assertTrue(result.contains("First paragraph."))
 		assertTrue(result.contains("Second paragraph."))
 	}
 
 	@Test
-	fun `markdownToSafeHtml renders each extra blank line as a break`() {
+	fun `markdownToSafeHtml renders each blank line as a break`() {
 		val markdown = "First paragraph.\n\n\n\nSecond paragraph."
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
-		assertEquals(2, countBreaks(result))
+		assertEquals(3, countBreaks(result))
 		assertTrue(result.contains("First paragraph."))
 		assertTrue(result.contains("Second paragraph."))
 	}
@@ -228,7 +279,7 @@ class MarkdownServiceTest {
 	@Test
 	fun `markdownToSafeHtml caps a runaway run of blank lines`() {
 		val markdown = "First paragraph." + "\n".repeat(40) + "Second paragraph."
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
 		assertEquals(MarkdownService.MAX_CONSECUTIVE_BREAKS, countBreaks(result))
 	}
@@ -236,7 +287,7 @@ class MarkdownServiceTest {
 	@Test
 	fun `markdownToSafeHtml ignores blank lines before the first paragraph`() {
 		val markdown = "\n\n\n\nFirst paragraph."
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
 		assertEquals(0, countBreaks(result))
 	}
@@ -244,17 +295,27 @@ class MarkdownServiceTest {
 	@Test
 	fun `markdownToSafeHtml ignores trailing blank lines`() {
 		val markdown = "First paragraph." + "\n".repeat(6)
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
 		assertEquals(0, countBreaks(result))
 	}
 
 	@Test
-	fun `markdownToSafeHtml leaves blank lines inside fenced code untouched`() {
-		val markdown = "```\nfirst\n\n\n\nsecond\n```"
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+	fun `markdownToSafeHtml leaves blank lines around a heading to the heading's own spacing`() {
+		val markdown = "## Chapter One\n\nFirst paragraph.\n\n\n## Chapter Two"
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
 		assertEquals(0, countBreaks(result))
+		assertEquals(2, countTag(result, "h2"))
+	}
+
+	@Test
+	fun `markdownToSafeHtml leaves lines and blank lines inside fenced code untouched`() {
+		val markdown = "```\nfirst\n\n\n\nsecond\n```"
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertEquals(0, countBreaks(result))
+		assertEquals(0, countTag(result, "p"))
 		assertTrue(result.contains("first"))
 		assertTrue(result.contains("second"))
 	}
@@ -262,51 +323,59 @@ class MarkdownServiceTest {
 	@Test
 	fun `markdownToSafeHtml leaves blank lines inside an indented code block untouched`() {
 		val markdown = "Intro:\n\n    code line one\n\n\n    code line two\n\nOutro."
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
 		assertEquals(0, countBreaks(result))
 		assertEquals(1, countTag(result, "pre"))
 	}
 
 	@Test
-	fun `markdownToSafeHtml leaves a fence nested in a list item untouched`() {
-		val markdown = "- item\n\n    ```\n    code\n\n\n    more\n    ```"
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
-
-		assertEquals(0, countBreaks(result))
-		assertFalse(result.contains("&lt;br"))
-		assertTrue(result.contains("code"))
-		assertTrue(result.contains("more"))
-	}
-
-	@Test
-	fun `markdownToSafeHtml does not close a fence on a different delimiter`() {
-		val markdown = "```\nline one\n~~~\nline two\n\n\nline three\n```\n\nAfter."
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
-
-		assertEquals(0, countBreaks(result))
-		assertFalse(result.contains("&lt;br"))
-		assertTrue(result.contains("After."))
-	}
-
-	@Test
-	fun `markdownToSafeHtml does not close a fence on a shorter delimiter`() {
-		val markdown = "````\nline one\n```\nline two\n\n\nline three\n````\n\nAfter."
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
-
-		assertEquals(0, countBreaks(result))
-		assertFalse(result.contains("&lt;br"))
-		assertTrue(result.contains("After."))
-	}
-
-	@Test
-	fun `markdownToSafeHtml keeps a list intact when extra blank lines follow it`() {
+	fun `markdownToSafeHtml keeps a list intact`() {
 		val markdown = "- item 1\n- item 2\n\n\nAfter the list."
-		val result = markdownService.markdownToSafeHtml(markdown, preserveBlankLines = true)
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
 
-		assertTrue(result.contains("<ul>"))
-		assertEquals(1, countBreaks(result))
+		assertEquals(1, countTag(result, "ul"))
+		assertEquals(2, countTag(result, "li"))
+		assertEquals(0, countBreaks(result))
 		assertTrue(result.contains("After the list."))
+	}
+
+	@Test
+	fun `markdownToSafeHtml keeps a wrapped list item as one item`() {
+		val markdown = "- item one\n  continued\n- item two"
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertEquals(2, countTag(result, "li"))
+		assertEquals(0, countTag(result, "p"))
+	}
+
+	@Test
+	fun `markdownToSafeHtml gives a quoted line its own paragraph`() {
+		val markdown = "> quote line one\n> quote line two"
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertEquals(1, countTag(result, "blockquote"))
+		assertEquals(2, countTag(result, "p"))
+		assertEquals(0, countBreaks(result))
+	}
+
+	@Test
+	fun `markdownToSafeHtml renders a blank line inside a quote as a break`() {
+		val markdown = "> quote line one\n>\n> quote line two"
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertEquals(1, countTag(result, "blockquote"))
+		assertEquals(2, countTag(result, "p"))
+		assertEquals(1, countBreaks(result))
+	}
+
+	@Test
+	fun `markdownToSafeHtml keeps a table intact`() {
+		val markdown = "| a | b |\n| --- | --- |\n| 1 | 2 |\n\nAfter."
+		val result = markdownService.markdownToSafeHtml(markdown, preserveLineBreaks = true)
+
+		assertEquals(0, countBreaks(result))
+		assertTrue(result.contains("After."))
 	}
 
 	private fun countBreaks(html: String) = Regex("<br\\s*/?>").findAll(html).count()


### PR DESCRIPTION
A reader reported that a story looks nothing on the web like it does in the app. A page of dialogue arrived as one packed block of text.

### What was wrong

Two things, both in how markdown became HTML:

- **Single newlines were reflowed.** CommonMark joins a run of single-newline lines into one paragraph, separated by spaces. The editor shows each line on its own line, so a passage of dialogue that reads as five lines in the app read as one wall of text on the web.
- **A single blank line disappeared.** Story paragraphs carry no vertical margin (the indent does the separating), so the paragraph break a blank line produced was invisible. Only the *second* and later blank lines of a run rendered as space.

### The rule now

Prose is laid out the way the author typed it, which is what they see in the editor: **every newline starts a new line, every blank line is a blank line.** Lists, tables, code and headings keep markdown's own layout, and blank lines next to them add nothing — those blocks carry their own spacing already.

`MarkdownService` gives each authored line its own `<p>` and emits a `<br />` per blank line between paragraphs. Both are AST-level generating providers rather than a line-based rewrite of the source, so code blocks, tables, lists and rules are untouched by construction — the old fence-tracking preprocessor is gone. Blockquotes get the same treatment.

### Consistency between the two web views

Checked, since it wasn't obvious which page the report came from: the private author view (`/story/...`) and the public reader page (`/a/...`) both go through `StoryRendererService` → `MarkdownService` and both render into `.story-content` in `story.css`. They already agreed, and they change together here.

One difference did turn up: the public page declares the story's language on `<html lang>`, so a French story hyphenates by French rules, while the author's own page used the viewer's UI locale. The story language now reaches the prose element on both.

### The exports had the same bug

DOCX, RTF, PDF and EPUB all reflowed prose the same way, for the same reason.

- The prose-HTML rules move to `base/markdown/ProseHtml.kt`, so the server's pages and the client's EPUB share one definition instead of drifting apart.
- `parseProseMarkdown` — which DOCX, RTF and PDF all consume — gives each authored line its own paragraph and each blank line a `ProseBlock.Blank`.
- A body paragraph carries space after it only where prose *ends*. Lines that run on into more prose sit tight, so the indent parts them and the author's blank lines are the only gaps.
- Quoted passages keep their lines, and a quote's own `>` markers no longer leak into the text of a continuation line.

### Everything else the renderer can emit

Walking every construct turned up three more the page got wrong:

- **Tables collapsed into gibberish.** The sanitizer allowed no table elements, and a stripped element keeps its text, so `| Name | Rank |` reached the reader as `NameRank`. Tables are allowed now and styled to match, column alignment included.
- **An ordered list starting at 5 rendered as 1.** The generator emitted `start` all along; the policy dropped it.
- **Line endings weren't normalized.** The old preprocessor did it as a side effect of rebuilding the source line by line, so CRLF prose would have regressed to one run-on paragraph.

Images and task-list checkboxes stay excluded, deliberately: a remote image on a public page is a tracking pixel, and a checkbox is a form control. That rule — anything the parser can emit needs an allowlist entry or a deliberate exclusion — is written down now, since it's what made tables fail silently.

`RENDER_VERSION` goes to v4 and moves into the fingerprint, so it invalidates readers' ETags as well as the disk cache; it only keyed the disk cache before, and a bump alone would have quietly done nothing.

### Verifying

`MarkdownServiceTest`, `StoryRendererServiceTest`, `PdfProseMarkdownTest`, `DocxStoryRendererTest`, `RtfStoryRendererTest` and `EpubStoryRendererTest` cover the line and blank-line rules, the structural blocks that must not change, the scene seam, and paragraph spacing. Rendered pages were eyeballed in a browser against the real stylesheet, and the PDF read page by page.

### Known limits

Emphasis that spans a line break keeps the lines joined — splitting there would cross the tags — and list items keep markdown's layout rather than the author's line breaks. Both are pinned by tests.
