### PR TITLE
Let the editor take input before the spell check finishes

### DIFF
--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
@@ -96,10 +96,12 @@ fun FocusModeUi(component: FocusMode) {
 					sceneContentMarkdown(buffer.content)
 				}
 				loadSceneContent(markdownExtension, sceneMarkdown)
+				// Squiggles are decoration, so the editor takes input the moment the
+				// text is in and the check catches up behind it.
+				hasReceivedInitialBuffer = true
 				// Importing emits no edit operations, so the incremental checker never
 				// sees this text. The one-shot check already ran against an empty document.
 				textEditorState.runFullSpellCheck()
-				hasReceivedInitialBuffer = true
 			}
 		}
 	}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -122,10 +122,12 @@ fun SceneEditorUi(
 					sceneContentMarkdown(buffer.content)
 				}
 				loadSceneContent(markdownExtension, sceneMarkdown)
+				// Squiggles are decoration, so the editor takes input the moment the
+				// text is in and the check catches up behind it.
+				hasReceivedInitialBuffer = true
 				// Importing emits no edit operations, so the incremental checker never
 				// sees this text. The one-shot check already ran against an empty document.
 				textEditorState.runFullSpellCheck()
-				hasReceivedInitialBuffer = true
 			}
 		}
 	}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,7 +100,7 @@ korge-core = "6.0.0"
 bouncycastle = "1.85"
 kotlinx-io-okio = "0.9.1"
 
-compose-texteditor = "2.4.2"
+compose-texteditor = "2.4.3"
 kotlin-multiplatform-diff = "1.3.0"
 platform-spellcheckerkt = "1.3.2"
 nucleus = "2.1.9"


### PR DESCRIPTION
Opening a ~1500 word scene left the editor rendering and scrolling normally but refusing clicks for several seconds, until the spell check finished and the red squiggles appeared.

Two independent causes.

**The editor was switched off until the check finished.** `SceneEditorUi` passed `enabled = hasReceivedInitialBuffer` to `SpellCheckingTextEditor`, and set that flag only after `runFullSpellCheck()` returned. In the library `enabled = false` means read-only and unable to take focus, so input was gated on a decoration pass. Scrolling kept working because the check suspends on every lookup, leaving the UI thread free — which is what made this look like a slow spell checker rather than a disabled editor. `FocusModeUi` had the same ordering.

The flag now flips as soon as the content is loaded. It also gates the edit-operation collector, which stays correct: spell check spans go through `updateRichSpans`, which never emits an edit operation, so the collector still starts against populated content and the scan can't dirty the buffer.

**The scan resumed on the UI dispatcher once per word.** Fixed upstream in ComposeTextEditor 2.4.3 and picked up here. `runFullWordCheck` awaited `isCorrectWord` per word, and every `EditorSpellChecker` hops to a worker internally (`PlatformSpellChecker` wraps each call in `withContext(Dispatchers.IO)`), so each word resumed back on the caller's dispatcher — which, via `LaunchedEffect`, is the UI dispatcher. Measured at 999 UI tasks for a 1000 word document. The lookups are now gathered in a single `withContext`, and span mutation still happens on the caller's dispatcher afterwards so the atomic swap and cancellation behaviour are unchanged. Roughly 270ms to 77ms for 1500 words on a busy UI thread.

Because input is no longer blocked during a scan, an edit can now race one. 2.4.3 re-scans when the document hash changes mid-scan rather than planting ranges that describe text which has moved.

## Testing

Verified by hand on a 3829 word chapter: the editor takes the caret immediately, and the squiggles arrive noticeably faster than before.

`:composeUi:desktopTest` and `:composeUi:compileAndroidMain` pass. Upstream adds `SpellCheckDispatchCostTest`, which pins the UI dispatch count and covers the stale-range guard.

## Note

One part of the load path is still unmeasured: `importMarkdown` runs on the main thread in the same effect, and the numbers above came from probes using a mock text measurer, so real text shaping was excluded from them.
