### PR TITLE
Ask Merge vs Replace on login instead of "Remove Local Content?"

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_account_settings.xml
+++ b/common/src/commonMain/composeResources/values/strings_account_settings.xml
@@ -48,10 +48,16 @@
 	<string name="settings_server_setup_login_button">Log In</string>
 	<string name="settings_server_setup_create_button">Create</string>
 	<string name="settings_server_setup_cancel_button">Cancel</string>
-	<string name="remove_local_dialog_title">Remove Local Content?</string>
-	<string
-		name="remove_local_dialog_message">Should we remove your current local content before syncing? If not, we will attempt to merge your local content with the server content. If the content is unrelated, it could cause problems.
-	</string>
+	<string name="merge_projects_dialog_title">Merge existing projects with the server?</string>
+	<string name="merge_projects_mode_label">PROJECT DATA</string>
+	<string name="merge_projects_mode_merge">Merge</string>
+	<string name="merge_projects_mode_replace">Replace</string>
+	<string name="merge_projects_explain_merge">Hammer will match your local projects to projects already on the server by name. Projects that only exist on the server will be downloaded, and projects that only exist on this device will be uploaded.</string>
+	<string name="merge_projects_explain_replace">All of your local projects will be deleted and replaced with whatever is on the server.</string>
+	<string name="merge_projects_continue_button">Continue</string>
+	<string name="merge_projects_replace_confirm_title">Delete all local projects?</string>
+	<string name="merge_projects_replace_confirm_message">This permanently deletes every project on this device and replaces them with the projects from the server. This cannot be undone.</string>
+	<string name="merge_projects_replace_confirm_button">Delete and Replace</string>
 	<string name="settings_platform_settings_title">Platform Settings</string>
 	<string name="settings_platform_settings_empty">No platform-specific settings.</string>
 	<string name="settings_keep_screen_on">Keep screen on</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettings.kt
