### PR TITLE
Keep unsaved edits through a device rotation

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/storyideas/StoryIdeas.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/storyideas/StoryIdeas.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ideasrepository.IdeaError
 import com.darkrockstudios.apps.hammer.base.http.storyideas.StoryIdea
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.HammerComponent
+import kotlinx.serialization.Serializable
 
 interface StoryIdeas : HammerComponent {
 	val state: Value<State>
@@ -16,8 +17,14 @@ interface StoryIdeas : HammerComponent {
 	fun closeEditor()
 	fun suggestTags(prefix: String): List<String>
 
-	suspend fun createIdea(title: String?, content: String, tags: Set<String>): IdeaError
-	suspend fun saveIdea(id: IdeaId, title: String?, content: String, tags: Set<String>): IdeaError
+	fun beginEdit()
+	fun discardEdit()
+	fun updateTitle(title: String)
+	fun updateContent(content: String)
+	fun updateTags(tags: List<String>)
+	fun updateTagDraft(tagDraft: String)
+
+	suspend fun saveDraft(): SaveResult
 	suspend fun deleteIdea(id: IdeaId)
 	suspend fun archiveIdea(id: IdeaId)
 	suspend fun unarchiveIdea(id: IdeaId)
@@ -28,10 +35,46 @@ interface StoryIdeas : HammerComponent {
 	data class State(
 		val ideas: List<StoryIdea> = emptyList(),
 		val editor: Editor? = null,
+		val draft: Draft? = null,
 	)
 
 	sealed class Editor {
 		data object Create : Editor()
 		data class Edit(val idea: StoryIdea) : Editor()
+	}
+
+	/**
+	 * The editor's working copy, alongside the baseline it was seeded from. Owned by the component
+	 * rather than the composable so an Android configuration change or process death can't take
+	 * unsaved text with it.
+	 *
+	 * Set whenever an editor opens and left in place when it closes, so the outgoing editor still
+	 * has something to render while it animates away. Only meaningful while [State.editor] is set.
+	 */
+	@Serializable
+	data class Draft(
+		val isEditing: Boolean,
+		val title: String = "",
+		val content: String = "",
+		val tags: List<String> = emptyList(),
+		/** Typed into the tag field but not yet committed to a chip; folded in on save. */
+		val tagDraft: String = "",
+		val savedTitle: String? = null,
+		val savedContent: String = "",
+		val savedTags: Set<String> = emptySet(),
+	) {
+		val isDirty: Boolean
+			get() = isEditing && (
+				title != savedTitle.orEmpty() ||
+					content != savedContent ||
+					tags.toSet() != savedTags ||
+					tagDraft.isNotBlank()
+				)
+	}
+
+	sealed interface SaveResult {
+		data object Created : SaveResult
+		data object Saved : SaveResult
+		data class Failed(val error: IdeaError) : SaveResult
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/storyideas/StoryIdeasComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/storyideas/StoryIdeasComponent.kt
@@ -17,6 +17,7 @@ import com.darkrockstudios.apps.hammer.base.http.storyideas.StoryIdea
 import com.darkrockstudios.apps.hammer.common.data.tagindex.AccountTagService
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
 import org.koin.core.component.inject
 
 class StoryIdeasComponent(
@@ -27,10 +28,20 @@ class StoryIdeasComponent(
 	private val promoteIdeaUseCase: PromoteIdeaUseCase by inject()
 	private val accountTagService: AccountTagService by inject()
 
-	private val _state = MutableValue(StoryIdeas.State())
+	private val _state = MutableValue(restoreState())
 	override val state: Value<StoryIdeas.State> = _state
 
 	init {
+		stateKeeper.register(EDITOR_KEY, SavedEditor.serializer()) {
+			val editor = _state.value.editor
+			val draft = _state.value.draft
+			if (editor == null || draft == null) {
+				null
+			} else {
+				SavedEditor(idea = (editor as? StoryIdeas.Editor.Edit)?.idea, draft = draft)
+			}
+		}
+
 		scope.launch {
 			ideasRepository.ideasFlow.collect { ideas ->
 				withContext(dispatcherMain) {
@@ -43,18 +54,66 @@ class StoryIdeasComponent(
 		scope.launch { accountTagService.refreshProjectTags() }
 	}
 
+	private fun restoreState(): StoryIdeas.State {
+		val saved = stateKeeper.consume(EDITOR_KEY, SavedEditor.serializer())
+			?: return StoryIdeas.State()
+
+		return StoryIdeas.State(
+			editor = saved.idea?.let { StoryIdeas.Editor.Edit(it) } ?: StoryIdeas.Editor.Create,
+			draft = saved.draft,
+		)
+	}
+
 	override fun showCreate() {
-		_state.update { it.copy(editor = StoryIdeas.Editor.Create) }
+		_state.update {
+			it.copy(
+				editor = StoryIdeas.Editor.Create,
+				draft = StoryIdeas.Draft(isEditing = true),
+			)
+		}
 	}
 
 	override fun editIdea(id: IdeaId) {
 		val idea = _state.value.ideas.find { it.id == id } ?: return
-		_state.update { it.copy(editor = StoryIdeas.Editor.Edit(idea)) }
+		_state.update {
+			it.copy(
+				editor = StoryIdeas.Editor.Edit(idea),
+				// An existing idea opens read-only; creating starts straight in edit mode.
+				draft = idea.asDraft(isEditing = false),
+			)
+		}
 	}
 
 	override fun closeEditor() {
+		// The draft is left behind on purpose: the detail pane cross-fades out after the editor
+		// clears, and it still needs something to draw. Reopening always seeds a fresh draft.
 		_state.update { it.copy(editor = null) }
 	}
+
+	override fun beginEdit() {
+		updateDraft { it.copy(isEditing = true) }
+	}
+
+	override fun discardEdit() {
+		if (_state.value.editor is StoryIdeas.Editor.Create) {
+			closeEditor()
+		} else {
+			updateDraft { draft ->
+				draft.copy(
+					isEditing = false,
+					title = draft.savedTitle.orEmpty(),
+					content = draft.savedContent,
+					tags = draft.savedTags.toList(),
+					tagDraft = "",
+				)
+			}
+		}
+	}
+
+	override fun updateTitle(title: String) = updateDraft { it.copy(title = title) }
+	override fun updateContent(content: String) = updateDraft { it.copy(content = content) }
+	override fun updateTags(tags: List<String>) = updateDraft { it.copy(tags = tags) }
+	override fun updateTagDraft(tagDraft: String) = updateDraft { it.copy(tagDraft = tagDraft) }
 
 	override fun suggestTags(prefix: String): List<String> {
 		// Uncapped: the tag field filters out tags already on the idea, so a small hard cap here
@@ -63,15 +122,52 @@ class StoryIdeasComponent(
 		return accountTagService.suggest(prefix, limit = Int.MAX_VALUE).map { it.tag }
 	}
 
-	override suspend fun createIdea(title: String?, content: String, tags: Set<String>): IdeaError {
-		return ideasRepository.createIdea(content = content, title = title, tags = tags).toIdeaError()
-	}
+	override suspend fun saveDraft(): StoryIdeas.SaveResult {
+		val editor = _state.value.editor ?: return StoryIdeas.SaveResult.Failed(IdeaError.EMPTY)
+		val draft = _state.value.draft ?: return StoryIdeas.SaveResult.Failed(IdeaError.EMPTY)
 
-	override suspend fun saveIdea(id: IdeaId, title: String?, content: String, tags: Set<String>): IdeaError {
-		val idea = ideasRepository.getIdeaById(id) ?: return IdeaError.EMPTY
-		return ideasRepository.updateIdea(
-			idea.copy(title = title, content = content, tags = tags)
-		).toIdeaError()
+		val title = draft.title.trim().ifEmpty { null }
+		val pendingTag = draft.tagDraft.trim().removePrefix("#")
+		val tags = if (pendingTag.isEmpty()) draft.tags.toSet() else draft.tags.toSet() + pendingTag
+
+		val result = withContext(dispatcherDefault) {
+			when (editor) {
+				StoryIdeas.Editor.Create -> ideasRepository.createIdea(
+					content = draft.content,
+					title = title,
+					tags = tags,
+				)
+
+				is StoryIdeas.Editor.Edit -> {
+					val stored = ideasRepository.getIdeaById(editor.idea.id)
+					if (stored == null) {
+						CResult.failure<StoryIdea>(InvalidIdea(IdeaError.EMPTY))
+					} else {
+						ideasRepository.updateIdea(
+							stored.copy(title = title, content = draft.content, tags = tags)
+						)
+					}
+				}
+			}
+		}
+
+		return when (result) {
+			is ClientResult.Failure -> StoryIdeas.SaveResult.Failed(
+				(result.exception as? InvalidIdea)?.error ?: IdeaError.EMPTY
+			)
+
+			is ClientResult.Success -> withContext(dispatcherMain) {
+				if (editor is StoryIdeas.Editor.Create) {
+					closeEditor()
+					StoryIdeas.SaveResult.Created
+				} else {
+					// Re-baseline off what was actually stored, so the trimming and tag cleaning
+					// the repository applies don't leave the editor looking dirty.
+					updateDraft { result.data.asDraft(isEditing = false) }
+					StoryIdeas.SaveResult.Saved
+				}
+			}
+		}
 	}
 
 	override suspend fun deleteIdea(id: IdeaId) {
@@ -90,8 +186,31 @@ class StoryIdeasComponent(
 		return promoteIdeaUseCase(id)
 	}
 
-	private fun ClientResult<StoryIdea>.toIdeaError(): IdeaError = when (this) {
-		is ClientResult.Success -> IdeaError.NONE
-		is ClientResult.Failure -> (exception as? InvalidIdea)?.error ?: IdeaError.EMPTY
+	private fun updateDraft(transform: (StoryIdeas.Draft) -> StoryIdeas.Draft) {
+		_state.update { state ->
+			val draft = state.draft ?: return@update state
+			state.copy(draft = transform(draft))
+		}
+	}
+
+	private fun StoryIdea.asDraft(isEditing: Boolean) = StoryIdeas.Draft(
+		isEditing = isEditing,
+		title = title.orEmpty(),
+		content = content,
+		tags = tags.toList(),
+		savedTitle = title,
+		savedContent = content,
+		savedTags = tags,
+	)
+
+	@Serializable
+	private data class SavedEditor(
+		/** Null while creating a new idea. */
+		val idea: StoryIdea?,
+		val draft: StoryIdeas.Draft,
+	)
+
+	private companion object {
+		const val EDITOR_KEY = "story-ideas-editor"
 	}
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/storyideas/StoryIdeasComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectselection/storyideas/StoryIdeasComponent.kt
@@ -157,15 +157,19 @@ class StoryIdeasComponent(
 			)
 
 			is ClientResult.Success -> withContext(dispatcherMain) {
-				if (editor is StoryIdeas.Editor.Create) {
-					closeEditor()
-					StoryIdeas.SaveResult.Created
-				} else {
-					// Re-baseline off what was actually stored, so the trimming and tag cleaning
-					// the repository applies don't leave the editor looking dirty.
-					updateDraft { result.data.asDraft(isEditing = false) }
-					StoryIdeas.SaveResult.Saved
+				val created = editor is StoryIdeas.Editor.Create
+				// The editor can move on while the write is in flight; the result belongs to the
+				// one that started it, so don't stamp it onto whatever is open now.
+				if (isStillOpen(editor)) {
+					if (created) {
+						closeEditor()
+					} else {
+						// Re-baseline off what was actually stored, so the trimming and tag cleaning
+						// the repository applies don't leave the editor looking dirty.
+						updateDraft { result.data.asDraft(isEditing = false) }
+					}
 				}
+				if (created) StoryIdeas.SaveResult.Created else StoryIdeas.SaveResult.Saved
 			}
 		}
 	}
@@ -184,6 +188,14 @@ class StoryIdeasComponent(
 
 	override suspend fun promoteIdea(id: IdeaId): CResult<ProjectDef> {
 		return promoteIdeaUseCase(id)
+	}
+
+	private fun isStillOpen(editor: StoryIdeas.Editor): Boolean {
+		val current = _state.value.editor
+		return when (editor) {
+			StoryIdeas.Editor.Create -> current is StoryIdeas.Editor.Create
+			is StoryIdeas.Editor.Edit -> (current as? StoryIdeas.Editor.Edit)?.idea?.id == editor.idea.id
+		}
 	}
 
 	private fun updateDraft(transform: (StoryIdeas.Draft) -> StoryIdeas.Draft) {

--- a/common/src/desktopTest/kotlin/components/storyideas/StoryIdeasComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyideas/StoryIdeasComponentTest.kt
@@ -17,6 +17,8 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSeri
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.fakefilesystem.FakeFileSystem
@@ -143,6 +145,37 @@ class StoryIdeasComponentTest : ComponentTest() {
 		assertFalse(draft.isEditing)
 		assertFalse(draft.isDirty)
 		assertEquals("v2", draft.savedContent)
+	}
+
+	@Test
+	fun `A save landing after the editor moved on leaves the new draft alone`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+		comp.writeIdea(content = "first")
+		comp.writeIdea(content = "second")
+		advanceUntilIdle()
+
+		val first = comp.state.value.ideas.single { it.content == "first" }
+		val second = comp.state.value.ideas.single { it.content == "second" }
+
+		comp.editIdea(first.id)
+		comp.beginEdit()
+		comp.updateContent("first, rewritten")
+
+		// Unconfined so the save runs up to its first suspension, leaving the write in flight
+		// while the editor is switched underneath it.
+		val save = async(UnconfinedTestDispatcher(testScheduler)) { comp.saveDraft() }
+		assertFalse(save.isCompleted, "The write must still be in flight for this to test anything")
+		comp.editIdea(second.id)
+		advanceUntilIdle()
+
+		assertEquals(StoryIdeas.SaveResult.Saved, save.await())
+		assertEquals("first, rewritten", comp.state.value.ideas.single { it.id == first.id }.content)
+
+		val draft = comp.state.value.draft!!
+		assertEquals("second", draft.content, "The open editor still shows the idea it was opened on")
+		assertEquals("second", draft.savedContent)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/components/storyideas/StoryIdeasComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyideas/StoryIdeasComponentTest.kt
@@ -1,5 +1,6 @@
 package components.storyideas
 
+import com.darkrockstudios.apps.hammer.base.IdeaId
 import com.darkrockstudios.apps.hammer.common.components.projectselection.storyideas.StoryIdeas
 import com.darkrockstudios.apps.hammer.common.components.projectselection.storyideas.StoryIdeasComponent
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
@@ -24,7 +25,9 @@ import org.junit.jupiter.api.Test
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import utils.ComponentTest
+import utils.TestComponentContext
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -59,7 +62,21 @@ class StoryIdeasComponentTest : ComponentTest() {
 		})
 	}
 
-	private fun newComponent() = StoryIdeasComponent(componentContext = context)
+	private fun newComponent(componentContext: TestComponentContext = context) =
+		StoryIdeasComponent(componentContext = componentContext)
+
+	/** Types a whole idea into the create editor and saves it. */
+	private suspend fun StoryIdeas.writeIdea(
+		title: String? = null,
+		content: String,
+		tags: List<String> = emptyList(),
+	): StoryIdeas.SaveResult {
+		showCreate()
+		if (title != null) updateTitle(title)
+		updateContent(content)
+		updateTags(tags)
+		return saveDraft()
+	}
 
 	@Test
 	fun `Created ideas appear in component state`() = runTest(mainTestDispatcher) {
@@ -67,12 +84,13 @@ class StoryIdeasComponentTest : ComponentTest() {
 		context.resume()
 		advanceUntilIdle()
 
-		val error = comp.createIdea(title = "Tides", content = "A story about tides", tags = setOf("ocean"))
+		val result = comp.writeIdea(title = "Tides", content = "A story about tides", tags = listOf("ocean"))
 		advanceUntilIdle()
 
-		assertEquals(IdeaError.NONE, error)
+		assertEquals(StoryIdeas.SaveResult.Created, result)
 		assertEquals(1, comp.state.value.ideas.size)
 		assertEquals("Tides", comp.state.value.ideas.single().title)
+		assertNull(comp.state.value.editor, "Saving a new idea closes the editor")
 	}
 
 	@Test
@@ -80,7 +98,7 @@ class StoryIdeasComponentTest : ComponentTest() {
 		val comp = newComponent()
 		context.resume()
 		advanceUntilIdle()
-		comp.createIdea(title = null, content = "edit me", tags = emptySet())
+		comp.writeIdea(content = "edit me")
 		advanceUntilIdle()
 		val idea = comp.state.value.ideas.single()
 
@@ -91,6 +109,8 @@ class StoryIdeasComponentTest : ComponentTest() {
 		val editor = comp.state.value.editor
 		assertIs<StoryIdeas.Editor.Edit>(editor)
 		assertEquals(idea, editor.idea)
+		assertEquals("edit me", comp.state.value.draft?.content)
+		assertFalse(comp.state.value.draft!!.isEditing, "An existing idea opens read-only")
 
 		comp.closeEditor()
 		assertNull(comp.state.value.editor)
@@ -101,18 +121,158 @@ class StoryIdeasComponentTest : ComponentTest() {
 		val comp = newComponent()
 		context.resume()
 		advanceUntilIdle()
-		comp.createIdea(title = null, content = "v1", tags = emptySet())
+		comp.writeIdea(content = "v1")
 		advanceUntilIdle()
 		val idea = comp.state.value.ideas.single()
 
-		val error = comp.saveIdea(idea.id, title = "Now titled", content = "v2", tags = setOf("t"))
+		comp.editIdea(idea.id)
+		comp.beginEdit()
+		comp.updateTitle("Now titled")
+		comp.updateContent("v2")
+		comp.updateTags(listOf("t"))
+		val result = comp.saveDraft()
 		advanceUntilIdle()
 
-		assertEquals(IdeaError.NONE, error)
+		assertEquals(StoryIdeas.SaveResult.Saved, result)
 		val updated = comp.state.value.ideas.single()
 		assertEquals("v2", updated.content)
 		assertEquals("Now titled", updated.title)
 		assertEquals(setOf("t"), updated.tags)
+		// Back to read-only, showing what was stored rather than looking unsaved.
+		val draft = comp.state.value.draft!!
+		assertFalse(draft.isEditing)
+		assertFalse(draft.isDirty)
+		assertEquals("v2", draft.savedContent)
+	}
+
+	@Test
+	fun `A tag typed but not committed is folded in on save`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.showCreate()
+		comp.updateContent("half typed")
+		comp.updateTags(listOf("committed"))
+		comp.updateTagDraft("#pending")
+		comp.saveDraft()
+		advanceUntilIdle()
+
+		assertEquals(setOf("committed", "pending"), comp.state.value.ideas.single().tags)
+	}
+
+	@Test
+	fun `Discarding an edit restores the stored idea`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+		comp.writeIdea(title = "Keep", content = "original")
+		advanceUntilIdle()
+
+		comp.editIdea(comp.state.value.ideas.single().id)
+		comp.beginEdit()
+		comp.updateContent("scribbled over")
+		assertTrue(comp.state.value.draft!!.isDirty)
+
+		comp.discardEdit()
+
+		val draft = comp.state.value.draft!!
+		assertFalse(draft.isEditing)
+		assertEquals("original", draft.content)
+		assertEquals("Keep", draft.title)
+	}
+
+	@Test
+	fun `An unsaved draft survives process death`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+		comp.writeIdea(title = "Stored title", content = "stored body")
+		advanceUntilIdle()
+		val idea = comp.state.value.ideas.single()
+
+		comp.editIdea(idea.id)
+		comp.beginEdit()
+		comp.updateTitle("Typed title")
+		comp.updateContent("typed body, never saved")
+		comp.updateTags(listOf("fresh"))
+		comp.updateTagDraft("half-typ")
+
+		val restoredContext = context.saveAndRecreate()
+		val restored = newComponent(restoredContext)
+		restoredContext.resume()
+		advanceUntilIdle()
+
+		val editor = restored.state.value.editor
+		assertIs<StoryIdeas.Editor.Edit>(editor)
+		assertEquals(idea.id, editor.idea.id)
+
+		val draft = restored.state.value.draft!!
+		assertTrue(draft.isEditing)
+		assertEquals("Typed title", draft.title)
+		assertEquals("typed body, never saved", draft.content)
+		assertEquals(listOf("fresh"), draft.tags)
+		assertEquals("half-typ", draft.tagDraft)
+		// The baseline came back too, so the editor still knows it has unsaved changes.
+		assertEquals("stored body", draft.savedContent)
+		assertTrue(draft.isDirty)
+	}
+
+	@Test
+	fun `A restored draft can still be saved`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+		comp.writeIdea(content = "stored body")
+		advanceUntilIdle()
+
+		comp.editIdea(comp.state.value.ideas.single().id)
+		comp.beginEdit()
+		comp.updateContent("typed body, never saved")
+
+		val restoredContext = context.saveAndRecreate()
+		val restored = newComponent(restoredContext)
+		restoredContext.resume()
+		advanceUntilIdle()
+
+		val result = restored.saveDraft()
+		advanceUntilIdle()
+
+		assertEquals(StoryIdeas.SaveResult.Saved, result)
+		assertEquals("typed body, never saved", restored.state.value.ideas.single().content)
+	}
+
+	@Test
+	fun `Nothing is stashed when no editor is open`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+		comp.writeIdea(content = "just browsing")
+		advanceUntilIdle()
+
+		val restoredContext = context.saveAndRecreate()
+		val restored = newComponent(restoredContext)
+		restoredContext.resume()
+		advanceUntilIdle()
+
+		assertNull(restored.state.value.editor)
+		assertNull(restored.state.value.draft)
+	}
+
+	@Test
+	fun `An empty idea is rejected`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.showCreate()
+		comp.updateTitle("Title only")
+		val result = comp.saveDraft()
+		advanceUntilIdle()
+
+		assertEquals(StoryIdeas.SaveResult.Failed(IdeaError.EMPTY), result)
+		assertTrue(comp.state.value.ideas.isEmpty())
+		assertIs<StoryIdeas.Editor.Create>(comp.state.value.editor, "A rejected idea keeps the editor open")
 	}
 
 	@Test
@@ -120,7 +280,7 @@ class StoryIdeasComponentTest : ComponentTest() {
 		val comp = newComponent()
 		context.resume()
 		advanceUntilIdle()
-		comp.createIdea(title = null, content = "doomed", tags = emptySet())
+		comp.writeIdea(content = "doomed")
 		advanceUntilIdle()
 		val idea = comp.state.value.ideas.single()
 
@@ -135,7 +295,7 @@ class StoryIdeasComponentTest : ComponentTest() {
 		val comp = newComponent()
 		context.resume()
 		advanceUntilIdle()
-		comp.createIdea(title = null, content = "keep", tags = emptySet())
+		comp.writeIdea(content = "keep")
 		advanceUntilIdle()
 		val idea = comp.state.value.ideas.single()
 
@@ -150,12 +310,23 @@ class StoryIdeasComponentTest : ComponentTest() {
 		val comp = newComponent()
 		context.resume()
 		advanceUntilIdle()
-		comp.createIdea(title = null, content = "a", tags = setOf("gothic", "ghost"))
-		comp.createIdea(title = null, content = "b", tags = setOf("gothic"))
+		comp.writeIdea(content = "a", tags = listOf("gothic", "ghost"))
+		comp.writeIdea(content = "b", tags = listOf("gothic"))
 		advanceUntilIdle()
 
 		assertEquals(listOf("gothic", "ghost"), comp.suggestTags("g"))
 		assertEquals(listOf("gothic"), comp.suggestTags("go"))
 		assertTrue(comp.suggestTags("x").isEmpty())
+	}
+
+	@Test
+	fun `Editing an unknown idea does nothing`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.editIdea(IdeaId.randomUUID())
+
+		assertNull(comp.state.value.editor)
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/SerializableSaver.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/SerializableSaver.kt
@@ -41,8 +41,8 @@ inline fun <reified T : Any> serializableSaverNonNull(): Saver<T, String> = Save
 )
 
 /**
- * A string list that survives a configuration change. Use it for draft collections — tags, chips,
- * selections — that a plain [mutableStateListOf] would drop when the composition is rebuilt.
+ * A string list that survives a configuration change. Use it for draft collections (tags, chips,
+ * selections) that a plain [mutableStateListOf] would drop when the composition is rebuilt.
  */
 @Composable
 fun rememberSaveableStringList(): SnapshotStateList<String> = rememberSaveable(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/SerializableSaver.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/SerializableSaver.kt
@@ -1,6 +1,12 @@
 package com.darkrockstudios.apps.hammer.common.compose
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
 import kotlinx.serialization.json.Json
 
 /**
@@ -33,3 +39,15 @@ inline fun <reified T : Any> serializableSaverNonNull(): Saver<T, String> = Save
 	save = { value -> Json.encodeToString(value) },
 	restore = { json -> Json.decodeFromString(json) }
 )
+
+/**
+ * A string list that survives a configuration change. Use it for draft collections — tags, chips,
+ * selections — that a plain [mutableStateListOf] would drop when the composition is rebuilt.
+ */
+@Composable
+fun rememberSaveableStringList(): SnapshotStateList<String> = rememberSaveable(
+	saver = listSaver<SnapshotStateList<String>, String>(
+		save = { it.toList() },
+		restore = { it.toMutableStateList() },
+	)
+) { mutableStateListOf() }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
@@ -49,7 +50,8 @@ fun HdHairlineTagField(
 	testTag: String? = null,
 	onDraftChange: (String) -> Unit = {},
 ) {
-	var draft by remember { mutableStateOf("") }
+	// Saveable so a configuration change can't drop a tag that was typed but not yet committed.
+	var draft by rememberSaveable { mutableStateOf("") }
 	val updateDraft: (String) -> Unit = {
 		draft = it
 		onDraftChange(it)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -51,6 +50,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.glyph
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownEditField
 import com.darkrockstudios.apps.hammer.common.compose.rememberIoDispatcher
+import com.darkrockstudios.apps.hammer.common.compose.rememberSaveableStringList
 import com.darkrockstudios.apps.hammer.common.compose.rememberStrRes
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.retryingFileDialog
@@ -114,7 +114,7 @@ internal fun CreateEntryUi(
 
 	var name by rememberSaveable { mutableStateOf("") }
 	var description by rememberSaveable { mutableStateOf("") }
-	val tags = remember { mutableStateListOf<String>() }
+	val tags = rememberSaveableStringList()
 	var selectedType by rememberSaveable { mutableStateOf(EntryType.PERSON) }
 
 	var imagePath by remember { mutableStateOf<PlatformFile?>(null) }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
@@ -88,17 +88,20 @@ internal fun ViewEntryUi(
 	var entryNameText by rememberSaveable { mutableStateOf(state.content?.name ?: "") }
 	var entryText by rememberSaveable { mutableStateOf(state.content?.text ?: "") }
 	var discardConfirm by rememberSaveable { mutableStateOf(false) }
+	var seeded by rememberSaveable { mutableStateOf(false) }
 
 	val screen = LocalScreenCharacteristic.current
 	val isCompact = screen.windowWidthClass == WindowWidthSizeClass.Compact
 
 	LaunchedEffect(state.content) {
 		val loaded = state.content ?: return@LaunchedEffect
-		// A configuration change re-runs this effect over the restored draft, so re-seeding
-		// unconditionally would throw away whatever the user had typed but not saved.
-		if (state.editName || state.editText) return@LaunchedEffect
+		// Once the fields hold the entry, an open edit owns them: re-seeding would discard
+		// unsaved text. Until then they must be filled even if the edit started first,
+		// otherwise a save writes an empty entry.
+		if (seeded && (state.editName || state.editText)) return@LaunchedEffect
 		entryNameText = loaded.name
 		entryText = loaded.text
+		seeded = true
 	}
 
 	val ruleColor = MaterialTheme.colorScheme.outlineVariant

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
@@ -93,10 +93,12 @@ internal fun ViewEntryUi(
 	val isCompact = screen.windowWidthClass == WindowWidthSizeClass.Compact
 
 	LaunchedEffect(state.content) {
-		state.content?.let {
-			entryNameText = it.name
-			entryText = it.text
-		}
+		val loaded = state.content ?: return@LaunchedEffect
+		// A configuration change re-runs this effect over the restored draft, so re-seeding
+		// unconditionally would throw away whatever the user had typed but not saved.
+		if (state.editName || state.editText) return@LaunchedEffect
+		entryNameText = loaded.name
+		entryText = loaded.text
 	}
 
 	val ruleColor = MaterialTheme.colorScheme.outlineVariant

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/CreateNoteUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/notes/CreateNoteUi.kt
@@ -22,6 +22,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineTag
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSectionHeader
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownEditField
+import com.darkrockstudios.apps.hammer.common.compose.rememberSaveableStringList
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NoteError
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
@@ -46,7 +47,7 @@ fun CreateNoteUi(
 	val strRes = rememberStrRes()
 	var newNoteError by remember { mutableStateOf(false) }
 	var resetVersion by remember { mutableStateOf(0) }
-	val tags = remember { mutableStateListOf<String>() }
+	val tags = rememberSaveableStringList()
 
 	val wordCount = remember(noteText) {
 		noteText.split(Regex("\\s+")).count { it.isNotBlank() }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/storyideas/StoryIdeasUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/storyideas/StoryIdeasUi.kt
@@ -58,6 +58,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -202,6 +204,16 @@ private enum class IdeasSortMode(
 	TitleAsc(Res.string.ideas_sort_title_az, Res.string.ideas_sort_glyph_title_az),
 }
 
+private val IdeasSortModeSaver = Saver<IdeasSortMode, String>(
+	save = { it.name },
+	restore = { IdeasSortMode.valueOf(it) },
+)
+
+private val TagSetSaver = listSaver<Set<String>, String>(
+	save = { it.toList() },
+	restore = { it.toSet() },
+)
+
 private fun StoryIdea.wordCount(): Int =
 	content.split(Regex("\\s+")).count { it.isNotBlank() }
 
@@ -268,8 +280,12 @@ private fun IdeasBrowse(
 	val isWide = screen.isWide
 
 	var searchQuery by rememberSaveable { mutableStateOf("") }
-	var sortMode by remember { mutableStateOf(IdeasSortMode.DateDesc) }
-	var activeTags by remember { mutableStateOf<Set<String>>(emptySet()) }
+	var sortMode by rememberSaveable(stateSaver = IdeasSortModeSaver) {
+		mutableStateOf(IdeasSortMode.DateDesc)
+	}
+	var activeTags by rememberSaveable(stateSaver = TagSetSaver) {
+		mutableStateOf<Set<String>>(emptySet())
+	}
 	var showArchived by rememberSaveable { mutableStateOf(false) }
 	var showSearchBar by rememberSaveable { mutableStateOf(false) }
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/storyideas/StoryIdeasUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/storyideas/StoryIdeasUi.kt
@@ -183,6 +183,7 @@ import kotlin.time.Instant
 import androidx.compose.foundation.lazy.staggeredgrid.items as staggeredItems
 
 const val IDEAS_CREATE_FAB_TAG = "ideas-create-fab"
+const val IDEAS_EDITOR_TITLE_TAG = "ideas-editor-title"
 const val IDEAS_EDITOR_BODY_TAG = "ideas-editor-body"
 const val IDEAS_EDITOR_CONFIRM_TAG = "ideas-editor-confirm"
 const val IDEAS_EDITOR_CANCEL_TAG = "ideas-editor-cancel"
@@ -233,10 +234,12 @@ fun StoryIdeasUi(
 			contentKey = { it != null },
 			label = "StoryIdeasEditorSwap",
 		) { editor ->
-			if (editor != null) {
+			val draft = state.draft
+			if (editor != null && draft != null) {
 				IdeaDetail(
 					component = component,
 					editor = editor,
+					draft = draft,
 					rootSnackbar = rootSnackbar,
 					sharedTransitionScope = this@SharedTransitionLayout,
 					animatedVisibilityScope = this@AnimatedContent,
@@ -651,6 +654,7 @@ private fun IdeaStamps(idea: StoryIdea) {
 private fun IdeaDetail(
 	component: StoryIdeas,
 	editor: StoryIdeas.Editor,
+	draft: StoryIdeas.Draft,
 	rootSnackbar: RootSnackbarHostState,
 	sharedTransitionScope: SharedTransitionScope,
 	animatedVisibilityScope: AnimatedVisibilityScope,
@@ -662,34 +666,18 @@ private fun IdeaDetail(
 	val existing = (editor as? StoryIdeas.Editor.Edit)?.idea
 	val isCreate = existing == null
 
-	// Creating starts straight in edit mode; an existing idea opens read-only.
-	var isEditing by rememberSaveable(editor) { mutableStateOf(isCreate) }
-	var titleText by remember(editor) { mutableStateOf(existing?.title.orEmpty()) }
-	var contentText by remember(editor) { mutableStateOf(existing?.content.orEmpty()) }
-	var tags by remember(editor) { mutableStateOf(existing?.tags?.toList().orEmpty()) }
-	// A tag typed into the field but not yet committed with Enter/comma; folded in on save
-	// so it can't be silently dropped.
-	var tagDraft by remember(editor) { mutableStateOf("") }
-	// The view body reflects saved edits without waiting for the state flow to round-trip.
-	var savedTitle by remember(editor) { mutableStateOf(existing?.title) }
-	var savedContent by remember(editor) { mutableStateOf(existing?.content.orEmpty()) }
-	var savedTags by remember(editor) { mutableStateOf(existing?.tags ?: emptySet()) }
+	// The draft lives in the component so a configuration change can't take unsaved text with it.
+	val isEditing = draft.isEditing
+	val isDirty = draft.isDirty
 
-	var confirmDelete by remember { mutableStateOf(false) }
-	var confirmDiscard by remember { mutableStateOf(false) }
-	var confirmClose by remember { mutableStateOf(false) }
-	var confirmPromote by remember { mutableStateOf(false) }
+	var confirmDelete by rememberSaveable { mutableStateOf(false) }
+	var confirmDiscard by rememberSaveable { mutableStateOf(false) }
+	var confirmClose by rememberSaveable { mutableStateOf(false) }
+	var confirmPromote by rememberSaveable { mutableStateOf(false) }
 
-	val isDirty = isEditing && (
-		titleText != savedTitle.orEmpty() ||
-			contentText != savedContent ||
-			tags.toSet() != savedTags ||
-			tagDraft.isNotBlank()
-		)
-
-	val charCount = contentText.length
+	val charCount = draft.content.length
 	val overLimit = charCount > StoryIdea.MAX_CONTENT_LENGTH
-	val canSave = contentText.isNotBlank() && !overLimit
+	val canSave = draft.content.isNotBlank() && !overLimit
 
 	suspend fun showError(error: IdeaError) {
 		when (error) {
@@ -709,43 +697,20 @@ private fun IdeaDetail(
 
 	val saveChanges: () -> Unit = {
 		scope.launch {
-			val title = titleText.trim().ifEmpty { null }
-			val pendingTag = tagDraft.trim().removePrefix("#")
-			val allTags = if (pendingTag.isEmpty()) tags.toSet() else tags.toSet() + pendingTag
-			val error = if (existing == null) {
-				component.createIdea(title, contentText, allTags)
-			} else {
-				component.saveIdea(existing.id, title, contentText, allTags)
-			}
-			if (error == IdeaError.NONE) {
-				if (isCreate) {
-					withContext(mainDispatcher) { component.closeEditor() }
+			when (val result = component.saveDraft()) {
+				StoryIdeas.SaveResult.Created ->
 					rootSnackbar.showSnackbar(strRes.get(Res.string.ideas_toast_created))
-				} else {
-					withContext(mainDispatcher) {
-						savedTitle = title
-						savedContent = contentText
-						savedTags = allTags
-						tags = allTags.toList()
-						tagDraft = ""
-						isEditing = false
-					}
+
+				StoryIdeas.SaveResult.Saved ->
 					rootSnackbar.showSnackbar(strRes.get(Res.string.ideas_toast_saved))
-				}
-			} else {
-				showError(error)
+
+				is StoryIdeas.SaveResult.Failed -> showError(result.error)
 			}
 		}
 	}
 
 	val cancelEdit: () -> Unit = {
-		if (isDirty) {
-			confirmDiscard = true
-		} else if (isCreate) {
-			component.closeEditor()
-		} else {
-			isEditing = false
-		}
+		if (isDirty) confirmDiscard = true else component.discardEdit()
 	}
 
 	val requestClose: () -> Unit = {
@@ -839,7 +804,7 @@ private fun IdeaDetail(
 				idea = existing,
 				sharedTransitionScope = sharedTransitionScope,
 				animatedVisibilityScope = animatedVisibilityScope,
-				onEdit = { isEditing = true },
+				onEdit = component::beginEdit,
 				onSave = saveChanges,
 				onCancel = cancelEdit,
 				onPromote = { confirmPromote = true },
@@ -853,13 +818,13 @@ private fun IdeaDetail(
 
 			if (isEditing) {
 				EditBody(
-					titleText = titleText,
-					onTitleChanged = { titleText = it },
-					tags = tags,
-					onTagsChanged = { tags = it },
-					onTagDraftChanged = { tagDraft = it },
-					contentText = contentText,
-					onContentChanged = { contentText = it },
+					titleText = draft.title,
+					onTitleChanged = component::updateTitle,
+					tags = draft.tags,
+					onTagsChanged = component::updateTags,
+					onTagDraftChanged = component::updateTagDraft,
+					contentText = draft.content,
+					onContentChanged = component::updateContent,
 					suggestTags = component::suggestTags,
 					modifier = Modifier.weight(1f),
 				)
@@ -867,17 +832,17 @@ private fun IdeaDetail(
 				EditStatusFooter(charCount = charCount, overLimit = overLimit)
 			} else {
 				ViewBody(
-					title = savedTitle,
-					markdown = savedContent,
-					tags = savedTags,
+					title = draft.savedTitle,
+					markdown = draft.savedContent,
+					tags = draft.savedTags,
 					idea = existing,
 					sharedTransitionScope = sharedTransitionScope,
 					animatedVisibilityScope = animatedVisibilityScope,
-					onEnterEdit = { isEditing = true },
+					onEnterEdit = component::beginEdit,
 					modifier = Modifier.weight(1f, fill = false),
 				)
 
-				ViewFolioFooter(markdown = savedContent, tagCount = savedTags.size)
+				ViewFolioFooter(markdown = draft.savedContent, tagCount = draft.savedTags.size)
 			}
 		}
 		}
@@ -895,10 +860,7 @@ private fun IdeaDetail(
 			if (confirmClose || isCreate) {
 				component.closeEditor()
 			} else {
-				titleText = savedTitle.orEmpty()
-				contentText = savedContent
-				tags = savedTags.toList()
-				isEditing = false
+				component.discardEdit()
 			}
 			confirmDiscard = false
 			confirmClose = false
@@ -1192,6 +1154,7 @@ private fun EditBody(
 				onValueChange = onTitleChanged,
 				placeholder = Res.string.ideas_title_placeholder.get(),
 				onFocusChanged = { titleFocused = it },
+				testTag = IDEAS_EDITOR_TITLE_TAG,
 				modifier = Modifier
 					.fillMaxWidth()
 					.padding(horizontal = Ui.Padding.XL)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SaveDraftDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SaveDraftDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -36,7 +37,7 @@ internal fun SaveDraftDialog(
 	val strRes = rememberStrRes()
 	val scope = rememberCoroutineScope()
 	val mainDispatcher = rememberMainDispatcher()
-	var draftName by remember { mutableStateOf("") }
+	var draftName by rememberSaveable { mutableStateOf("") }
 
 	val metadataState by component.sceneMetadataComponent.state.subscribeAsState()
 	val currentDraftName = metadataState.metadata.currentDraftName

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/CreateTimeLineEventUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/timeline/CreateTimeLineEventUi.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -19,6 +20,7 @@ import com.darkrockstudios.apps.hammer.common.components.timeline.CreateTimeLine
 import com.darkrockstudios.apps.hammer.common.compose.*
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.*
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownEditField
+import com.darkrockstudios.apps.hammer.common.compose.rememberSaveableStringList
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineEventError
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
@@ -40,10 +42,10 @@ fun CreateTimeLineEventUi(
 	val strRes = rememberStrRes()
 	val state by component.state.subscribeAsState()
 	val contentText by component.contentText.subscribeAsState()
-	var dateText by remember { mutableStateOf("") }
+	var dateText by rememberSaveable { mutableStateOf("") }
 	var dateFocused by remember { mutableStateOf(false) }
 	var resetVersion by remember { mutableStateOf(0) }
-	val tags = remember { mutableStateListOf<String>() }
+	val tags = rememberSaveableStringList()
 
 	val wordCount = remember(contentText) {
 		contentText.split(Regex("\\s+")).count { it.isNotBlank() }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/storyideas/StoryIdeasUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/storyideas/StoryIdeasUi.Preview.kt
@@ -9,7 +9,6 @@ import com.darkrockstudios.apps.hammer.common.components.projectselection.storyi
 import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
 import com.darkrockstudios.apps.hammer.common.data.CResult
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.ideasrepository.IdeaError
 import com.darkrockstudios.apps.hammer.base.http.storyideas.StoryIdea
 import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
 import com.darkrockstudios.apps.hammer.common.preview.TABLET_HEIGHT_DP
@@ -95,6 +94,20 @@ private val previewIdeas = listOf(
 	),
 )
 
+private fun previewDraft(editor: StoryIdeas.Editor?): StoryIdeas.Draft? = when (editor) {
+	null -> null
+	StoryIdeas.Editor.Create -> StoryIdeas.Draft(isEditing = true)
+	is StoryIdeas.Editor.Edit -> StoryIdeas.Draft(
+		isEditing = false,
+		title = editor.idea.title.orEmpty(),
+		content = editor.idea.content,
+		tags = editor.idea.tags.toList(),
+		savedTitle = editor.idea.title,
+		savedContent = editor.idea.content,
+		savedTags = editor.idea.tags,
+	)
+}
+
 private fun fakeComponent(
 	editor: StoryIdeas.Editor? = null,
 ): StoryIdeas = object : StoryIdeas {
@@ -102,6 +115,7 @@ private fun fakeComponent(
 		StoryIdeas.State(
 			ideas = previewIdeas,
 			editor = editor,
+			draft = previewDraft(editor),
 		)
 	)
 
@@ -109,8 +123,13 @@ private fun fakeComponent(
 	override fun editIdea(id: IdeaId) {}
 	override fun closeEditor() {}
 	override fun suggestTags(prefix: String): List<String> = emptyList()
-	override suspend fun createIdea(title: String?, content: String, tags: Set<String>) = IdeaError.NONE
-	override suspend fun saveIdea(id: IdeaId, title: String?, content: String, tags: Set<String>) = IdeaError.NONE
+	override fun beginEdit() {}
+	override fun discardEdit() {}
+	override fun updateTitle(title: String) {}
+	override fun updateContent(content: String) {}
+	override fun updateTags(tags: List<String>) {}
+	override fun updateTagDraft(tagDraft: String) {}
+	override suspend fun saveDraft(): StoryIdeas.SaveResult = StoryIdeas.SaveResult.Saved
 	override suspend fun deleteIdea(id: IdeaId) {}
 	override suspend fun archiveIdea(id: IdeaId) {}
 	override suspend fun unarchiveIdea(id: IdeaId) {}

--- a/composeUi/src/desktopTest/kotlin/StoryIdeasRotationTest.kt
+++ b/composeUi/src/desktopTest/kotlin/StoryIdeasRotationTest.kt
@@ -1,0 +1,55 @@
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInput
+import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.projectselection.storyideas.IDEAS_EDITOR_TITLE_TAG
+import com.darkrockstudios.apps.hammer.common.projectselection.storyideas.StoryIdeasUi
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression cover for #885. An Android configuration change tears the composition down and builds
+ * it again while the Decompose component (created with `retainedComponent`) lives on, so anything
+ * the editor keeps in a plain `remember` is gone by the time the new composition runs.
+ *
+ * Bumping the `key` below reproduces that half of a rotation: the whole subtree is disposed and
+ * recomposed against the same component. `androidx.compose.ui.test.StateRestorationTester` would
+ * be the closer fit, but it is an unimplemented stub on the desktop target.
+ */
+class StoryIdeasRotationTest : BaseTest() {
+
+	@get:Rule
+	val compose = createComposeRule()
+
+	@Test
+	fun `An unsaved draft survives the composition being recreated`() {
+		val component = FakeStoryIdeas()
+		component.showCreate()
+		val epoch = mutableStateOf(0)
+		var buildCount = 0
+
+		compose.setContent {
+			// Koin stays outside the key: its teardown would otherwise race the rebuilt subtree.
+			KoinApplicationPreview {
+				key(epoch.value) {
+					remember { buildCount++ }
+					StoryIdeasUi(component = component, rootSnackbar = rememberRootSnackbarHostState())
+				}
+			}
+		}
+
+		compose.onNodeWithTag(IDEAS_EDITOR_TITLE_TAG).performTextInput("Tides")
+
+		epoch.value++
+		compose.waitForIdle()
+
+		assertEquals(2, buildCount, "The subtree should have been thrown away and built again")
+		compose.onNodeWithTag(IDEAS_EDITOR_TITLE_TAG).assertTextEquals("Tides")
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/StoryIdeasTestFixtures.kt
+++ b/composeUi/src/desktopTest/kotlin/StoryIdeasTestFixtures.kt
@@ -1,0 +1,83 @@
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.decompose.value.update
+import com.darkrockstudios.apps.hammer.base.IdeaId
+import com.darkrockstudios.apps.hammer.base.http.storyideas.StoryIdea
+import com.darkrockstudios.apps.hammer.common.components.projectselection.storyideas.StoryIdeas
+import com.darkrockstudios.apps.hammer.common.data.CResult
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import kotlin.time.Instant
+
+internal fun storyIdea(
+	uuid: String,
+	content: String,
+	title: String? = null,
+	archived: Boolean = false,
+) = StoryIdea(
+	id = IdeaId(uuid),
+	created = Instant.parse("2026-07-01T12:00:00Z"),
+	updated = Instant.parse("2026-07-01T12:00:00Z"),
+	title = title,
+	content = content,
+	archived = if (archived) Instant.parse("2026-07-02T12:00:00Z") else null,
+)
+
+/**
+ * In-memory stand-in for `StoryIdeasComponent`. It owns the editor draft the same way the real
+ * component does, which is the whole point: the UI must not keep unsaved text of its own.
+ */
+internal class FakeStoryIdeas(ideas: List<StoryIdea> = emptyList()) : StoryIdeas {
+	private val _state = MutableValue(StoryIdeas.State(ideas = ideas))
+	override val state: Value<StoryIdeas.State> = _state
+
+	var createShownCount = 0
+	var editedId: IdeaId? = null
+
+	override fun showCreate() {
+		createShownCount++
+		_state.update {
+			it.copy(editor = StoryIdeas.Editor.Create, draft = StoryIdeas.Draft(isEditing = true))
+		}
+	}
+
+	override fun editIdea(id: IdeaId) {
+		editedId = id
+		val idea = _state.value.ideas.find { it.id == id } ?: return
+		_state.update {
+			it.copy(
+				editor = StoryIdeas.Editor.Edit(idea),
+				draft = StoryIdeas.Draft(
+					isEditing = false,
+					title = idea.title.orEmpty(),
+					content = idea.content,
+					tags = idea.tags.toList(),
+					savedTitle = idea.title,
+					savedContent = idea.content,
+					savedTags = idea.tags,
+				),
+			)
+		}
+	}
+
+	override fun closeEditor() = _state.update { it.copy(editor = null) }
+	override fun suggestTags(prefix: String): List<String> = emptyList()
+	override fun beginEdit() = updateDraft { it.copy(isEditing = true) }
+	override fun discardEdit() = updateDraft { it.copy(isEditing = false) }
+	override fun updateTitle(title: String) = updateDraft { it.copy(title = title) }
+	override fun updateContent(content: String) = updateDraft { it.copy(content = content) }
+	override fun updateTags(tags: List<String>) = updateDraft { it.copy(tags = tags) }
+	override fun updateTagDraft(tagDraft: String) = updateDraft { it.copy(tagDraft = tagDraft) }
+	override suspend fun saveDraft(): StoryIdeas.SaveResult = StoryIdeas.SaveResult.Saved
+	override suspend fun deleteIdea(id: IdeaId) {}
+	override suspend fun archiveIdea(id: IdeaId) {}
+	override suspend fun unarchiveIdea(id: IdeaId) {}
+	override suspend fun promoteIdea(id: IdeaId): CResult<ProjectDef> =
+		CResult.failure(Exception("fake"))
+
+	private fun updateDraft(transform: (StoryIdeas.Draft) -> StoryIdeas.Draft) {
+		_state.update { state ->
+			val draft = state.draft ?: return@update state
+			state.copy(draft = transform(draft))
+		}
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/StoryIdeasUiTest.kt
+++ b/composeUi/src/desktopTest/kotlin/StoryIdeasUiTest.kt
@@ -3,67 +3,28 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.arkivanov.decompose.value.MutableValue
-import com.arkivanov.decompose.value.Value
+import androidx.compose.ui.test.performTextInput
 import com.darkrockstudios.apps.hammer.base.IdeaId
-import com.darkrockstudios.apps.hammer.common.components.projectselection.storyideas.StoryIdeas
 import com.darkrockstudios.apps.hammer.common.compose.rememberRootSnackbarHostState
-import com.darkrockstudios.apps.hammer.common.data.CResult
-import com.darkrockstudios.apps.hammer.common.data.ProjectDef
-import com.darkrockstudios.apps.hammer.common.data.ideasrepository.IdeaError
-import com.darkrockstudios.apps.hammer.base.http.storyideas.StoryIdea
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
 import com.darkrockstudios.apps.hammer.common.projectselection.storyideas.IDEAS_CREATE_FAB_TAG
+import com.darkrockstudios.apps.hammer.common.projectselection.storyideas.IDEAS_EDITOR_TITLE_TAG
 import com.darkrockstudios.apps.hammer.common.projectselection.storyideas.StoryIdeasUi
 import com.darkrockstudios.apps.hammer.common.projectselection.storyideas.ideaCardTag
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.time.Instant
 
 class StoryIdeasUiTest : BaseTest() {
 
 	@get:Rule
 	val compose = createComposeRule()
 
-	private class FakeStoryIdeas(ideas: List<StoryIdea>) : StoryIdeas {
-		override val state: Value<StoryIdeas.State> = MutableValue(StoryIdeas.State(ideas = ideas))
-
-		var createShownCount = 0
-		var editedId: IdeaId? = null
-
-		override fun showCreate() {
-			createShownCount++
-		}
-
-		override fun editIdea(id: IdeaId) {
-			editedId = id
-		}
-
-		override fun closeEditor() {}
-		override fun suggestTags(prefix: String): List<String> = emptyList()
-		override suspend fun createIdea(title: String?, content: String, tags: Set<String>) = IdeaError.NONE
-		override suspend fun saveIdea(id: IdeaId, title: String?, content: String, tags: Set<String>) = IdeaError.NONE
-		override suspend fun deleteIdea(id: IdeaId) {}
-		override suspend fun archiveIdea(id: IdeaId) {}
-		override suspend fun unarchiveIdea(id: IdeaId) {}
-		override suspend fun promoteIdea(id: IdeaId): CResult<ProjectDef> =
-			CResult.failure(Exception("fake"))
-	}
-
-	private fun idea(uuid: String, content: String, title: String? = null, archived: Boolean = false) = StoryIdea(
-		id = IdeaId(uuid),
-		created = Instant.parse("2026-07-01T12:00:00Z"),
-		updated = Instant.parse("2026-07-01T12:00:00Z"),
-		title = title,
-		content = content,
-		archived = if (archived) Instant.parse("2026-07-02T12:00:00Z") else null,
-	)
-
 	@Test
 	fun `Idea cards render title and content`() {
 		val component = FakeStoryIdeas(
 			listOf(
-				idea("00000000-0000-0000-0000-000000000001", "A courier of dreams", title = "The Courier"),
+				storyIdea("00000000-0000-0000-0000-000000000001", "A courier of dreams", title = "The Courier"),
 			)
 		)
 
@@ -77,10 +38,12 @@ class StoryIdeasUiTest : BaseTest() {
 
 	@Test
 	fun `FAB opens the create editor`() {
-		val component = FakeStoryIdeas(emptyList())
+		val component = FakeStoryIdeas()
 
 		compose.setContent {
-			StoryIdeasUi(component = component, rootSnackbar = rememberRootSnackbarHostState())
+			KoinApplicationPreview {
+				StoryIdeasUi(component = component, rootSnackbar = rememberRootSnackbarHostState())
+			}
 		}
 
 		compose.onNodeWithTag(IDEAS_CREATE_FAB_TAG).performClick()
@@ -91,10 +54,12 @@ class StoryIdeasUiTest : BaseTest() {
 	@Test
 	fun `Clicking a card opens it for editing`() {
 		val uuid = "00000000-0000-0000-0000-000000000002"
-		val component = FakeStoryIdeas(listOf(idea(uuid, "tap me")))
+		val component = FakeStoryIdeas(listOf(storyIdea(uuid, "tap me")))
 
 		compose.setContent {
-			StoryIdeasUi(component = component, rootSnackbar = rememberRootSnackbarHostState())
+			KoinApplicationPreview {
+				StoryIdeasUi(component = component, rootSnackbar = rememberRootSnackbarHostState())
+			}
 		}
 
 		compose.onNodeWithTag(ideaCardTag(uuid)).performClick()
@@ -106,8 +71,8 @@ class StoryIdeasUiTest : BaseTest() {
 	fun `Archived ideas are hidden from the active list`() {
 		val component = FakeStoryIdeas(
 			listOf(
-				idea("00000000-0000-0000-0000-000000000003", "active spark"),
-				idea("00000000-0000-0000-0000-000000000004", "archived spark", archived = true),
+				storyIdea("00000000-0000-0000-0000-000000000003", "active spark"),
+				storyIdea("00000000-0000-0000-0000-000000000004", "archived spark", archived = true),
 			)
 		)
 
@@ -117,5 +82,21 @@ class StoryIdeasUiTest : BaseTest() {
 
 		compose.onNodeWithText("active spark").assertIsDisplayed()
 		compose.onNodeWithText("archived spark").assertDoesNotExist()
+	}
+
+	@Test
+	fun `Typing in the editor writes through to the component`() {
+		val component = FakeStoryIdeas()
+		component.showCreate()
+
+		compose.setContent {
+			KoinApplicationPreview {
+				StoryIdeasUi(component = component, rootSnackbar = rememberRootSnackbarHostState())
+			}
+		}
+
+		compose.onNodeWithTag(IDEAS_EDITOR_TITLE_TAG).performTextInput("Tides")
+
+		assertEquals("Tides", component.state.value.draft?.title)
 	}
 }


### PR DESCRIPTION
Fixes #885.

## The bug

Rotating an Android device wipes whatever you had typed in the Story Ideas editor.

Both Android activities build their Decompose root with `retainedComponent`, so the component tree survives a configuration change. The composition does not. Every draft field in `IdeaDetail` lived in a plain `remember(editor)`, so the rebuilt composition re-seeded them from the last *saved* idea and the unsaved text was gone.

## The fix

The Ideas editor draft moves into `StoryIdeasComponent`: title, body, tags, the tag token typed but not yet committed to a chip, whether the editor is in edit mode, and the saved baseline the dirty check compares against. It is also registered with the `stateKeeper`, matching what `ViewNoteComponent` and friends already do, so the draft survives process death as well as rotation.

`createIdea`/`saveIdea` are replaced by `saveDraft()`, which reads the draft, folds in a pending tag, and re-baselines off the `StoryIdea` the repository actually stored (so the repository's trimming and tag cleaning don't leave the editor looking dirty right after a save). `beginEdit`/`discardEdit`/`update*` replace the local setters.

One deliberate wrinkle: `closeEditor()` clears `editor` but leaves `draft` in place, because the detail pane cross-fades out after the editor clears and still needs something to draw. Reopening always seeds a fresh draft.

## The broader check the issue asked for

Auditing every editable surface for the same failure mode turned up five more cases of genuine unsaved-content loss, all fixed here:

| Surface | Problem |
|---|---|
| Encyclopedia entry view | `entryNameText`/`entryText` were `rememberSaveable`, but `LaunchedEffect(state.content)` re-seeded them from the last saved content on every fresh composition, undoing the restore. Now skipped while an edit is in progress. |
| Note / timeline event / encyclopedia entry create screens | Tag lists were `remember { mutableStateListOf() }`. New shared `rememberSaveableStringList()` helper. |
| `HdHairlineTagField` | The typed-but-uncommitted token was a plain `remember`. Affects every tag field in the app. |
| Timeline event create | `dateText` was a plain `remember`. |
| Scene save-draft dialog | The typed draft name was a plain `remember`; the dialog itself is component-driven, so it survived the rotation and reopened empty. |

Verified safe already (component-held or `rememberSaveable`): the scene body editor and focus mode, scene metadata, note view, timeline event view, global search, project create, server login/signup, all sync conflict editors, and the add-note widget activity.

### Knowingly left alone

Not unsaved prose, so out of scope for this fix, but worth a follow-up:

- Notes browse and timeline overview reset their sort/tag filters.
- The encyclopedia create screen loses a staged (not yet uploaded) image pick; `PlatformFile` isn't saveable.
- `ProjectDataConflict` resets its five radio selections mid conflict-resolution.
- The scene editor's find bar closes and the buffer re-imports, so the caret and scroll position jump to the top. The text itself is safe.

## Tests

- `StoryIdeasComponentTest` grows to 13 cases, including `An unsaved draft survives process death` and `A restored draft can still be saved`, driven through `TestComponentContext.saveAndRecreate()`.
- `StoryIdeasRotationTest` reproduces the reported bug: it types into the editor, throws the whole subtree away and rebuilds it against the same component (asserting the rebuild actually happened), then checks the text is still there. `StateRestorationTester` would have been the closer fit but is an unimplemented `TODO()` stub on the desktop target.
- `StoryIdeasUiTest` gains a write-through case and now uses a stateful `FakeStoryIdeas` that owns the draft the way the real component does.

`:common:desktopTest`, `:composeUi:desktopTest`, and `:android:compileDebugKotlin` all pass.
