### PR TITLE
Let users widen the editor on wide screens with a drag handle

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusMode.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusMode.kt
@@ -19,12 +19,17 @@ interface FocusMode {
 	fun increaseTextSize()
 	fun resetTextSize()
 
+	/** Persists the user's editor max width in dp. Call on drag end, not per frame. */
+	fun setEditorMaxWidth(width: Float)
+	fun resetEditorMaxWidth()
+
 	data class State(
 		val projectDef: ProjectDef,
 		val sceneItem: SceneItem,
 		val sceneBuffer: SceneBuffer? = null,
 		val isLoading: Boolean = true,
 		val textSize: Float = GlobalSettings.DEFAULT_FONT_SIZE,
+		val editorMaxWidth: Float = GlobalSettings.DEFAULT_EDITOR_WIDTH,
 		val spellChecker: PlatformSpellChecker? = null,
 		val spellCheckingEnabled: Boolean = false,
 	)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusModeComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusModeComponent.kt
@@ -5,6 +5,7 @@ import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.getAndUpdate
 import com.arkivanov.decompose.value.update
 import com.darkrockstudios.apps.hammer.common.components.ProjectComponentBase
+import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.clampEditorWidth
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.decreaseEditorTextSize
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.increaseEditorTextSize
 import com.darkrockstudios.apps.hammer.common.data.*
@@ -39,6 +40,7 @@ class FocusModeComponent(
 			projectDef = projectDef,
 			sceneItem = sceneItem,
 			spellCheckingEnabled = (settingsRepository.globalSettings.spellCheckSettings.isEnabledInFocusMode()),
+			editorMaxWidth = settingsRepository.globalSettings.editorMaxWidth,
 		)
 	)
 	override val state = _state
@@ -114,6 +116,26 @@ class FocusModeComponent(
 		}
 	}
 