@@ -21,13 +21,22 @@ interface AccountSettings : ComponentToaster {
 	fun reinstallExampleProject(onComplete: (Boolean) -> Unit)
 	fun beginSetupServer()
 	fun cancelServerSetup()
+	/**
+	 * [replaceLocalContent] is only ever true when the user explicitly chose "Replace" in the merge
+	 * prompt. When it is false and the login would merge real local work into a different server,
+	 * this raises that prompt instead of running the setup; see [chooseMerge] / [chooseReplace].
+	 */
 	fun setupServer(
 		url: String,
 		email: String,
 		password: String,
 		create: Boolean,
-		removeLocalContent: Boolean
+		replaceLocalContent: Boolean
 	)
+
+	fun chooseMerge()
+	fun chooseReplace()
+	fun cancelMergePrompt()
 
 	fun acceptTos()
 	fun declineTos()
@@ -65,6 +74,7 @@ interface AccountSettings : ComponentToaster {
 		@Transient val serverError: String? = null,
 		@Transient val serverWorking: Boolean = false,
 		@Transient val tosChallenge: TermsOfServiceChallenge? = null,
+		@Transient val mergePrompt: Boolean = false,
 		val syncAutomaticSync: Boolean,
 		val syncAutomaticBackups: Boolean,
 		val syncAutoCloseDialog: Boolean,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
@@ -40,7 +40,9 @@ import com.darkrockstudios.apps.hammer.settings_server_setup_toast_failure
 import com.darkrockstudios.apps.hammer.settings_server_setup_toast_failure_unknown
 import com.darkrockstudios.apps.hammer.settings_server_setup_toast_success
 import com.darkrockstudios.apps.hammer.settings_server_tos_declined
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -75,6 +77,7 @@ class AccountSettingsComponent(
 
 	private var serverSetupJob: Job? = null
 	private var pendingServerSetup: PendingServerSetup? = null
+	private var promptedSetup: PendingServerSetup? = null
 
 	override val platformSettings: PlatformSettings by inject { parametersOf(componentContext) }
 	override val spellCheckSettings: SpellCheckSettings = SpellCheckSettingsComponent(componentContext)
@@ -181,12 +184,14 @@ class AccountSettingsComponent(
 			globalSettingsStore.deleteServerSettings()
 		}
 		pendingServerSetup = null
+		promptedSetup = null
 		_state.getAndUpdate {
 			it.copy(
 				serverSetup = false,
 				serverError = null,
 				serverWorking = false,
 				tosChallenge = null,
+				mergePrompt = false,
 			)
 		}
 	}
@@ -288,7 +293,7 @@ class AccountSettingsComponent(
 		email: String,
 		password: String,
 		create: Boolean,
-		removeLocalContent: Boolean
+		replaceLocalContent: Boolean
 	) {
 		cancelSetupJob()
 
@@ -326,13 +331,85 @@ class AccountSettingsComponent(
 			}
 
 			// All validation passed, proceed with server setup
-			if (removeLocalContent) {
-				removeLocalContent()
-			}
+			val pending = PendingServerSetup(
+				url = cleanUrl,
+				email = email.trim(),
+				password = password,
+				create = create,
+				replaceLocalContent = replaceLocalContent,
+			)
 
-			val pending = PendingServerSetup(cleanUrl, email.trim(), password, create)
-			pendingServerSetup = pending
+			if (shouldPromptForMerge(pending)) {
+				promptedSetup = pending
+				withContext(mainDispatcher) {
+					_state.getAndUpdate {
+						it.copy(
+							mergePrompt = true,
+							serverSetup = false,
+							serverWorking = false,
+						)
+					}
+				}
+			} else {
+				pendingServerSetup = pending
+				performServerSetup(pending, acceptedTosVersion = null)
+			}
+		}
+	}
+
+	/**
+	 * Only worth asking when logging in to a *different* server while holding real local work:
+	 * everything else has one sensible answer. Re-reads the projects directory rather than trusting
+	 * anything the UI passed in, so a stale caller can only cost a prompt, never local content.
+	 */
+	private suspend fun shouldPromptForMerge(pending: PendingServerSetup): Boolean {
+		if (pending.create || pending.replaceLocalContent) return false
+
+		val current = _state.value
+		val sameServer = current.currentUrl == pending.url && current.currentEmail == pending.email
+		if (sameServer) return false
+
+		return withContext(dispatcherIo) {
+			projectsRepository.getProjects().any { exampleProjectRepository.isExampleProject(it).not() }
+		}
+	}
+
+	override fun chooseMerge() = resumePromptedSetup(replaceLocalContent = false)
+
+	override fun chooseReplace() = resumePromptedSetup(replaceLocalContent = true)
+
+	private fun resumePromptedSetup(replaceLocalContent: Boolean) {
+		val prompted = promptedSetup ?: return
+		promptedSetup = null
+
+		val pending = prompted.copy(replaceLocalContent = replaceLocalContent)
+		pendingServerSetup = pending
+
+		cancelSetupJob()
+		serverSetupJob = scope.launch {
+			withContext(mainDispatcher) {
+				_state.getAndUpdate {
+					it.copy(
+						mergePrompt = false,
+						serverSetup = true,
+						serverError = null,
+						serverWorking = true,
+					)
+				}
+			}
+			// Credentials were validated before the prompt was raised.
 			performServerSetup(pending, acceptedTosVersion = null)
+		}
+	}
+
+	override fun cancelMergePrompt() {
+		promptedSetup = null
+		_state.getAndUpdate {
+			it.copy(
+				mergePrompt = false,
+				serverSetup = true,
+				serverWorking = false,
+			)
 		}
 	}
 
@@ -379,7 +456,13 @@ class AccountSettingsComponent(
 		)
 		withContext(mainDispatcher) {
 			when (result) {
-				is ServerSetupResult.Success -> {
+				is ServerSetupResult.Success -> withContext(NonCancellable) {
+					// The local wipe waits until the account is confirmed: a bad password, an
+					// unreachable server or a declined ToS must never cost the user their work.
+					// NonCancellable so a close/ESC landing here can't strand valid tokens either.
+					if (shouldRemoveLocalContent(pending)) {
+						withContext(dispatcherIo) { removeLocalContent() }
+					}
 					pendingServerSetup = null
 					// A freshly created account holds no projects, so any serverProjectId from a
 					// previous server is stale and would make sync skip re-creating the project.
@@ -447,9 +530,25 @@ class AccountSettingsComponent(
 		}
 	}
 
-	private suspend fun removeLocalContent() {
+	/**
+	 * Logging in with nothing but the bundled example project is a clean slate: drop it rather than
+	 * uploading it to the account and propagating it to every other device.
+	 */
+	private suspend fun shouldRemoveLocalContent(pending: PendingServerSetup): Boolean {
+		if (pending.create) return false
+		if (pending.replaceLocalContent) return true
+
+		return withContext(dispatcherIo) {
+			val projects = projectsRepository.getProjects()
+			projects.size == 1 && exampleProjectRepository.isExampleProject(projects.first())
+		}
+	}
+
+	private fun removeLocalContent() {
 		projectsRepository.getProjects().forEach { projectDef ->
-			projectsRepository.deleteProject(projectDef)
+			if (projectsRepository.deleteProject(projectDef).not()) {
+				Napier.w("Failed to delete local project '${projectDef.name}' during server setup")
+			}
 		}
 	}
 
@@ -488,6 +587,7 @@ private data class PendingServerSetup(
 	val email: String,
 	val password: String,
 	val create: Boolean,
+	val replaceLocalContent: Boolean,
 )
 
 @Serializable

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
@@ -331,12 +331,17 @@ class AccountSettingsComponent(
 			}
 
 			// All validation passed, proceed with server setup
+			val cleanEmail = email.trim()
+			val current = _state.value
 			val pending = PendingServerSetup(
 				url = cleanUrl,
-				email = email.trim(),
+				email = cleanEmail,
 				password = password,
 				create = create,
 				replaceLocalContent = replaceLocalContent,
+				// Captured now: AccountUseCase writes provisional settings, so by the time the
+				// result comes back the state already names the server being logged in to.
+				sameServer = current.currentUrl == cleanUrl && current.currentEmail == cleanEmail,
 			)
 
 			if (shouldPromptForMerge(pending)) {
@@ -363,11 +368,7 @@ class AccountSettingsComponent(
 	 * anything the UI passed in, so a stale caller can only cost a prompt, never local content.
 	 */
 	private suspend fun shouldPromptForMerge(pending: PendingServerSetup): Boolean {
-		if (pending.create || pending.replaceLocalContent) return false
-
-		val current = _state.value
-		val sameServer = current.currentUrl == pending.url && current.currentEmail == pending.email
-		if (sameServer) return false
+		if (pending.create || pending.replaceLocalContent || pending.sameServer) return false
 
 		return withContext(dispatcherIo) {
 			projectsRepository.getProjects().any { exampleProjectRepository.isExampleProject(it).not() }
@@ -457,13 +458,15 @@ class AccountSettingsComponent(
 		withContext(mainDispatcher) {
 			when (result) {
 				is ServerSetupResult.Success -> withContext(NonCancellable) {
+					// Cleared before the wipe suspends: cancelServerSetup() deletes the server
+					// settings whenever a setup is pending, and these tokens are now valid.
+					pendingServerSetup = null
 					// The local wipe waits until the account is confirmed: a bad password, an
 					// unreachable server or a declined ToS must never cost the user their work.
 					// NonCancellable so a close/ESC landing here can't strand valid tokens either.
 					if (shouldRemoveLocalContent(pending)) {
 						withContext(dispatcherIo) { removeLocalContent() }
 					}
-					pendingServerSetup = null
 					// A freshly created account holds no projects, so any serverProjectId from a
 					// previous server is stale and would make sync skip re-creating the project.
 					if (pending.create) {
@@ -531,12 +534,14 @@ class AccountSettingsComponent(
 	}
 
 	/**
-	 * Logging in with nothing but the bundled example project is a clean slate: drop it rather than
-	 * uploading it to the account and propagating it to every other device.
+	 * Logging in to a new server with nothing but the bundled example project is a clean slate: drop
+	 * it rather than uploading it to the account and propagating it to every other device. Re-auth
+	 * against the configured server is not a clean slate, so it keeps whatever is there.
 	 */
 	private suspend fun shouldRemoveLocalContent(pending: PendingServerSetup): Boolean {
 		if (pending.create) return false
 		if (pending.replaceLocalContent) return true
+		if (pending.sameServer) return false
 
 		return withContext(dispatcherIo) {
 			val projects = projectsRepository.getProjects()
@@ -588,6 +593,7 @@ private data class PendingServerSetup(
 	val password: String,
 	val create: Boolean,
 	val replaceLocalContent: Boolean,
+	val sameServer: Boolean,
 )
 
 @Serializable

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExampleProjectRepository.kt
@@ -38,6 +38,13 @@ abstract class ExampleProjectRepository(
 	fun shouldInstallFirstTime(): Boolean =
 		!globalSettingsStore.globalSettings.nux.exampleProjectCreated
 
+	/**
+	 * The NUX flag alone is not enough (it is never cleared when the example is deleted or renamed),
+	 * and the name alone is not enough (a user may name their own project this). Both together are.
+	 */
+	fun isExampleProject(projectDef: ProjectDef): Boolean =
+		projectDef.name == PROJECT_NAME && globalSettingsStore.globalSettings.nux.exampleProjectCreated
+
 	fun install() {
 		removeExampleProject()
 		platformInstall()

--- a/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
@@ -20,7 +20,6 @@ import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetada
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.getDefaultRootDocumentDirectory
-import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
 import io.mockk.coEvery
@@ -33,11 +32,11 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
+import okio.ForwardingFileSystem
 import okio.Path
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -65,6 +64,9 @@ class AccountSettingsComponentTest : BaseTest() {
 	private lateinit var accountUseCase: AccountUseCase
 	private lateinit var projectsRepository: ProjectsRepository
 
+	/** Set by a test to interleave an action with the post-success wipe. */
+	private var onFirstDelete: (() -> Unit)? = null
+
 	private val projectsDir: Path =
 		getDefaultRootDocumentDirectory().toPath() / GlobalSettingsStore.DEFAULT_PROJECTS_DIR
 
@@ -88,6 +90,9 @@ class AccountSettingsComponentTest : BaseTest() {
 		ffs.createDirectories(projectsDir)
 		toml = createTomlSerializer()
 
+		onFirstDelete = null
+		val hookedFs = DeleteHookFileSystem(ffs) { onFirstDelete?.invoke() }
+
 		globalSettingsStore = mockk(relaxed = true)
 		globalSettingsUpdates = MutableSharedFlow(replay = 1)
 		every { globalSettingsStore.globalSettingsUpdates } returns globalSettingsUpdates
@@ -102,21 +107,21 @@ class AccountSettingsComponentTest : BaseTest() {
 		accountUseCase = mockk(relaxed = true)
 
 		val testModule = module {
-			single<FileSystem> { ffs }
+			single<FileSystem> { hookedFs }
 			single { toml }
 			single { globalSettingsStore } bind GlobalSettingsStore::class
 			single<Clock> { Clock.System }
 			single {
 				ProjectsRepository(
-					fileSystem = ffs,
+					fileSystem = hookedFs,
 					globalSettingsStore = globalSettingsStore,
-					projectsMetadataDatasource = ProjectMetadataDatasource(ffs, toml),
+					projectsMetadataDatasource = ProjectMetadataDatasource(hookedFs, toml),
 					toml = toml,
 					deviceLocaleResolver = mockk(relaxed = true),
 				)
 			} bind ProjectsRepository::class
 			single<ExampleProjectRepository> {
-				FakeExampleProjectRepository(globalSettingsStore, ffs, toml, get())
+				FakeExampleProjectRepository(globalSettingsStore, hookedFs, toml, get())
 			} bind ExampleProjectRepository::class
 			single { accountUseCase } bind AccountUseCase::class
 			single { mockk<StrRes>(relaxed = true) } bind StrRes::class
@@ -420,6 +425,45 @@ class AccountSettingsComponentTest : BaseTest() {
 	}
 
 	@Test
+	fun `Re-authenticating against the configured server keeps the example project`() = runTest {
+		seedProject(ExampleProjectRepository.PROJECT_NAME)
+		setupSucceeds()
+		serverSettingsUpdates.emit(
+			ServerSettings(
+				url = "example.com",
+				email = "writer@example.com",
+				userId = 1L,
+				bearerToken = null,
+				refreshToken = null,
+			)
+		)
+
+		val component = newComponent()
+		advanceUntilIdle()
+		component.logIn()
+		advanceUntilIdle()
+
+		assertEquals(listOf(ExampleProjectRepository.PROJECT_NAME), localProjectNames())
+	}
+
+	@Test
+	fun `Cancelling while the post-success wipe runs keeps the new credentials`() = runTest {
+		seedProject(PROJECT_A)
+		setupSucceeds()
+
+		val component = newComponent()
+		advanceUntilIdle()
+		// The wipe runs off the main dispatcher, so a close or ESC can land while it is in flight.
+		// By then the account exists and its tokens must survive.
+		onFirstDelete = { component.cancelServerSetup() }
+		component.logIn(replaceLocalContent = true)
+		advanceUntilIdle()
+
+		verify(exactly = 0) { globalSettingsStore.deleteServerSettings() }
+		assertEquals(emptyList(), localProjectNames())
+	}
+
+	@Test
 	fun `Terms of service challenge is surfaced and acceptance retries the request`() = runTest {
 		coEvery {
 			accountUseCase.setupServer(any(), any(), any(), any(), null)
@@ -468,6 +512,22 @@ class AccountSettingsComponentTest : BaseTest() {
 	private companion object {
 		const val PROJECT_A = "Test Project A"
 		const val PROJECT_B = "Test Project B"
+	}
+}
+
+/** Runs [onFirstDelete] once, on the first deletion, so a test can act from inside a wipe. */
+private class DeleteHookFileSystem(
+	delegate: FileSystem,
+	private val onFirstDelete: () -> Unit,
+) : ForwardingFileSystem(delegate) {
+	private var fired = false
+
+	override fun delete(path: Path, mustExist: Boolean) {
+		if (!fired) {
+			fired = true
+			onFirstDelete()
+		}
+		super.delete(path, mustExist)
 	}
 }
 

--- a/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
@@ -3,18 +3,24 @@ package components.projectselection
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
+import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
 import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettingsComponent
 import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.PlatformSettings
+import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.ExampleProjectRepository
-import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.account.AccountUseCase
 import com.darkrockstudios.apps.hammer.common.data.account.ServerSetupResult
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.NewUserExperience
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.SpellCheckerSettings
+import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
+import com.darkrockstudios.apps.hammer.common.getDefaultRootDocumentDirectory
+import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
 import io.mockk.coEvery
@@ -30,13 +36,20 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import net.peanuuutz.tomlkt.Toml
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.test.get
 import utils.BaseTest
+import kotlin.time.Clock
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AccountSettingsComponentTest : BaseTest() {
@@ -44,18 +57,24 @@ class AccountSettingsComponentTest : BaseTest() {
 	private lateinit var lifecycle: LifecycleRegistry
 	private lateinit var context: DefaultComponentContext
 
+	private lateinit var ffs: FakeFileSystem
+	private lateinit var toml: Toml
 	private lateinit var globalSettingsStore: GlobalSettingsStore
 	private lateinit var globalSettingsUpdates: MutableSharedFlow<GlobalSettings>
-	private lateinit var serverSettingsUpdates: SharedFlow<ServerSettings?>
+	private lateinit var serverSettingsUpdates: MutableSharedFlow<ServerSettings?>
 	private lateinit var accountUseCase: AccountUseCase
 	private lateinit var projectsRepository: ProjectsRepository
 
+	private val projectsDir: Path =
+		getDefaultRootDocumentDirectory().toPath() / GlobalSettingsStore.DEFAULT_PROJECTS_DIR
+
 	private var globalSettings = GlobalSettings(
-		projectsDirectory = "",
+		projectsDirectory = projectsDir.toString(),
 		spellCheckSettings = SpellCheckerSettings(locale = mockk()),
 		automaticSyncing = true,
 		autoCloseSyncDialog = true,
 		automaticBackups = true,
+		nux = NewUserExperience(exampleProjectCreated = true),
 	)
 
 	@BeforeEach
@@ -64,6 +83,10 @@ class AccountSettingsComponentTest : BaseTest() {
 
 		lifecycle = LifecycleRegistry()
 		context = DefaultComponentContext(lifecycle = lifecycle)
+
+		ffs = FakeFileSystem()
+		ffs.createDirectories(projectsDir)
+		toml = createTomlSerializer()
 
 		globalSettingsStore = mockk(relaxed = true)
 		globalSettingsUpdates = MutableSharedFlow(replay = 1)
@@ -77,22 +100,69 @@ class AccountSettingsComponentTest : BaseTest() {
 		every { spellCheckerFactory.availableLocales() } returns emptyList()
 
 		accountUseCase = mockk(relaxed = true)
-		projectsRepository = mockk(relaxed = true)
 
 		val testModule = module {
+			single<FileSystem> { ffs }
+			single { toml }
 			single { globalSettingsStore } bind GlobalSettingsStore::class
-			single { mockk<ExampleProjectRepository>(relaxed = true) } bind ExampleProjectRepository::class
+			single<Clock> { Clock.System }
+			single {
+				ProjectsRepository(
+					fileSystem = ffs,
+					globalSettingsStore = globalSettingsStore,
+					projectsMetadataDatasource = ProjectMetadataDatasource(ffs, toml),
+					toml = toml,
+					deviceLocaleResolver = mockk(relaxed = true),
+				)
+			} bind ProjectsRepository::class
+			single<ExampleProjectRepository> {
+				FakeExampleProjectRepository(globalSettingsStore, ffs, toml, get())
+			} bind ExampleProjectRepository::class
 			single { accountUseCase } bind AccountUseCase::class
-			single { projectsRepository } bind ProjectsRepository::class
 			single { mockk<StrRes>(relaxed = true) } bind StrRes::class
 			single { spellCheckerFactory }
 			factory { mockk<PlatformSettings>(relaxed = true) } bind PlatformSettings::class
 		}
 		setupKoin(testModule)
+		projectsRepository = get()
 		lifecycle.resume()
 	}
 
 	private fun newComponent() = AccountSettingsComponent(componentContext = context)
+
+	private fun seedProject(name: String) {
+		val dir = projectsDir / name
+		ffs.createDirectories(dir)
+		ffs.write(dir / ProjectMetadata.FILENAME) { writeUtf8("") }
+	}
+
+	private fun localProjectNames(): List<String> =
+		ffs.list(projectsDir).map { it.name }.sorted()
+
+	private fun setupSucceeds() {
+		coEvery { accountUseCase.setupServer(any(), any(), any(), any(), any()) } returns
+			ServerSetupResult.Success
+	}
+
+	private fun AccountSettingsComponent.logIn(
+		url: String = "example.com",
+		email: String = "writer@example.com",
+		replaceLocalContent: Boolean = false,
+	) = setupServer(
+		url = url,
+		email = email,
+		password = "Password1!",
+		create = false,
+		replaceLocalContent = replaceLocalContent,
+	)
+
+	private fun AccountSettingsComponent.createAccount() = setupServer(
+		url = "example.com",
+		email = "writer@example.com",
+		password = "Password1!",
+		create = true,
+		replaceLocalContent = false,
+	)
 
 	@Test
 	fun `Auto-sync setting update is reflected in state`() = runTest {
@@ -120,63 +190,105 @@ class AccountSettingsComponentTest : BaseTest() {
 
 	@Test
 	fun `Creating a new account clears stale server project IDs`() = runTest {
-		val projectA = mockk<ProjectDef>()
-		val projectB = mockk<ProjectDef>()
-		every { projectsRepository.getProjects() } returns listOf(projectA, projectB)
-		coEvery {
-			accountUseCase.setupServer(
-				any(),
-				any(),
-				any(),
-				any(),
-				any()
-			)
-		} returns ServerSetupResult.Success
+		seedProject(PROJECT_A)
+		seedProject(PROJECT_B)
+		setupSucceeds()
 
 		val component = newComponent()
-		component.setupServer(
-			url = "example.com",
-			email = "writer@example.com",
-			password = "Password1!",
-			create = true,
-			removeLocalContent = false,
+		advanceUntilIdle()
+		projectsRepository.setProjectId(
+			projectsRepository.getProjectDefinition(PROJECT_A),
+			ProjectId("stale-a"),
 		)
+		projectsRepository.setProjectId(
+			projectsRepository.getProjectDefinition(PROJECT_B),
+			ProjectId("stale-b"),
+		)
+
+		component.createAccount()
 		advanceUntilIdle()
 
-		verify { projectsRepository.removeProjectId(projectA) }
-		verify { projectsRepository.removeProjectId(projectB) }
+		assertNull(projectsRepository.getProjectId(projectsRepository.getProjectDefinition(PROJECT_A)))
+		assertNull(projectsRepository.getProjectId(projectsRepository.getProjectDefinition(PROJECT_B)))
 	}
 
 	@Test
 	fun `Logging in to an existing account leaves server project IDs untouched`() = runTest {
-		val projectA = mockk<ProjectDef>()
-		every { projectsRepository.getProjects() } returns listOf(projectA)
-		coEvery {
-			accountUseCase.setupServer(
-				any(),
-				any(),
-				any(),
-				any(),
-				any()
-			)
-		} returns ServerSetupResult.Success
+		seedProject(PROJECT_A)
+		setupSucceeds()
 
 		val component = newComponent()
-		component.setupServer(
-			url = "example.com",
-			email = "writer@example.com",
-			password = "Password1!",
-			create = false,
-			removeLocalContent = false,
-		)
+		advanceUntilIdle()
+		val projectA = projectsRepository.getProjectDefinition(PROJECT_A)
+		projectsRepository.setProjectId(projectA, ProjectId("keep-me"))
+
+		component.logIn()
+		advanceUntilIdle()
+		component.chooseMerge()
 		advanceUntilIdle()
 
-		verify(exactly = 0) { projectsRepository.removeProjectId(any()) }
+		assertEquals(ProjectId("keep-me"), projectsRepository.getProjectId(projectA))
 	}
 
 	@Test
-	fun `Terms of service challenge is surfaced and acceptance retries the request`() = runTest {
-		every { projectsRepository.getProjects() } returns emptyList()
+	fun `A failed login leaves local projects untouched`() = runTest {
+		seedProject(PROJECT_A)
+		seedProject(PROJECT_B)
+		coEvery { accountUseCase.setupServer(any(), any(), any(), any(), any()) } returns
+			ServerSetupResult.Failure(displayMessage = null, exception = null)
+
+		val component = newComponent()
+		component.logIn(replaceLocalContent = true)
+		advanceUntilIdle()
+
+		assertEquals(listOf(PROJECT_A, PROJECT_B), localProjectNames())
+	}
+
+	@Test
+	fun `Logging in with only the example project silently drops it`() = runTest {
+		seedProject(ExampleProjectRepository.PROJECT_NAME)
+		setupSucceeds()
+
+		val component = newComponent()
+		component.logIn()
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.mergePrompt)
+		assertEquals(emptyList(), localProjectNames())
+	}
+
+	@Test
+	fun `A failed login with only the example project keeps it`() = runTest {
+		seedProject(ExampleProjectRepository.PROJECT_NAME)
+		coEvery { accountUseCase.setupServer(any(), any(), any(), any(), any()) } returns
+			ServerSetupResult.Failure(displayMessage = null, exception = null)
+
+		val component = newComponent()
+		component.logIn()
+		advanceUntilIdle()
+
+		assertEquals(listOf(ExampleProjectRepository.PROJECT_NAME), localProjectNames())
+	}
+
+	@Test
+	fun `Declining terms of service keeps the example project`() = runTest {
+		seedProject(ExampleProjectRepository.PROJECT_NAME)
+		coEvery {
+			accountUseCase.setupServer(any(), any(), any(), any(), null)
+		} returns ServerSetupResult.TermsRequired(TermsOfServiceChallenge(text = "Legal text", version = "v1"))
+
+		val component = newComponent()
+		component.logIn()
+		advanceUntilIdle()
+		component.declineTos()
+		advanceUntilIdle()
+
+		assertEquals(listOf(ExampleProjectRepository.PROJECT_NAME), localProjectNames())
+	}
+
+	@Test
+	fun `Accepting terms of service still drops the example project`() = runTest {
+		seedProject(ExampleProjectRepository.PROJECT_NAME)
 		coEvery {
 			accountUseCase.setupServer(any(), any(), any(), any(), null)
 		} returns ServerSetupResult.TermsRequired(TermsOfServiceChallenge(text = "Legal text", version = "v1"))
@@ -185,13 +297,139 @@ class AccountSettingsComponentTest : BaseTest() {
 		} returns ServerSetupResult.Success
 
 		val component = newComponent()
-		component.setupServer(
-			url = "example.com",
-			email = "writer@example.com",
-			password = "Password1!",
-			create = true,
-			removeLocalContent = false,
+		component.logIn()
+		advanceUntilIdle()
+		component.acceptTos()
+		advanceUntilIdle()
+
+		assertEquals(emptyList(), localProjectNames())
+	}
+
+	@Test
+	fun `Creating an account with only the example project keeps it`() = runTest {
+		seedProject(ExampleProjectRepository.PROJECT_NAME)
+		setupSucceeds()
+
+		val component = newComponent()
+		component.createAccount()
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.mergePrompt)
+		assertEquals(listOf(ExampleProjectRepository.PROJECT_NAME), localProjectNames())
+	}
+
+	@Test
+	fun `Creating an account with real projects never prompts`() = runTest {
+		seedProject(PROJECT_A)
+		setupSucceeds()
+
+		val component = newComponent()
+		component.createAccount()
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.mergePrompt)
+		assertEquals(listOf(PROJECT_A), localProjectNames())
+	}
+
+	@Test
+	fun `Logging in to a new server with real projects raises the merge prompt`() = runTest {
+		seedProject(PROJECT_A)
+		setupSucceeds()
+
+		val component = newComponent()
+		component.logIn()
+		advanceUntilIdle()
+
+		assertTrue(component.state.value.mergePrompt)
+		assertFalse(component.state.value.serverSetup)
+		coVerify(exactly = 0) { accountUseCase.setupServer(any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `Choosing merge runs the setup and keeps every local project`() = runTest {
+		seedProject(PROJECT_A)
+		seedProject(PROJECT_B)
+		setupSucceeds()
+
+		val component = newComponent()
+		component.logIn()
+		advanceUntilIdle()
+		component.chooseMerge()
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.mergePrompt)
+		coVerify(exactly = 1) { accountUseCase.setupServer(any(), any(), any(), any(), any()) }
+		assertEquals(listOf(PROJECT_A, PROJECT_B), localProjectNames())
+	}
+
+	@Test
+	fun `Choosing replace deletes every local project`() = runTest {
+		seedProject(PROJECT_A)
+		seedProject(PROJECT_B)
+		setupSucceeds()
+
+		val component = newComponent()
+		component.logIn()
+		advanceUntilIdle()
+		component.chooseReplace()
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.mergePrompt)
+		assertEquals(emptyList(), localProjectNames())
+	}
+
+	@Test
+	fun `Cancelling the merge prompt returns to setup without contacting the server`() = runTest {
+		seedProject(PROJECT_A)
+		setupSucceeds()
+
+		val component = newComponent()
+		component.logIn()
+		advanceUntilIdle()
+		component.cancelMergePrompt()
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.mergePrompt)
+		assertTrue(component.state.value.serverSetup)
+		coVerify(exactly = 0) { accountUseCase.setupServer(any(), any(), any(), any(), any()) }
+		assertEquals(listOf(PROJECT_A), localProjectNames())
+	}
+
+	@Test
+	fun `Re-authenticating against the configured server never prompts`() = runTest {
+		seedProject(PROJECT_A)
+		setupSucceeds()
+		serverSettingsUpdates.emit(
+			ServerSettings(
+				url = "example.com",
+				email = "writer@example.com",
+				userId = 1L,
+				bearerToken = null,
+				refreshToken = null,
+			)
 		)
+
+		val component = newComponent()
+		advanceUntilIdle()
+		component.logIn()
+		advanceUntilIdle()
+
+		assertFalse(component.state.value.mergePrompt)
+		coVerify(exactly = 1) { accountUseCase.setupServer(any(), any(), any(), any(), any()) }
+		assertEquals(listOf(PROJECT_A), localProjectNames())
+	}
+
+	@Test
+	fun `Terms of service challenge is surfaced and acceptance retries the request`() = runTest {
+		coEvery {
+			accountUseCase.setupServer(any(), any(), any(), any(), null)
+		} returns ServerSetupResult.TermsRequired(TermsOfServiceChallenge(text = "Legal text", version = "v1"))
+		coEvery {
+			accountUseCase.setupServer(any(), any(), any(), any(), "v1")
+		} returns ServerSetupResult.Success
+
+		val component = newComponent()
+		component.createAccount()
 		advanceUntilIdle()
 
 		assertEquals("Legal text", component.state.value.tosChallenge?.text)
@@ -213,13 +451,7 @@ class AccountSettingsComponentTest : BaseTest() {
 		} returns ServerSetupResult.TermsRequired(TermsOfServiceChallenge(text = "Legal text", version = "v1"))
 
 		val component = newComponent()
-		component.setupServer(
-			url = "example.com",
-			email = "writer@example.com",
-			password = "Password1!",
-			create = true,
-			removeLocalContent = false,
-		)
+		component.createAccount()
 		advanceUntilIdle()
 		assertNotNull(component.state.value.tosChallenge)
 
@@ -231,5 +463,27 @@ class AccountSettingsComponentTest : BaseTest() {
 		verify { globalSettingsStore.deleteServerSettings() }
 		// Only the initial challenge attempt ran; declining never resubmits.
 		coVerify(exactly = 1) { accountUseCase.setupServer(any(), any(), any(), any(), any()) }
+	}
+
+	private companion object {
+		const val PROJECT_A = "Test Project A"
+		const val PROJECT_B = "Test Project B"
+	}
+}
+
+private class FakeExampleProjectRepository(
+	globalSettingsStore: GlobalSettingsStore,
+	fileSystem: FileSystem,
+	toml: Toml,
+	clock: Clock,
+) : ExampleProjectRepository(globalSettingsStore, fileSystem, toml, clock) {
+	override fun removeExampleProject() {
+		fileSystem.deleteRecursively(projectsDir() / PROJECT_NAME)
+	}
+
+	override fun platformInstall() {
+		val dir = projectsDir() / PROJECT_NAME
+		fileSystem.createDirectories(dir)
+		fileSystem.write(dir / ProjectMetadata.FILENAME) { writeUtf8("") }
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/MergeProjectsDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/MergeProjectsDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -53,8 +54,10 @@ fun MergeProjectsDialog(component: AccountSettings) {
 	var renderInternal by remember { mutableStateOf(state.mergePrompt) }
 	LaunchedEffect(state.mergePrompt) { if (state.mergePrompt) renderInternal = true }
 
-	var mode by remember(state.mergePrompt) { mutableStateOf(MergeMode.Merge) }
-	var confirmReplace by remember(state.mergePrompt) { mutableStateOf(false) }
+	// Keyed on renderInternal, not mergePrompt: the choice has to outlive the exit animation, and
+	// resetting on close would visibly snap the picker back to Merge on the way out.
+	var mode by rememberSaveable(renderInternal) { mutableStateOf(MergeMode.Merge) }
+	var confirmReplace by rememberSaveable(renderInternal) { mutableStateOf(false) }
 
 	if (renderInternal) {
 		AnimatedDialogContainer(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/MergeProjectsDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/MergeProjectsDialog.kt
@@ -1,0 +1,193 @@
+package com.darkrockstudios.apps.hammer.common.projectselection.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import com.darkrockstudios.apps.hammer.*
+import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettings
+import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialogContainer
+import com.darkrockstudios.apps.hammer.common.compose.ConfirmationDialog
+import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdButtonBar
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineSegmentedPicker
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMasthead
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
+import com.darkrockstudios.apps.hammer.common.compose.resources.get
+
+private val DialogMaxWidth = 480.dp
+
+enum class MergeMode {
+	Merge,
+	Replace,
+}
+
+/**
+ * Raised in place of the server setup dialog when logging in to a new server would merge real local
+ * work into it. A sibling of [ServerSetupDialog] and [TermsOfServiceDialog] rather than a child, so
+ * the two never stack.
+ */
+@Composable
+fun MergeProjectsDialog(component: AccountSettings) {
+	val state by component.state.subscribeAsState()
+
+	var renderInternal by remember { mutableStateOf(state.mergePrompt) }
+	LaunchedEffect(state.mergePrompt) { if (state.mergePrompt) renderInternal = true }
+
+	var mode by remember(state.mergePrompt) { mutableStateOf(MergeMode.Merge) }
+	var confirmReplace by remember(state.mergePrompt) { mutableStateOf(false) }
+
+	if (renderInternal) {
+		AnimatedDialogContainer(
+			isOpen = state.mergePrompt,
+			onDismissRequest = { component.cancelMergePrompt() },
+			onClosed = { renderInternal = false },
+			properties = DialogProperties(usePlatformDefaultWidth = false),
+		) {
+			MergeProjectsDialogContent(
+				mode = mode,
+				onModeChange = { mode = it },
+				onCancel = { component.cancelMergePrompt() },
+				onContinue = {
+					when (mode) {
+						MergeMode.Merge -> component.chooseMerge()
+						MergeMode.Replace -> confirmReplace = true
+					}
+				},
+				modifier = Modifier.predictiveBackTransform(),
+			)
+		}
+	}
+
+	ConfirmationDialog(
+		visible = confirmReplace,
+		title = Res.string.merge_projects_replace_confirm_title.get(),
+		message = Res.string.merge_projects_replace_confirm_message.get(),
+		confirmLabel = Res.string.merge_projects_replace_confirm_button.get(),
+		cancelLabel = Res.string.confirm_dialog_negative.get(),
+		onConfirm = {
+			confirmReplace = false
+			component.chooseReplace()
+		},
+		onDismiss = { confirmReplace = false },
+		destructive = true,
+		kind = "DELETE",
+	)
+}
+
+/**
+ * The static chrome of [MergeProjectsDialog] without the [AnimatedDialogContainer] wrapper.
+ * Render this directly in a `@Preview`: the Desktop preview renderer can't advance the enter
+ * animation, so only this settles to an opaque frame.
+ */
+@Composable
+fun MergeProjectsDialogContent(
+	mode: MergeMode,
+	onModeChange: (MergeMode) -> Unit,
+	onCancel: () -> Unit,
+	onContinue: () -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	Surface(
+		modifier = modifier
+			.padding(Ui.Padding.M)
+			.widthIn(max = DialogMaxWidth)
+			.fillMaxWidth(),
+		shape = RectangleShape,
+		color = MaterialTheme.colorScheme.surface,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+		border = BorderStroke(
+			width = Dp.Hairline,
+			color = MaterialTheme.colorScheme.outlineVariant,
+		),
+	) {
+		Column {
+			HdMasthead(
+				section = "SYNC PROJECTS",
+				trailing = {
+					HdMastheadAction(label = "× CLOSE", onClick = onCancel)
+				},
+			)
+			HdFolioDivider()
+
+			Text(
+				text = Res.string.merge_projects_dialog_title.get(),
+				style = MaterialTheme.typography.headlineSmall,
+				color = MaterialTheme.colorScheme.onSurface,
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(
+						start = Ui.Padding.XL,
+						end = Ui.Padding.XL,
+						top = Ui.Padding.L,
+						bottom = Ui.Padding.S,
+					),
+			)
+
+			Column(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(
+						start = Ui.Padding.XL,
+						end = Ui.Padding.XL,
+						top = Ui.Padding.L,
+						bottom = Ui.Padding.L,
+					),
+				verticalArrangement = Arrangement.spacedBy(Ui.Padding.L),
+			) {
+				HdHairlineSegmentedPicker(
+					title = Res.string.merge_projects_mode_label.get(),
+					options = MergeMode.entries,
+					selected = mode,
+					onSelect = onModeChange,
+					label = { it.label() },
+				)
+
+				Text(
+					text = mode.explanation(),
+					style = MaterialTheme.typography.bodyMedium.copy(lineHeight = 22.sp),
+					color = MaterialTheme.colorScheme.onSurfaceVariant,
+				)
+			}
+
+			HdButtonBar(
+				cancelLabel = Res.string.settings_server_setup_cancel_button.get(),
+				primaryLabel = Res.string.merge_projects_continue_button.get(),
+				onCancel = onCancel,
+				onPrimary = onContinue,
+				primaryDanger = mode == MergeMode.Replace,
+			)
+		}
+	}
+}
+
+@Composable
+private fun MergeMode.label(): String = when (this) {
+	MergeMode.Merge -> Res.string.merge_projects_mode_merge.get()
+	MergeMode.Replace -> Res.string.merge_projects_mode_replace.get()
+}
+
+@Composable
+private fun MergeMode.explanation(): String = when (this) {
+	MergeMode.Merge -> Res.string.merge_projects_explain_merge.get()
+	MergeMode.Replace -> Res.string.merge_projects_explain_replace.get()
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSettingsUi.kt
@@ -120,6 +120,7 @@ fun ServerSettingsUi(
 
 	Toaster(component, rootSnackbar)
 	ServerSetupDialog(component, scope)
+	MergeProjectsDialog(component)
 	TermsOfServiceDialog(component)
 
 	if (showHelpDialog) {

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSetupDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSetupDialog.kt
@@ -19,7 +19,6 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
 import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettings
 import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialogContainer
-import com.darkrockstudios.apps.hammer.common.compose.SimpleConfirm
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
@@ -71,7 +70,6 @@ fun ServerSetupDialogContent(
 	val state by component.state.subscribeAsState()
 
 	var passwordVisible by rememberSaveable(state.serverSetup) { mutableStateOf(false) }
-	var confirmDeleteLocal by rememberSaveable(state.serverSetup) { mutableStateOf<Boolean?>(null) }
 	var showHelpDialog by rememberSaveable { mutableStateOf(false) }
 	val existingServer = rememberSaveable(state.serverSetup) {
 		state.serverWorking.not()
@@ -184,53 +182,27 @@ fun ServerSetupDialogContent(
 				color = MaterialTheme.colorScheme.outlineVariant,
 			)
 
+			// The component decides whether a login needs the merge/replace prompt; the UI only
+			// ever asks for the non-destructive setup.
+			fun setupServer(create: Boolean) {
+				component.setupServer(
+					url = state.serverUrl ?: "",
+					email = state.serverEmail ?: "",
+					password = state.serverPassword ?: "",
+					create = create,
+					replaceLocalContent = false,
+				)
+			}
+
 			ActionRow(
 				working = state.serverWorking,
 				isLoggedIn = state.serverIsLoggedIn,
 				canCreate = state.currentUrl == null,
 				onCancel = { scope.launch { component.cancelServerSetup() } },
-				onCreate = { confirmDeleteLocal = true },
-				onLogin = {
-					if (state.serverIsLoggedIn.not()) {
-						confirmDeleteLocal = false
-					} else {
-						component.setupServer(
-							url = state.serverUrl ?: "",
-							email = state.serverEmail ?: "",
-							password = state.serverPassword ?: "",
-							create = false,
-							removeLocalContent = false,
-						)
-					}
-				},
+				onCreate = { setupServer(create = true) },
+				onLogin = { setupServer(create = false) },
 			)
 		}
-	}
-
-	confirmDeleteLocal?.let { create ->
-		fun setupServer(create: Boolean, removeLocal: Boolean) {
-			component.setupServer(
-				url = state.serverUrl ?: "",
-				email = state.serverEmail ?: "",
-				password = state.serverPassword ?: "",
-				create = create,
-				removeLocalContent = removeLocal,
-			)
-		}
-
-		SimpleConfirm(
-			title = Res.string.remove_local_dialog_title.get(),
-			message = Res.string.remove_local_dialog_message.get(),
-			implicitCancel = false,
-			onDismiss = {
-				setupServer(create, false)
-				confirmDeleteLocal = null
-			},
-			onConfirm = {
-				setupServer(create, true)
-				confirmDeleteLocal = null
-			},
-		)
 	}
 
 	if (showHelpDialog) {

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/MergeProjectsDialog.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/MergeProjectsDialog.Preview.kt
@@ -1,0 +1,42 @@
+package com.darkrockstudios.apps.hammer.common.preview
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.projectselection.settings.MergeMode
+import com.darkrockstudios.apps.hammer.common.projectselection.settings.MergeProjectsDialogContent
+
+@Preview(widthDp = 560, heightDp = 440)
+@Composable
+fun MergeProjectsDialogMergePreview() = MergeProjectsDialogPreview(MergeMode.Merge)
+
+@Preview(widthDp = 560, heightDp = 440)
+@Composable
+fun MergeProjectsDialogReplacePreview() = MergeProjectsDialogPreview(MergeMode.Replace)
+
+@Composable
+private fun MergeProjectsDialogPreview(mode: MergeMode) {
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, true) {
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.background(MaterialTheme.colorScheme.background),
+				contentAlignment = Alignment.Center,
+			) {
+				MergeProjectsDialogContent(
+					mode = mode,
+					onModeChange = {},
+					onCancel = {},
+					onContinue = {},
+				)
+			}
+		}
+	}
+}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
@@ -61,9 +61,13 @@ internal fun accountSettingsComponent(state: AccountSettings.State = defaultAcco
 			email: String,
 			password: String,
 			create: Boolean,
-			removeLocalContent: Boolean
+			replaceLocalContent: Boolean
 		) {
 		}
+
+		override fun chooseMerge() {}
+		override fun chooseReplace() {}
+		override fun cancelMergePrompt() {}
 
 		override fun acceptTos() {}
 		override fun declineTos() {}


### PR DESCRIPTION
Setting up a sync server popped a "Remove Local Content?" confirm on both the Create-account and the
first-time Log In path. It was confusing, unskippable (`implicitCancel = false`, so neither answer
aborted), and it fired even for a brand-new user whose only project was the bundled example.

Worse, `removeLocalContent()` ran *before* the network call. A typo'd password, an unreachable server
or a declined Terms-of-Service prompt deleted every local project anyway. There is no backup and no
undo.

## What this does

Only ask when the answer actually matters, and never delete on a login that did not succeed.

| Local projects | Action | Prompt | Local content |
|---|---|---|---|
| none | create or log in | none | nothing to do |
| example only | create account | none | kept |
| example only | log in | none | example dropped after login succeeds |
| real projects | create account | none | kept |
| real projects | log in, same server (re-auth) | none | kept |
| real projects | log in, new server | Merge / Replace, default Merge | per choice |

Replace requires a second destructive confirmation.

The wipe now happens in the `ServerSetupResult.Success` branch, so a failed login costs nothing. That
also closes a case where create-account plus "remove local" plus declining the ToS left the user with
no projects *and* no account.

## Design rule

**The UI never computes the destructive boolean.** An earlier draft put a `hasMergeableProjects` flag
in `AccountSettings.State`; because it defaults to `false` and fills asynchronously, a StateKeeper
restore or a fast tap would have wiped everything with no prompt. The component owns both decisions
and re-reads the projects directory when it acts, so a stale caller can only cost a *missing prompt*,
never local content. `setupServer`'s `replaceLocalContent` is true only from an explicit Replace.

## Follow-up commits

A review of the first commit turned up two more data-loss paths, both fixed here:

- **Cancel during the success window.** The wipe suspends onto `dispatcherIo` while
  `pendingServerSetup` is still set, so a close or ESC in that window ran `cancelServerSetup()` and
  deleted the tokens that had just been obtained, then the wipe finished anyway. `NonCancellable`
  does not help, since it stops cancellation rather than main-thread interleaving.
  `pendingServerSetup` is now released before the first suspension point.
- **Re-auth deleting the example project.** `shouldRemoveLocalContent` had no same-server guard, so a
  routine token-expiry re-login dropped the example project even though no account switch happened.
  `PendingServerSetup` now carries `sameServer`, captured when the setup is built because
  `AccountUseCase` writes provisional settings before the result comes back.

The dialog also keeps its selection across the exit animation and an Android configuration change.

## Tests

`AccountSettingsComponentTest` runs against a real `ProjectsRepository` over a `FakeFileSystem`, so
assertions read "the directory is gone" rather than verifying a mock call. Only `AccountUseCase`, the
network boundary, stays mocked.

Covered: failed login keeps content; ToS decline keeps it; ToS accept still drops it (the flag rides
`PendingServerSetup` through the retry); merge keeps every project; replace deletes them; cancel
contacts nothing; same-server re-auth neither prompts nor deletes; and a cancel arriving mid-wipe
leaves the new credentials intact.

That last one needed a scheduling hook to hit deterministically. `TestDispatcher` has an internal
constructor and both `ProjectsRepository` and `isExampleProject` are final, so the injected
`FileSystem` is wrapped in an okio `ForwardingFileSystem` that fires once on the first `delete`,
landing the cancel inside `removeLocalContent`.

## Known gap

`isExampleProject` is close to a name-only test: `nux.exampleProjectCreated` is set for every install
and never cleared, so a user whose only project happens to be named "Alice In Wonderland" loses it on
first login with no prompt. Closing that properly needs an identity marker written into project
metadata at install time, which felt like its own change.

Two related sync bugs that this makes more likely to be hit are fixed on separate branches:
adopting server projects by name before uploading, and clearing per-project sync baselines when a
project moves to a different server.
