### PR TITLE
Fix ClosedScopeException on scene metadata panel destroy, clarify sync log strings

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -144,13 +144,12 @@
 
 	<string name="sync_log_account_project_create_server_success">Created project on server: %1$s</string>
 	<string name="sync_log_account_project_create_server_failure">Failed to create project on server: %1$s</string>
+	<string name="sync_log_account_project_id_save_failure">Project created on server, but failed to save its ID locally: %1$s</string>
 	<string name="sync_log_account_project_create_client">Created local project: %1$s</string>
 	<string name="sync_log_account_project_create_client_local">Setting local project Server ID:
 		%1$s
 	</string>
-	<string name="sync_log_account_project_create_client_failure">Failed to create server project:
-		%1$s
-	</string>
+	<string name="sync_log_account_project_create_client_failure">Failed to create local project from server: %1$s</string>
 	<string name="sync_log_account_project_create_client_name_taken">Skipped server project %1$s: a local project of that name already syncs with a different server project</string>
 
 	<string name="sync_log_begin_account">Syncing Account...</string>

--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -149,7 +149,7 @@
 	<string name="sync_log_account_project_create_client_local">Setting local project Server ID:
 		%1$s
 	</string>
-	<string name="sync_log_account_project_create_client_failure">Failed to create local project from server: %1$s</string>
+	<string name="sync_log_account_project_create_local_failure">Failed to create local project from server: %1$s</string>
 	<string name="sync_log_account_project_create_client_name_taken">Skipped server project %1$s: a local project of that name already syncs with a different server project</string>
 
 	<string name="sync_log_begin_account">Syncing Account...</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectroot/ProjectRootComponent.kt
