### PR TITLE
Clear a project's sync baseline when it moves to a new server project

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettings.kt
@@ -42,7 +42,7 @@ interface AccountSettings : ComponentToaster {
 	fun declineTos()
 
 	suspend fun authTest(): Boolean
-	fun removeServer()
+	suspend fun removeServer()
 
 	suspend fun setAutomaticBackups(value: Boolean)
 	suspend fun setAutoCloseDialogs(value: Boolean)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/accountsettings/AccountSettingsComponent.kt
@@ -210,12 +210,12 @@ class AccountSettingsComponent(
 		return accountUseCase.testAuth()
 	}
 
-	override fun removeServer() {
+	override suspend fun removeServer() {
 		globalSettingsStore.deleteServerSettings()
 		clearAllProjectIds()
 	}
 
-	private fun clearAllProjectIds() {
+	private suspend fun clearAllProjectIds() {
 		projectsRepository.getProjects().forEach { projectDef ->
 			projectsRepository.removeProjectId(projectDef = projectDef)
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataDatasource.kt
@@ -96,3 +96,19 @@ fun saveStoredProjectData(
 ) {
 	fileSystem.writeToml(projectDef.path.toOkioPath() / ProjectDataDatasource.FILENAME, toml, stored)
 }
+
+/**
+ * Drops [StoredProjectData.lastSyncedHash] while leaving [StoredProjectData.data] intact, for when
+ * the project starts pointing at a different server project and the old baseline no longer
+ * describes any agreement. Never creates the file: no file means no baseline to clear.
+ */
+fun clearProjectDataSyncBaseline(
+	projectDef: ProjectDef,
+	fileSystem: FileSystem,
+	toml: Toml,
+) {
+	if (!fileSystem.exists(projectDef.path.toOkioPath() / ProjectDataDatasource.FILENAME)) return
+	val stored = readStoredProjectData(projectDef, fileSystem, toml)
+	if (stored.lastSyncedHash == null) return
+	saveStoredProjectData(projectDef, fileSystem, toml, stored.copy(lastSyncedHash = null))
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataRepository.kt
@@ -47,6 +47,20 @@ class ProjectDataRepository(
 	}
 
 	/**
+	 * Sync-only: drop [StoredProjectData.lastSyncedHash], keeping [ProjectData] intact, for when the
+	 * project starts pointing at a different server project. Goes through the same lock as every
+	 * other write so a concurrent [updateData] can't persist the stale baseline back out of the
+	 * cache. Never creates the file: no baseline recorded means nothing to clear.
+	 */
+	suspend fun clearSyncBaseline() = mutex.withLock {
+		val current = _state.value ?: datasource.load()
+		if (current.lastSyncedHash == null) return@withLock
+		val next = current.copy(lastSyncedHash = null)
+		datasource.save(next)
+		_state.value = next
+	}
+
+	/**
 	 * Sync-only: replace both [ProjectData] and [StoredProjectData.lastSyncedHash]
 	 * atomically, e.g. after a successful upload or after fast-forwarding to
 	 * the server's state.

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectsrepository/ProjectsRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectsrepository/ProjectsRepository.kt
@@ -14,18 +14,20 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.migrator.PROJECT_DATA_VERSION
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
 import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.projectdata.clearProjectDataSyncBaseline
 import com.darkrockstudios.apps.hammer.common.data.projectdata.saveStoredProjectData
-import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.deleteProjectSyncJournal
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository.Companion.MAX_FILENAME_LENGTH
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository.Companion.RECOVERED_PROJECT_NAME
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository.Companion.encodeForFilename
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository.Companion.sanitizeFileName
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository.Companion.validateFileName
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.clearProjectSyncBaseline
 import com.darkrockstudios.apps.hammer.common.data.toMsg
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
@@ -38,12 +40,14 @@ import com.darkrockstudios.apps.hammer.create_project_error_too_long
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
 import okio.IOException
 import okio.Path.Companion.toPath
 import org.jetbrains.compose.resources.StringResource
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.getScopeId
 import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 import kotlin.coroutines.CoroutineContext
@@ -54,6 +58,7 @@ class ProjectsRepository(
 	globalSettingsStore: GlobalSettingsStore,
 	private val projectsMetadataDatasource: ProjectMetadataDatasource,
 	private val toml: Toml,
+	private val json: Json,
 	private val deviceLocaleResolver: DeviceLocaleResolver,
 ) : KoinComponent {
 
@@ -93,20 +98,19 @@ class ProjectsRepository(
 		getProjectsDirectory()
 	}
 
-	fun removeProjectId(projectDef: ProjectDef) {
+	suspend fun removeProjectId(projectDef: ProjectDef) {
+		clearSyncBaseline(projectDef)
 		projectsMetadataDatasource.updateMetadata(projectDef) {
 			it.copy(info = it.info.copy(serverProjectId = null))
 		}
-		clearSyncBaseline(projectDef)
 	}
 
-	fun setProjectId(projectDef: ProjectDef, projectId: ProjectId) {
-		val previousId = getProjectId(projectDef)
+	suspend fun setProjectId(projectDef: ProjectDef, projectId: ProjectId) {
+		if (getProjectId(projectDef) != projectId) {
+			clearSyncBaseline(projectDef)
+		}
 		projectsMetadataDatasource.updateMetadata(projectDef) {
 			it.copy(info = it.info.copy(serverProjectId = projectId))
-		}
-		if (previousId != projectId) {
-			clearSyncBaseline(projectDef)
 		}
 	}
 
@@ -116,10 +120,24 @@ class ProjectsRepository(
 	 * an untouched project reads as "already in sync": its content is never uploaded, and
 	 * `ProjectDataSyncOperation` fast-forwards the local copy to the new server's empty one.
 	 * The user's data is untouched — only the baseline goes, so the next sync uploads everything.
+	 *
+	 * Runs before the id is written: the two are separate files, so a failure or crash between them
+	 * must leave a project that still points at the old server rather than one pointing at the new
+	 * server with the old server's baseline, which is the corrupt state this exists to prevent.
 	 */
-	private fun clearSyncBaseline(projectDef: ProjectDef) {
-		deleteProjectSyncJournal(projectDef, fileSystem)
-		clearProjectDataSyncBaseline(projectDef, fileSystem, toml)
+	private suspend fun clearSyncBaseline(projectDef: ProjectDef) {
+		clearProjectSyncBaseline(projectDef, fileSystem, json)
+
+		// An open project serves project data from ProjectDataRepository's cache, so clearing only
+		// the file would leave the stale hash live (and get it written straight back out).
+		val openProject = getKoin()
+			.getScopeOrNull(ProjectDefScope(projectDef).getScopeId())
+			?.get<ProjectDataRepository>()
+		if (openProject != null) {
+			openProject.clearSyncBaseline()
+		} else {
+			clearProjectDataSyncBaseline(projectDef, fileSystem, toml)
+		}
 	}
 
 	fun getProjectId(projectDef: ProjectDef): ProjectId? {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectsrepository/ProjectsRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectsrepository/ProjectsRepository.kt
@@ -15,7 +15,9 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.isSuccess
 import com.darkrockstudios.apps.hammer.common.data.migrator.PROJECT_DATA_VERSION
 import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
+import com.darkrockstudios.apps.hammer.common.data.projectdata.clearProjectDataSyncBaseline
 import com.darkrockstudios.apps.hammer.common.data.projectdata.saveStoredProjectData
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.deleteProjectSyncJournal
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository.Companion.MAX_FILENAME_LENGTH
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository.Companion.RECOVERED_PROJECT_NAME
@@ -95,12 +97,29 @@ class ProjectsRepository(
 		projectsMetadataDatasource.updateMetadata(projectDef) {
 			it.copy(info = it.info.copy(serverProjectId = null))
 		}
+		clearSyncBaseline(projectDef)
 	}
 
 	fun setProjectId(projectDef: ProjectDef, projectId: ProjectId) {
+		val previousId = getProjectId(projectDef)
 		projectsMetadataDatasource.updateMetadata(projectDef) {
 			it.copy(info = it.info.copy(serverProjectId = projectId))
 		}
+		if (previousId != projectId) {
+			clearSyncBaseline(projectDef)
+		}
+	}
+
+	/**
+	 * The entity journal and `lastSyncedHash` record what one specific server already confirmed.
+	 * Once the project points somewhere else they describe an agreement that no longer exists, and
+	 * an untouched project reads as "already in sync": its content is never uploaded, and
+	 * `ProjectDataSyncOperation` fast-forwards the local copy to the new server's empty one.
+	 * The user's data is untouched — only the baseline goes, so the next sync uploads everything.
+	 */
+	private fun clearSyncBaseline(projectDef: ProjectDef) {
+		deleteProjectSyncJournal(projectDef, fileSystem)
+		clearProjectDataSyncBaseline(projectDef, fileSystem, toml)
 	}
 
 	fun getProjectId(projectDef: ProjectDef): ProjectId? {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataDatasource.kt
@@ -103,14 +103,38 @@ class SyncDataDatasource(
 }
 
 /**
- * Deletes the entity journal so [SyncDataDatasource.createSyncData] rebuilds it from local state on
- * the next sync. For scope-less callers (no per-project Koin scope) that move a project to a
- * different server project, where every id, hash and deletion the journal records was agreed with
- * a server that no longer has this project.
+ * Resets everything in the entity journal that records agreement with a *specific* server, for
+ * scope-less callers moving a project to a different server project. Local pending work the new
+ * server has never seen — [ProjectSynchronizationData.dirty], `newIds`, `deletedIds`, `lastId` —
+ * is kept, so an unsynced edit or a tombstone can't be lost by the move. Dirty entries keep their
+ * id but drop [EntityOriginalState.originalHash]: a baseline the old server confirmed would forge
+ * a phantom conflict against the new one, while a null baseline uploads unconditionally.
+ *
+ * No-op when the journal doesn't exist. A corrupt journal is deleted so
+ * [SyncDataDatasource.createSyncData] rebuilds it from local state, matching [loadSyncData].
  */
-fun deleteProjectSyncJournal(projectDef: ProjectDef, fileSystem: FileSystem) {
+// Corrupt sync data recovers by deleting it; not an error to surface.
+@Suppress("SwallowedException")
+fun clearProjectSyncBaseline(projectDef: ProjectDef, fileSystem: FileSystem, json: Json) {
 	val path = projectDef.path.toOkioPath() / SyncDataDatasource.SYNC_FILE_NAME
-	if (fileSystem.exists(path)) {
+	if (!fileSystem.exists(path)) return
+
+	val current = try {
+		fileSystem.read(path) { json.decodeFromString<ProjectSynchronizationData>(readUtf8()) }
+	} catch (e: SerializationException) {
 		fileSystem.delete(path)
+		return
 	}
+
+	val cleared = current.copy(
+		currentSyncId = null,
+		lastSync = Instant.DISTANT_PAST,
+		dirty = current.dirty.map { it.copy(originalHash = null) },
+		syncedHashes = emptyMap(),
+		cachedProjectHash = null,
+		hashAlgoVersion = 0,
+	)
+	if (cleared == current) return
+
+	fileSystem.write(path) { writeUtf8(json.encodeToString(cleared)) }
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/SyncDataDatasource.kt
@@ -101,3 +101,16 @@ class SyncDataDatasource(
 		const val SYNC_FILE_NAME = "sync.json"
 	}
 }
+
+/**
+ * Deletes the entity journal so [SyncDataDatasource.createSyncData] rebuilds it from local state on
+ * the next sync. For scope-less callers (no per-project Koin scope) that move a project to a
+ * different server project, where every id, hash and deletion the journal records was agreed with
+ * a server that no longer has this project.
+ */
+fun deleteProjectSyncJournal(projectDef: ProjectDef, fileSystem: FileSystem) {
+	val path = projectDef.path.toOkioPath() / SyncDataDatasource.SYNC_FILE_NAME
+	if (fileSystem.exists(path)) {
+		fileSystem.delete(path)
+	}
+}

--- a/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectselection/AccountSettingsComponentTest.kt
@@ -5,6 +5,7 @@ import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.TermsOfServiceChallenge
+import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettingsComponent
 import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.PlatformSettings
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
@@ -117,6 +118,7 @@ class AccountSettingsComponentTest : BaseTest() {
 					globalSettingsStore = globalSettingsStore,
 					projectsMetadataDatasource = ProjectMetadataDatasource(hookedFs, toml),
 					toml = toml,
+					json = createJsonSerializer(),
 					deviceLocaleResolver = mockk(relaxed = true),
 				)
 			} bind ProjectsRepository::class

--- a/common/src/desktopTest/kotlin/repositories/ideas/PromoteIdeaUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/ideas/PromoteIdeaUseCaseTest.kt
@@ -67,6 +67,7 @@ class PromoteIdeaUseCaseTest : BaseTest() {
 			globalSettingsStore = globalSettingsStore,
 			projectsMetadataDatasource = ProjectMetadataDatasource(ffs, toml),
 			toml = toml,
+			json = createJsonSerializer(),
 			deviceLocaleResolver = deviceLocaleResolver,
 		)
 		val ideasDatasource = IdeasDatasource(ffs, StoryIdeaCodec(toml), globalSettingsStore)

--- a/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryBaseTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositoryBaseTest.kt
@@ -1,5 +1,6 @@
 package repositories.projectsrepository
 
+import com.darkrockstudios.apps.hammer.base.http.createJsonSerializer
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectmetadata.ProjectMetadataDatasource
@@ -14,6 +15,7 @@ import io.mockk.coJustAwait
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.serialization.json.Json
 import net.peanuuutz.tomlkt.Toml
 import okio.FileSystem
 import okio.fakefilesystem.FakeFileSystem
@@ -27,10 +29,11 @@ abstract class ProjectsRepositoryBaseTest : BaseTest() {
 	protected lateinit var projectsMetaDatasource: ProjectMetadataDatasource
 	protected lateinit var settings: GlobalSettings
 	protected lateinit var toml: Toml
+	protected lateinit var json: Json
 	protected lateinit var deviceLocaleResolver: DeviceLocaleResolver
 
 	protected fun projectsRepository(fs: FileSystem = ffs) =
-		ProjectsRepository(fs, settingsRepo, projectsMetaDatasource, toml, deviceLocaleResolver)
+		ProjectsRepository(fs, settingsRepo, projectsMetaDatasource, toml, json, deviceLocaleResolver)
 
 	@BeforeEach
 	override fun setup() {
@@ -38,6 +41,7 @@ abstract class ProjectsRepositoryBaseTest : BaseTest() {
 
 		ffs = FakeFileSystem()
 		toml = createTomlSerializer()
+		json = createJsonSerializer()
 		deviceLocaleResolver = mockk()
 		every { deviceLocaleResolver.getCurrentLocale() } returns Locale.forLanguage("en", "US")
 

--- a/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositorySyncBaselineTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositorySyncBaselineTest.kt
@@ -1,0 +1,121 @@
+package repositories.projectsrepository
+
+import PROJECT_1_NAME
+import com.darkrockstudios.apps.hammer.base.ProjectId
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
+import com.darkrockstudios.apps.hammer.common.data.projectdata.readStoredProjectData
+import com.darkrockstudios.apps.hammer.common.data.projectdata.saveStoredProjectData
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataDatasource
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import createProject
+import getProjectDef
+import kotlinx.coroutines.test.runTest
+import okio.Path
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * A project's sync baseline (the entity journal and `lastSyncedHash`) records what a *specific*
+ * server has already confirmed. Carrying it onto a different server makes an untouched project
+ * look "already in sync", so its content is never pushed and the local copy fast-forwards to the
+ * new server's empty one.
+ */
+class ProjectsRepositorySyncBaselineTest : ProjectsRepositoryBaseTest() {
+
+	private val projectDef = getProjectDef(PROJECT_1_NAME)
+
+	private fun syncJournalPath(): Path =
+		projectDef.path.toOkioPath() / SyncDataDatasource.SYNC_FILE_NAME
+
+	private fun seedBaseline() {
+		ffs.write(syncJournalPath()) { writeUtf8("""{"lastId":42}""") }
+		saveStoredProjectData(
+			projectDef,
+			ffs,
+			toml,
+			StoredProjectData(
+				data = ProjectData(authorName = "Author"),
+				lastSyncedHash = "hash-agreed-with-the-old-server",
+			),
+		)
+	}
+
+	private fun storedProjectData(): StoredProjectData =
+		readStoredProjectData(projectDef, ffs, toml)
+
+	@Test
+	fun `Moving a project to a different server id clears its sync baseline`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		seedBaseline()
+		val repo = projectsRepository()
+
+		repo.setProjectId(projectDef, ProjectId("id-on-the-new-server"))
+
+		assertFalse(ffs.exists(syncJournalPath()), "the entity journal must not survive the move")
+		assertNull(
+			storedProjectData().lastSyncedHash,
+			"the project-data baseline must not survive the move",
+		)
+	}
+
+	@Test
+	fun `Clearing the sync baseline preserves the project data itself`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		seedBaseline()
+		val repo = projectsRepository()
+
+		repo.setProjectId(projectDef, ProjectId("id-on-the-new-server"))
+
+		assertEquals(
+			ProjectData(authorName = "Author"),
+			storedProjectData().data,
+			"only the baseline is stale; the user's data must be left alone so it can be uploaded",
+		)
+	}
+
+	@Test
+	fun `Re-writing the same project id leaves the sync baseline alone`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		val sameId = ProjectId("id-already-recorded")
+		val repo = projectsRepository()
+		repo.setProjectId(projectDef, sameId)
+		seedBaseline()
+
+		repo.setProjectId(projectDef, sameId)
+
+		assertTrue(ffs.exists(syncJournalPath()), "an unchanged id is not a server change")
+		assertEquals("hash-agreed-with-the-old-server", storedProjectData().lastSyncedHash)
+	}
+
+	@Test
+	fun `Removing a project id clears its sync baseline`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		seedBaseline()
+		val repo = projectsRepository()
+
+		// removeServer() and create-account both clear ids; whatever the project is uploaded to
+		// next has never seen it.
+		repo.removeProjectId(projectDef)
+
+		assertFalse(ffs.exists(syncJournalPath()))
+		assertNull(storedProjectData().lastSyncedHash)
+		assertEquals(ProjectData(authorName = "Author"), storedProjectData().data)
+	}
+
+	@Test
+	fun `Clearing the baseline of a never-synced project is a no-op`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		val repo = projectsRepository()
+
+		repo.setProjectId(projectDef, ProjectId("first-ever-id"))
+
+		// No journal is fabricated, and no project_data.toml is written just to hold a null.
+		assertFalse(ffs.exists(syncJournalPath()))
+		assertFalse(ffs.exists(projectDef.path.toOkioPath() / ProjectDataDatasource.FILENAME))
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositorySyncBaselineTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectsrepository/ProjectsRepositorySyncBaselineTest.kt
@@ -3,27 +3,36 @@ package repositories.projectsrepository
 import PROJECT_1_NAME
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.createProjectScope
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
 import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.projectdata.readStoredProjectData
 import com.darkrockstudios.apps.hammer.common.data.projectdata.saveStoredProjectData
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityOriginalState
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.ProjectSynchronizationData
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataDatasource
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import createProject
 import getProjectDef
 import kotlinx.coroutines.test.runTest
 import okio.Path
 import org.junit.jupiter.api.Test
+import org.koin.dsl.module
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 /**
- * A project's sync baseline (the entity journal and `lastSyncedHash`) records what a *specific*
- * server has already confirmed. Carrying it onto a different server makes an untouched project
- * look "already in sync", so its content is never pushed and the local copy fast-forwards to the
- * new server's empty one.
+ * A project's sync baseline (the entity journal's confirmed hashes and `lastSyncedHash`) records
+ * what a *specific* server has already confirmed. Carrying it onto a different server makes an
+ * untouched project look "already in sync", so its content is never pushed and the local copy
+ * fast-forwards to the new server's empty one. Local pending work must survive the clear, though:
+ * the new server has never seen it either.
  */
 class ProjectsRepositorySyncBaselineTest : ProjectsRepositoryBaseTest() {
 
@@ -32,8 +41,20 @@ class ProjectsRepositorySyncBaselineTest : ProjectsRepositoryBaseTest() {
 	private fun syncJournalPath(): Path =
 		projectDef.path.toOkioPath() / SyncDataDatasource.SYNC_FILE_NAME
 
+	private val seededJournal = ProjectSynchronizationData(
+		currentSyncId = "session-on-the-old-server",
+		lastId = 42,
+		newIds = listOf(41, 42),
+		lastSync = Instant.fromEpochSeconds(1_000_000),
+		dirty = listOf(EntityOriginalState(5, "hash-agreed-with-the-old-server")),
+		deletedIds = setOf(7),
+		syncedHashes = mapOf(5 to "hash-agreed-with-the-old-server"),
+		cachedProjectHash = "project-hash-agreed-with-the-old-server",
+		hashAlgoVersion = 3,
+	)
+
 	private fun seedBaseline() {
-		ffs.write(syncJournalPath()) { writeUtf8("""{"lastId":42}""") }
+		ffs.write(syncJournalPath()) { writeUtf8(json.encodeToString(seededJournal)) }
 		saveStoredProjectData(
 			projectDef,
 			ffs,
@@ -45,21 +66,53 @@ class ProjectsRepositorySyncBaselineTest : ProjectsRepositoryBaseTest() {
 		)
 	}
 
+	private fun readJournal(): ProjectSynchronizationData =
+		ffs.read(syncJournalPath()) { json.decodeFromString(readUtf8()) }
+
 	private fun storedProjectData(): StoredProjectData =
 		readStoredProjectData(projectDef, ffs, toml)
 
 	@Test
-	fun `Moving a project to a different server id clears its sync baseline`() = scope.runTest {
+	fun `Moving a project to a different server id drops what the old server confirmed`() =
+		scope.runTest {
+			createProject(ffs, PROJECT_1_NAME)
+			seedBaseline()
+			val repo = projectsRepository()
+
+			repo.setProjectId(projectDef, ProjectId("id-on-the-new-server"))
+
+			val journal = readJournal()
+			assertEquals(emptyMap(), journal.syncedHashes, "confirmed hashes were the old server's")
+			assertNull(journal.cachedProjectHash)
+			assertEquals(0, journal.hashAlgoVersion)
+			assertNull(journal.currentSyncId, "the sync session belonged to the old server")
+			assertEquals(Instant.DISTANT_PAST, journal.lastSync)
+			assertNull(
+				storedProjectData().lastSyncedHash,
+				"the project-data baseline must not survive the move",
+			)
+		}
+
+	@Test
+	fun `Moving a project keeps local work the new server has never seen`() = scope.runTest {
 		createProject(ffs, PROJECT_1_NAME)
 		seedBaseline()
 		val repo = projectsRepository()
 
 		repo.setProjectId(projectDef, ProjectId("id-on-the-new-server"))
 
-		assertFalse(ffs.exists(syncJournalPath()), "the entity journal must not survive the move")
-		assertNull(
-			storedProjectData().lastSyncedHash,
-			"the project-data baseline must not survive the move",
+		val journal = readJournal()
+		assertEquals(seededJournal.lastId, journal.lastId)
+		assertEquals(seededJournal.newIds, journal.newIds)
+		assertEquals(
+			seededJournal.deletedIds,
+			journal.deletedIds,
+			"a tombstone the old server never got must still be pushed to the new one",
+		)
+		assertEquals(
+			listOf(EntityOriginalState(5, originalHash = null)),
+			journal.dirty,
+			"the edit is still pending, but its baseline was agreed with the old server",
 		)
 	}
 
@@ -88,7 +141,7 @@ class ProjectsRepositorySyncBaselineTest : ProjectsRepositoryBaseTest() {
 
 		repo.setProjectId(projectDef, sameId)
 
-		assertTrue(ffs.exists(syncJournalPath()), "an unchanged id is not a server change")
+		assertEquals(seededJournal, readJournal(), "an unchanged id is not a server change")
 		assertEquals("hash-agreed-with-the-old-server", storedProjectData().lastSyncedHash)
 	}
 
@@ -102,7 +155,7 @@ class ProjectsRepositorySyncBaselineTest : ProjectsRepositoryBaseTest() {
 		// next has never seen it.
 		repo.removeProjectId(projectDef)
 
-		assertFalse(ffs.exists(syncJournalPath()))
+		assertEquals(emptyMap(), readJournal().syncedHashes)
 		assertNull(storedProjectData().lastSyncedHash)
 		assertEquals(ProjectData(authorName = "Author"), storedProjectData().data)
 	}
@@ -117,5 +170,47 @@ class ProjectsRepositorySyncBaselineTest : ProjectsRepositoryBaseTest() {
 		// No journal is fabricated, and no project_data.toml is written just to hold a null.
 		assertFalse(ffs.exists(syncJournalPath()))
 		assertFalse(ffs.exists(projectDef.path.toOkioPath() / ProjectDataDatasource.FILENAME))
+	}
+
+	@Test
+	fun `Clearing the baseline of an open project drops its cached copy too`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		seedBaseline()
+		val projectDataRepository = openProject()
+		// An open project serves project data from memory, so the stale hash has to go from there
+		// as well or the next sync still fast-forwards onto the new server's empty copy.
+		assertEquals("hash-agreed-with-the-old-server", projectDataRepository.load().lastSyncedHash)
+
+		projectsRepository().setProjectId(projectDef, ProjectId("id-on-the-new-server"))
+
+		assertNull(projectDataRepository.load().lastSyncedHash)
+		assertNull(storedProjectData().lastSyncedHash)
+		assertEquals(ProjectData(authorName = "Author"), projectDataRepository.load().data)
+	}
+
+	/** Mirrors the project scope `mainModule` opens when a project is opened in the editor. */
+	private fun openProject(): ProjectDataRepository {
+		setupKoin(
+			module {
+				scope<ProjectDefScope> {
+					scoped<ProjectDef> { get<ProjectDefScope>().projectDef }
+					scoped { ProjectDataDatasource(ffs, toml, get()) }
+					scoped { ProjectDataRepository(get(), get()) }
+				}
+			}
+		)
+		return createProjectScope(projectDef).get()
+	}
+
+	@Test
+	fun `A corrupt journal is discarded so the next sync rebuilds it`() = scope.runTest {
+		createProject(ffs, PROJECT_1_NAME)
+		ffs.write(syncJournalPath()) { writeUtf8("not json at all") }
+		val repo = projectsRepository()
+
+		repo.setProjectId(projectDef, ProjectId("id-on-the-new-server"))
+
+		assertFalse(ffs.exists(syncJournalPath()))
+		assertTrue(ffs.exists(projectDef.path.toOkioPath()))
 	}
 }

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -434,7 +434,7 @@ class ClientAccountSynchronizerTest {
 
 		assertTrue(result)
 		coVerify { serverProjectsApi.createProject("LocalNovel", "sync-1") }
-		verify { projectsRepository.setProjectId(def, newId) }
+		coVerify { projectsRepository.setProjectId(def, newId) }
 		assertTrue(readSyncData().projectsToCreate.isEmpty())
 	}
 
@@ -457,7 +457,7 @@ class ClientAccountSynchronizerTest {
 
 		assertTrue(result)
 		coVerify { serverProjectsApi.createProject("ResetServerNovel", "sync-1") }
-		verify { projectsRepository.setProjectId(def, freshId) }
+		coVerify { projectsRepository.setProjectId(def, freshId) }
 	}
 
 	@Test
@@ -530,7 +530,7 @@ class ClientAccountSynchronizerTest {
 		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
 
 		assertTrue(result)
-		verify { projectsRepository.deleteProject(def) }
+		coVerify { projectsRepository.deleteProject(def) }
 	}
 
 	@Test
@@ -603,8 +603,8 @@ class ClientAccountSynchronizerTest {
 
 		assertTrue(result)
 		coVerify { serverProjectsApi.deleteProject(id, "sync-1") }
-		verify(exactly = 0) { projectsRepository.createProject(any(), any()) }
-		verify(exactly = 0) { projectsRepository.setProjectId(any(), any()) }
+		coVerify(exactly = 0) { projectsRepository.createProject(any(), any()) }
+		coVerify(exactly = 0) { projectsRepository.setProjectId(any(), any()) }
 	}
 
 	@Test
@@ -623,8 +623,8 @@ class ClientAccountSynchronizerTest {
 		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
 
 		assertTrue(result)
-		verify { projectsRepository.createProject("ServerNovel", any()) }
-		verify { projectsRepository.setProjectId(createdDef, serverId) }
+		coVerify { projectsRepository.createProject("ServerNovel", any()) }
+		coVerify { projectsRepository.setProjectId(createdDef, serverId) }
 	}
 
 	@Test
@@ -645,8 +645,8 @@ class ClientAccountSynchronizerTest {
 		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
 
 		assertTrue(result)
-		verify { projectsRepository.createProject(safeName, any()) }
-		verify(exactly = 0) { projectsRepository.createProject(mangledName, any()) }
-		verify { projectsRepository.setProjectId(createdDef, serverId) }
+		coVerify { projectsRepository.createProject(safeName, any()) }
+		coVerify(exactly = 0) { projectsRepository.createProject(mangledName, any()) }
+		coVerify { projectsRepository.setProjectId(createdDef, serverId) }
 	}
 }

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FetchServerDataOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FetchServerDataOperationTest.kt
@@ -200,7 +200,7 @@ class FetchServerDataOperationTest : BaseTest() {
 
 		assertFalse(isSuccess(result))
 		// Only a 410 proves the id is dead; a transient failure must not discard it.
-		verify(exactly = 0) { projectsRepository.removeProjectId(any()) }
+		coVerify(exactly = 0) { projectsRepository.removeProjectId(any()) }
 	}
 
 	@Test
@@ -223,7 +223,7 @@ class FetchServerDataOperationTest : BaseTest() {
 		val result = execute(op)
 
 		assertFalse(isSuccess(result))
-		verify { projectsRepository.removeProjectId(projectDef) }
+		coVerify { projectsRepository.removeProjectId(projectDef) }
 	}
 
 	private suspend fun stubSettingsAndMetadata() {

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
@@ -73,7 +73,7 @@ internal fun accountSettingsComponent(state: AccountSettings.State = defaultAcco
 		override fun declineTos() {}
 
 		override suspend fun authTest() = true
-		override fun removeServer() {}
+		override suspend fun removeServer() {}
 		override suspend fun setAutomaticBackups(value: Boolean) {}
 		override suspend fun setAutoCloseDialogs(value: Boolean) {}
 		override suspend fun setAutoSyncing(value: Boolean) {}


### PR DESCRIPTION
The per-project sync journal (`sync.json`) and `StoredProjectData.lastSyncedHash` record what one specific server confirmed, but nothing scoped them to that server. When a project starts pointing at a different server project, both survive and describe an agreement that no longer exists.

## This is data loss, not a skipped upload

The suspicion when this was queued was that a stale baseline makes a project look clean and skip pushing content. The entity-transfer path is actually fine: with a fresh server `lastId = 0`, every `thisId > serverSyncData.lastId`, so entities do upload.

The real defect is in `ProjectDataSyncOperation`. An untouched project has `localHash == lastSyncedHash`, which takes the "local unchanged since last sync, fast-forward to the server copy" branch, and that branch **overwrites local project data with the new server's empty copy**. Author name and other project settings are gone, and nothing was uploaded. The existing test `local unchanged since last sync fast-forwards to the server copy` documents that branch as correct, which it is within a single server; the operation simply cannot tell the difference.

## Fix

Clear the baseline at the root rather than per-operation. `ProjectsRepository.setProjectId` clears it when the id actually changes, and `removeProjectId` always does. That covers every route into the situation: cross-server merge, create-account via `clearAllProjectIds`, `removeServer`, and the 410-stale-id path in `FetchServerDataOperation`, which recreates the project under a fresh server id and had the same hole.

The clear is deliberately narrow: only what a server confirmed goes.

- **Journal.** The file is rewritten, not deleted. `syncedHashes`, `cachedProjectHash`, `hashAlgoVersion`, `currentSyncId` and `lastSync` are reset; `dirty`, `newIds`, `deletedIds` and `lastId` are local pending work the new server has never seen, so they stay. Dirty entries keep their id but drop `originalHash` — a baseline the old server confirmed would forge a phantom conflict against the new one, while a null baseline uploads unconditionally. Deleting the journal outright would have lost an unsynced edit to the server's older copy, and would have resurrected a deletion whose id `createSyncData` can't recover (tombstones above `peekLastId()`).
- **Project data.** `lastSyncedHash` is nulled while `data` is left intact. Keeping `data` is what makes the next sync upload instead of fast-forward. When the project is open, `ProjectDataRepository` is serving that data from memory, so the clear goes through the repository under its own lock — clearing only the file would leave the stale hash live and get it written straight back out on the next edit.

The clear runs *before* the new id is written. The two live in separate files, so a failure or crash between them must leave a project still pointing at the old server rather than one pointing at the new server with the old server's baseline, which is the corrupt state this exists to prevent.

Both file-level clears go through scope-less helpers in each format's owning datasource, per the one-owner-per-persisted-format rule in CLAUDE.md, so `project_data.toml` and `sync.json` each keep a single writer.

`removeProjectId`/`setProjectId` are suspend now, which makes `AccountSettings.removeServer()` suspend too. User content is never touched; only the baseline goes.

## Not in scope

Per-device writing-activity logs are also server-scoped and also survive a server move: `WritingActivitySyncOperation` only overwrites the slots the new server returns, so foreign device logs that existed only on the old server linger locally and inflate stats. That is user-visible history rather than a sync baseline, and dropping it is a product decision, not a correctness fix — left alone here.

## Tests

Eight in a new `ProjectsRepositorySyncBaselineTest`:

- moving to a new server id drops the confirmed hashes, cached project hash, sync session and `lastSync`
- moving keeps `lastId`, `newIds`, `deletedIds`, and the dirty entries minus their old baselines
- the project data itself survives the clear
- the project-data baseline is dropped for an open project, cache included
- re-writing the same id is not a server change and leaves the baseline alone
- clearing a never-synced project is a no-op and fabricates no files
- a corrupt journal is discarded so the next sync rebuilds it
