### PR TITLE
Make scene tree nesting legible

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_scene_list.xml
+++ b/common/src/commonMain/composeResources/values/strings_scene_list.xml
@@ -58,6 +58,7 @@
 	<string name="scene_move_dialog_dismiss_button">Cancel</string>
 
 	<string name="scene_list_count_format">%1$d · %2$d GR</string>
+	<string name="scene_group_scene_count_format">%1$d SCN</string>
 	<string name="scene_list_create_menu_scene">New Scene</string>
 	<string name="scene_list_create_menu_group">New Group</string>
 	<string name="scene_list_add_button">Add</string>

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
@@ -208,6 +208,22 @@ These set up the page. Use them before reaching for raw `Column` /
       │ └─[ KTOR · HTTPS ]─────────[ LAST SYNC 14:32 ]┘  │
       └──────────────────────────────────────────────────┘
 
+- **[`HdIndentRails`](HdIndentRails.kt)** — the nesting vocabulary for
+  tree rows: `HdIndentStep` (one level = one disclosure column),
+  `hdIndentFor(depth)` for a row's start inset, and
+  `Modifier.hdIndentRails(levels, color)` to draw one vertical hairline
+  per ancestor, each centered on the disclosure column that owns it.
+  Every row in a tree — parent and leaf alike — takes its inset from
+  `hdIndentFor`, and a leaf adds one more `HdIndentStep` to clear the
+  chevron column, so a child's label sits exactly one step right of its
+  parent's. The rails are the marginalia rule applied along the depth
+  axis: without them 16dp steps stop being traceable past two levels.
+
+      ⌄ Chapter I                    3 SCN
+      ┆   At Home
+      ┆ ⌄ Chapter II                 2 SCN
+      ┆ ┆   The Pool of Tears
+
 - **[`HdScrollAwayFooter`](HdScrollAwayFooter.kt)**: hairline action
   strip that floats over the bottom of a scrolling pane and slides away
   as the reader scrolls down. It is an **overlay**, never a sibling in

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdIndentRails.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdIndentRails.kt
@@ -1,0 +1,53 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/** One nesting level in a tree row: the width of a disclosure column. */
+val HdIndentStep: Dp = 16.dp
+
+/**
+ * Start of a row's own content at [depth], counting the outer gutter.
+ * Depth 1 is a top level row.
+ */
+fun hdIndentFor(depth: Int, gutter: Dp = HdIndentStep, step: Dp = HdIndentStep): Dp =
+	gutter + step * (depth - 1).coerceAtLeast(0)
+
+/**
+ * Vertical hairline rails, one per ancestor level, descending through a nested row.
+ * Each rail is centered on the disclosure column of the ancestor that owns it, so a
+ * child row reads as hanging off its parent's chevron.
+ *
+ * ```
+ * ⌄ Chapter I
+ * ┆  ⌄ Scene Group
+ * ┆  ┆   Scene name
+ * ```
+ *
+ * [levels] is the number of ancestors above this row: `depth - 1`.
+ */
+fun Modifier.hdIndentRails(
+	levels: Int,
+	color: Color,
+	gutter: Dp = HdIndentStep,
+	step: Dp = HdIndentStep,
+): Modifier {
+	if (levels <= 0) return this
+	return drawBehind {
+		val stepPx = step.toPx()
+		val centerOffset = gutter.toPx() + (stepPx / 2f)
+		repeat(levels) { level ->
+			val x = centerOffset + (stepPx * level)
+			drawLine(
+				color = color,
+				start = Offset(x, 0f),
+				end = Offset(x, size.height),
+				strokeWidth = Dp.Hairline.toPx(),
+			)
+		}
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneGroupItem.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneGroupItem.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -25,11 +23,16 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdIndentStep
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.hdIndentFor
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.hdIndentRails
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeValue
 import com.darkrockstudios.apps.hammer.scene_group_item_collapsed
 import com.darkrockstudios.apps.hammer.scene_group_item_expanded
+import com.darkrockstudios.apps.hammer.scene_group_scene_count_format
 
 fun sceneGroupTag(id: Int) = "scene-group-$id"
 
@@ -48,12 +51,17 @@ internal fun SceneGroupItem(
 	onCreateGroupClick: (scene: SceneItem) -> Unit,
 ) {
 	val (scene: SceneItem, _, _, children: List<TreeValue<SceneItem>>) = sceneNode
-	val isTopLevel = sceneNode.depth == 1
+	val isTopLevel = sceneNode.depth <= 1
+	val indent = hdIndentFor(sceneNode.depth)
+	val railColor = MaterialTheme.colorScheme.outlineVariant
 
 	val groupModifier = draggable
 		.fillMaxWidth()
 		.testTag(sceneGroupTag(scene.id))
+		.hdIndentRails(levels = sceneNode.depth - 1, color = railColor)
 		.clickable { toggleExpand(scene.id) }
+
+	val sceneCount = sceneNode.count { it.value.type == SceneItem.Type.Scene }
 
 	SceneGroupActionContainer(
 		scene = scene,
@@ -66,63 +74,55 @@ internal fun SceneGroupItem(
 	) {
 		Box(modifier = groupModifier) {
 			Column(modifier = Modifier.fillMaxWidth()) {
-				if (isTopLevel) {
-					HorizontalDivider(
-						thickness = Dp.Hairline,
-						color = MaterialTheme.colorScheme.outlineVariant,
-					)
-				}
+				// A chapter break cuts the full panel; a nested rule hangs at the group's own indent.
+				HorizontalDivider(
+					modifier = Modifier.padding(start = if (isTopLevel) 0.dp else indent),
+					thickness = Dp.Hairline,
+					color = MaterialTheme.colorScheme.outlineVariant,
+				)
 
 				Row(
 					modifier = Modifier
 						.fillMaxWidth()
 						.padding(
-							start = if (isTopLevel) {
-								Ui.Padding.XL
-							} else {
-								Ui.Padding.XL + (Ui.Padding.XL * (sceneNode.depth - 2).coerceAtLeast(0))
-							},
+							start = indent,
 							end = Ui.Padding.XL,
 							top = Ui.Padding.L,
 							bottom = Ui.Padding.L,
 						),
 					verticalAlignment = Alignment.CenterVertically,
 				) {
-					if (isTopLevel) {
-						Icon(
-							imageVector = if (collapsed) Icons.AutoMirrored.Filled.KeyboardArrowRight else Icons.Filled.KeyboardArrowDown,
-							contentDescription = if (collapsed) {
-								Res.string.scene_group_item_collapsed.get()
-							} else {
-								Res.string.scene_group_item_expanded.get()
-							},
-							tint = MaterialTheme.colorScheme.onSurfaceVariant,
-							modifier = Modifier.size(16.dp).padding(end = Ui.Padding.S),
-						)
-						Text(
-							text = scene.name,
-							style = MaterialTheme.typography.titleSmall,
-							fontWeight = FontWeight.Medium,
-							color = MaterialTheme.colorScheme.onSurface,
-							modifier = Modifier.weight(1f),
-						)
-					} else {
-						Icon(
-							imageVector = if (collapsed) Icons.Filled.Folder else Icons.Filled.FolderOpen,
-							contentDescription = if (collapsed) {
-								Res.string.scene_group_item_collapsed.get()
-							} else {
-								Res.string.scene_group_item_expanded.get()
-							},
-							tint = MaterialTheme.colorScheme.onSurfaceVariant,
-							modifier = Modifier.size(20.dp).padding(end = Ui.Padding.M),
-						)
-						Text(
-							text = scene.name,
-							style = MaterialTheme.typography.bodyMedium,
-							fontWeight = FontWeight.Medium,
-							color = MaterialTheme.colorScheme.onSurface,
-							modifier = Modifier.weight(1f),
+					Icon(
+						imageVector = if (collapsed) {
+							Icons.AutoMirrored.Filled.KeyboardArrowRight
+						} else {
+							Icons.Filled.KeyboardArrowDown
+						},
+						contentDescription = if (collapsed) {
+							Res.string.scene_group_item_collapsed.get()
+						} else {
+							Res.string.scene_group_item_expanded.get()
+						},
+						tint = MaterialTheme.colorScheme.onSurfaceVariant,
+						modifier = Modifier.size(HdIndentStep),
+					)
+
+					Text(
+						text = scene.name,
+						style = if (isTopLevel) {
+							MaterialTheme.typography.titleSmall
+						} else {
+							MaterialTheme.typography.bodyMedium
+						},
+						fontWeight = FontWeight.Medium,
+						color = MaterialTheme.colorScheme.onSurface,
+						modifier = Modifier.weight(1f),
+					)
+
+					if (sceneCount > 0) {
+						HdMonoLabel(
+							text = Res.string.scene_group_scene_count_format.get(sceneCount),
+							modifier = Modifier.padding(start = Ui.Padding.M),
 						)
 					}
 				}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneItem.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/SceneItem.kt
@@ -15,9 +15,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdIndentStep
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.hdIndentFor
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.hdIndentRails
 import com.darkrockstudios.apps.hammer.common.compose.leftBorder
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 
@@ -40,6 +42,7 @@ internal fun SceneItem(
 ) {
 	val bg = if (isSelected) MaterialTheme.colorScheme.surfaceContainer else Color.Transparent
 	val accent = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
+	val railColor = MaterialTheme.colorScheme.outlineVariant
 
 	SceneItemActionContainer(
 		scene,
@@ -54,6 +57,7 @@ internal fun SceneItem(
 				.fillMaxWidth()
 				.testTag(sceneItemTag(scene.id))
 				.background(bg)
+				.hdIndentRails(levels = depth - 1, color = railColor)
 				.leftBorder(2.dp, accent)
 				.combinedClickable(onClick = { onSceneSelected(scene) })
 		) {
@@ -61,7 +65,8 @@ internal fun SceneItem(
 				modifier = Modifier
 					.fillMaxWidth()
 					.padding(
-						start = sceneRowStartPadding(depth),
+						// Clears the disclosure column, so scene names line up with group names.
+						start = hdIndentFor(depth) + HdIndentStep,
 						end = Ui.Padding.XL,
 						top = Ui.Padding.M,
 						bottom = Ui.Padding.M,
@@ -85,6 +90,3 @@ internal fun SceneItem(
 		}
 	}
 }
-
-private fun sceneRowStartPadding(depth: Int): Dp =
-	Ui.Padding.XXL + (Ui.Padding.XL * (depth - 1).coerceAtLeast(0))

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/scenetree/SceneTree.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarList
 import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.hdIndentFor
 
 /**
  * The root composable take takes a scene tree and handles rendering, reorder, collapsing
@@ -151,7 +152,7 @@ private fun Modifier.reorderableModifier(state: SceneTreeState): Modifier {
 	}
 }
 
-private val NESTING_INSET = 16f.dp
+private val EDGE_INSET = 16f.dp
 
 @Composable
 private fun drawInsertLine(
@@ -210,8 +211,8 @@ private fun drawInsertLine(
 			nestingDept = parentNode.depth + 1
 		}
 
-		val insetSize = (nestingDept * NESTING_INSET.toPx())
-		val endX = size.width - NESTING_INSET.toPx()
+		val insetSize = hdIndentFor(nestingDept).toPx()
+		val endX = size.width - EDGE_INSET.toPx()
 
 		drawLine(
 			start = Offset(x = insetSize, y = lineY),

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/SceneListUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/SceneListUi.Preview.kt
@@ -12,6 +12,7 @@ import com.darkrockstudios.apps.hammer.common.Padded
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.scenelist.SceneList
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
 import com.darkrockstudios.apps.hammer.common.data.MoveRequest
 import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
@@ -56,6 +57,99 @@ fun ScreenSceneListUiTabletPreview() {
 		}
 	}
 }
+
+@Preview(widthDp = 320, heightDp = 780)
+@Composable
+fun ScreenSceneListUiNestedPreview() = NestedSceneList(useDarkTheme = true)
+
+@Preview(widthDp = 320, heightDp = 780)
+@Composable
+fun ScreenSceneListUiNestedLightPreview() = NestedSceneList(useDarkTheme = false)
+
+@Composable
+private fun NestedSceneList(useDarkTheme: Boolean) {
+	val snackbarHostState = rememberRootSnackbarHostState()
+
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, useDarkTheme) {
+			val summary = nestedSceneSummary()
+			val component = fakeComponent(
+				SceneList.State(
+					projectDef = fakeProjectDef(),
+					sceneSummary = summary,
+					selectedSceneItem = summary.sceneTree.find { it.value.name == SELECTED_SCENE }?.value,
+				)
+			)
+			SceneListUi(component, snackbarHostState)
+		}
+	}
+}
+
+private const val SELECTED_SCENE = "Down the hole"
+private const val DIRTY_SCENE = "White Rabbit Arrives"
+
+private fun nestedSceneSummary(): SceneSummary {
+	var nextId = 1
+	fun scene(name: String) = TreeNode(namedScene(nextId++, name, SceneItem.Type.Scene))
+	fun group(name: String) = TreeNode(namedScene(nextId++, name, SceneItem.Type.Group))
+
+	val tree = Tree<SceneItem>()
+	val root = TreeNode(namedScene(0, "Root", SceneItem.Type.Root))
+
+	root.addChild(scene("Title"))
+	root.addChild(
+		group("Chapter I").apply {
+			addChild(scene("At Home"))
+		}
+	)
+	root.addChild(scene("A Caucus Race and a Long Tale"))
+	root.addChild(
+		group("Chapter IV").apply {
+			addChild(scene("Mushroom Consumed"))
+			addChild(
+				group("Chapter III").apply {
+					addChild(scene("Down the hole"))
+					addChild(
+						group("Chapter II").apply {
+							addChild(scene("The Pool of Tears"))
+							addChild(scene("White Rabbit Arrives"))
+						}
+					)
+				}
+			)
+			addChild(scene("The Rabbit Sends in a Little Bill"))
+			addChild(scene("Bottom of Chimney"))
+		}
+	)
+	root.addChild(
+		group("Chapter VI").apply {
+			addChild(
+				group("Chapter V").apply {
+					addChild(scene("Pig and Pepper"))
+				}
+			)
+		}
+	)
+	root.addChild(group("Chapter VII"))
+
+	tree.setRoot(root)
+
+	val immutable = tree.toImmutableTree()
+	val dirtyId = immutable.first { it.value.name == DIRTY_SCENE }.value.id
+
+	return SceneSummary(
+		immutable,
+		persistentSetOf(dirtyId),
+	)
+}
+
+private fun namedScene(id: Int, name: String, type: SceneItem.Type) = SceneItem(
+	projectDef = fakeProjectDef(),
+	type = type,
+	id = id,
+	name = name,
+	order = id,
+)
 
 private fun fakeSceneSummary(): SceneSummary {
 	val tree = Tree<SceneItem>()


### PR DESCRIPTION
After the redesign it was hard to tell how scene groups nested. Two causes.

**The indent was wrong.** `SceneGroupItem` computed nested-group padding as
`XL + XL * (depth - 2)`. At depth 2 that is `XL + 0`, so a group nested inside a
chapter got exactly the same start padding as the chapter itself. Only depth 3 and
below indented at all.

**Nothing shared a grid.** Groups and scenes used different formulas off different
bases (`XL` vs `XXL`) with different icon widths, so even where the math was right
the rows did not line up. On top of that the top level got a chevron and nested
groups got a folder icon, so a nested chapter read as a different kind of thing
rather than the same thing one level down.

## Changes

- New design system primitive `HdIndentRails`: `HdIndentStep`, `hdIndentFor(depth)`,
  and `Modifier.hdIndentRails(levels, color)`, which draws one vertical hairline per
  ancestor, each centered on the disclosure column that owns it. That is the
  marginalia rule from the design README applied along the depth axis; without it
  16dp steps stop being traceable past two levels. Documented in `DESIGN_README.md`.
- Every row takes its inset from `hdIndentFor(depth)`; a scene adds one more step to
  clear the chevron column. A group's title and its child scenes' titles land exactly
  one step apart on a strict 16dp grid. Scene indentation is numerically identical to
  before, only groups moved.
- Chevron at every depth, folder icons dropped. Group rows get a mono `N SCN` greeble
  carrying the real descendant scene count, so they stay unmistakable against scenes.
- Section rules hang at the group's own indent; top level chapter breaks still cut the
  full panel, which keeps chapters visually louder than sub-groups.
- The drag insert line reads the same indent metric, so the drop indicator lands on the
  row grid instead of its own.

## Testing

- `:composeUi:desktopTest` passes; desktop, Android and iOS metadata all compile.
- New `ScreenSceneListUiNestedPreview` / `...NestedLightPreview` reproduce a four-deep
  tree with groups and scenes interleaved, rendered and checked in both themes.
- Ran the desktop client against a real project.
