### PR TITLE
Search allowed users by email

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/admin/WhiteListRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/admin/WhiteListRepository.kt
@@ -29,15 +29,33 @@ class WhiteListRepository(
 		return whiteListDao.getPaginated(limit, offset, sortOldestFirst)
 	}
 
-	suspend fun getWhiteListWithAccountStatus(page: Int, pageSize: Int, sortOldestFirst: Boolean = false) =
+	/** A blank [emailSearch] lists everything; otherwise only emails containing it. */
+	suspend fun getWhiteListWithAccountStatus(
+		page: Int,
+		pageSize: Int,
+		sortOldestFirst: Boolean = false,
+		emailSearch: String? = null,
+	) = if (emailSearch.isNullOrBlank()) {
 		whiteListDao.getPaginatedWithAccountStatus(
 			limit = pageSize.toLong(),
 			offset = (page * pageSize).toLong(),
 			sortOldestFirst = sortOldestFirst
 		)
+	} else {
+		whiteListDao.searchPaginatedWithAccountStatus(
+			pattern = emailSearchPattern(emailSearch),
+			limit = pageSize.toLong(),
+			offset = (page * pageSize).toLong(),
+			sortOldestFirst = sortOldestFirst
+		)
+	}
 
-	suspend fun getWhiteListCount(): Long {
-		return whiteListDao.getWhiteListCount()
+	suspend fun getWhiteListCount(emailSearch: String? = null): Long {
+		return if (emailSearch.isNullOrBlank()) {
+			whiteListDao.getWhiteListCount()
+		} else {
+			whiteListDao.searchCount(emailSearchPattern(emailSearch))
+		}
 	}
 
 	/** False for an entry whose expiry has passed, even if the reaping job hasn't run yet. */
@@ -115,5 +133,14 @@ class WhiteListRepository(
 	companion object {
 		const val MAX_REASON_LENGTH = 32
 		const val REASON_EXISTING_ACCOUNT = "Existing account"
+
+		/** `%` and `_` are LIKE wildcards; an admin typing `a_b@` means those literally. */
+		internal fun emailSearchPattern(raw: String): String {
+			val escaped = raw.trim()
+				.replace("\\", "\\\\")
+				.replace("%", "\\%")
+				.replace("_", "\\_")
+			return "%$escaped%"
+		}
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/WhiteListDao.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/WhiteListDao.kt
@@ -68,19 +68,36 @@ open class WhiteListDao(
 	): List<GetPaginatedWithAccountStatus> =
 		withContext(ioDispatcher) {
 			return@withContext if (sortOldestFirst) {
-				queries.getPaginatedWithAccountStatusOldestFirst(limit, offset).executeAsList().map {
-					GetPaginatedWithAccountStatus(
-						email = it.email,
-						date_added = it.date_added,
-						reason = it.reason,
-						expires = it.expires,
-						has_account = it.has_account
-					)
-				}
+				queries.getPaginatedWithAccountStatusOldestFirst(
+					limit, offset, ::GetPaginatedWithAccountStatus
+				).executeAsList()
 			} else {
 				queries.getPaginatedWithAccountStatus(limit, offset).executeAsList()
 			}
 		}
+
+	/** [pattern] is a LIKE pattern; see `WhiteListRepository.emailSearchPattern`. */
+	open suspend fun searchPaginatedWithAccountStatus(
+		pattern: String,
+		limit: Long,
+		offset: Long,
+		sortOldestFirst: Boolean = false
+	): List<GetPaginatedWithAccountStatus> =
+		withContext(ioDispatcher) {
+			return@withContext if (sortOldestFirst) {
+				queries.searchPaginatedWithAccountStatusOldestFirst(
+					pattern, limit, offset, ::GetPaginatedWithAccountStatus
+				).executeAsList()
+			} else {
+				queries.searchPaginatedWithAccountStatus(
+					pattern, limit, offset, ::GetPaginatedWithAccountStatus
+				).executeAsList()
+			}
+		}
+
+	open suspend fun searchCount(pattern: String): Long = withContext(ioDispatcher) {
+		return@withContext queries.searchCount(pattern).executeAsOne()
+	}
 
 	open suspend fun getByEmail(email: String): WhiteList? = withContext(ioDispatcher) {
 		return@withContext queries.getByEmail(email).executeAsOneOrNull()

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/admin/WhitelistPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/admin/WhitelistPage.kt
@@ -13,6 +13,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.utils.io.*
+import java.net.URLEncoder
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -40,6 +41,9 @@ internal fun Route.whiteListRoutes(
 /** The `never` preset and a blank custom date both mean "no expiry". */
 internal const val EXPIRY_PRESET_NEVER = "never"
 internal const val EXPIRY_PRESET_CUSTOM = "custom"
+
+/** The practical ceiling on an email address, so a search can't be arbitrarily long. */
+private const val MAX_SEARCH_LENGTH = 254
 
 /**
  * Resolves the add/edit form's expiry controls to an instant, or null for "never".
@@ -86,8 +90,10 @@ private fun Route.whitelistAdd(whiteListRepository: WhiteListRepository, clock: 
 		val params = call.receiveParameters()
 		val email = params["email"]?.trim().orEmpty()
 		val reason = params["reason"]?.trim().orEmpty()
-		val page = params["page"]?.toIntOrNull() ?: 0
-		val sortOldestFirst = params["sortOldestFirst"]?.toBoolean() ?: false
+		// The response is always the unfiltered first page, newest first, so a newly added
+		// entry is visible instead of landing outside the admin's current page or filter.
+		val page = 0
+		val sortOldestFirst = false
 
 		// Validate email format
 		if (email.isEmpty()) {
@@ -148,12 +154,13 @@ private fun Route.whitelistRemove(whiteListRepository: WhiteListRepository) {
 		val email = params["email"]?.trim().orEmpty()
 		val page = params["page"]?.toIntOrNull() ?: 0
 		val sortOldestFirst = params["sortOldestFirst"]?.toBoolean() ?: false
+		val search = params["q"]
 
 		if (email.isNotEmpty()) {
 			whiteListRepository.removeFromWhiteList(email)
 		}
 
-		val model = getWhitelistModel(call, whiteListRepository, page, sortOldestFirst)
+		val model = getWhitelistModel(call, whiteListRepository, page, sortOldestFirst, search)
 		call.respond(MustacheContent("partials/allowed-users.mustache", model))
 	}
 }
@@ -165,12 +172,13 @@ private fun Route.whitelistEditReason(whiteListRepository: WhiteListRepository) 
 		val reason = params["reason"]?.trim().orEmpty()
 		val page = params["page"]?.toIntOrNull() ?: 0
 		val sortOldestFirst = params["sortOldestFirst"]?.toBoolean() ?: false
+		val search = params["q"]
 
 		if (email.isEmpty()) {
 			val model = getWhitelistModelWithError(
 				call, whiteListRepository, page,
 				call.msg("admin_allowedusers_error_emailrequired"),
-				sortOldestFirst
+				sortOldestFirst, search
 			)
 			call.respond(MustacheContent("partials/allowed-users.mustache", model))
 			return@post
@@ -180,7 +188,7 @@ private fun Route.whitelistEditReason(whiteListRepository: WhiteListRepository) 
 			val model = getWhitelistModelWithError(
 				call, whiteListRepository, page,
 				call.msg("admin_allowedusers_error_reasontoolong"),
-				sortOldestFirst
+				sortOldestFirst, search
 			)
 			call.respond(MustacheContent("partials/allowed-users.mustache", model))
 			return@post
@@ -188,7 +196,7 @@ private fun Route.whitelistEditReason(whiteListRepository: WhiteListRepository) 
 
 		whiteListRepository.updateReason(email, reason)
 
-		val model = getWhitelistModel(call, whiteListRepository, page, sortOldestFirst)
+		val model = getWhitelistModel(call, whiteListRepository, page, sortOldestFirst, search)
 		call.respond(MustacheContent("partials/allowed-users.mustache", model))
 	}
 }
@@ -199,12 +207,13 @@ private fun Route.whitelistEditExpiry(whiteListRepository: WhiteListRepository, 
 		val email = params["email"]?.trim().orEmpty()
 		val page = params["page"]?.toIntOrNull() ?: 0
 		val sortOldestFirst = params["sortOldestFirst"]?.toBoolean() ?: false
+		val search = params["q"]
 
 		if (email.isEmpty()) {
 			val model = getWhitelistModelWithError(
 				call, whiteListRepository, page,
 				call.msg("admin_allowedusers_error_emailrequired"),
-				sortOldestFirst
+				sortOldestFirst, search
 			)
 			call.respond(MustacheContent("partials/allowed-users.mustache", model))
 			return@post
@@ -221,7 +230,7 @@ private fun Route.whitelistEditExpiry(whiteListRepository: WhiteListRepository, 
 			val model = getWhitelistModelWithError(
 				call, whiteListRepository, page,
 				call.msg("admin_allowedusers_error_expiryinvalid"),
-				sortOldestFirst
+				sortOldestFirst, search
 			)
 			call.respond(MustacheContent("partials/allowed-users.mustache", model))
 			return@post
@@ -229,7 +238,7 @@ private fun Route.whitelistEditExpiry(whiteListRepository: WhiteListRepository, 
 
 		whiteListRepository.updateExpiry(email, parsedExpiry.expires)
 
-		val model = getWhitelistModel(call, whiteListRepository, page, sortOldestFirst)
+		val model = getWhitelistModel(call, whiteListRepository, page, sortOldestFirst, search)
 		call.respond(MustacheContent("partials/allowed-users.mustache", model))
 	}
 }
@@ -245,7 +254,8 @@ internal suspend fun getWhitelistModel(
 	call: ApplicationCall,
 	whiteListRepository: WhiteListRepository,
 	page: Int? = null,
-	sortOldestFirst: Boolean? = null
+	sortOldestFirst: Boolean? = null,
+	search: String? = null,
 ): MutableMap<String, Any> {
 	val queryPage = call.request.queryParameters["page"]?.toIntOrNull()
 	val actualPage = page ?: queryPage ?: 0
@@ -253,13 +263,18 @@ internal suspend fun getWhitelistModel(
 	val querySortOldestFirst = call.request.queryParameters["sortOldestFirst"]?.toBoolean()
 	val actualSortOldestFirst = sortOldestFirst ?: querySortOldestFirst ?: false
 
+	val actualSearch = (search ?: call.request.queryParameters["q"])
+		?.trim().orEmpty().take(MAX_SEARCH_LENGTH)
+	val searchFilter = actualSearch.ifEmpty { null }
+
 	val pageSize = 10
-	val totalCount = whiteListRepository.getWhiteListCount()
+	val totalCount = whiteListRepository.getWhiteListCount(searchFilter)
 	val totalPages = ceil(totalCount.toDouble() / pageSize).toInt()
 	val currentPage = if (totalPages > 0) actualPage.coerceIn(0, totalPages - 1) else 0
 
-	val whitelistEntries =
-		whiteListRepository.getWhiteListWithAccountStatus(currentPage, pageSize, actualSortOldestFirst)
+	val whitelistEntries = whiteListRepository.getWhiteListWithAccountStatus(
+		currentPage, pageSize, actualSortOldestFirst, searchFilter
+	)
 	val whitelistItems = whitelistEntries.map { entry ->
 		mapOf(
 			"email" to entry.email,
@@ -288,6 +303,10 @@ internal suspend fun getWhitelistModel(
 	whitelist["prevPage"] = currentPage - 1
 	whitelist["sortOldestFirst"] = actualSortOldestFirst
 	whitelist["sortNewestFirst"] = !actualSortOldestFirst
+	whitelist["search"] = actualSearch
+	// Reflected into hx-get URLs, where mustache's HTML escaping alone isn't enough.
+	whitelist["searchEnc"] = URLEncoder.encode(actualSearch, Charsets.UTF_8)
+	whitelist["hasSearch"] = actualSearch.isNotEmpty()
 
 	val model = call.withDefaults()
 	model["whitelist"] = whitelist
@@ -300,9 +319,10 @@ private suspend fun getWhitelistModelWithError(
 	whiteListRepository: WhiteListRepository,
 	page: Int,
 	errorMessage: String,
-	sortOldestFirst: Boolean? = null
+	sortOldestFirst: Boolean? = null,
+	search: String? = null,
 ): MutableMap<String, Any> {
-	val model = getWhitelistModel(call, whiteListRepository, page, sortOldestFirst)
+	val model = getWhitelistModel(call, whiteListRepository, page, sortOldestFirst, search)
 	model["error"] = errorMessage
 	return model
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/admin/WhitelistPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/admin/WhitelistPage.kt
@@ -90,17 +90,17 @@ private fun Route.whitelistAdd(whiteListRepository: WhiteListRepository, clock: 
 		val params = call.receiveParameters()
 		val email = params["email"]?.trim().orEmpty()
 		val reason = params["reason"]?.trim().orEmpty()
-		// The response is always the unfiltered first page, newest first, so a newly added
-		// entry is visible instead of landing outside the admin's current page or filter.
-		val page = 0
-		val sortOldestFirst = false
+		// A rejected add is not an add, so the error lands in the admin's current view.
+		val page = params["page"]?.toIntOrNull() ?: 0
+		val sortOldestFirst = params["sortOldestFirst"]?.toBoolean() ?: false
+		val search = params["q"]
 
 		// Validate email format
 		if (email.isEmpty()) {
 			val model = getWhitelistModelWithError(
 				call, whiteListRepository, page,
 				call.msg("admin_allowedusers_error_emailrequired"),
-				sortOldestFirst
+				sortOldestFirst, search
 			)
 			call.respond(MustacheContent("partials/allowed-users.mustache", model))
 			return@post
@@ -110,7 +110,7 @@ private fun Route.whitelistAdd(whiteListRepository: WhiteListRepository, clock: 
 			val model = getWhitelistModelWithError(
 				call, whiteListRepository, page,
 				call.msg("admin_allowedusers_error_emailinvalid"),
-				sortOldestFirst
+				sortOldestFirst, search
 			)
 			call.respond(MustacheContent("partials/allowed-users.mustache", model))
 			return@post
@@ -123,7 +123,7 @@ private fun Route.whitelistAdd(whiteListRepository: WhiteListRepository, clock: 
 			val model = getWhitelistModelWithError(
 				call, whiteListRepository, page,
 				call.msg("admin_allowedusers_error_reasontoolong"),
-				sortOldestFirst
+				sortOldestFirst, search
 			)
 			call.respond(MustacheContent("partials/allowed-users.mustache", model))
 			return@post
@@ -134,7 +134,7 @@ private fun Route.whitelistAdd(whiteListRepository: WhiteListRepository, clock: 
 			val model = getWhitelistModelWithError(
 				call, whiteListRepository, page,
 				call.msg("admin_allowedusers_error_expiryinvalid"),
-				sortOldestFirst
+				sortOldestFirst, search
 			)
 			call.respond(MustacheContent("partials/allowed-users.mustache", model))
 			return@post
@@ -143,7 +143,10 @@ private fun Route.whitelistAdd(whiteListRepository: WhiteListRepository, clock: 
 		// All validation passed
 		whiteListRepository.addToWhiteList(email, actualReason, parsedExpiry.expires)
 
-		val model = getWhitelistModel(call, whiteListRepository, page, sortOldestFirst)
+		// A new entry is only guaranteed visible on the unfiltered first page, newest first,
+		// so the successful response resets the view and tells the client to match it.
+		call.response.header(HxResponseHeaders.Trigger, "whitelist-added")
+		val model = getWhitelistModel(call, whiteListRepository, page = 0, sortOldestFirst = false, search = "")
 		call.respond(MustacheContent("partials/allowed-users.mustache", model))
 	}
 }
@@ -297,6 +300,8 @@ internal suspend fun getWhitelistModel(
 	whitelist["currentPage"] = currentPage
 	whitelist["currentPageDisplay"] = currentPage + 1
 	whitelist["totalPages"] = totalPages
+	// Mustache renders a section on a boxed 0, so paging needs its own boolean.
+	whitelist["hasPages"] = totalPages > 0
 	whitelist["hasNextPage"] = currentPage < totalPages - 1
 	whitelist["hasPrevPage"] = currentPage > 0
 	whitelist["nextPage"] = currentPage + 1

--- a/server/src/main/resources/assets/css/admin.css
+++ b/server/src/main/resources/assets/css/admin.css
@@ -290,6 +290,18 @@
 	gap: 0.75rem;
 }
 
+.whitelist-search {
+	display: flex;
+	gap: 0.75rem;
+	align-items: flex-end;
+	margin-bottom: 1rem;
+}
+
+.whitelist-search__field {
+	flex: 1;
+	margin-bottom: 0;
+}
+
 .whitelist-controls {
 	display: flex;
 	align-items: center;
@@ -297,6 +309,28 @@
 	margin-bottom: 1rem;
 	padding-bottom: 0.75rem;
 	border-bottom: 2px solid var(--neutral-200);
+}
+
+/* Pushed left of the sort button, which the container's flex-end would otherwise pin it to. */
+.whitelist-controls__filter {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	margin-right: auto;
+	font-size: 0.875rem;
+	color: var(--text-secondary);
+}
+
+.whitelist-controls__filter code {
+	font-family: 'Kingthings Typewriter', 'Courier New', monospace;
+	color: var(--text-primary);
+	word-break: break-all;
+}
+
+.whitelist-controls .whitelist-controls__filter-clear {
+	padding: 0.25rem 0.5rem;
+	border: none;
+	line-height: 1;
 }
 
 .whitelist-controls .btn {
@@ -704,6 +738,16 @@
 
 	.status-label {
 		min-width: auto;
+	}
+
+	.whitelist-controls {
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.whitelist-controls__filter {
+		margin-right: 0;
+		width: 100%;
 	}
 
 	.whitelist-entry {

--- a/server/src/main/resources/i18n/Messages_en.properties
+++ b/server/src/main/resources/i18n/Messages_en.properties
@@ -436,6 +436,11 @@ admin_allowedusers_sort_newest_first=Sort: Newest First
 admin_allowedusers_sort_oldest_first=Sort: Oldest First
 admin_allowedusers_account_created=Account Created
 admin_allowedusers_no_account=No Account
+admin_allowedusers_search_label=Search by email
+admin_allowedusers_search_placeholder=Filter by full or partial email
+admin_allowedusers_search_clear=Clear search
+admin_allowedusers_search_filtered_by=Filtered by:
+admin_allowedusers_search_empty=No allowed users match that email.
 admin_dialog_cancel=Cancel
 # Error Pages - Common
 error_button_home=Go Home

--- a/server/src/main/resources/templates/admin-allowed-users.mustache
+++ b/server/src/main/resources/templates/admin-allowed-users.mustache
@@ -24,7 +24,7 @@
 					  hx-post="/admin/allowed-users/add"
 					  hx-target="#whitelist"
 					  hx-swap="innerHTML"
-					  hx-on::after-request="this.reset(); syncAddExpiryDateVisibility(); resetWhitelistSearchInput()">
+					  hx-include="#whitelist-search, #whitelist-sort-state, #whitelist-page-state">
 					<div class="form-group">
 						<label for="email" class="form-field__label">{{msg.admin_allowedusers_email_label}}</label>
 						<input id="email" name="email" type="email" class="form-input"
@@ -70,6 +70,7 @@
 								   hx-get="/admin/allowed-users/user-fragment"
 								   hx-target="#whitelist"
 								   hx-swap="innerHTML"
+								   hx-include="#whitelist-sort-state"
 								   hx-trigger="input changed delay:300ms, search"/>
 						</div>
 					</div>
@@ -262,6 +263,13 @@
 	function resetWhitelistSearchInput() {
 		document.getElementById('whitelist-search').value = '';
 	}
+
+	// Only a successful add emits this, so a rejected one keeps the typed values and the filter.
+	document.body.addEventListener('whitelist-added', function () {
+		document.getElementById('add-whitelist-form').reset();
+		syncAddExpiryDateVisibility();
+		resetWhitelistSearchInput();
+	});
 
 	// Close dialog on escape key
 	document.addEventListener('keydown', function (e) {

--- a/server/src/main/resources/templates/admin-allowed-users.mustache
+++ b/server/src/main/resources/templates/admin-allowed-users.mustache
@@ -24,9 +24,7 @@
 					  hx-post="/admin/allowed-users/add"
 					  hx-target="#whitelist"
 					  hx-swap="innerHTML"
-					  hx-on::after-request="this.reset(); syncAddExpiryDateVisibility()">
-					<input type="hidden" name="page" id="add-form-page" value="0"/>
-					<input type="hidden" name="sortOldestFirst" id="add-form-sort" value="false"/>
+					  hx-on::after-request="this.reset(); syncAddExpiryDateVisibility(); resetWhitelistSearchInput()">
 					<div class="form-group">
 						<label for="email" class="form-field__label">{{msg.admin_allowedusers_email_label}}</label>
 						<input id="email" name="email" type="email" class="form-input"
@@ -62,9 +60,23 @@
 				</form>
 
 				<div class="whitelist-container">
+					<div class="whitelist-search">
+						<div class="form-field whitelist-search__field">
+							<label class="form-field__label form-field__label--small"
+								   for="whitelist-search">{{msg.admin_allowedusers_search_label}}</label>
+							<input id="whitelist-search" name="q" type="search" class="form-input"
+								   autocomplete="off"
+								   placeholder="{{msg.admin_allowedusers_search_placeholder}}"
+								   hx-get="/admin/allowed-users/user-fragment"
+								   hx-target="#whitelist"
+								   hx-swap="innerHTML"
+								   hx-trigger="input changed delay:300ms, search"/>
+						</div>
+					</div>
+
 					<div id="whitelist"
 						 hx-get="/admin/allowed-users/user-fragment"
-						 hx-trigger="load, whitelist-updated from:body"
+						 hx-trigger="load"
 						 hx-swap="innerHTML">
 						<!-- List of allowed users loaded here -->
 					</div>
@@ -93,6 +105,7 @@
 				<input type="hidden" name="email" id="edit-reason-email"/>
 				<input type="hidden" name="page" id="edit-reason-page"/>
 				<input type="hidden" name="sortOldestFirst" id="edit-reason-sort"/>
+				<input type="hidden" name="q" id="edit-reason-q"/>
 				<div class="form-field">
 					<label for="edit-reason-input"
 						   class="form-field__label">{{msg.admin_allowedusers_reason_label}}</label>
@@ -133,6 +146,7 @@
 					<input type="hidden" name="email" id="edit-expiry-email"/>
 				<input type="hidden" name="page" id="edit-expiry-page"/>
 				<input type="hidden" name="sortOldestFirst" id="edit-expiry-sort"/>
+				<input type="hidden" name="q" id="edit-expiry-q"/>
 				<div class="form-field">
 					<label for="edit-expiry-preset"
 						   class="form-field__label">{{msg.admin_allowedusers_expiry_change_label}}</label>
@@ -181,6 +195,7 @@
 		document.getElementById('edit-expiry-email').value = email;
 		document.getElementById('edit-expiry-page').value = btn.dataset.page;
 		document.getElementById('edit-expiry-sort').value = btn.dataset.sortOldestFirst;
+		document.getElementById('edit-expiry-q').value = btn.dataset.q || '';
 
 		// Default to a no-op: an entry with an expiry opens on "specific date" showing
 		// its current value; an entry with no expiry opens on "Never".
@@ -215,6 +230,7 @@
 		document.getElementById('edit-reason-input').value = reason;
 		document.getElementById('edit-reason-page').value = page;
 		document.getElementById('edit-reason-sort').value = sortOldestFirst;
+		document.getElementById('edit-reason-q').value = btn.dataset.q || '';
 
 		const dialog = document.getElementById('edit-reason-dialog');
 		dialog.classList.remove('hidden', 'closing');
@@ -235,19 +251,17 @@
 		}, 200);
 	}
 
-	// Update form hidden fields when whitelist is loaded/updated
-	document.body.addEventListener('htmx:afterSwap', function (event) {
-		if (event.detail.target.id === 'whitelist') {
-			// Extract current page and sort from the loaded content
-			const urlParams = new URLSearchParams(window.location.search);
-			const currentPage = urlParams.get('page') || '0';
-			const sortOldestFirst = urlParams.get('sortOldestFirst') || 'false';
+	function clearWhitelistSearch() {
+		const input = document.getElementById('whitelist-search');
+		input.value = '';
+		htmx.trigger(input, 'search');
+		input.focus();
+	}
 
-			// Update add form hidden inputs
-			document.getElementById('add-form-page').value = currentPage;
-			document.getElementById('add-form-sort').value = sortOldestFirst;
-		}
-	});
+	// The add response is deliberately unfiltered, so the field is emptied to match.
+	function resetWhitelistSearchInput() {
+		document.getElementById('whitelist-search').value = '';
+	}
 
 	// Close dialog on escape key
 	document.addEventListener('keydown', function (e) {

--- a/server/src/main/resources/templates/partials/allowed-users.mustache
+++ b/server/src/main/resources/templates/partials/allowed-users.mustache
@@ -4,8 +4,18 @@
 	{{/error}}
 
 	<div class="whitelist-controls">
+		{{#hasSearch}}
+			<span class="whitelist-controls__filter">
+				{{msg.admin_allowedusers_search_filtered_by}} <code>{{search}}</code>
+				<button type="button" class="btn btn--ghost whitelist-controls__filter-clear"
+						onclick="clearWhitelistSearch()"
+						aria-label="{{msg.admin_allowedusers_search_clear}}">
+					<i class="fa-solid fa-xmark"></i>
+				</button>
+			</span>
+		{{/hasSearch}}
 		{{#sortNewestFirst}}
-			<button hx-get="/admin/allowed-users/user-fragment?page={{currentPage}}&sortOldestFirst=true"
+			<button hx-get="/admin/allowed-users/user-fragment?page={{currentPage}}&sortOldestFirst=true&q={{searchEnc}}"
 			hx-target="#whitelist"
 			hx-swap="innerHTML"
 			class="btn btn--ghost">
@@ -14,7 +24,7 @@
 			</button>
 		{{/sortNewestFirst}}
 		{{#sortOldestFirst}}
-			<button hx-get="/admin/allowed-users/user-fragment?page={{currentPage}}&sortOldestFirst=false"
+			<button hx-get="/admin/allowed-users/user-fragment?page={{currentPage}}&sortOldestFirst=false&q={{searchEnc}}"
 			hx-target="#whitelist"
 			hx-swap="innerHTML"
 			class="btn btn--ghost">
@@ -61,6 +71,7 @@
 						data-reason="{{reason}}"
 						data-page="{{currentPage}}"
 						data-sort-oldest-first="{{sortOldestFirst}}"
+						data-q="{{search}}"
 						onclick="openEditReasonDialog(this)">
 					<i class="fa-solid fa-pen"></i>
 					{{msg.admin_allowedusers_edit_button}}
@@ -72,6 +83,7 @@
 							data-expires-raw="{{expiresRaw}}"
 							data-page="{{currentPage}}"
 							data-sort-oldest-first="{{sortOldestFirst}}"
+							data-q="{{search}}"
 							onclick="openEditExpiryDialog(this)">
 						<i class="fa-solid fa-hourglass-half"></i>
 						{{msg.admin_allowedusers_edit_expiry_button}}
@@ -85,6 +97,7 @@
 					<input type="hidden" name="email" value="{{email}}"/>
 					<input type="hidden" name="page" value="{{currentPage}}"/>
 					<input type="hidden" name="sortOldestFirst" value="{{sortOldestFirst}}"/>
+					<input type="hidden" name="q" value="{{search}}"/>
 					<button type="submit" class="btn btn--danger">{{msg.admin_allowedusers_remove_button}}</button>
 				</form>
 			</div>
@@ -92,14 +105,21 @@
 	{{/items}}
 	{{^items}}
 		<div class="empty-state">
-		<p>{{msg.admin_allowedusers_empty}}</p>
-	</div>
+			{{#hasSearch}}
+				<p>{{msg.admin_allowedusers_search_empty}}</p>
+				<button type="button" class="btn btn--ghost"
+						onclick="clearWhitelistSearch()">{{msg.admin_allowedusers_search_clear}}</button>
+			{{/hasSearch}}
+			{{^hasSearch}}
+				<p>{{msg.admin_allowedusers_empty}}</p>
+			{{/hasSearch}}
+		</div>
 	{{/items}}
 
 	{{#totalPages}}
 		<div class="pagination">
 			{{#hasPrevPage}}
-				<button hx-get="/admin/allowed-users/user-fragment?page={{prevPage}}&sortOldestFirst={{sortOldestFirst}}"
+				<button hx-get="/admin/allowed-users/user-fragment?page={{prevPage}}&sortOldestFirst={{sortOldestFirst}}&q={{searchEnc}}"
 				hx-target="#whitelist"
 				hx-swap="innerHTML"
 				class="pagination-button">
@@ -112,7 +132,7 @@
     </span>
 
 			{{#hasNextPage}}
-				<button hx-get="/admin/allowed-users/user-fragment?page={{nextPage}}&sortOldestFirst={{sortOldestFirst}}"
+				<button hx-get="/admin/allowed-users/user-fragment?page={{nextPage}}&sortOldestFirst={{sortOldestFirst}}&q={{searchEnc}}"
 				hx-target="#whitelist"
 				hx-swap="innerHTML"
 				class="pagination-button">

--- a/server/src/main/resources/templates/partials/allowed-users.mustache
+++ b/server/src/main/resources/templates/partials/allowed-users.mustache
@@ -3,6 +3,10 @@
 		<div class="error-message">{{error}}</div>
 	{{/error}}
 
+	{{! Controls outside this fragment pull the current view state from here via hx-include. }}
+	<input type="hidden" id="whitelist-sort-state" name="sortOldestFirst" value="{{sortOldestFirst}}"/>
+	<input type="hidden" id="whitelist-page-state" name="page" value="{{currentPage}}"/>
+
 	<div class="whitelist-controls">
 		{{#hasSearch}}
 			<span class="whitelist-controls__filter">
@@ -116,7 +120,7 @@
 		</div>
 	{{/items}}
 
-	{{#totalPages}}
+	{{#hasPages}}
 		<div class="pagination">
 			{{#hasPrevPage}}
 				<button hx-get="/admin/allowed-users/user-fragment?page={{prevPage}}&sortOldestFirst={{sortOldestFirst}}&q={{searchEnc}}"
@@ -140,5 +144,5 @@
 				</button>
 			{{/hasNextPage}}
 		</div>
-	{{/totalPages}}
+	{{/hasPages}}
 {{/whitelist}}

--- a/server/src/main/sqldelight/com/darkrockstudios/apps/hammer/WhiteList.sq
+++ b/server/src/main/sqldelight/com/darkrockstudios/apps/hammer/WhiteList.sq
@@ -76,8 +76,31 @@ LEFT JOIN account a ON w.email = a.email
 ORDER BY w.date_added ASC
 LIMIT ? OFFSET ?;
 
+-- Admin email search. A wildcard match can't ride the citext equality operator, so both
+-- sides are narrowed to text and matched with ILIKE, which is unambiguously
+-- case-insensitive. The repository escapes % and _ in the admin's input before binding.
+searchPaginatedWithAccountStatus:
+SELECT w.*, (a.email IS NOT NULL) AS has_account
+FROM white_list w
+LEFT JOIN account a ON w.email = a.email
+WHERE CAST(w.email AS TEXT) ILIKE ?
+ORDER BY w.date_added DESC
+LIMIT ? OFFSET ?;
+
+searchPaginatedWithAccountStatusOldestFirst:
+SELECT w.*, (a.email IS NOT NULL) AS has_account
+FROM white_list w
+LEFT JOIN account a ON w.email = a.email
+WHERE CAST(w.email AS TEXT) ILIKE ?
+ORDER BY w.date_added ASC
+LIMIT ? OFFSET ?;
+
 getCount:
 SELECT count(*) FROM white_list;
+
+searchCount:
+SELECT count(*) FROM white_list
+WHERE CAST(email AS TEXT) ILIKE ?;
 
 getByEmail:
 SELECT * FROM white_list WHERE email = CAST(? AS CITEXT);

--- a/server/src/main/sqldelight/com/darkrockstudios/apps/hammer/WhiteList.sq
+++ b/server/src/main/sqldelight/com/darkrockstudios/apps/hammer/WhiteList.sq
@@ -52,28 +52,31 @@ getAll:
 SELECT * FROM white_list
 ORDER BY email ASC;
 
+-- Every paginated query breaks ties on email. backfillFromAccounts stamps all the rows
+-- it migrates with one timestamp, so date_added alone leaves LIMIT/OFFSET free to repeat
+-- and skip entries across pages.
 getPaginated:
 SELECT * FROM white_list
-ORDER BY date_added DESC
+ORDER BY date_added DESC, email ASC
 LIMIT ? OFFSET ?;
 
 getPaginatedOldestFirst:
 SELECT * FROM white_list
-ORDER BY date_added ASC
+ORDER BY date_added ASC, email ASC
 LIMIT ? OFFSET ?;
 
 getPaginatedWithAccountStatus:
 SELECT w.*, (a.email IS NOT NULL) AS has_account
 FROM white_list w
 LEFT JOIN account a ON w.email = a.email
-ORDER BY w.date_added DESC
+ORDER BY w.date_added DESC, w.email ASC
 LIMIT ? OFFSET ?;
 
 getPaginatedWithAccountStatusOldestFirst:
 SELECT w.*, (a.email IS NOT NULL) AS has_account
 FROM white_list w
 LEFT JOIN account a ON w.email = a.email
-ORDER BY w.date_added ASC
+ORDER BY w.date_added ASC, w.email ASC
 LIMIT ? OFFSET ?;
 
 -- Admin email search. A wildcard match can't ride the citext equality operator, so both
@@ -84,7 +87,7 @@ SELECT w.*, (a.email IS NOT NULL) AS has_account
 FROM white_list w
 LEFT JOIN account a ON w.email = a.email
 WHERE CAST(w.email AS TEXT) ILIKE ?
-ORDER BY w.date_added DESC
+ORDER BY w.date_added DESC, w.email ASC
 LIMIT ? OFFSET ?;
 
 searchPaginatedWithAccountStatusOldestFirst:
@@ -92,7 +95,7 @@ SELECT w.*, (a.email IS NOT NULL) AS has_account
 FROM white_list w
 LEFT JOIN account a ON w.email = a.email
 WHERE CAST(w.email AS TEXT) ILIKE ?
-ORDER BY w.date_added ASC
+ORDER BY w.date_added ASC, w.email ASC
 LIMIT ? OFFSET ?;
 
 getCount:

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/WhiteListRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/WhiteListRepositoryTest.kt
@@ -361,6 +361,34 @@ class WhiteListRepositoryTest : BaseTest() {
 	}
 
 	@Test
+	fun `paging is stable when every entry shares a date_added`() = runTest {
+		// backfillFromAccounts stamps every migrated row with one timestamp, so the sort
+		// key alone can't order them and LIMIT/OFFSET needs a unique tiebreaker.
+		val emails = (1..15).map { "user%02d@example.com".format(it) }
+		emails.forEach { whiteListDao.addToWhiteList(it, Instant.fromEpochSeconds(0), "Test") }
+
+		val repo = createRepo()
+		val firstPage = repo.getWhiteListWithAccountStatus(0, 10).map { it.email }
+		val secondPage = repo.getWhiteListWithAccountStatus(1, 10).map { it.email }
+
+		assertEquals(emails.take(10), firstPage, "Ties break on email, so paging is deterministic")
+		assertEquals(emails.drop(10), secondPage)
+		assertEquals(emails, firstPage + secondPage, "Every entry appears exactly once")
+	}
+
+	@Test
+	fun `filtered paging is stable when every entry shares a date_added`() = runTest {
+		val emails = (1..15).map { "alice%02d@example.com".format(it) }
+		emails.forEach { whiteListDao.addToWhiteList(it, Instant.fromEpochSeconds(0), "Test") }
+
+		val repo = createRepo()
+		val firstPage = repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "alice").map { it.email }
+		val secondPage = repo.getWhiteListWithAccountStatus(1, 10, emailSearch = "alice").map { it.email }
+
+		assertEquals(emails, firstPage + secondPage, "Every match appears exactly once across pages")
+	}
+
+	@Test
 	fun `emailSearchPattern - wraps in wildcards and escapes LIKE metacharacters`() {
 		assertEquals("%alice%", WhiteListRepository.emailSearchPattern("alice"))
 		assertEquals("%alice%", WhiteListRepository.emailSearchPattern("  alice  "))

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/WhiteListRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/admin/WhiteListRepositoryTest.kt
@@ -250,4 +250,126 @@ class WhiteListRepositoryTest : BaseTest() {
 		assertTrue(repo.validateExpiry(clock.now() + 1.days))
 		assertFalse(repo.validateExpiry(clock.now() - 1.days), "A past expiry is meaningless")
 	}
+
+	@Test
+	fun `email search - matches a partial email and excludes the rest`() = runTest {
+		seedEmails("alice@example.com", "alicia@example.com", "bob@example.com")
+
+		val repo = createRepo()
+		val result = repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "alic")
+
+		assertEquals(
+			listOf("alice@example.com", "alicia@example.com"),
+			result.map { it.email }.sorted()
+		)
+	}
+
+	@Test
+	fun `email search - matches anywhere in the address, not just the start`() = runTest {
+		seedEmails("someone@hammer.ink", "other@example.com")
+
+		val repo = createRepo()
+		val result = repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "hammer.ink")
+
+		assertEquals(listOf("someone@hammer.ink"), result.map { it.email })
+	}
+
+	@Test
+	fun `email search - is case insensitive`() = runTest {
+		// Bypasses the repository's cleanEmail so a mixed-case row really lands in the table.
+		whiteListDao.addToWhiteList("Alice@Example.com", Instant.fromEpochSeconds(0), "Test")
+
+		val repo = createRepo()
+
+		assertEquals(1, repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "alice").size)
+		assertEquals(1, repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "ALICE").size)
+		assertEquals(1L, repo.getWhiteListCount("alice"))
+	}
+
+	@Test
+	fun `email search - honours both sort directions`() = runTest {
+		whiteListDao.addToWhiteList("alice.old@example.com", Instant.fromEpochSeconds(1000), "Test")
+		whiteListDao.addToWhiteList("alice.new@example.com", Instant.fromEpochSeconds(9000), "Test")
+		whiteListDao.addToWhiteList("bob@example.com", Instant.fromEpochSeconds(5000), "Test")
+
+		val repo = createRepo()
+
+		val newestFirst = repo.getWhiteListWithAccountStatus(0, 10, sortOldestFirst = false, emailSearch = "alice")
+		val oldestFirst = repo.getWhiteListWithAccountStatus(0, 10, sortOldestFirst = true, emailSearch = "alice")
+
+		assertEquals(listOf("alice.new@example.com", "alice.old@example.com"), newestFirst.map { it.email })
+		assertEquals(listOf("alice.old@example.com", "alice.new@example.com"), oldestFirst.map { it.email })
+	}
+
+	@Test
+	fun `email search - count matches the filter and pages are disjoint`() = runTest {
+		seedEmails(*(1..15).map { "alice$it@example.com" }.toTypedArray())
+		seedEmails("bob@example.com", "carol@example.com")
+
+		val repo = createRepo()
+
+		assertEquals(15L, repo.getWhiteListCount("alice"))
+		assertEquals(17L, repo.getWhiteListCount(), "An absent filter still counts everything")
+
+		val firstPage = repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "alice").map { it.email }
+		val secondPage = repo.getWhiteListWithAccountStatus(1, 10, emailSearch = "alice").map { it.email }
+
+		assertEquals(10, firstPage.size)
+		assertEquals(5, secondPage.size)
+		assertTrue(firstPage.intersect(secondPage.toSet()).isEmpty(), "Pages must not overlap")
+	}
+
+	@Test
+	fun `email search - underscore is matched literally, not as a wildcard`() = runTest {
+		seedEmails("a_b@example.com", "axb@example.com")
+
+		val repo = createRepo()
+		val result = repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "a_b")
+
+		assertEquals(listOf("a_b@example.com"), result.map { it.email })
+	}
+
+	@Test
+	fun `email search - a bare percent matches nothing rather than everything`() = runTest {
+		seedEmails("alice@example.com", "bob@example.com")
+
+		val repo = createRepo()
+
+		assertEquals(0L, repo.getWhiteListCount("%"))
+		assertTrue(repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "%").isEmpty())
+	}
+
+	@Test
+	fun `email search - surrounding whitespace is ignored`() = runTest {
+		seedEmails("alice@example.com", "bob@example.com")
+
+		val repo = createRepo()
+		val result = repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "  alice  ")
+
+		assertEquals(listOf("alice@example.com"), result.map { it.email })
+	}
+
+	@Test
+	fun `email search - a null or blank filter lists everything`() = runTest {
+		seedEmails("alice@example.com", "bob@example.com")
+
+		val repo = createRepo()
+
+		assertEquals(2, repo.getWhiteListWithAccountStatus(0, 10, emailSearch = null).size)
+		assertEquals(2, repo.getWhiteListWithAccountStatus(0, 10, emailSearch = "   ").size)
+		assertEquals(2L, repo.getWhiteListCount("   "))
+	}
+
+	@Test
+	fun `emailSearchPattern - wraps in wildcards and escapes LIKE metacharacters`() {
+		assertEquals("%alice%", WhiteListRepository.emailSearchPattern("alice"))
+		assertEquals("%alice%", WhiteListRepository.emailSearchPattern("  alice  "))
+		assertEquals("%a\\_b%", WhiteListRepository.emailSearchPattern("a_b"))
+		assertEquals("%50\\%%", WhiteListRepository.emailSearchPattern("50%"))
+		assertEquals("%a\\\\b%", WhiteListRepository.emailSearchPattern("a\\b"))
+	}
+
+	private suspend fun seedEmails(vararg emails: String) {
+		emails.forEach { whiteListDao.addToWhiteList(it, Instant.fromEpochSeconds(0), "Test") }
+	}
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/AdminWhitelistSearchPageTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/AdminWhitelistSearchPageTest.kt
@@ -226,6 +226,92 @@ class AdminWhitelistSearchPageTest : EndToEndTest() {
 	}
 
 	@Test
+	fun `a search with no matches renders no pagination bar`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com")
+
+		login().use { authed ->
+			val body = authed.fragment("?q=nobody")
+
+			assertFalse(
+				body.contains("class=\"pagination\""),
+				"Zero matches means zero pages, so no pagination bar should render",
+			)
+		}
+	}
+
+	@Test
+	fun `the fragment exposes its sort state so a search can preserve it`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com")
+
+		login().use { authed ->
+			assertContains(
+				authed.fragment("?sortOldestFirst=true"),
+				"id=\"whitelist-sort-state\"",
+			)
+			assertContains(
+				authed.fragment("?sortOldestFirst=true"),
+				"name=\"sortOldestFirst\" value=\"true\"",
+			)
+		}
+	}
+
+	@Test
+	fun `a rejected add keeps the admin's filter and page`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com", "bob@example.com")
+
+		login().use { authed ->
+			val body = authed.postFragment(
+				"add",
+				"email=not-an-email&reason=Beta+tester&expiryPreset=never&expiryDate=&page=0&sortOldestFirst=false&q=alice"
+			)
+
+			assertContains(body, "Invalid email address format")
+			assertContains(body, "alice@example.com")
+			assertFalse(
+				body.contains("bob@example.com"),
+				"A validation error is not an add, so the admin's filter must survive it",
+			)
+		}
+	}
+
+	@Test
+	fun `a successful add signals the client to reset the form`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+
+		login().use { authed ->
+			val ok = authed.post(route("admin/allowed-users/add")) {
+				header("HX-Request", "true")
+				contentType(ContentType.Application.FormUrlEncoded)
+				setBody(
+					"email=${URLEncoder.encode("carol@example.com", "UTF-8")}" +
+						"&reason=Beta+tester&expiryPreset=never&expiryDate=&q=alice"
+				)
+			}
+			assertEquals(HttpStatusCode.OK, ok.status)
+			assertEquals(
+				"whitelist-added",
+				ok.headers["HX-Trigger"],
+				"Only a real add may tell the client to clear the form and search",
+			)
+
+			val rejected = authed.post(route("admin/allowed-users/add")) {
+				header("HX-Request", "true")
+				contentType(ContentType.Application.FormUrlEncoded)
+				setBody("email=not-an-email&reason=Beta+tester&expiryPreset=never&expiryDate=&q=alice")
+			}
+			assertEquals(HttpStatusCode.OK, rejected.status)
+			assertEquals(null, rejected.headers["HX-Trigger"], "A rejected add must not signal a reset")
+		}
+	}
+
+	@Test
 	fun `a query containing markup is escaped in both the body and the reflected links`(): Unit = runBlocking {
 		doStartServer()
 		seed()

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/AdminWhitelistSearchPageTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/AdminWhitelistSearchPageTest.kt
@@ -1,0 +1,246 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.e2e.util.E2eTestData
+import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
+import com.darkrockstudios.apps.hammer.e2e.util.TestAccount
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.net.URLEncoder
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+/**
+ * Drives the allowed-users email search over real HTTP, so the query's trip through the
+ * route, the repository and the rendered fragment is exercised end to end.
+ */
+class AdminWhitelistSearchPageTest : EndToEndTest() {
+
+	private val email = "admin@test.com"
+	private val password = "password123!@#"
+
+	private fun seed() = runBlocking {
+		E2eTestData.createAccount(TestAccount(email, password, isAdmin = true), database())
+		addEntries(email)
+	}
+
+	private fun addEntries(vararg emails: String) {
+		emails.forEach {
+			database().serverDatabase.whiteListQueries
+				.addToWhiteList(it, Clock.System.now(), "Beta tester", null)
+		}
+	}
+
+	private suspend fun login(): HttpClient {
+		val authed = HttpClient { install(HttpCookies) }
+		val response = authed.post(route("login")) {
+			contentType(ContentType.Application.FormUrlEncoded)
+			setBody(
+				"email=${URLEncoder.encode(email, "UTF-8")}" +
+					"&password=${URLEncoder.encode(password, "UTF-8")}"
+			)
+		}
+		assertEquals(HttpStatusCode.Found, response.status)
+		return authed
+	}
+
+	private suspend fun HttpClient.fragment(query: String = ""): String {
+		val response = get(route("admin/allowed-users/user-fragment$query")) {
+			header("HX-Request", "true")
+		}
+		assertEquals(HttpStatusCode.OK, response.status)
+		return response.bodyAsText()
+	}
+
+	private suspend fun HttpClient.postFragment(action: String, body: String): String {
+		val response = post(route("admin/allowed-users/$action")) {
+			header("HX-Request", "true")
+			contentType(ContentType.Application.FormUrlEncoded)
+			setBody(body)
+		}
+		assertEquals(HttpStatusCode.OK, response.status)
+		return response.bodyAsText()
+	}
+
+	@Test
+	fun `a search filters the list to matching emails`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com", "alicia@example.com", "bob@example.com")
+
+		login().use { authed ->
+			val body = authed.fragment("?q=alic")
+
+			assertContains(body, "alice@example.com")
+			assertContains(body, "alicia@example.com")
+			assertFalse(body.contains("bob@example.com"), "Non-matching entries must be filtered out")
+		}
+	}
+
+	@Test
+	fun `no search lists everything`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com", "bob@example.com")
+
+		login().use { authed ->
+			val body = authed.fragment()
+
+			assertContains(body, "alice@example.com")
+			assertContains(body, "bob@example.com")
+		}
+	}
+
+	@Test
+	fun `pagination is scoped to the filtered set`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries(*(1..15).map { "alice$it@example.com" }.toTypedArray())
+		addEntries("bob@example.com")
+
+		login().use { authed ->
+			val firstPage = authed.fragment("?q=alice")
+			val secondPage = authed.fragment("?q=alice&page=1")
+
+			assertContains(firstPage, "of 2", message = "15 matches over a page size of 10 is two pages")
+			assertEquals(10, firstPage.split("class=\"whitelist-entry\"").size - 1)
+			assertEquals(5, secondPage.split("class=\"whitelist-entry\"").size - 1)
+			assertFalse(secondPage.contains("bob@example.com"), "The filter must survive paging")
+		}
+	}
+
+	@Test
+	fun `the sort and pagination controls carry the query forward`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries(*(1..15).map { "alice$it@example.com" }.toTypedArray())
+
+		login().use { authed ->
+			val body = authed.fragment("?q=alice")
+
+			assertContains(body, "sortOldestFirst=true&q=alice")
+			assertContains(body, "page=1&sortOldestFirst=false&q=alice")
+		}
+	}
+
+	@Test
+	fun `the remove form carries the query so the filter survives a removal`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com", "alicia@example.com", "bob@example.com")
+
+		login().use { authed ->
+			val listed = authed.fragment("?q=alic")
+			assertContains(listed, "name=\"q\" value=\"alic\"")
+
+			val afterRemove = authed.postFragment(
+				"remove",
+				"email=${URLEncoder.encode("alicia@example.com", "UTF-8")}&page=0&sortOldestFirst=false&q=alic"
+			)
+
+			assertContains(afterRemove, "alice@example.com")
+			assertFalse(afterRemove.contains("alicia@example.com"), "The removed entry should be gone")
+			assertFalse(afterRemove.contains("bob@example.com"), "The filter must survive the removal")
+		}
+	}
+
+	@Test
+	fun `editing a reason keeps the filtered view`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com", "bob@example.com")
+
+		login().use { authed ->
+			val body = authed.postFragment(
+				"edit-reason",
+				"email=${URLEncoder.encode("alice@example.com", "UTF-8")}&reason=Friend&page=0&sortOldestFirst=false&q=alice"
+			)
+
+			assertContains(body, "alice@example.com")
+			assertContains(body, "Friend")
+			assertFalse(body.contains("bob@example.com"), "The filter must survive the edit")
+		}
+	}
+
+	@Test
+	fun `adding returns the unfiltered first page so the new entry is visible`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("bob@example.com")
+
+		login().use { authed ->
+			val body = authed.postFragment(
+				"add",
+				"email=${URLEncoder.encode("carol@example.com", "UTF-8")}" +
+					"&reason=Beta+tester&expiryPreset=never&expiryDate=&page=3&q=alice"
+			)
+
+			assertContains(body, "carol@example.com", message = "The new entry must be visible")
+			assertContains(body, "bob@example.com", message = "The add response is deliberately unfiltered")
+			assertFalse(body.contains("whitelist-controls__filter"), "No filter chip should render")
+		}
+	}
+
+	@Test
+	fun `a search with no matches renders its own empty state`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com")
+
+		login().use { authed ->
+			val body = authed.fragment("?q=nobody")
+
+			assertContains(body, "No allowed users match that email.")
+			assertFalse(
+				body.contains("No allowed users yet"),
+				"The add-your-first empty state is wrong when a filter is active",
+			)
+		}
+	}
+
+	@Test
+	fun `an active filter is surfaced with a clear control`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com")
+
+		login().use { authed ->
+			assertContains(authed.fragment("?q=alice"), "whitelist-controls__filter")
+			assertFalse(
+				authed.fragment().contains("whitelist-controls__filter"),
+				"An unfiltered list should show no filter chip",
+			)
+		}
+	}
+
+	@Test
+	fun `a query containing markup is escaped in both the body and the reflected links`(): Unit = runBlocking {
+		doStartServer()
+		seed()
+		addEntries("alice@example.com")
+
+		login().use { authed ->
+			val hostile = "<script>alert(1)</script>"
+			val body = authed.fragment("?q=${URLEncoder.encode(hostile, "UTF-8")}")
+
+			assertFalse(body.contains("<script>alert(1)</script>"), "Raw markup must never be reflected")
+			assertContains(body, "&lt;script&gt;")
+			assertTrue(
+				body.contains("q=%3Cscript%3E"),
+				"The query must be URL encoded where it is reflected into an hx-get",
+			)
+		}
+	}
+}


### PR DESCRIPTION
Adds a search field to the Allowed Users admin page. Type a full or partial email and the list below filters to matches, case-insensitively, matching anywhere in the address.

## Behaviour

- Live search, debounced 300ms, with a "Filtered by: `bob`" chip carrying a clear control.
- The query survives the sort toggle, pagination, remove, and both edit dialogs, so acting on a row keeps you in your filtered view.
- A zero-match search gets its own empty state rather than the misleading "No allowed users yet. Add one above to get started."
- Adding a user deliberately returns the unfiltered first page, newest first, so the new entry is visible instead of landing outside your current page or filter. A *rejected* add is not an add: validation errors keep your page, sort, query and the values you typed.

## Implementation notes

**The search input lives in the page shell, not the swapped fragment.** `#whitelist` is replaced wholesale by `hx-swap="innerHTML"` on every interaction, so an input inside it would be destroyed and recreated on each keystroke's response and lose focus and caret. This mirrors `#logControls` on the monitoring logs page. The fragment instead renders its view state as hidden inputs that the search box and add form pull in via `hx-include`.

**`CAST(email AS TEXT) ILIKE ?` deliberately contradicts the citext comment above it in `WhiteList.sq`.** That comment is about `=`, where the explicit citext cast buys case-insensitivity. For `LIKE`/`ILIKE` the operator resolution goes the other way, and leaving it citext can silently yield a case-*sensitive* match.

**A filtered count query is mandatory.** `totalPages` is derived from the count, so without one the pagination would size itself from the unfiltered total.

`%` and `_` in the admin's input are escaped, since `_` is legal and common in email local parts and would otherwise match any character.

This also fixes three pre-existing issues on the code path it touches:

- Every paginated whitelist query ordered on `date_added` alone. `backfillFromAccounts` stamps every row it migrates with a single timestamp, leaving `LIMIT/OFFSET` free to repeat and skip rows across pages. All six now break ties on `email`.
- The pagination bar rendered "Page 1 of 0" on an empty list, because `{{#totalPages}}` guards on a boxed `Integer` and mustache.java renders a section on `0`. Now guarded on its own boolean.
- The add form's `htmx:afterSwap` handler read a `window.location.search` that is always empty on this page, so it never did anything; the reset it was meant to produce is now stated outright by the add route. The dead `whitelist-updated from:body` trigger, which no route ever emitted, is gone.

## Testing

1189 server tests pass. New coverage:

- **Repository, against real Postgres** — partial and anywhere-in-address matching, case-insensitivity (seeded past `cleanEmail` so a genuinely mixed-case row lands in the table), filtered counts and disjoint filtered pages, literal `_`, a bare `%` matching nothing rather than everything, whitespace, null/blank, and the paging invariant when every row shares a timestamp.
- **Routes, over real HTTP** — filtering, filtered pagination, the query surviving every control and mutation, the differentiated empty state, the deliberate add reset and its `HX-Trigger`, a rejected add preserving context, and an XSS regression asserting `<script>` is escaped in the body and `%3Cscript%3E` in the reflected `hx-get`.

The htmx wiring was verified against the real htmx 2.0.4 build in a browser: five keystrokes 60ms apart coalesce into one request, the input contributes its own `q` plus the included sort state, and the add form carries `q`, `sortOldestFirst` and `page`.

**Not verified: the visual pass.** The layout of the search field and filter chip, and focus retention while typing, have not been looked at in a running admin session.