+	override fun setEditorMaxWidth(width: Float) {
+		scope.launch {
+			settingsRepository.updateSettings {
+				it.copy(
+					editorMaxWidth = clampEditorWidth(width)
+				)
+			}
+		}
+	}
+
+	override fun resetEditorMaxWidth() {
+		scope.launch {
+			settingsRepository.updateSettings {
+				it.copy(
+					editorMaxWidth = GlobalSettings.DEFAULT_EDITOR_WIDTH
+				)
+			}
+		}
+	}
+
 	private fun subscribeToBufferUpdates() {
 		Napier.d { "FocusModeComponent start collecting buffer updates" }
 
@@ -129,6 +151,7 @@ class FocusModeComponent(
 					_state.getAndUpdate {
 						it.copy(
 							textSize = settings.editorFontSize,
+							editorMaxWidth = settings.editorMaxWidth,
 							spellCheckingEnabled = settings.spellCheckSettings.isEnabledInFocusMode(),
 						)
 					}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditor.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditor.kt
@@ -51,6 +51,10 @@ interface SceneEditor : HammerComponent, ComponentToaster {
 	fun decreaseTextSize()
 	fun increaseTextSize()
 	fun resetTextSize()
+
+	/** Persists the user's editor max width in dp. Call on drag end, not per frame. */
+	fun setEditorMaxWidth(width: Float)
+	fun resetEditorMaxWidth()
 	fun enterFocusMode()
 
 	data class State(
@@ -68,6 +72,7 @@ interface SceneEditor : HammerComponent, ComponentToaster {
 		val showMetadataModal: Boolean = false,
 		val menuItems: Set<MenuItemDescriptor> = emptySet(),
 		val textSize: Float = GlobalSettings.DEFAULT_FONT_SIZE,
+		val editorMaxWidth: Float = GlobalSettings.DEFAULT_EDITOR_WIDTH,
 		val spellChecker: PlatformSpellChecker? = null,
 		val spellCheckingEnabled: Boolean = true,
 	)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditorComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditorComponent.kt
@@ -16,6 +16,7 @@ import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftRepository
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings.Companion.DEFAULT_EDITOR_WIDTH
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings.Companion.DEFAULT_FONT_SIZE
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
@@ -55,6 +56,7 @@ class SceneEditorComponent(
 			sceneItem = originalSceneItem,
 			spellCheckingEnabled = settingsRepository.globalSettings.spellCheckSettings.enabled,
 			metadataPanelVisible = settingsRepository.globalSettings.metadataPanelVisible,
+			editorMaxWidth = settingsRepository.globalSettings.editorMaxWidth,
 		)
 	)
 	override val state: Value<SceneEditor.State> = _state
@@ -84,12 +86,14 @@ class SceneEditorComponent(
 				val current = _state.value
 				if (
 					current.spellCheckingEnabled != settings.spellCheckSettings.enabled ||
-					current.metadataPanelVisible != settings.metadataPanelVisible
+					current.metadataPanelVisible != settings.metadataPanelVisible ||
+					current.editorMaxWidth != settings.editorMaxWidth
 				) {
 					_state.update {
 						it.copy(
 							spellCheckingEnabled = settings.spellCheckSettings.enabled,
 							metadataPanelVisible = settings.metadataPanelVisible,
+							editorMaxWidth = settings.editorMaxWidth,
 						)
 					}
 				}
@@ -457,6 +461,26 @@ class SceneEditorComponent(
 			settingsRepository.updateSettings {
 				it.copy(
 					editorFontSize = DEFAULT_FONT_SIZE
+				)
+			}
+		}
+	}
+
+	override fun setEditorMaxWidth(width: Float) {
+		scope.launch {
+			settingsRepository.updateSettings {
+				it.copy(
+					editorMaxWidth = clampEditorWidth(width)
+				)
+			}
+		}
+	}
+
+	override fun resetEditorMaxWidth() {
+		scope.launch {
+			settingsRepository.updateSettings {
+				it.copy(
+					editorMaxWidth = DEFAULT_EDITOR_WIDTH
 				)
 			}
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditorUtils.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditorUtils.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor
 
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import korlibs.memory.clamp
 
 val MIN_FONT_SIZE = 8f
@@ -11,4 +12,8 @@ fun increaseEditorTextSize(currentSize: Float): Float {
 
 fun decreaseEditorTextSize(currentSize: Float): Float {
 	return (currentSize - 1f).clamp(MIN_FONT_SIZE, MAX_FONT_SIZE)
+}
+
+fun clampEditorWidth(width: Float): Float {
+	return width.clamp(GlobalSettings.MIN_EDITOR_WIDTH, GlobalSettings.MAX_EDITOR_WIDTH)
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/GlobalSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/GlobalSettings.kt
@@ -24,6 +24,12 @@ data class GlobalSettings(
 	val automaticSyncing: Boolean = true,
 	val nux: NewUserExperience = NewUserExperience(),
 	val editorFontSize: Float = DEFAULT_FONT_SIZE,
+	/**
+	 * The scene editor's maximum column width in dp; rendered width is
+	 * min(available width, this). Only takes effect on windows wide enough
+	 * to exceed it.
+	 */
+	val editorMaxWidth: Float = DEFAULT_EDITOR_WIDTH,
 	val enableDndInFocusMode: Boolean = false,
 	/**
 	 * Whether the scene metadata panel is visible on wide layouts. UI state,
@@ -54,6 +60,9 @@ data class GlobalSettings(
 		const val DEFAULT_BACKUPS = 20
 		const val MAX_BACKUPS = 50
 		const val DEFAULT_FONT_SIZE = 16f
+		const val DEFAULT_EDITOR_WIDTH = 700f
+		const val MIN_EDITOR_WIDTH = 700f
+		const val MAX_EDITOR_WIDTH = 1400f
 	}
 }
 

--- a/common/src/desktopTest/kotlin/components/storyeditor/focusmode/FocusModeComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyeditor/focusmode/FocusModeComponentTest.kt
@@ -166,6 +166,43 @@ class FocusModeComponentTest : ComponentTest() {
 	}
 
 	@Test
+	fun `Editor width controls persist through settings`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.setEditorMaxWidth(900f)
+		advanceUntilIdle()
+		assertEquals(900f, settingsTransform.captured(GlobalSettings(projectsDirectory = "/p")).editorMaxWidth)
+
+		comp.setEditorMaxWidth(5000f)
+		advanceUntilIdle()
+		assertEquals(
+			GlobalSettings.MAX_EDITOR_WIDTH,
+			settingsTransform.captured(GlobalSettings(projectsDirectory = "/p")).editorMaxWidth,
+		)
+
+		comp.resetEditorMaxWidth()
+		advanceUntilIdle()
+		assertEquals(
+			GlobalSettings.DEFAULT_EDITOR_WIDTH,
+			settingsTransform.captured(GlobalSettings(projectsDirectory = "/p")).editorMaxWidth,
+		)
+	}
+
+	@Test
+	fun `Settings updates change the editor width in state`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		settingsUpdates.emit(GlobalSettings(projectsDirectory = "/projects", editorMaxWidth = 1200f))
+		advanceUntilIdle()
+
+		assertEquals(1200f, comp.state.value.editorMaxWidth)
+	}
+
+	@Test
 	fun `External buffer updates refresh state and force an editor update`() = runTest(mainTestDispatcher) {
 		val comp = newComponent()
 		context.resume()

--- a/common/src/desktopTest/kotlin/components/storyeditor/sceneeditor/SceneEditorComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyeditor/sceneeditor/SceneEditorComponentTest.kt
@@ -391,6 +391,50 @@ class SceneEditorComponentTest : ComponentTest() {
 		assertTrue(expected > GlobalSettings.DEFAULT_FONT_SIZE)
 	}
 
+	// --- editor width (settings writes) --------------------------------------
+
+	@Test
+	fun `initial state seeds editorMaxWidth from settings`() = runTest(mainTestDispatcher) {
+		globalSettings = settings().copy(editorMaxWidth = 900f)
+
+		val comp = newComponent()
+
+		assertEquals(900f, comp.state.value.editorMaxWidth)
+	}
+
+	@Test
+	fun `setEditorMaxWidth persists the width`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+
+		comp.setEditorMaxWidth(900f)
+		advanceUntilIdle()
+
+		assertEquals(900f, settingsAction.captured(globalSettings).editorMaxWidth)
+	}
+
+	@Test
+	fun `setEditorMaxWidth clamps out-of-range widths`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+
+		comp.setEditorMaxWidth(5000f)
+		advanceUntilIdle()
+		assertEquals(GlobalSettings.MAX_EDITOR_WIDTH, settingsAction.captured(globalSettings).editorMaxWidth)
+
+		comp.setEditorMaxWidth(100f)
+		advanceUntilIdle()
+		assertEquals(GlobalSettings.MIN_EDITOR_WIDTH, settingsAction.captured(globalSettings).editorMaxWidth)
+	}
+
+	@Test
+	fun `resetEditorMaxWidth persists the default width`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+
+		comp.resetEditorMaxWidth()
+		advanceUntilIdle()
+
+		assertEquals(GlobalSettings.DEFAULT_EDITOR_WIDTH, settingsAction.captured(globalSettings).editorMaxWidth)
+	}
+
 	// --- forwarding ----------------------------------------------------------
 
 	@Test

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -651,8 +651,8 @@ class ClientAccountSynchronizerTest {
 		// Uploading first would leave an orphan second "MyNovel" on the server that every
 		// other device then downloads as an empty duplicate.
 		coVerify(exactly = 0) { serverProjectsApi.createProject(any(), any()) }
-		verify { projectsRepository.setProjectId(def, serverId) }
-		verify(exactly = 0) { projectsRepository.setProjectId(def, duplicateId) }
+		coVerify { projectsRepository.setProjectId(def, serverId) }
+		coVerify(exactly = 0) { projectsRepository.setProjectId(def, duplicateId) }
 	}
 
 	@Test
@@ -676,7 +676,7 @@ class ClientAccountSynchronizerTest {
 
 		assertTrue(result)
 		coVerify(exactly = 0) { serverProjectsApi.createProject(any(), any()) }
-		verify { projectsRepository.setProjectId(def, serverId) }
+		coVerify { projectsRepository.setProjectId(def, serverId) }
 		// Left queued, it would try to duplicate the project again on every future sync.
 		assertTrue(readSyncData().projectsToCreate.isEmpty())
 	}
@@ -708,7 +708,7 @@ class ClientAccountSynchronizerTest {
 
 		assertTrue(result)
 		// Adopting the orphan abandons the server project actually holding the manuscript.
-		verify(exactly = 0) { projectsRepository.setProjectId(def, orphanId) }
+		coVerify(exactly = 0) { projectsRepository.setProjectId(def, orphanId) }
 		coVerify(exactly = 0) { serverProjectsApi.createProject(any(), any()) }
 	}
 
@@ -736,9 +736,9 @@ class ClientAccountSynchronizerTest {
 
 		assertTrue(result)
 		verify(exactly = 1) { projectsRepository.createProject("My Novel", any()) }
-		verify { projectsRepository.setProjectId(createdDef, firstId) }
+		coVerify { projectsRepository.setProjectId(createdDef, firstId) }
 		// The second one would silently steal the only local project the first just claimed.
-		verify(exactly = 0) { projectsRepository.setProjectId(createdDef, secondId) }
+		coVerify(exactly = 0) { projectsRepository.setProjectId(createdDef, secondId) }
 	}
 
 	@Test

--- a/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HorizontalResizePointerIcon.kt
+++ b/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HorizontalResizePointerIcon.kt
@@ -1,0 +1,5 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.ui.input.pointer.PointerIcon
+
+actual fun horizontalResizePointerIcon(): PointerIcon = PointerIcon.Default

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/TextEditorDefaults.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/TextEditorDefaults.kt
@@ -3,5 +3,6 @@ package com.darkrockstudios.apps.hammer.common
 import androidx.compose.ui.unit.dp
 
 object TextEditorDefaults {
+	val MIN_WIDTH = 128.dp
 	val MAX_WIDTH = 700.dp
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
@@ -312,6 +312,24 @@ The handwriting of the system. Reach for these instead of styling
   Use where a dropdown would be unwieldy: dozens to hundreds of
   options, e.g. every platform locale. Optional muted clear row above
   the list resets the selection.
+- **[`HdResizeHandle`](HdResizeHandle.kt)**: full-height 16dp gutter
+  on the start edge of a centered, width-capped column (the scene
+  editor, focus mode) that drags the column wider or narrower. Shows
+  the `HdDragHandle` grip glyph at low alpha, full alpha on hover or
+  drag; desktop gets a horizontal-resize cursor via expect/actual
+  (the scrollbar-rail precedent for desktop-flavored affordances);
+  double-click resets. Reports drag deltas outward-positive
+  regardless of layout direction, so callers stay RTL-safe and a
+  centered column grows by twice the reported delta. Pair it with
+  `rememberHdResizeHandleState`, which owns the drag math,
+  commit-on-drag-end, and the `showHandle` gate that hides it on
+  narrow layouts (`RESIZE_HANDLE_MIN_SLACK` beyond the column's
+  minimum width, so an over-wide persisted value can always be
+  shrunk back).
+
+      ┆▪ ▪┆ ┌────────────────────┐
+      ┆▪ ▪┆ │  centered column   │
+      ┆▪ ▪┆ └────────────────────┘
 
 ### Categorization
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdResizeHandle.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdResizeHandle.kt
@@ -1,0 +1,182 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+
+const val HD_RESIZE_HANDLE_TAG = "hd-resize-handle"
+
+val RESIZE_HANDLE_WIDTH = 16.dp
+
+/** Minimum horizontal slack beyond the column's minimum width before a resize handle is worth showing. */
+val RESIZE_HANDLE_MIN_SLACK = 48.dp
+
+private val RESIZE_HANDLE_TOUCH_WIDTH = 48.dp
+private const val RESIZE_HANDLE_REST_ALPHA = 0.3f
+
+/**
+ * Drag state for a centered column resized by [HdResizeHandle]. Holds the in-flight
+ * width locally during a drag and fires [onCommit] once on drag end, so callers can
+ * persist without per-frame writes.
+ */
+@Stable
+class HdResizeHandleState internal constructor() {
+	internal var clampWidth: (Float) -> Float = { it }
+	internal var onCommit: (Float) -> Unit = {}
+	internal var onReset: () -> Unit = {}
+	internal var persistedWidth by mutableStateOf(0f)
+	internal var availableWidth by mutableStateOf(0.dp)
+
+	private var dragWidth by mutableStateOf<Float?>(null)
+	private var dragging = false
+
+	/** Live column max width in dp: the in-flight drag value, else the persisted one. */
+	val width: Dp get() = (dragWidth ?: persistedWidth).dp
+
+	/**
+	 * True when the window is wide enough for resizing to be meaningful. Keyed off the
+	 * column's minimum width, never its current one, so the handle (and its reset) stays
+	 * reachable even when the persisted width exceeds the window, and never un-composes
+	 * mid-drag (which would drop the draggable's onDragStopped and lose the commit).
+	 */
+	val showHandle: Boolean get() = availableWidth >= clampWidth(0f).dp + RESIZE_HANDLE_MIN_SLACK
+
+	fun onOutwardDrag(delta: Dp) {
+		dragging = true
+		val target = (dragWidth ?: persistedWidth) + 2 * delta.value
+		dragWidth = clampWidth(target).coerceAtMost(availableWidth.value)
+	}
+
+	fun onDragEnd() {
+		dragging = false
+		dragWidth?.let { onCommit(it) }
+	}
+
+	fun reset() {
+		dragWidth = null
+		onReset()
+	}
+
+	internal fun clearDragUnlessActive() {
+		if (!dragging) dragWidth = null
+	}
+}
+
+@Composable
+fun rememberHdResizeHandleState(
+	persistedWidth: Float,
+	availableWidth: Dp,
+	clampWidth: (Float) -> Float,
+	onCommit: (Float) -> Unit,
+	onReset: () -> Unit,
+): HdResizeHandleState {
+	val state = remember { HdResizeHandleState() }
+	state.clampWidth = clampWidth
+	state.onCommit = onCommit
+	state.onReset = onReset
+	state.persistedWidth = persistedWidth
+	state.availableWidth = availableWidth
+	// The persisted value catching up to a committed drag releases the local override;
+	// skipped while a drag is active so a late settings echo can't snap the column mid-gesture.
+	LaunchedEffect(persistedWidth) { state.clearDragUnlessActive() }
+	return state
+}
+
+/**
+ * A full-height gutter on the start edge of a centered, width-capped column
+ * that lets the user drag the column wider or narrower. The grip glyph sits
+ * subdued until hovered or dragged; the pointer becomes a horizontal-resize
+ * cursor on desktop. Double-click resets. The hit strip is wider than the
+ * visual gutter so touch drags can land.
+ *
+ * ```
+ *   ┆▪ ▪┆ ┌────────────────────┐
+ *   ┆▪ ▪┆ │  centered column   │
+ *   ┆▪ ▪┆ └────────────────────┘
+ * ```
+ *
+ * [onOutwardDrag] reports deltas as outward-positive (away from the column's
+ * center) regardless of layout direction, so callers stay RTL-safe. A centered
+ * column grows by twice the outward delta. Pair with [rememberHdResizeHandleState],
+ * which owns that math plus commit-on-drag-end.
+ */
+@Composable
+fun HdResizeHandle(
+	onOutwardDrag: (Dp) -> Unit,
+	onDragEnd: () -> Unit,
+	onReset: () -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	val density = LocalDensity.current
+	val layoutDirection = LocalLayoutDirection.current
+	val interactionSource = remember { MutableInteractionSource() }
+	val hovered by interactionSource.collectIsHoveredAsState()
+	val dragged by interactionSource.collectIsDraggedAsState()
+	val glyphAlpha = animateFloatAsState(
+		if (hovered || dragged) 1f else RESIZE_HANDLE_REST_ALPHA
+	)
+	val resizeCursor = remember { horizontalResizePointerIcon() }
+
+	Box(
+		modifier = modifier
+			.fillMaxHeight()
+			.width(RESIZE_HANDLE_WIDTH),
+		contentAlignment = Alignment.Center,
+	) {
+		// requiredWidth overflows the 16dp layout slot without shifting the column.
+		Box(
+			modifier = Modifier
+				.requiredWidth(RESIZE_HANDLE_TOUCH_WIDTH)
+				.fillMaxHeight()
+				.testTag(HD_RESIZE_HANDLE_TAG)
+				.hoverable(interactionSource)
+				.pointerHoverIcon(resizeCursor)
+				.draggable(
+					orientation = Orientation.Horizontal,
+					state = rememberDraggableState { deltaPx ->
+						val outwardPx = if (layoutDirection == LayoutDirection.Ltr) -deltaPx else deltaPx
+						onOutwardDrag(with(density) { outwardPx.toDp() })
+					},
+					interactionSource = interactionSource,
+					onDragStopped = { onDragEnd() },
+				)
+				.pointerInput(onReset) {
+					detectTapGestures(onDoubleTap = { onReset() })
+				},
+			contentAlignment = Alignment.Center,
+		) {
+			HdDragHandle(modifier = Modifier.graphicsLayer { alpha = glyphAlpha.value })
+		}
+	}
+}
+
+expect fun horizontalResizePointerIcon(): PointerIcon

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -37,12 +38,15 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.TextEditorDefaults
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.focusmode.FocusMode
+import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.clampEditorWidth
 import com.darkrockstudios.apps.hammer.common.compose.ComposeRichText
 import com.darkrockstudios.apps.hammer.common.compose.LocalMarkdownConfig
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.findShortcutModifier
 import com.darkrockstudios.apps.hammer.common.compose.rememberDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.markdown.updateMarkdownConfiguration
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdResizeHandle
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.rememberHdResizeHandleState
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownFormatBar
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
@@ -161,25 +165,44 @@ fun FocusModeUi(component: FocusMode) {
 				)
 			}
 
-			Row(
-				modifier = Modifier.fillMaxSize(),
-				horizontalArrangement = Arrangement.Center
-			) {
-				SpellCheckingTextEditor(
-					state = textEditorState,
-					contentPadding = PaddingValues(Ui.Padding.XL),
-					enabled = hasReceivedInitialBuffer,
-					style = rememberTextEditorStyle(
-						textStyle = TextStyle.Default.copy(
-							textIndent = TextIndent(firstLine = 24.sp)
-						),
-						focusedBorderColor = Color.Transparent,
-					),
-					modifier = Modifier
-						.background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
-						.fillMaxHeight()
-						.widthIn(128.dp, TextEditorDefaults.MAX_WIDTH),
+			BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+				val widthState = rememberHdResizeHandleState(
+					persistedWidth = state.editorMaxWidth,
+					availableWidth = maxWidth,
+					clampWidth = ::clampEditorWidth,
+					onCommit = component::setEditorMaxWidth,
+					onReset = component::resetEditorMaxWidth,
 				)
+				val editorMaxWidth = widthState.width
+
+				Row(
+					modifier = Modifier.fillMaxSize(),
+					horizontalArrangement = Arrangement.Center
+				) {
+					if (widthState.showHandle) {
+						HdResizeHandle(
+							onOutwardDrag = widthState::onOutwardDrag,
+							onDragEnd = widthState::onDragEnd,
+							onReset = widthState::reset,
+						)
+					}
+
+					SpellCheckingTextEditor(
+						state = textEditorState,
+						contentPadding = PaddingValues(Ui.Padding.XL),
+						enabled = hasReceivedInitialBuffer,
+						style = rememberTextEditorStyle(
+							textStyle = TextStyle.Default.copy(
+								textIndent = TextIndent(firstLine = 24.sp)
+							),
+							focusedBorderColor = Color.Transparent,
+						),
+						modifier = Modifier
+							.background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
+							.fillMaxHeight()
+							.widthIn(TextEditorDefaults.MIN_WIDTH, editorMaxWidth),
+					)
+				}
 			}
 		}
 	}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.sp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.common.TextEditorDefaults
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.SceneEditor
+import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.clampEditorWidth
 import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialog
 import com.darkrockstudios.apps.hammer.common.compose.ComposeRichText
 import com.darkrockstudios.apps.hammer.common.compose.LocalMarkdownConfig
@@ -57,6 +58,8 @@ import com.darkrockstudios.apps.hammer.common.compose.Toaster
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.findShortcutModifier
 import com.darkrockstudios.apps.hammer.common.compose.markdown.updateMarkdownConfiguration
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdResizeHandle
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.rememberHdResizeHandleState
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownFormatBar
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.markdownFormatShortcuts
 import com.darkrockstudios.apps.hammer.common.compose.saveShortcutModifier
@@ -151,8 +154,17 @@ fun SceneEditorUi(
 				CircularProgressIndicator()
 			}
 		} else {
-			val remainingWidth = remember(boxWithConstraintsScope.maxWidth) {
-				boxWithConstraintsScope.maxWidth - TextEditorDefaults.MAX_WIDTH
+			val widthState = rememberHdResizeHandleState(
+				persistedWidth = state.editorMaxWidth,
+				availableWidth = boxWithConstraintsScope.maxWidth,
+				clampWidth = ::clampEditorWidth,
+				onCommit = component::setEditorMaxWidth,
+				onReset = component::resetEditorMaxWidth,
+			)
+			val editorMaxWidth = widthState.width
+
+			val remainingWidth = remember(boxWithConstraintsScope.maxWidth, editorMaxWidth) {
+				boxWithConstraintsScope.maxWidth - editorMaxWidth
 			}
 			val isWide = remember(remainingWidth) { remainingWidth >= SCENE_METADATA_MIN_WIDTH }
 			SideEffect { component.setLayoutMode(isWide) }
@@ -201,6 +213,14 @@ fun SceneEditorUi(
 					modifier = Modifier.fillMaxSize(),
 					horizontalArrangement = Arrangement.Center
 				) {
+					if (widthState.showHandle) {
+						HdResizeHandle(
+							onOutwardDrag = widthState::onOutwardDrag,
+							onDragEnd = widthState::onDragEnd,
+							onReset = widthState::reset,
+						)
+					}
+
 					SpellCheckingTextEditor(
 						state = textEditorState,
 						contentPadding = PaddingValues(Ui.Padding.XL),
@@ -216,7 +236,7 @@ fun SceneEditorUi(
 							.testTag(SCENE_EDITOR_TEXT_TAG)
 							.background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
 							.fillMaxHeight()
-							.widthIn(128.dp, TextEditorDefaults.MAX_WIDTH),
+							.widthIn(TextEditorDefaults.MIN_WIDTH, editorMaxWidth),
 					)
 
 					HorizontalDivider(modifier = Modifier.fillMaxHeight().width(1.dp))

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HorizontalResizePointerIcon.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HorizontalResizePointerIcon.kt
@@ -1,0 +1,7 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.ui.input.pointer.PointerIcon
+import java.awt.Cursor
+
+actual fun horizontalResizePointerIcon(): PointerIcon =
+	PointerIcon(Cursor(Cursor.E_RESIZE_CURSOR))

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/designsystem/DesignSystem.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/designsystem/DesignSystem.Preview.kt
@@ -59,6 +59,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRailDest
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdPlainSection
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdReferenceChip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdReferenceChipVariant
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdResizeHandle
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdResponsiveStrip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdScrollAwayFooter
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSearchField
@@ -1129,6 +1130,28 @@ fun DesignSystemGalleryPreview() {
 					destinations = bottomBarPreviewDestinations,
 					selectedId = "home",
 					onSelect = {},
+				)
+			}
+		}
+	}
+}
+
+@Preview
+@Composable
+fun ResizeHandlePreview() {
+	AppTheme(globalSettingsPreview, useDarkTheme = true) {
+		PreviewSurface {
+			Row(modifier = Modifier.height(120.dp)) {
+				HdResizeHandle(
+					onOutwardDrag = {},
+					onDragEnd = {},
+					onReset = {},
+				)
+				Box(
+					modifier = Modifier
+						.width(240.dp)
+						.fillMaxHeight()
+						.background(MaterialTheme.colorScheme.surfaceVariant),
 				)
 			}
 		}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/FocusModeUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/FocusModeUi.Preview.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.common.data.PlatformRichText
 import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
 import com.darkrockstudios.apps.hammer.common.data.SceneContent
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
 import com.darkrockstudios.apps.hammer.common.preview.TABLET_HEIGHT_DP
 import com.darkrockstudios.apps.hammer.common.preview.TABLET_WIDTH_DP
 import com.darkrockstudios.apps.hammer.common.preview.TabletPreviewSurface
@@ -18,14 +19,18 @@ import com.darkrockstudios.apps.hammer.common.storyeditor.focusmode.FocusModeUi
 @Preview
 @Composable
 fun ScreenFocusModeUiPreview() {
-	FocusModeUi(focusMode)
+	KoinApplicationPreview {
+		FocusModeUi(focusMode)
+	}
 }
 
 @Preview(widthDp = TABLET_WIDTH_DP, heightDp = TABLET_HEIGHT_DP)
 @Composable
 fun ScreenFocusModeUiTabletPreview() {
-	TabletPreviewSurface {
-		FocusModeUi(focusMode)
+	KoinApplicationPreview {
+		TabletPreviewSurface {
+			FocusModeUi(focusMode)
+		}
 	}
 }
 
@@ -54,4 +59,6 @@ private val focusMode = object : FocusMode {
 	override fun decreaseTextSize() {}
 	override fun increaseTextSize() {}
 	override fun resetTextSize() {}
+	override fun setEditorMaxWidth(width: Float) {}
+	override fun resetEditorMaxWidth() {}
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneEditorUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneEditorUi.Preview.kt
@@ -127,5 +127,7 @@ private fun fakeComponent() = object : SceneEditor {
 	override fun decreaseTextSize() {}
 	override fun increaseTextSize() {}
 	override fun resetTextSize() {}
+	override fun setEditorMaxWidth(width: Float) {}
+	override fun resetEditorMaxWidth() {}
 	override fun enterFocusMode() {}
 }

--- a/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HorizontalResizePointerIcon.kt
+++ b/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HorizontalResizePointerIcon.kt
@@ -1,0 +1,5 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.ui.input.pointer.PointerIcon
+
+actual fun horizontalResizePointerIcon(): PointerIcon = PointerIcon.Default


### PR DESCRIPTION
## What

Writers on wide desktops complained the editor column (fixed 700dp) is too narrow. This adds a drag handle on the left edge of the editor column, in both the scene editor and focus mode, that widens the column symmetrically. The value is stored as the editor's *maximum* width: rendered width is always `min(window, userMax)`, so narrow windows behave exactly as before.

## How

- `GlobalSettings.editorMaxWidth` (default 700, clamped 700-1400) persisted locally; defaulted field, so existing TOML needs no migration. Components seed from and observe the settings store; both editors share the one value.
- New `HdResizeHandle` design-system component: 16dp hairline-vocabulary gutter with the `HdDragHandle` grip glyph (subdued at rest, full on hover/drag), a 48dp hit strip for touch, horizontal-resize cursor on desktop via expect/actual, double-click to reset. Drag deltas are reported outward-positive so call sites are RTL-safe.
- `rememberHdResizeHandleState` owns the drag math: live width stays UI-local during the drag and persists once on drag end (no per-frame disk writes), the settings echo can't snap the column mid-gesture, and the handle's visibility is keyed off the column's *minimum* width so an over-wide persisted value can always be shrunk back on a smaller window.
- Widening past the threshold moves the scene metadata sidebar to its modal mode, same as shrinking the window does today (editor wins).

## Testing

- Component tests for seed/clamp/persist/reset in both editors (`:common:desktopTest`, full suite green).
- Previews rendered and inspected: new `HdResizeHandle` gallery entry, wide scene editor, focus mode (also fixed the focus mode previews, which crashed on a missing Koin context since before this branch).
- First commit fixes a pre-existing desktopTest compile break on develop (`verify` -> `coVerify` for the now-suspend `setProjectId`).