### PR TITLE
Give the review dialog's scene list room to breathe

### DIFF
--- a/server/src/main/resources/assets/css/story.css
+++ b/server/src/main/resources/assets/css/story.css
@@ -1840,6 +1840,7 @@
 	max-width: 540px;
 	width: 92%;
 	max-height: calc(100vh - 48px);
+	max-height: calc(100dvh - 48px);
 	display: flex;
 	flex-direction: column;
 	/* Fully opaque: this dialog is tall enough to overlap the page footer,
@@ -1854,11 +1855,18 @@
 .dialog--review form {
 	display: flex;
 	flex-direction: column;
+	flex: 1 1 auto;
 	min-height: 0;
 }
 
+/* The only scroll region in the dialog. The scene list renders at its full
+   height inside it, so the whole form scrolls as one column between the pinned
+   header and actions instead of nesting a second scroller. */
 .dialog--review .dialog__body {
+	flex: 1 1 auto;
+	min-height: 0;
 	overflow-y: auto;
+	overscroll-behavior: contain;
 }
 
 .review-form__row {
@@ -1932,13 +1940,17 @@
 	color: var(--neutral-400);
 }
 
-.review-form__scene-tree {
+/* Frames the master row and the list as one control. Nothing here scrolls: the
+   list is as tall as the story is long and the dialog body scrolls it. */
+.review-form__scene-box {
 	border: 1px solid var(--neutral-200);
 	border-radius: 10px;
 	background: #ffffff;
+	overflow: hidden;
+}
+
+.review-form__scene-tree {
 	padding: 0.4rem 0;
-	max-height: 260px;
-	overflow-y: auto;
 }
 
 .review-scene-master {
@@ -1947,12 +1959,9 @@
 	justify-content: space-between;
 	gap: 0.6rem;
 	padding: 0.55rem 1rem;
-	margin: 0 0.4rem 0.25rem 0.4rem;
 	border-bottom: 1px dashed var(--neutral-200);
-	position: sticky;
-	top: 0;
-	background: #ffffff;
-	z-index: 1;
+	background: #faf6ee;
+	flex-shrink: 0;
 }
 
 .review-scene-master__name {
@@ -2087,9 +2096,49 @@
 	color: var(--neutral-600);
 }
 
+/* Short viewports: give the dialog's own chrome back to the scene list */
+@media only screen and (max-height: 900px) {
+	.dialog--review {
+		max-height: calc(100vh - 16px);
+		max-height: calc(100dvh - 16px);
+	}
+
+	.dialog--review .dialog__header,
+	.dialog--review .dialog__actions {
+		padding-top: 0.75rem;
+		padding-bottom: 0.75rem;
+	}
+
+	.dialog--review .dialog__body {
+		padding: 1rem 1.25rem;
+	}
+
+	.dialog--review .form-field:not(:last-child) {
+		margin-bottom: 0.85rem;
+	}
+
+	.review-form__note {
+		min-height: 2.2rem;
+	}
+}
+
 @media only screen and (max-width: 600px) {
 	.review-form__row {
 		flex-direction: column;
 		gap: 0;
+	}
+
+	/* Full-height sheet, so the list gets every pixel the phone has */
+	.dialog--review {
+		width: 100%;
+		max-width: 100%;
+		height: 100vh;
+		height: 100dvh;
+		max-height: 100vh;
+		max-height: 100dvh;
+		margin: 0;
+		border-radius: 0;
+		border-left: none;
+		border-right: none;
 	}
 }

--- a/server/src/main/resources/templates/partials/review-request-dialog.mustache
+++ b/server/src/main/resources/templates/partials/review-request-dialog.mustache
@@ -67,7 +67,7 @@
 					</div>
 				</div>
 
-				<div class="form-field">
+				<div class="form-field review-form__scenes">
 					<div class="review-form__scenes-head">
 						<span class="form-field__label">{{msg.review_dialog_scenes}}</span>
 						<span class="review-form__scene-count"
@@ -75,34 +75,36 @@
 							  data-total="{{sceneCount}}"
 							  data-none-label="{{msg.review_dialog_scenes_none}}">{{msg.review_dialog_scenes_none}}</span>
 					</div>
-					<div class="review-form__scene-tree" id="review-scene-tree">
+					<div class="review-form__scene-box">
 						<div class="review-scene-master">
 							<span class="review-scene-master__name">{{msg.review_dialog_all_scenes}}</span>
 							<button type="button" class="review-scene-master__toggle" id="review-select-all"
 									data-select-label="{{msg.review_dialog_select_all}}"
 									data-clear-label="{{msg.review_dialog_clear_all}}">{{msg.review_dialog_select_all}}</button>
 						</div>
-						{{#sceneTree}}
-							{{#isGroup}}
-								<div class="review-scene-group" style="padding-left: {{indentPx}}px;">
-									<span class="review-scene-group__name">{{name}}</span>
-									<button type="button"
-											class="review-scene-group__toggle"
-											data-group-depth="{{depth}}"
-											data-select-label="{{msg.review_dialog_select_all}}"
-											data-clear-label="{{msg.review_dialog_clear_all}}">{{msg.review_dialog_select_all}}</button>
-								</div>
-							{{/isGroup}}
-							{{#isScene}}
-								<label class="review-scene-row" style="padding-left: {{indentPx}}px;"
-									   data-depth="{{depth}}">
-									<input type="checkbox" name="sceneIds" value="{{id}}"
-										   class="review-scene-row__check">
-									<span class="review-scene-row__box"><i class="fa-solid fa-check"></i></span>
-									<span class="review-scene-row__name">{{name}}</span>
-								</label>
-							{{/isScene}}
-						{{/sceneTree}}
+						<div class="review-form__scene-tree" id="review-scene-tree">
+							{{#sceneTree}}
+								{{#isGroup}}
+									<div class="review-scene-group" style="padding-left: {{indentPx}}px;">
+										<span class="review-scene-group__name">{{name}}</span>
+										<button type="button"
+												class="review-scene-group__toggle"
+												data-group-depth="{{depth}}"
+												data-select-label="{{msg.review_dialog_select_all}}"
+												data-clear-label="{{msg.review_dialog_clear_all}}">{{msg.review_dialog_select_all}}</button>
+									</div>
+								{{/isGroup}}
+								{{#isScene}}
+									<label class="review-scene-row" style="padding-left: {{indentPx}}px;"
+										   data-depth="{{depth}}">
+										<input type="checkbox" name="sceneIds" value="{{id}}"
+											   class="review-scene-row__check">
+										<span class="review-scene-row__box"><i class="fa-solid fa-check"></i></span>
+										<span class="review-scene-row__name">{{name}}</span>
+									</label>
+								{{/isScene}}
+							{{/sceneTree}}
+						</div>
 					</div>
 				</div>
 			</div>

--- a/server/src/main/resources/templates/story.mustache
+++ b/server/src/main/resources/templates/story.mustache
@@ -126,10 +126,13 @@
 					</div>
 					{{> partials/review-panel}}
 				</div>
-				<div id="review-dialog-container"></div>
 			</aside>
 		</div>
 	</div>
 </main>
+
+<!-- Outside the sidebar: position:sticky there makes a stacking context the
+     overlay's z-index can't escape, which paints it under the site header. -->
+<div id="review-dialog-container"></div>
 
 {{> footer}}


### PR DESCRIPTION
The scene picker in **Request a Review** was cramped and scrolled oddly. Three separate causes.

### The list was a scroller inside a scroller

`.dialog__body` scrolled, and inside it `.review-form__scene-tree` was capped at `max-height: 260px` and scrolled again, so the list stayed the same size no matter how tall the window was. The dialog body is now the only scroll region and the list renders at its full height inside it, between the pinned title bar and the pinned Cancel/Send row.

Verified by enumerating every element in the dialog whose `scrollHeight` exceeds its `clientHeight`, at 390x780, 560x620 and 900x700: `dialog__body` is the only one in all three.

### "All scenes / Select all" ghosted the rows behind it

That row was `position: sticky` inside the inner scroller, with `0.4rem` side margins while the scroller carried `0.4rem` of top padding. Sticky pins to the top of the *padding* box, so rows scrolled through the strip above it and through the gutters beside it. It is now a plain header bar sitting above the list, outside the scroller, inside a new `.review-form__scene-box` wrapper that owns the border and radius. Nothing scrolls under it, so nothing can show through.

### The dialog rendered under the site header on short screens

`#review-dialog-container` lived inside `<aside class="story-sidebar">`, which is `position: sticky` at >=1024px. Sticky always creates a stacking context, so the overlay's `z-index: 1000` was scoped inside it and could never beat the header's `z-index: 100`. Moved the container out to a sibling of `<main>`.

Confirmed both ways with `elementFromPoint` over the header: inside the aside it returns the header's own element, outside it returns `.dialog-overlay`.

### Small screens

`dvh` alongside `vh` (mobile browser chrome eats `vh`), trimmed dialog padding under 900px tall, and a full-bleed sheet under 600px wide.

### Testing

`./gradlew server:test --tests "*Review*" --tests "*StoryPage*"` -> 70 tests, 0 failures. Layout checked by hand against the real stylesheets across the viewport sizes above, and in the running dev server.

### Follow-ups, not in this PR

- The master "Select all" and the "n selected" counter now scroll away with the rest of the form. Per-chapter "Select all" stays inline where you are. Options if it bites: make the bar sticky within the body scroller, or move the counter into the actions row next to Send.
- The note textarea is around 110px of usually-empty box above the list. Collapsing it behind an "Add a note" link is the biggest remaining win on short screens.
- Collapsible chapters would make the list scale past a 12-chapter book.