@@ -41,7 +41,7 @@ class ProjectRootComponent(
 	initialDeepLink: ProjectDeepLink? = null,
 ) : ProjectComponentBase(projectDef, componentContext), ProjectRoot {
 
-	private val syncJournal: SyncJournal by projectInject()
+	private val syncJournal: SyncJournal = projectGet()
 	private val sceneEditor: SceneEditorService by projectInject()
 	private val projectDataRepository: ProjectDataRepository by projectInject()
 	private val encyclopediaService: EncyclopediaService by projectInject()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
@@ -21,6 +21,7 @@ import com.darkrockstudios.apps.hammer.common.data.tagindex.parseTagInput
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.APP_SCOPE
 import com.darkrockstudios.apps.hammer.common.util.debounceUntilQuiescent
 import io.github.aakira.napier.Napier
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
@@ -63,6 +64,7 @@ class SceneMetadataPanelComponent(
 	override val state: Value<SceneMetadataPanel.State> = _state
 
 	private var bufferUpdateSubscription: Job? = null
+	private var metadataLoaded = false
 
 	private val _metadataUpdateFlow = MutableSharedFlow<SceneMetadata>(
 		extraBufferCapacity = 1,
@@ -148,6 +150,7 @@ class SceneMetadataPanelComponent(
 
 	private suspend fun loadMetadataData() {
 		val metadata = sceneEditor.loadSceneMetadata(originalSceneItem.id)
+		metadataLoaded = true
 		_state.getAndUpdate {
 			it.copy(
 				metadata = metadata,
@@ -333,10 +336,20 @@ class SceneMetadataPanelComponent(
 		bufferUpdateSubscription?.cancel()
 		bufferUpdateSubscription = null
 
-		val scrubbed = scrubInvalidReferences(state.value.metadata)
-		val editor = sceneEditor
+		// If the load never completed, state still holds the default empty metadata;
+		// flushing it would wipe the scene's stored metadata.
+		if (metadataLoaded.not()) return
+
+		// The scrub does filesystem walks, so it runs off the lifecycle thread.
+		val metadata = state.value.metadata
 		appScope.launch {
-			editor.storeMetadata(scrubbed, originalSceneItem.id)
+			try {
+				sceneEditor.storeMetadata(scrubInvalidReferences(metadata), originalSceneItem.id)
+			} catch (e: CancellationException) {
+				throw e
+			} catch (e: Exception) {
+				Napier.e("Failed to flush metadata for scene ${originalSceneItem.id}", e)
+			}
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
@@ -11,6 +11,7 @@ import com.darkrockstudios.apps.hammer.common.data.SceneSummary
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.projectGet
 import com.darkrockstudios.apps.hammer.common.data.projectInject
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.countWords
 import com.darkrockstudios.apps.hammer.common.data.references.ScrubInvalidReferencesUseCase
@@ -42,9 +43,13 @@ class SceneMetadataPanelComponent(
 	SceneMetadataPanel {
 
 	private val appScope: CoroutineScope by inject(named(APP_SCOPE))
-	private val sceneEditor: SceneEditorService by projectInject()
+
+	// Resolved eagerly because onDestroy uses them, and on project close the project scope is
+	// closed before this component is destroyed: a lazy first-resolve there would crash.
+	private val sceneEditor: SceneEditorService = projectGet()
+	private val scrubInvalidReferences: ScrubInvalidReferencesUseCase = projectGet()
+
 	private val encyclopediaService: EncyclopediaService by projectInject()
-	private val scrubInvalidReferences: ScrubInvalidReferencesUseCase by projectInject()
 
 	private val searchableEntries = MutableStateFlow<List<SearchableEntry>>(emptyList())
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
@@ -21,7 +21,6 @@ import com.darkrockstudios.apps.hammer.common.data.tagindex.parseTagInput
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.APP_SCOPE
 import com.darkrockstudios.apps.hammer.common.util.debounceUntilQuiescent
 import io.github.aakira.napier.Napier
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
@@ -31,6 +30,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okio.IOException
 import org.koin.core.component.inject
 import org.koin.core.qualifier.named
 import kotlin.time.Duration.Companion.milliseconds
@@ -345,9 +345,7 @@ class SceneMetadataPanelComponent(
 		appScope.launch {
 			try {
 				sceneEditor.storeMetadata(scrubInvalidReferences(metadata), originalSceneItem.id)
-			} catch (e: CancellationException) {
-				throw e
-			} catch (e: Exception) {
+			} catch (e: IOException) {
 				Napier.e("Failed to flush metadata for scene ${originalSceneItem.id}", e)
 			}
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectScoped.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectScoped.kt
@@ -26,9 +26,10 @@ inline fun <reified T : Any> ProjectScoped.projectInject(
 
 /**
  * Resolves from the Project Scope immediately, at construction time. Use instead of
- * [projectInject] for any dependency a component touches in onDestroy: on project close the
- * scope is closed before child components are destroyed, so a first lazy resolution there
- * throws ClosedScopeException.
+ * [projectInject] for any dependency a component touches during teardown (onStop/onDestroy):
+ * on project close the scope is closed before child components are destroyed, so a first lazy
+ * resolution there either throws ClosedScopeException (scope handle already materialized) or
+ * silently resolves against a fresh replacement scope that never ran project initialization.
  */
 inline fun <reified T : Any> ProjectScoped.projectGet(
 	qualifier: Qualifier? = null,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectScoped.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectScoped.kt
@@ -23,3 +23,14 @@ inline fun <reified T : Any> ProjectScoped.projectInject(
 	lazy(mode) {
 		projectScope.get<T>(qualifier, parameters)
 	}
+
+/**
+ * Resolves from the Project Scope immediately, at construction time. Use instead of
+ * [projectInject] for any dependency a component touches in onDestroy: on project close the
+ * scope is closed before child components are destroyed, so a first lazy resolution there
+ * throws ClosedScopeException.
+ */
+inline fun <reified T : Any> ProjectScoped.projectGet(
+	qualifier: Qualifier? = null,
+	noinline parameters: ParametersDefinition? = null
+): T = projectScope.get(qualifier, parameters)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -524,8 +524,8 @@ class ClientAccountSynchronizer(
 					onLog(
 						syncAccLogE(
 							strRes.get(
-								Res.string.sync_log_account_project_create_client_failure,
-								serverProject.toString(),
+								Res.string.sync_log_account_project_create_local_failure,
+								serverProject.name,
 							)
 						)
 					)
@@ -577,9 +577,23 @@ class ClientAccountSynchronizer(
 				// Save the newly provisioned project id
 				val response = result.getOrThrow()
 				val projectDef = projectsRepository.getProjectDefinition(projectName)
-				try {
+				val idSaved = try {
 					projectsRepository.setProjectId(projectDef, response.projectId)
+					true
+				} catch (e: Exception) {
+					Napier.e("Failed to save project id for $projectName", e)
+					onLog(
+						syncAccLogE(
+							strRes.get(
+								Res.string.sync_log_account_project_id_save_failure,
+								projectName
+							)
+						)
+					)
+					false
+				}
 
+				if (idSaved) {
 					onLog(
 						syncAccLogI(
 							strRes.get(
@@ -593,16 +607,6 @@ class ClientAccountSynchronizer(
 							projectsToCreate = syncData.projectsToCreate - projectName,
 						)
 					}
-				} catch (e: Exception) {
-					Napier.e("Failed to save project id for $projectName", e)
-					onLog(
-						syncAccLogE(
-							strRes.get(
-								Res.string.sync_log_account_project_id_save_failure,
-								projectName
-							)
-						)
-					)
 				}
 			} else {
 				onLog(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -598,7 +598,7 @@ class ClientAccountSynchronizer(
 					onLog(
 						syncAccLogE(
 							strRes.get(
-								Res.string.sync_log_account_project_create_server_failure,
+								Res.string.sync_log_account_project_id_save_failure,
 								projectName
 							)
 						)

--- a/common/src/desktopTest/kotlin/components/storyeditor/sceneeditor/SceneEditorComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyeditor/sceneeditor/SceneEditorComponentTest.kt
@@ -9,6 +9,7 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.SpellCheckerSettings
 import com.darkrockstudios.apps.hammer.common.data.references.AutoConfirmReferencesUseCase
+import com.darkrockstudios.apps.hammer.common.data.references.ScrubInvalidReferencesUseCase
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import com.darkrockstudios.apps.hammer.common.data.tree.ImmutableTree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeValue
@@ -34,7 +35,8 @@ import kotlin.time.Instant
 @OptIn(ExperimentalCoroutinesApi::class)
 // These tests drive lifecycle by calling onCreate()/onStart()/onStop() directly rather than
 // context.resume(), which keeps the eagerly-constructed child SceneMetadataPanelComponent dormant
-// so its dependencies don't need registering.
+// so its lazy dependencies don't need registering. Its construction-time dependencies
+// (SceneEditorService, ScrubInvalidReferencesUseCase) still must be registered.
 class SceneEditorComponentTest : ComponentTest() {
 
 	private val sceneItem = SceneItem(projectDef, SceneItem.Type.Scene, id = 7, name = "Chapter One", order = 0)
@@ -102,6 +104,7 @@ class SceneEditorComponentTest : ComponentTest() {
 			single { sceneEditor } bind SceneEditorService::class
 			single { draftsRepository } bind SceneDraftRepository::class
 			single { autoConfirm } bind AutoConfirmReferencesUseCase::class
+			single<ScrubInvalidReferencesUseCase> { mockk(relaxed = true) }
 		})
 
 		closeCount = 0

--- a/common/src/desktopTest/kotlin/components/storyeditor/scenemetadata/SceneMetadataPanelComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyeditor/scenemetadata/SceneMetadataPanelComponentTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import okio.IOException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.core.qualifier.named
@@ -84,6 +85,23 @@ class SceneMetadataPanelComponentTest : ComponentTest() {
 				match { it.outline == "Final outline edit" },
 				sceneItem.id,
 			)
+		}
+	}
+
+	@Test
+	fun `Destroy flush IO failure does not propagate`() = runTest(mainTestDispatcher) {
+		coEvery { sceneEditor.storeMetadata(any(), any()) } throws IOException("volume gone")
+
+		val component = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		component.updateOutline("Final outline edit")
+		context.destroy()
+		advanceUntilIdle()
+
+		coVerify {
+			sceneEditor.storeMetadata(any(), sceneItem.id)
 		}
 	}
 

--- a/common/src/desktopTest/kotlin/components/storyeditor/scenemetadata/SceneMetadataPanelComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyeditor/scenemetadata/SceneMetadataPanelComponentTest.kt
@@ -14,6 +14,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -85,6 +86,25 @@ class SceneMetadataPanelComponentTest : ComponentTest() {
 			)
 		}
 	}
+
+	@Test
+	fun `Destroy before the metadata load completes does not overwrite stored metadata`() =
+		runTest(mainTestDispatcher) {
+			coEvery { sceneEditor.loadSceneMetadata(any()) } coAnswers { awaitCancellation() }
+
+			val component = newComponent()
+			context.resume()
+			advanceUntilIdle()
+
+			context.destroy()
+			advanceUntilIdle()
+
+			// State still holds the default empty SceneMetadata; flushing it would wipe the
+			// scene's real outline/notes/references on disk.
+			coVerify(exactly = 0) {
+				sceneEditor.storeMetadata(any(), any())
+			}
+		}
 
 	@Test
 	fun `Destroy after the project scope closed does not crash and still flushes metadata`() =

--- a/common/src/desktopTest/kotlin/components/storyeditor/scenemetadata/SceneMetadataPanelComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyeditor/scenemetadata/SceneMetadataPanelComponentTest.kt
@@ -1,0 +1,111 @@
+package components.storyeditor.scenemetadata
+
+import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.scenemetadata.SceneMetadataPanelComponent
+import com.darkrockstudios.apps.hammer.common.data.SceneItem
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
+import com.darkrockstudios.apps.hammer.common.data.references.ScrubInvalidReferencesUseCase
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.APP_SCOPE
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import utils.ComponentTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SceneMetadataPanelComponentTest : ComponentTest() {
+
+	private lateinit var sceneEditor: SceneEditorService
+
+	private val sceneItem
+		get() = SceneItem(
+			projectDef = projectDef,
+			type = SceneItem.Type.Scene,
+			id = 1,
+			name = "Scene 1",
+			order = 0,
+		)
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+
+		sceneEditor = mockk(relaxed = true)
+		every { sceneEditor.metadataUpdateFlow } returns MutableSharedFlow()
+		every { sceneEditor.getSceneBuffer(any<SceneItem>()) } returns null
+		every { sceneEditor.getSceneFilePathOrNull(any()) } returns null
+		coEvery { sceneEditor.loadSceneMetadata(any()) } returns SceneMetadata()
+
+		val encyclopediaService = mockk<EncyclopediaService>(relaxed = true)
+		every { encyclopediaService.entryListFlow } returns MutableSharedFlow()
+		coEvery { encyclopediaService.ensureEntriesLoaded() } returns emptyList()
+
+		setupComponentKoin(module {
+			single<CoroutineScope>(named(APP_SCOPE)) { scope }
+			scope<ProjectDefScope> {
+				scoped { sceneEditor }
+				scoped { encyclopediaService }
+				scoped { ScrubInvalidReferencesUseCase(mockk(relaxed = true)) }
+			}
+		})
+	}
+
+	private fun newComponent() = SceneMetadataPanelComponent(
+		componentContext = context,
+		originalSceneItem = sceneItem,
+		showEntry = { },
+		onShowGlobalSearchForTag = { },
+	)
+
+	@Test
+	fun `Destroy flushes pending metadata edits`() = runTest(mainTestDispatcher) {
+		val component = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		component.updateOutline("Final outline edit")
+		context.destroy()
+		advanceUntilIdle()
+
+		coVerify {
+			sceneEditor.storeMetadata(
+				match { it.outline == "Final outline edit" },
+				sceneItem.id,
+			)
+		}
+	}
+
+	@Test
+	fun `Destroy after the project scope closed does not crash and still flushes metadata`() =
+		runTest(mainTestDispatcher) {
+			val component = newComponent()
+			context.resume()
+			advanceUntilIdle()
+
+			component.updateOutline("Final outline edit")
+
+			// Project close order on desktop: the Koin scope closes first, then Compose
+			// disposal destroys the components.
+			component.projectScope.scope.close()
+			context.destroy()
+			advanceUntilIdle()
+
+			coVerify {
+				sceneEditor.storeMetadata(
+					match { it.outline == "Final outline edit" },
+					sceneItem.id,
+				)
+			}
+		}
+}

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -25,6 +25,12 @@ import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectsApi
 import com.darkrockstudios.apps.hammer.common.util.NetworkConnectivity
+import com.darkrockstudios.apps.hammer.common.util.StrRes
+import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.sync_log_account_project_create_local_failure
+import com.darkrockstudios.apps.hammer.sync_log_account_project_create_server_success
+import com.darkrockstudios.apps.hammer.sync_log_account_project_id_save_failure
+import org.jetbrains.compose.resources.StringResource
 import io.ktor.http.*
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
@@ -90,7 +96,7 @@ class ClientAccountSynchronizerTest {
 		error = HttpResponseError(error = "Unauthorized", displayMessage = "nope"),
 	)
 
-	private fun createSynchronizer() = ClientAccountSynchronizer(
+	private fun createSynchronizer(strRes: StrRes = TestStrRes()) = ClientAccountSynchronizer(
 		fileSystem = ffs,
 		globalSettingsStore = globalSettingsStore,
 		projectsRepository = projectsRepository,
@@ -99,8 +105,22 @@ class ClientAccountSynchronizerTest {
 		networkConnectivity = networkConnectivity,
 		json = json,
 		toml = Toml,
-		strRes = TestStrRes(),
+		strRes = strRes,
 	)
+
+	private class RecordingStrRes : StrRes {
+		val calls = mutableListOf<Pair<StringResource, List<Any>>>()
+
+		override suspend fun get(str: StringResource): String {
+			calls.add(str to emptyList())
+			return "test"
+		}
+
+		override suspend fun get(str: StringResource, vararg args: Any): String {
+			calls.add(str to args.toList())
+			return "test"
+		}
+	}
 
 	@BeforeEach
 	fun setup() {
@@ -439,6 +459,30 @@ class ClientAccountSynchronizerTest {
 	}
 
 	@Test
+	fun `syncProjects keeps the queued creation and logs an id-save failure when saving the new id fails`() = runTest {
+		writeSyncData(emptySyncData().copy(projectsToCreate = setOf("LocalNovel")))
+		val def = projectDef("LocalNovel")
+		val newId = ProjectId.randomUUID()
+
+		every { projectsRepository.getProjects(any()) } returns listOf(def)
+		every { projectsRepository.getProjectId(def) } returns null
+		every { projectsRepository.getProjectDefinition("LocalNovel") } returns def
+		coEvery { serverProjectsApi.createProject("LocalNovel", "sync-1") } returns
+			Result.success(CreateProjectResponse(newId, alreadyExisted = false))
+		coEvery { projectsRepository.setProjectId(def, newId) } throws IllegalStateException("disk error")
+
+		val strRes = RecordingStrRes()
+		val result = createSynchronizer(strRes).syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		// The entry must survive so the next sync can retry saving the id.
+		assertEquals(setOf("LocalNovel"), readSyncData().projectsToCreate)
+		val resources = strRes.calls.map { it.first }
+		assertTrue(resources.contains(Res.string.sync_log_account_project_id_save_failure))
+		assertFalse(resources.contains(Res.string.sync_log_account_project_create_server_success))
+	}
+
+	@Test
 	fun `syncProjects recreates a project whose cached id the server neither holds nor tombstoned`() = runTest {
 		writeSyncData(emptySyncData())
 		val staleId = ProjectId.randomUUID()
@@ -625,6 +669,27 @@ class ClientAccountSynchronizerTest {
 		assertTrue(result)
 		coVerify { projectsRepository.createProject("ServerNovel", any()) }
 		coVerify { projectsRepository.setProjectId(createdDef, serverId) }
+	}
+
+	@Test
+	fun `syncProjects logs the project name when local creation from a server project fails`() = runTest {
+		writeSyncData(emptySyncData())
+		val serverId = ProjectId.randomUUID()
+		val serverProject = ApiProjectDefinition(name = "ServerNovel", uuid = serverId)
+
+		coEvery { serverProjectsApi.beginProjectsSync() } returns
+			Result.success(emptyServerResponse().copy(projects = setOf(serverProject)))
+		every { projectsRepository.getProjects(any()) } returns emptyList()
+		every { projectsRepository.findProject("ServerNovel") } returns null
+		every { projectsRepository.createProject("ServerNovel", any()) } returns
+			CResult.failure(error = "creation failed")
+
+		val strRes = RecordingStrRes()
+		val result = createSynchronizer(strRes).syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		val logged = strRes.calls.single { it.first == Res.string.sync_log_account_project_create_local_failure }
+		assertEquals(listOf<Any>("ServerNovel"), logged.second)
 	}
 
 	@Test


### PR DESCRIPTION
Follow-ups from the 2026-08-11 ghost-projects data-loss investigation (secondary findings, not the root cause; that was fixed by #857 and #889).

## Crash: ClosedScopeException in SceneMetadataPanelComponent.onDestroy

On project close, desktop's `ApplicationState.closeProject()` closes the Koin project scope first, then the window-state change disposes the composition and destroys components. `SceneMetadataPanelComponent.onDestroy` then did its first lazy resolve of `scrubInvalidReferences` against the closed scope and threw an uncaught `ClosedScopeException` on the main thread (seen in the user's crash report on v3.8.0, still present until now).

Fix: a new `projectGet()` helper in `ProjectScoped.kt` resolves from the project scope eagerly at construction. The component now uses it for the two dependencies `onDestroy` touches (`sceneEditor`, `scrubInvalidReferences`). The final metadata flush is deliberately kept rather than skipped when the scope is closed: `storeDirtyBuffers` only covers scene content on close, so the onDestroy write is the only flush for metadata edits inside the 500ms debounce window. Both held references are safe post-close (the scrub is a pure filter over the encyclopedia cache; `storeMetadata` writes a file that still exists).

No other component resolves project-scoped lazies in `onDestroy`; this was the only instance of the pattern.

## Misleading account sync log strings

- The branch where the server create succeeds but saving the returned project id locally throws was logging "Failed to create project on server". This is the exact line that misdirected the investigation. It now uses a new string: "Project created on server, but failed to save its ID locally: %1$s".
- `sync_log_account_project_create_client_failure` said "Failed to create server project" for a local create failure, and was missing its `%1$s` placeholder. Now: "Failed to create local project from server: %1$s".

Only `values/` was edited; translations come from Crowdin.

## Tests

New `SceneMetadataPanelComponentTest` written repro-first: the closed-scope test failed with `ClosedScopeException` before the fix, matching the field crash stack line for line, and both tests now verify the metadata flush still happens. `SceneEditorComponentTest` gained a `ScrubInvalidReferencesUseCase` registration since the child panel now resolves it at construction. Full `desktopTest` suite passes.
