### PR TITLE
Adopt server projects by name before uploading local ones

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -151,6 +151,7 @@
 	<string name="sync_log_account_project_create_client_failure">Failed to create server project:
 		%1$s
 	</string>
+	<string name="sync_log_account_project_create_client_name_taken">Skipped server project %1$s: a local project of that name already syncs with a different server project</string>
 
 	<string name="sync_log_begin_account">Syncing Account...</string>
 	<string name="sync_log_begin_projects">Syncing Projects...</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -447,30 +447,37 @@ class ClientAccountSynchronizer(
 			onLog
 		)
 
+		// Claim server projects by name before uploading anything. The other order uploads a
+		// same-named local project as a second server project and only then overwrites its id
+		// with the name match, stranding an orphan duplicate on the server.
+		val claimedNames = createLocalProjectsFromServer(newServerProjects, onLog)
+
 		createProjectsOnServer(
 			localProjectsWithIds,
+			claimedNames,
 			clientSyncData,
 			serverSyncData,
 			serverKnownIds,
 			onLog,
 			onUnauthorized,
 		)
-
-		createLocalProjectsFromServer(newServerProjects, onLog)
 	}
 
 	/**
-	 * Create local projects from server
+	 * Create local projects from server. Returns the local names now backed by a server project,
+	 * whether adopted or freshly created, so [createProjectsOnServer] does not re-upload them.
 	 */
 	private suspend fun createLocalProjectsFromServer(
 		newServerProjects: List<ApiProjectDefinition>,
 		onLog: OnSyncLog
-	) {
+	): Set<String> {
+		val claimedNames = mutableSetOf<String>()
 		newServerProjects.forEach { serverProject ->
 			val localName = ProjectsRepository.toLocalSafeName(serverProject.name)
 			val existingProject = projectsRepository.findProject(localName)
 			if (existingProject != null) {
 				projectsRepository.setProjectId(existingProject, serverProject.uuid)
+				claimedNames += existingProject.name
 				onLog(
 					syncAccLogI(
 						strRes.get(
@@ -484,6 +491,7 @@ class ClientAccountSynchronizer(
 				if (isSuccess(createResult)) {
 					val projectDef = createResult.data
 					projectsRepository.setProjectId(projectDef, serverProject.uuid)
+					claimedNames += projectDef.name
 					onLog(
 						syncAccLogI(
 							strRes.get(
@@ -504,37 +512,44 @@ class ClientAccountSynchronizer(
 				}
 			}
 		}
+		return claimedNames
 	}
 
 	/**
 	 * Create projects on the server which this client has created locally. A cached [ProjectId]
 	 * absent from [serverKnownIds] is dead (the client last synced against a different or
 	 * since-reset server): recreate it, or per-project sync gets an id it can only 410 on.
+	 *
+	 * [claimedNames] are local projects that just adopted a server project by name; uploading them
+	 * would duplicate that project on the server.
 	 */
 	private suspend fun createProjectsOnServer(
 		localProjectsWithIds: List<Pair<ProjectDef, ProjectId?>>,
+		claimedNames: Set<String>,
 		clientSyncData: ProjectsSynchronizationData,
 		serverSyncData: BeginProjectsSyncResponse,
 		serverKnownIds: Set<ProjectId>,
 		onLog: OnSyncLog,
 		onUnauthorized: suspend () -> Unit = {},
 	) {
-		val localOnly = localProjectsWithIds.filter { (_, uuid) ->
-			uuid == null || uuid !in serverKnownIds
+		val localOnly = localProjectsWithIds.filter { (def, uuid) ->
+			(uuid == null || uuid !in serverKnownIds) && def.name !in claimedNames
 		}.map { it.first.name }
 
 		// A queued name with no local project was deleted before it ever reached the server.
 		// Creating it would push an empty project to every device, and resolving its definition
-		// would point at a directory that is gone, so drop it instead.
+		// would point at a directory that is gone. A queued name that just adopted a server
+		// project is equally dead. Drop both rather than acting on them.
 		val localNames = localProjectsWithIds.mapTo(mutableSetOf()) { it.first.name }
-		val staleCreates = clientSyncData.projectsToCreate - localNames
-		if (staleCreates.isNotEmpty()) {
+		val withdrawnCreates = clientSyncData.projectsToCreate
+			.filterTo(mutableSetOf()) { it !in localNames || it in claimedNames }
+		if (withdrawnCreates.isNotEmpty()) {
 			updateSyncData { syncData ->
-				syncData.copy(projectsToCreate = syncData.projectsToCreate - staleCreates)
+				syncData.copy(projectsToCreate = syncData.projectsToCreate - withdrawnCreates)
 			}
 		}
 
-		val newLocalProjects = (clientSyncData.projectsToCreate - staleCreates) + localOnly
+		val newLocalProjects = (clientSyncData.projectsToCreate - withdrawnCreates) + localOnly
 		// Create projects on the server
 		newLocalProjects.forEach { projectName ->
 			val result = serverProjectsApi.createProject(projectName, serverSyncData.syncId)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -450,7 +450,8 @@ class ClientAccountSynchronizer(
 		// Claim server projects by name before uploading anything. The other order uploads a
 		// same-named local project as a second server project and only then overwrites its id
 		// with the name match, stranding an orphan duplicate on the server.
-		val claimedNames = createLocalProjectsFromServer(newServerProjects, onLog)
+		val liveServerIds = serverProjects.mapTo(mutableSetOf()) { it.uuid }
+		val claimedNames = createLocalProjectsFromServer(newServerProjects, liveServerIds, onLog)
 
 		createProjectsOnServer(
 			localProjectsWithIds,
@@ -466,9 +467,15 @@ class ClientAccountSynchronizer(
 	/**
 	 * Create local projects from server. Returns the local names now backed by a server project,
 	 * whether adopted or freshly created, so [createProjectsOnServer] does not re-upload them.
+	 *
+	 * A name match only claims a local project that is not already bound to one of
+	 * [liveServerIds]: re-pointing it would abandon the server project holding its content, and
+	 * two server names can sanitize to a single local name. Tombstoned ids are absent from
+	 * [liveServerIds], so a project whose server copy was deleted elsewhere can still be claimed.
 	 */
 	private suspend fun createLocalProjectsFromServer(
 		newServerProjects: List<ApiProjectDefinition>,
+		liveServerIds: Set<ProjectId>,
 		onLog: OnSyncLog
 	): Set<String> {
 		val claimedNames = mutableSetOf<String>()
@@ -476,6 +483,19 @@ class ClientAccountSynchronizer(
 			val localName = ProjectsRepository.toLocalSafeName(serverProject.name)
 			val existingProject = projectsRepository.findProject(localName)
 			if (existingProject != null) {
+				val existingId = projectsRepository.getProjectId(existingProject)
+				if (existingId != null && existingId in liveServerIds) {
+					onLog(
+						syncAccLogW(
+							strRes.get(
+								Res.string.sync_log_account_project_create_client_name_taken,
+								serverProject.name
+							)
+						)
+					)
+					return@forEach
+				}
+
 				projectsRepository.setProjectId(existingProject, serverProject.uuid)
 				claimedNames += existingProject.name
 				onLog(

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -628,6 +628,60 @@ class ClientAccountSynchronizerTest {
 	}
 
 	@Test
+	fun `syncProjects adopts a same-named server project instead of uploading a duplicate`() = runTest {
+		writeSyncData(emptySyncData())
+		val serverId = ProjectId.randomUUID()
+		val duplicateId = ProjectId.randomUUID()
+		val def = projectDef("MyNovel")
+
+		// Same name on both sides, and the local copy has never been synced anywhere.
+		coEvery { serverProjectsApi.beginProjectsSync() } returns Result.success(
+			emptyServerResponse().copy(projects = setOf(ApiProjectDefinition("MyNovel", serverId)))
+		)
+		every { projectsRepository.getProjects(any()) } returns listOf(def)
+		every { projectsRepository.getProjectId(def) } returns null
+		every { projectsRepository.findProject("MyNovel") } returns def
+		every { projectsRepository.getProjectDefinition("MyNovel") } returns def
+		coEvery { serverProjectsApi.createProject("MyNovel", "sync-1") } returns
+			Result.success(CreateProjectResponse(duplicateId, alreadyExisted = false))
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		// Uploading first would leave an orphan second "MyNovel" on the server that every
+		// other device then downloads as an empty duplicate.
+		coVerify(exactly = 0) { serverProjectsApi.createProject(any(), any()) }
+		verify { projectsRepository.setProjectId(def, serverId) }
+		verify(exactly = 0) { projectsRepository.setProjectId(def, duplicateId) }
+	}
+
+	@Test
+	fun `syncProjects withdraws a queued creation the server already holds under that name`() = runTest {
+		writeSyncData(emptySyncData().copy(projectsToCreate = setOf("MyNovel")))
+		val serverId = ProjectId.randomUUID()
+		val duplicateId = ProjectId.randomUUID()
+		val def = projectDef("MyNovel")
+
+		coEvery { serverProjectsApi.beginProjectsSync() } returns Result.success(
+			emptyServerResponse().copy(projects = setOf(ApiProjectDefinition("MyNovel", serverId)))
+		)
+		every { projectsRepository.getProjects(any()) } returns listOf(def)
+		every { projectsRepository.getProjectId(def) } returns null
+		every { projectsRepository.findProject("MyNovel") } returns def
+		every { projectsRepository.getProjectDefinition("MyNovel") } returns def
+		coEvery { serverProjectsApi.createProject("MyNovel", "sync-1") } returns
+			Result.success(CreateProjectResponse(duplicateId, alreadyExisted = false))
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		coVerify(exactly = 0) { serverProjectsApi.createProject(any(), any()) }
+		verify { projectsRepository.setProjectId(def, serverId) }
+		// Left queued, it would try to duplicate the project again on every future sync.
+		assertTrue(readSyncData().projectsToCreate.isEmpty())
+	}
+
+	@Test
 	fun `syncProjects sanitizes an illegal server project name before creating it locally`() = runTest {
 		writeSyncData(emptySyncData())
 		val serverId = ProjectId.randomUUID()

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -682,6 +682,66 @@ class ClientAccountSynchronizerTest {
 	}
 
 	@Test
+	fun `syncProjects leaves a project bound to a live server project alone when another shares its name`() = runTest {
+		writeSyncData(emptySyncData())
+		val liveId = ProjectId.randomUUID()
+		val orphanId = ProjectId.randomUUID()
+		val def = projectDef("My Novel")
+
+		// An account that still carries an orphan duplicate from the old upload-first ordering:
+		// its name sanitizes to the name of a local project already bound to a different server
+		// project.
+		coEvery { serverProjectsApi.beginProjectsSync() } returns Result.success(
+			emptyServerResponse().copy(
+				projects = setOf(
+					ApiProjectDefinition("My Novel", liveId),
+					ApiProjectDefinition("My#Novel", orphanId),
+				)
+			)
+		)
+		every { projectsRepository.getProjects(any()) } returns listOf(def)
+		every { projectsRepository.getProjectId(def) } returns liveId
+		every { projectsRepository.findProject("My Novel") } returns def
+		every { projectsRepository.getProjectDefinition("My Novel") } returns def
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		// Adopting the orphan abandons the server project actually holding the manuscript.
+		verify(exactly = 0) { projectsRepository.setProjectId(def, orphanId) }
+		coVerify(exactly = 0) { serverProjectsApi.createProject(any(), any()) }
+	}
+
+	@Test
+	fun `syncProjects binds only the first of two server projects sharing one local name`() = runTest {
+		writeSyncData(emptySyncData())
+		val firstId = ProjectId.randomUUID()
+		val secondId = ProjectId.randomUUID()
+		val createdDef = projectDef("My Novel")
+
+		coEvery { serverProjectsApi.beginProjectsSync() } returns Result.success(
+			emptyServerResponse().copy(
+				projects = setOf(
+					ApiProjectDefinition("My Novel", firstId),
+					ApiProjectDefinition("My#Novel", secondId),
+				)
+			)
+		)
+		every { projectsRepository.getProjects(any()) } returns emptyList()
+		every { projectsRepository.findProject("My Novel") } returnsMany listOf(null, createdDef)
+		every { projectsRepository.createProject("My Novel", any()) } returns CResult.success(createdDef)
+		every { projectsRepository.getProjectId(createdDef) } returns firstId
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		verify(exactly = 1) { projectsRepository.createProject("My Novel", any()) }
+		verify { projectsRepository.setProjectId(createdDef, firstId) }
+		// The second one would silently steal the only local project the first just claimed.
+		verify(exactly = 0) { projectsRepository.setProjectId(createdDef, secondId) }
+	}
+
+	@Test
 	fun `syncProjects sanitizes an illegal server project name before creating it locally`() = runTest {
 		writeSyncData(emptySyncData())
 		val serverId = ProjectId.randomUUID()


### PR DESCRIPTION
`ClientAccountSynchronizer.syncCreatedProjects` ran `createProjectsOnServer` *before*
`createLocalProjectsFromServer`, so a local project sharing a name with one already on the server was
uploaded first and only afterwards had its id overwritten by the name-matching branch.

## Fix

Adopt first, then upload. `createLocalProjectsFromServer` now returns the set of names it claimed,
covering both the branch where it adopts an existing local project and the one where it creates a new
one, and `createProjectsOnServer` skips anything in that set.

Queued creations are withdrawn on the same basis: a name in `clientSyncData.projectsToCreate` that
the server already holds is dropped from the journal, so a create queued before the adoption does not
re-fire on the next sync.

## How bad was the old ordering

Less bad than it looks against a current server, and worth stating plainly.
`server/.../projects/ProjectsRepository.kt:204` already dedupes `createProject` by name
(`findProjectByName` → `alreadyExisted = true`), so the upload usually returned the *existing* uuid
rather than minting a second project. The orphan duplicate only materialises when the local name and
the server name differ (`toLocalSafeName` sanitised the server's name) or against a server without
that dedupe. The reordering is still correct and saves a pointless round trip, but it is not fixing a
duplicate on every merge.

## Second commit: adoption is no longer name-only

Review of the first commit found the name match was too eager, which matters more now that a name
match also suppresses the upload.

`findProject(localName)` ignores whether the local project already carries a server id. An account
still holding an orphan duplicate could therefore have its local project re-pointed away from the
server project holding the manuscript, with the new skip rule guaranteeing nothing uploaded it back.
The same hole let two server names that sanitise to a single local name overwrite each other, last
one winning.

Adoption now claims a local project only when its id is absent from the live server set. The
collision case becomes first-wins and logs the server project it passed over. Tombstoned ids are
deliberately excluded from that set, so a project whose server copy was deleted elsewhere is still
claimable.

## Why it matters now

Making Merge the default in #888 means a login onto a populated account routinely has local and
server projects sharing names, which is the shape both of these depend on.

## Tests

Four in `ClientAccountSynchronizerTest`:

- a same-named server project is adopted rather than uploaded as a duplicate
- a queued creation the server already holds under that name is withdrawn
- a project bound to a live server project is left alone when another shares its name
- two server projects sharing one local name bind only the first
