### PR TITLE
Fix scenes becoming unreadable in a directory of exactly ten children

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneDatasource.kt
@@ -187,12 +187,20 @@ class SceneDatasource(
 		return scenePaths
 	}
 
+	/**
+	 * Scene paths directly inside [root], keyed by scene id. Two files claiming one id are settled
+	 * the same way [validateScenePaths] and [ScenePathIndex] settle them: the name-first path wins.
+	 * Every id lookup in the codebase must agree, or a pass that rewrites files picks a different
+	 * copy than the one the tree was loaded from and discards the other.
+	 */
 	fun getGroupChildPathsById(root: HPath): Map<Int, HPath> {
-		return getScenePathsFromFilesystem(root)
-			.map { scenePath ->
-				val sceneId = getSceneIdFromPath(scenePath.toHPath())
-				Pair(sceneId, scenePath)
-			}.associateBy({ it.first }, { it.second.toHPath() })
+		val byId = LinkedHashMap<Int, HPath>()
+		// filterScenePathsOkio sorts by name, so the first path seen for an id is the one it owns.
+		for (scenePath in getScenePathsFromFilesystem(root)) {
+			val sceneId = getSceneIdFromPath(scenePath.toHPath())
+			if (!byId.containsKey(sceneId)) byId[sceneId] = scenePath.toHPath()
+		}
+		return byId
 	}
 
 	fun moveScene(sourcePath: HPath, targetPath: HPath) {
@@ -216,8 +224,6 @@ class SceneDatasource(
 	}
 
 	fun getSceneFilename(path: HPath) = path.toOkioPath().name
-
-	fun getLastOrderNumber(parentPath: HPath): Int = countScenePathsIn(parentPath)
 
 	fun clearTempScene(sceneItem: SceneItem) {
 		val path = getSceneBufferTempPath(sceneItem).toOkioPath()
@@ -289,6 +295,13 @@ class SceneDatasource(
 		}
 	}
 
+	/**
+	 * The highest order number in use directly inside [parentPath]. Orders are a contiguous
+	 * 0-based sequence, so a directory of N children tops out at N-1. Both the order given to the
+	 * next child and the width of the zero-padded order field must derive from this, never from
+	 * the raw child count: at a power of ten the two disagree, and the names on disk stop matching
+	 * the ones [SceneRepository.getSceneFilePath] computes to read them back.
+	 */
 	fun countScenes(parentPath: HPath): Int = countScenePathsIn(parentPath) - 1
 
 	fun storeTempSceneBuffer(buffer: SceneBuffer): Boolean {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneEditorService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneEditorService.kt
@@ -185,7 +185,7 @@ class SceneEditorService(
 
 		sceneEditorRepository.markSceneForSynchronization(sceneItem)
 
-		val scenePath = sceneEditorRepository.getSceneFilePath(sceneItem)
+		val scenePath = sceneEditorRepository.resolveSceneContentPath(sceneItem)
 		val success = sceneContentRepository.persistBuffer(buffer, scenePath)
 
 		if (success) {
@@ -208,7 +208,7 @@ class SceneEditorService(
 	}
 
 	fun discardSceneBuffer(sceneDef: SceneItem) {
-		val scenePath = sceneEditorRepository.getSceneFilePath(sceneDef)
+		val scenePath = sceneEditorRepository.resolveSceneContentPath(sceneDef)
 		val reloaded = sceneContentRepository.discardBuffer(sceneDef, scenePath)
 		if (reloaded != null) {
 			writingSessionTracker.rememberBaseline(sceneDef.id, reloaded.content.coerceMarkdown())
@@ -292,7 +292,7 @@ class SceneEditorService(
 		val cached = sceneContentRepository.getSceneBuffer(sceneItem)
 		if (cached != null) return cached
 
-		val scenePath = sceneEditorRepository.getSceneFilePath(sceneItem)
+		val scenePath = sceneEditorRepository.resolveSceneContentPath(sceneItem)
 		val buffer = sceneContentRepository.loadBuffer(sceneItem, scenePath)
 		writingSessionTracker.rememberBaseline(sceneItem.id, buffer.content.coerceMarkdown())
 		return buffer

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sceneeditorrepository/SceneRepository.kt
@@ -156,9 +156,9 @@ class SceneRepository(
 		val parentPath = resolveParentPathFromFilesystem(parentId)
 
 		val orderDigits = if (isNewScene && willNextSceneIncreaseMagnitude(parentId)) {
-			sceneDatasource.getLastOrderNumber(parentPath).numDigits() + 1
+			sceneDatasource.countScenes(parentPath).numDigits() + 1
 		} else {
-			sceneDatasource.getLastOrderNumber(parentPath).numDigits()
+			sceneDatasource.countScenes(parentPath).numDigits()
 		}
 
 		return sceneFileName(sceneDef, orderDigits)
@@ -180,7 +180,16 @@ class SceneRepository(
 
 	/** How wide the order field is for items directly inside [parentPath]. */
 	private fun orderDigitsIn(parentPath: HPath): Int =
-		sceneDatasource.getLastOrderNumber(parentPath).numDigits()
+		sceneDatasource.countScenes(parentPath).numDigits()
+
+	/**
+	 * Where [sceneItem]'s content actually sits. Resolved by id from disk, falling back to the
+	 * computed name only for a scene that has no file yet. Reading or writing content through a
+	 * recomputed name lets any disagreement between the tree and disk silently retarget the
+	 * operation: reads land on nothing and come back empty, writes create a rival file.
+	 */
+	fun resolveSceneContentPath(sceneItem: SceneItem): HPath =
+		sceneDatasource.resolveScenePathFromFilesystem(sceneItem.id) ?: getSceneFilePath(sceneItem)
 
 	/** The path of [child] directly inside [parentPath], given the order field width there. */
 	private fun childScenePath(parentPath: HPath, child: SceneItem, orderDigits: Int): HPath =
@@ -570,10 +579,10 @@ class SceneRepository(
 
 	/**
 	 * Recursively moves [parentNode]'s children to their intended paths. Order padding is the
-	 * digit count of the children present on disk, computed once per directory: it is immune to
-	 * the moves below changing the directory's live count, and it matches the padding
-	 * [getSceneFilePath] derives from the directory's final disk count. Parents are finalized
-	 * before their children so every destination directory exists.
+	 * width of the highest order among the children present on disk, computed once per directory:
+	 * it is immune to the moves below changing the directory's live count, and it matches the
+	 * padding [getSceneFilePath] derives once the directory holds exactly these children. Parents
+	 * are finalized before their children so every destination directory exists.
 	 */
 	private fun rationalizeChildren(parentNode: TreeNode<SceneItem>, parentPath: HPath) {
 		// Children already inside this directory, snapshotted once: a sibling's rename never
@@ -586,7 +595,7 @@ class SceneRepository(
 			childPathsInDir.containsKey(node.value.id) ||
 				sceneDatasource.resolveScenePathFromFilesystem(node.value.id) != null
 		}
-		val orderDigits = presentCount.numDigits()
+		val orderDigits = (presentCount - 1).numDigits()
 
 		children.forEach { node ->
 			val intendedPath = childScenePath(parentPath, node.value, orderDigits)
@@ -774,7 +783,7 @@ class SceneRepository(
 	 */
 	fun loadSceneMarkdownRaw(
 		sceneItem: SceneItem,
-		scenePath: HPath = getSceneFilePath(sceneItem)
+		scenePath: HPath = resolveSceneContentPath(sceneItem)
 	): String =
 		sceneDatasource.loadSceneMarkdownRaw(sceneItem, scenePath)
 
@@ -786,7 +795,7 @@ class SceneRepository(
 	fun readSceneMarkdownInto(
 		sceneItem: SceneItem,
 		sink: ScanBuffers,
-		scenePath: HPath = getSceneFilePath(sceneItem),
+		scenePath: HPath = resolveSceneContentPath(sceneItem),
 	): Int = sceneDatasource.readSceneMarkdownInto(sceneItem, scenePath, sink)
 
 	/**
@@ -794,7 +803,7 @@ class SceneRepository(
 	 */
 	suspend fun storeSceneMarkdownRaw(
 		sceneItem: SceneContent,
-		scenePath: HPath = getSceneFilePath(sceneItem.scene)
+		scenePath: HPath = resolveSceneContentPath(sceneItem.scene)
 	): Boolean {
 		markForSynchronization(sceneItem.scene)
 

--- a/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneOrderPaddingWidthTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/sceneeditor/SceneOrderPaddingWidthTest.kt
@@ -1,0 +1,165 @@
+package repositories.sceneeditor
+
+import com.darkrockstudios.apps.hammer.common.data.InsertPosition
+import com.darkrockstudios.apps.hammer.common.data.MoveRequest
+import com.darkrockstudios.apps.hammer.common.data.SceneContent
+import com.darkrockstudios.apps.hammer.common.data.SceneItem
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneDatasource
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toHPath
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.test.assertEquals
+
+/**
+ * Scene content is read and written through a path built from the tree, so a name the tree
+ * derives differently than the one on disk silently retargets every content operation: reads
+ * land on nothing and come back empty, writes create a rival file.
+ *
+ * Order numbers are a contiguous 0-based sequence, so the zero-padded order field must be as
+ * wide as the highest order, not as wide as the child count. Those two disagree at every power
+ * of ten, which left a directory of exactly ten children unreadable.
+ */
+class SceneOrderPaddingWidthTest : SceneRepositoryTestBase() {
+
+	/** Scenes whose computed content path points at a file that is not there. */
+	private fun unreadableScenes(): List<String> = repo.getSceneTree()
+		.filter { !it.value.isRootScene }
+		.filter { !ffs.exists(repo.resolveSceneContentPath(it.value).toOkioPath()) }
+		.map { "id=${it.value.id} '${it.value.name}'" }
+
+	private fun computedPathsMissingOnDisk(): List<String> = repo.getSceneTree()
+		.filter { !it.value.isRootScene }
+		.filter { !ffs.exists(repo.getSceneFilePath(it.value.id).toOkioPath()) }
+		.map { "id=${it.value.id} '${it.value.name}'" }
+
+	@Test
+	fun `every scene stays readable at each child count across a padding boundary`() = runBlocking {
+		// Project 1's Group 2 ships with 3 children; grow it one at a time well past ten.
+		val group = repo.getSceneItemFromId(2) ?: error("group 2 missing")
+
+		val unreadableAtCount = mutableMapOf<Int, List<String>>()
+		repeat(10) { i ->
+			repo.createScene(group, "Added $i")
+			val childCount = 4 + i
+			val unreadable = computedPathsMissingOnDisk()
+			if (unreadable.isNotEmpty()) unreadableAtCount[childCount] = unreadable
+		}
+
+		assertEquals(emptyMap(), unreadableAtCount, "child counts whose scenes became unreadable")
+	}
+
+	@Test
+	fun `a group of exactly ten children keeps its content`() = runBlocking {
+		val group = repo.getSceneItemFromId(2) ?: error("group 2 missing")
+		repeat(7) { repo.createScene(group, "Added $it") }
+
+		// Ten children is the count where the order width and the child width disagree.
+		val groupDir = sceneDatasource.resolveScenePathFromFilesystem(2)!!.toOkioPath()
+		assertEquals(10, ffs.list(groupDir).size, "group should hold exactly ten children")
+
+		repo.getSceneTree()
+			.filter { it.value.type == SceneItem.Type.Scene }
+			.forEach { node ->
+				val path = sceneDatasource.resolveScenePathFromFilesystem(node.value.id)!!
+				ffs.write(path.toOkioPath()) { writeUtf8("content of ${node.value.id}") }
+			}
+
+		val readBack = repo.getSceneTree()
+			.filter { it.value.type == SceneItem.Type.Scene }
+			.associate { it.value.id to repo.loadSceneMarkdownRaw(it.value) }
+
+		val empty = readBack.filterValues { it.isBlank() }.keys
+		assertEquals(emptySet(), empty, "scenes that read back empty")
+	}
+
+	@Test
+	fun `saving into a group of ten children does not create a rival file`() = runBlocking {
+		val group = repo.getSceneItemFromId(2) ?: error("group 2 missing")
+		repeat(7) { repo.createScene(group, "Added $it") }
+
+		val groupDir = sceneDatasource.resolveScenePathFromFilesystem(2)!!.toOkioPath()
+		val before = ffs.list(groupDir).size
+
+		val scene = repo.getSceneItemFromId(3) ?: error("scene 3 missing")
+		repo.storeSceneMarkdownRaw(SceneContent(scene, "newly written prose"))
+
+		assertEquals(before, ffs.list(groupDir).size, "a save must overwrite, never add a file")
+		assertEquals("newly written prose", repo.loadSceneMarkdownRaw(scene))
+	}
+
+	@Test
+	fun `rationalizeTree and a reload resolve a duplicate id to the same file`() = runBlocking {
+		val group = repo.getSceneItemFromId(2) ?: error("group 2 missing")
+		repeat(7) { repo.createScene(group, "Added $it") }
+
+		val groupDir = sceneDatasource.resolveScenePathFromFilesystem(2)!!.toOkioPath()
+		val realPath = sceneDatasource.resolveScenePathFromFilesystem(3)!!.toOkioPath()
+		ffs.write(realPath) { writeUtf8("the copy the tree was loaded from") }
+
+		// A second file claiming scene 3, of the shape a mis-padded save used to leave behind.
+		ffs.write(groupDir.div("0${realPath.name}")) { writeUtf8("a rival copy") }
+
+		// Both the sync pass and a fresh load must settle on the name-first path. The reload goes
+		// through a new datasource, the way relaunching the app rebuilds the index from disk.
+		val reloaded = SceneDatasource(projectDef, ffs)
+		val reloadResolved = reloaded.resolveScenePathFromFilesystem(3)!!.toOkioPath().name
+		val fromDir = reloaded.getGroupChildPathsById(groupDir.toHPath())[3]!!
+			.toOkioPath().name
+
+		assertEquals(reloadResolved, fromDir, "every id lookup must agree on which file owns the id")
+	}
+
+	@Test
+	fun `computed paths survive random editing sessions`() = runBlocking {
+		val rng = Random(20260815)
+
+		repeat(400) {
+			val tree = repo.getSceneTree()
+			val all = tree.filter { !it.value.isRootScene }
+			val groups = tree.filter { it.value.type == SceneItem.Type.Group || it.value.isRootScene }
+			val scenes = all.filter { it.value.type == SceneItem.Type.Scene }
+
+			when (rng.nextInt(10)) {
+				in 0..3 -> {
+					val target = groups.random(rng)
+					repo.createScene(if (target.value.isRootScene) null else target.value, "S$it")
+				}
+
+				4 -> {
+					val target = groups.random(rng)
+					repo.createGroup(if (target.value.isRootScene) null else target.value, "G$it")
+				}
+
+				in 5..6 -> {
+					if (scenes.isNotEmpty()) repo.deleteScene(scenes.random(rng).value)
+				}
+
+				else -> {
+					if (all.size >= 2) {
+						val mover = all.random(rng)
+						val candidates = all.filter { target ->
+							target.value.id != mover.value.id &&
+								!tree.isAncestorOf(mover.index, target.index)
+						}
+						if (candidates.isNotEmpty()) {
+							val target = candidates.random(rng)
+							repo.moveScene(
+								MoveRequest(
+									id = mover.value.id,
+									toPosition = InsertPosition(
+										coords = tree.getCoordinatesFor(target),
+										before = rng.nextBoolean(),
+									),
+								)
+							)
+						}
+					}
+				}
+			}
+
+			assertEquals(emptyList(), unreadableScenes(), "unreadable after step $it")
+		}
+	}
+}


### PR DESCRIPTION
Investigating user reports of nested scenes missing from exports. The export was the visible symptom; the cause reaches the editor and sync too.

## The bug

Order numbers are a contiguous 0-based sequence, so the zero-padded order field must be as wide as the **highest order**, not the **child count**. Those agree everywhere except a power of ten.

Adding the tenth child to a directory:

- the rename trigger compared order numbers (`numDigits(8) < numDigits(9)` → false), so no re-pad pass ran
- the new file was written with `numDigits(9) = 1` → `9~Name~id.md`
- every later read computed `numDigits(10) = 2` → `09~Name~id.md` → miss

Growing to 11 children re-padded everything and healed it, so the window was exactly 10 (and would repeat at exactly 100).

## Why it was invisible

`loadSceneMarkdownRaw` catches the `IOException` and returns `""`. So an affected group exported as blank lines and opened as a blank editor, with only a log line. A save then wrote to the padded name, which `fileSystem.write` creates — leaving a rival file with the same scene id beside the real one, which is the duplicate-id corruption from #492.

Nested scenes were hit hardest: `getSceneFilePath` rebuilds *every* ancestor segment, so a group sitting at ten children took out its whole subtree, not just its direct children.

## Interaction with #886

`rationalizeTree` re-pads correctly and heals this, but it only runs from `ClientSceneSynchronizer`, so local-only users were never repaired.

More importantly, #886 replaced a first-match `find` over `getAllScenePaths()` with a `getGroupChildPathsById` snapshot. `associateBy` keeps the **last** entry, and the listing is name-sorted, so `"00~…" < "0~…"` meant the sync pass resolved a duplicate to the *older* file and rewrote the directory around it — discarding the newer copy. `validateScenePaths` and `ScenePathIndex` both settle duplicates first-wins, so the three disagreed.

## Changes

1. **`getGroupChildPathsById` keeps the name-first path.** All three id lookups now agree.
2. **`countScenes` is the last order index**, and all three padding sites use it. Deleted the misnamed `SceneDatasource.getLastOrderNumber` (it returned the raw count). `rationalizeChildren` follows the same convention.
3. **Content is addressed by `resolveSceneContentPath`** — resolved by id from disk, computed only for a scene with no file yet. Used by `loadSceneMarkdownRaw`, `readSceneMarkdownInto`, `storeSceneMarkdownRaw`, and the save/load/discard buffer paths. Makes the class of bug unreachable: reads and writes land on the real file even if a name is miscomputed again.

## Tests

`SceneOrderPaddingWidthTest`, 5 tests, all verified to fail on the pre-fix code:

- every child count across the boundary stays readable
- a group of exactly ten children keeps its content
- saving into a ten-child group doesn't fork a rival file
- `rationalizeTree` and a reload agree on which file owns a duplicate id
- 400-op random create/delete/move fuzz over the path invariant (this is what found the bug)

Full `:common:desktopTest` green: 1717 tests, 0 failures.

## Follow-up, not in this PR

Projects already damaged still have a stray empty `00~…` beside the real `0~…`. These changes make that resolve consistently, but it resolves to the *empty* stray. A one-time repair preferring the non-empty file on an id collision would recover that prose — worth doing before this reaches users who typed into a blank editor.
